### PR TITLE
[WEF-218] 네이버 뉴스 파이프라인 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ DB_PASSWORD=change-this-password
 
 JWT_SECRET=change-this-jwt-secret
 AI_SERVER_URL=http://localhost:8000
+
+NAVER_CLIENT_ID=your-naver-client-id
+NAVER_CLIENT_SECRET=your-naver-client-secret

--- a/src/main/java/com/solv/wefin/WefinApplication.java
+++ b/src/main/java/com/solv/wefin/WefinApplication.java
@@ -2,7 +2,9 @@ package com.solv.wefin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class WefinApplication {
 

--- a/src/main/java/com/solv/wefin/domain/news/batch/NewsCollectScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/batch/NewsCollectScheduler.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.domain.news.batch;
+
+import com.solv.wefin.domain.news.service.NewsCollectService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NewsCollectScheduler {
+
+    private final NewsCollectService newsCollectService;
+
+    @Scheduled(cron = "${news.collect.cron:0 0 */2 * * *}")
+    public void collectNews() {
+        log.info("=== 뉴스 수집 배치 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            newsCollectService.collectAll();
+        } catch (Exception e) {
+            log.error("뉴스 수집 배치 실패: {}", e.getMessage(), e);
+        }
+
+        long elapsed = System.currentTimeMillis() - start;
+        log.info("=== 뉴스 수집 배치 종료 ({}ms) ===", elapsed);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/batch/NewsCollectScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/batch/NewsCollectScheduler.java
@@ -6,15 +6,23 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class NewsCollectScheduler {
 
     private final NewsCollectService newsCollectService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
 
     @Scheduled(cron = "${news.collect.cron:0 0 */2 * * *}")
     public void collectNews() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("뉴스 수집 배치가 이미 실행 중입니다. 스킵합니다.");
+            return;
+        }
+
         log.info("=== 뉴스 수집 배치 시작 ===");
         long start = System.currentTimeMillis();
 
@@ -22,9 +30,10 @@ public class NewsCollectScheduler {
             newsCollectService.collectAll();
         } catch (Exception e) {
             log.error("뉴스 수집 배치 실패: {}", e.getMessage(), e);
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 뉴스 수집 배치 종료 ({}ms) ===", elapsed);
         }
-
-        long elapsed = System.currentTimeMillis() - start;
-        log.info("=== 뉴스 수집 배치 종료 ({}ms) ===", elapsed);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/collector/NaverNewsCollector.java
+++ b/src/main/java/com/solv/wefin/domain/news/collector/NaverNewsCollector.java
@@ -3,8 +3,8 @@ package com.solv.wefin.domain.news.collector;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.news.dto.CollectedNewsDto;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -22,7 +22,6 @@ import java.util.*;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class NaverNewsCollector implements NewsCollector {
 
     private static final String SOURCE_NAME = "NaverNews";
@@ -40,6 +39,12 @@ public class NaverNewsCollector implements NewsCollector {
 
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
+
+    public NaverNewsCollector(@Qualifier("newsRestTemplate") RestTemplate restTemplate,
+                              ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
 
     @Value("${news.naver.client-id:}")
     private String clientId;

--- a/src/main/java/com/solv/wefin/domain/news/collector/NaverNewsCollector.java
+++ b/src/main/java/com/solv/wefin/domain/news/collector/NaverNewsCollector.java
@@ -1,0 +1,179 @@
+package com.solv.wefin.domain.news.collector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverNewsCollector implements NewsCollector {
+
+    private static final String SOURCE_NAME = "NaverNews";
+    private static final DateTimeFormatter RFC_1123 =
+            DateTimeFormatter.RFC_1123_DATE_TIME.withLocale(Locale.ENGLISH);
+
+    private static final Map<String, List<String>> CATEGORY_KEYWORDS = Map.of(
+            "DEFAULT", List.of("경제", "주식", "금리", "환율"),
+            "ECONOMY", List.of("경제", "금리", "환율"),
+            "POLITICS", List.of("정치 경제", "경제 정책"),
+            "SOCIETY", List.of("사회 경제", "부동산"),
+            "IT_SCIENCE", List.of("IT 경제", "핀테크"),
+            "GLOBAL", List.of("해외 경제", "글로벌 금융")
+    );
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${news.naver.client-id:}")
+    private String clientId;
+
+    @Value("${news.naver.client-secret:}")
+    private String clientSecret;
+
+    @Value("${news.naver.display:100}")
+    private int display;
+
+    @Value("${news.naver.base-url:https://openapi.naver.com/v1/search/news.json}")
+    private String baseUrl;
+
+    @Override
+    public String getSourceName() {
+        return SOURCE_NAME;
+    }
+
+    @Override
+    public List<CollectedNewsDto> collect(String category) {
+        Map<String, CollectedNewsDto> resultMap = new LinkedHashMap<>();
+        List<String> keywords = resolveKeywords(category);
+
+        for (String keyword : keywords) {
+            try {
+                List<CollectedNewsDto> articles = fetchByKeyword(keyword);
+                for (CollectedNewsDto dto : articles) {
+                    resultMap.putIfAbsent(dto.getOriginalUrl(), dto);
+                }
+            } catch (Exception e) {
+                log.warn("네이버 뉴스 수집 실패 - keyword: {}, error: {}", keyword, e.getMessage());
+            }
+        }
+
+        log.info("NaverNews 수집 완료 - category: {}, keywords: {}, count: {}",
+                category, keywords.size(), resultMap.size());
+
+        return new ArrayList<>(resultMap.values());
+    }
+
+    private List<CollectedNewsDto> fetchByKeyword(String keyword) {
+        String url = UriComponentsBuilder.fromHttpUrl(baseUrl)
+                .queryParam("query", keyword)
+                .queryParam("display", display)
+                .queryParam("start", 1)
+                .queryParam("sort", "date")
+                .build()
+                .toUriString();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("X-Naver-Client-Id", clientId);
+        headers.set("X-Naver-Client-Secret", clientSecret);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        List<CollectedNewsDto> results = new ArrayList<>();
+        JsonNode root = parseJson(response.getBody());
+        JsonNode items = root.path("items");
+
+        for (JsonNode item : items) {
+            try {
+                String originalLink = item.path("originallink").asText("");
+                String naverLink = item.path("link").asText("");
+                String articleUrl = originalLink.isBlank() ? naverLink : originalLink;
+
+                if (articleUrl.isBlank()) continue;
+
+                CollectedNewsDto dto = CollectedNewsDto.builder()
+                        .externalArticleId("naver:" + Math.abs(articleUrl.hashCode()))
+                        .originalUrl(articleUrl)
+                        .originalTitle(stripHtml(item.path("title").asText("")))
+                        .originalContent(stripHtml(item.path("description").asText("")))
+                        .originalThumbnailUrl(null)
+                        .originalPublishedAt(parseNaverDate(item.path("pubDate").asText(null)))
+                        .publisherName(extractPublisher(articleUrl))
+                        .rawPayload(objectMapper.writeValueAsString(item))
+                        .build();
+
+                results.add(dto);
+            } catch (Exception e) {
+                log.warn("네이버 뉴스 기사 파싱 실패: {}", e.getMessage());
+            }
+        }
+
+        return results;
+    }
+
+    private List<String> resolveKeywords(String category) {
+        if (category == null || category.isBlank()) {
+            return CATEGORY_KEYWORDS.get("DEFAULT");
+        }
+        return CATEGORY_KEYWORDS.getOrDefault(category.toUpperCase(), CATEGORY_KEYWORDS.get("DEFAULT"));
+    }
+
+    private JsonNode parseJson(String body) {
+        try {
+            return objectMapper.readTree(body);
+        } catch (Exception e) {
+            throw new RuntimeException("네이버 응답 파싱 실패", e);
+        }
+    }
+
+    private String stripHtml(String text) {
+        if (text == null || text.isBlank()) return text;
+        return text
+                .replaceAll("<[^>]+>", "")
+                .replace("&amp;", "&")
+                .replace("&lt;", "<")
+                .replace("&gt;", ">")
+                .replace("&quot;", "\"")
+                .replace("&#039;", "'")
+                .replace("&#39;", "'")
+                .trim();
+    }
+
+    private LocalDateTime parseNaverDate(String pubDate) {
+        if (pubDate == null || pubDate.isBlank()) return null;
+        try {
+            ZonedDateTime zdt = ZonedDateTime.parse(pubDate, RFC_1123);
+            return zdt.toLocalDateTime();
+        } catch (Exception e) {
+            log.debug("날짜 파싱 실패: {}", pubDate);
+            return null;
+        }
+    }
+
+    private String extractPublisher(String url) {
+        try {
+            String host = URI.create(url).getHost();
+            if (host == null) return "Unknown";
+            return host.startsWith("www.") ? host.substring(4) : host;
+        } catch (Exception e) {
+            return "Unknown";
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/collector/NewsCollector.java
+++ b/src/main/java/com/solv/wefin/domain/news/collector/NewsCollector.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.news.collector;
+
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
+
+import java.util.List;
+
+public interface NewsCollector {
+
+    String getSourceName();
+
+    List<CollectedNewsDto> collect(String category);
+}

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.news.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class NewsConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(10000);
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.client.RestTemplate;
 public class NewsConfig {
 
     @Bean
-    public RestTemplate restTemplate() {
+    public RestTemplate newsRestTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(5000);
         factory.setReadTimeout(10000);

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.news.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class NewsConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/controller/NewsCollectController.java
+++ b/src/main/java/com/solv/wefin/domain/news/controller/NewsCollectController.java
@@ -1,0 +1,24 @@
+package com.solv.wefin.domain.news.controller;
+
+import com.solv.wefin.domain.news.service.NewsCollectService;
+import com.solv.wefin.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequestMapping("/api/admin/news")
+@RequiredArgsConstructor
+public class NewsCollectController {
+
+    private final NewsCollectService newsCollectService;
+
+    @PostMapping("/collect")
+    public ApiResponse<String> collectNow() {
+        newsCollectService.collectAll();
+        return ApiResponse.success("뉴스 수집 완료");
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/dto/CollectedNewsDto.java
+++ b/src/main/java/com/solv/wefin/domain/news/dto/CollectedNewsDto.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.domain.news.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CollectedNewsDto {
+
+    private String externalArticleId;
+    private String originalUrl;
+    private String originalTitle;
+    private String originalContent;
+    private String originalThumbnailUrl;
+    private LocalDateTime originalPublishedAt;
+    private String publisherName;
+    private String rawPayload;
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.news.entity;
 
+import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -12,7 +13,7 @@ import java.time.LocalDateTime;
 @Table(name = "news_article")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NewsArticle {
+public class NewsArticle extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,14 +58,6 @@ public class NewsArticle {
 
     @Column(name = "collected_at")
     private LocalDateTime collectedAt;
-
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
 
     @Builder
     public NewsArticle(Long rawNewsArticleId, String publisherName, String title,

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.news.entity;
 
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
 import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -60,11 +61,11 @@ public class NewsArticle extends BaseEntity {
     private LocalDateTime collectedAt;
 
     @Builder
-    public NewsArticle(Long rawNewsArticleId, String publisherName, String title,
-                       String summary, String content, String originalUrl,
-                       String thumbnailUrl, LocalDateTime publishedAt,
-                       String category, String marketScope, String languageCode,
-                       String dedupKey, LocalDateTime collectedAt) {
+    private NewsArticle(Long rawNewsArticleId, String publisherName, String title,
+                        String summary, String content, String originalUrl,
+                        String thumbnailUrl, LocalDateTime publishedAt,
+                        String category, String marketScope, String languageCode,
+                        String dedupKey, LocalDateTime collectedAt) {
         this.rawNewsArticleId = rawNewsArticleId;
         this.publisherName = publisherName;
         this.title = title;
@@ -78,5 +79,23 @@ public class NewsArticle extends BaseEntity {
         this.languageCode = languageCode;
         this.dedupKey = dedupKey;
         this.collectedAt = collectedAt;
+    }
+
+    public static NewsArticle of(RawNewsArticle rawArticle, CollectedNewsDto dto,
+                                 String title, String content, String languageCode,
+                                 String marketScope, String dedupKey) {
+        return NewsArticle.builder()
+                .rawNewsArticleId(rawArticle.getId())
+                .publisherName(dto.getPublisherName())
+                .title(title)
+                .content(content)
+                .originalUrl(dto.getOriginalUrl())
+                .thumbnailUrl(dto.getOriginalThumbnailUrl())
+                .publishedAt(dto.getOriginalPublishedAt())
+                .languageCode(languageCode)
+                .marketScope(marketScope)
+                .dedupKey(dedupKey)
+                .collectedAt(rawArticle.getCollectedAt())
+                .build();
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -1,0 +1,89 @@
+package com.solv.wefin.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "news_article")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsArticle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_article_id")
+    private Long id;
+
+    @Column(name = "raw_news_article_id")
+    private Long rawNewsArticleId;
+
+    @Column(name = "publisher_name", nullable = false, length = 100)
+    private String publisherName;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "summary")
+    private String summary;
+
+    @Column(name = "content")
+    private String content;
+
+    @Column(name = "original_url", nullable = false)
+    private String originalUrl;
+
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    @Column(name = "published_at")
+    private LocalDateTime publishedAt;
+
+    @Column(name = "category", length = 50)
+    private String category;
+
+    @Column(name = "market_scope", length = 30)
+    private String marketScope;
+
+    @Column(name = "language_code", length = 10)
+    private String languageCode;
+
+    @Column(name = "dedup_key", length = 255)
+    private String dedupKey;
+
+    @Column(name = "collected_at")
+    private LocalDateTime collectedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public NewsArticle(Long rawNewsArticleId, String publisherName, String title,
+                       String summary, String content, String originalUrl,
+                       String thumbnailUrl, LocalDateTime publishedAt,
+                       String category, String marketScope, String languageCode,
+                       String dedupKey, LocalDateTime collectedAt) {
+        this.rawNewsArticleId = rawNewsArticleId;
+        this.publisherName = publisherName;
+        this.title = title;
+        this.summary = summary;
+        this.content = content;
+        this.originalUrl = originalUrl;
+        this.thumbnailUrl = thumbnailUrl;
+        this.publishedAt = publishedAt;
+        this.category = category;
+        this.marketScope = marketScope;
+        this.languageCode = languageCode;
+        this.dedupKey = dedupKey;
+        this.collectedAt = collectedAt;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticleTag.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticleTag.java
@@ -1,0 +1,54 @@
+package com.solv.wefin.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "news_article_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsArticleTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_article_tag_id")
+    private Long id;
+
+    @Column(name = "news_article_id", nullable = false)
+    private Long newsArticleId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tag_type", nullable = false, length = 30)
+    private TagType tagType;
+
+    @Column(name = "tag_code", nullable = false, length = 100)
+    private String tagCode;
+
+    @Column(name = "tag_name", nullable = false, length = 100)
+    private String tagName;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public NewsArticleTag(Long newsArticleId, TagType tagType, String tagCode, String tagName) {
+        this.newsArticleId = newsArticleId;
+        this.tagType = tagType;
+        this.tagCode = tagCode;
+        this.tagName = tagName;
+    }
+
+    public enum TagType {
+        STOCK, SECTOR, TOPIC
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsCollectBatch.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsCollectBatch.java
@@ -1,0 +1,75 @@
+package com.solv.wefin.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "news_collect_batch")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsCollectBatch {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_collect_batch_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_source_id", nullable = false)
+    private NewsSource newsSource;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "finished_at")
+    private LocalDateTime finishedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private BatchStatus status;
+
+    @Column(name = "requested_category", length = 50)
+    private String requestedCategory;
+
+    @Column(name = "collected_count", nullable = false)
+    private int collectedCount;
+
+    @Column(name = "failed_count", nullable = false)
+    private int failedCount;
+
+    @Column(name = "error_message")
+    private String errorMessage;
+
+    @Builder
+    public NewsCollectBatch(NewsSource newsSource, String requestedCategory) {
+        this.newsSource = newsSource;
+        this.requestedCategory = requestedCategory;
+        this.startedAt = LocalDateTime.now();
+        this.status = BatchStatus.RUNNING;
+        this.collectedCount = 0;
+        this.failedCount = 0;
+    }
+
+    public void success(int collectedCount) {
+        this.status = BatchStatus.SUCCESS;
+        this.collectedCount = collectedCount;
+        this.finishedAt = LocalDateTime.now();
+    }
+
+    public void fail(String errorMessage, int collectedCount, int failedCount) {
+        this.status = BatchStatus.FAILED;
+        this.errorMessage = errorMessage;
+        this.collectedCount = collectedCount;
+        this.failedCount = failedCount;
+        this.finishedAt = LocalDateTime.now();
+    }
+
+    public enum BatchStatus {
+        READY, RUNNING, SUCCESS, FAILED
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsCollectBatch.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsCollectBatch.java
@@ -55,9 +55,10 @@ public class NewsCollectBatch {
         this.failedCount = 0;
     }
 
-    public void success(int collectedCount) {
+    public void success(int collectedCount, int failedCount) {
         this.status = BatchStatus.SUCCESS;
         this.collectedCount = collectedCount;
+        this.failedCount = failedCount;
         this.finishedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsSource.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsSource.java
@@ -1,18 +1,17 @@
 package com.solv.wefin.domain.news.entity;
 
+import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(name = "news_source")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NewsSource {
+public class NewsSource extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,14 +30,6 @@ public class NewsSource {
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
-
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
 
     @Builder
     public NewsSource(String sourceName, SourceType sourceType, String baseUrl, Boolean isActive) {

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsSource.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsSource.java
@@ -19,7 +19,7 @@ public class NewsSource {
     @Column(name = "news_source_id")
     private Long id;
 
-    @Column(name = "source_name", nullable = false, length = 100)
+    @Column(name = "source_name", nullable = false, length = 100, unique = true)
     private String sourceName;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsSource.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsSource.java
@@ -1,0 +1,54 @@
+package com.solv.wefin.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "news_source")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsSource {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_source_id")
+    private Long id;
+
+    @Column(name = "source_name", nullable = false, length = 100)
+    private String sourceName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 50)
+    private SourceType sourceType;
+
+    @Column(name = "base_url")
+    private String baseUrl;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public NewsSource(String sourceName, SourceType sourceType, String baseUrl, Boolean isActive) {
+        this.sourceName = sourceName;
+        this.sourceType = sourceType;
+        this.baseUrl = baseUrl;
+        this.isActive = isActive;
+    }
+
+    public enum SourceType {
+        API, RSS, CRAWLER
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/RawNewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/RawNewsArticle.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.news.entity;
 
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -59,10 +60,10 @@ public class RawNewsArticle {
     private LocalDateTime collectedAt;
 
     @Builder
-    public RawNewsArticle(NewsSource newsSource, NewsCollectBatch newsCollectBatch,
-                          String externalArticleId, String originalUrl, String originalTitle,
-                          String originalContent, String originalThumbnailUrl,
-                          LocalDateTime originalPublishedAt, String rawPayload) {
+    private RawNewsArticle(NewsSource newsSource, NewsCollectBatch newsCollectBatch,
+                           String externalArticleId, String originalUrl, String originalTitle,
+                           String originalContent, String originalThumbnailUrl,
+                           LocalDateTime originalPublishedAt, String rawPayload) {
         this.newsSource = newsSource;
         this.newsCollectBatch = newsCollectBatch;
         this.externalArticleId = externalArticleId;
@@ -74,6 +75,20 @@ public class RawNewsArticle {
         this.rawPayload = rawPayload;
         this.processingStatus = ProcessingStatus.PENDING;
         this.collectedAt = LocalDateTime.now();
+    }
+
+    public static RawNewsArticle of(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
+        return RawNewsArticle.builder()
+                .newsSource(source)
+                .newsCollectBatch(batch)
+                .externalArticleId(dto.getExternalArticleId())
+                .originalUrl(dto.getOriginalUrl())
+                .originalTitle(dto.getOriginalTitle())
+                .originalContent(dto.getOriginalContent())
+                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
+                .originalPublishedAt(dto.getOriginalPublishedAt())
+                .rawPayload(dto.getRawPayload())
+                .build();
     }
 
     public void markNormalized() {

--- a/src/main/java/com/solv/wefin/domain/news/entity/RawNewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/RawNewsArticle.java
@@ -1,0 +1,94 @@
+package com.solv.wefin.domain.news.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "raw_news_article")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RawNewsArticle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "raw_news_article_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_source_id", nullable = false)
+    private NewsSource newsSource;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_collect_batch_id", nullable = false)
+    private NewsCollectBatch newsCollectBatch;
+
+    @Column(name = "external_article_id", length = 255)
+    private String externalArticleId;
+
+    @Column(name = "original_url", nullable = false)
+    private String originalUrl;
+
+    @Column(name = "original_title", nullable = false)
+    private String originalTitle;
+
+    @Column(name = "original_content")
+    private String originalContent;
+
+    @Column(name = "original_thumbnail_url")
+    private String originalThumbnailUrl;
+
+    @Column(name = "original_published_at")
+    private LocalDateTime originalPublishedAt;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "raw_payload", columnDefinition = "jsonb")
+    private String rawPayload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "processing_status", nullable = false, length = 30)
+    private ProcessingStatus processingStatus;
+
+    @Column(name = "collected_at", nullable = false)
+    private LocalDateTime collectedAt;
+
+    @Builder
+    public RawNewsArticle(NewsSource newsSource, NewsCollectBatch newsCollectBatch,
+                          String externalArticleId, String originalUrl, String originalTitle,
+                          String originalContent, String originalThumbnailUrl,
+                          LocalDateTime originalPublishedAt, String rawPayload) {
+        this.newsSource = newsSource;
+        this.newsCollectBatch = newsCollectBatch;
+        this.externalArticleId = externalArticleId;
+        this.originalUrl = originalUrl;
+        this.originalTitle = originalTitle;
+        this.originalContent = originalContent;
+        this.originalThumbnailUrl = originalThumbnailUrl;
+        this.originalPublishedAt = originalPublishedAt;
+        this.rawPayload = rawPayload;
+        this.processingStatus = ProcessingStatus.PENDING;
+        this.collectedAt = LocalDateTime.now();
+    }
+
+    public void markNormalized() {
+        this.processingStatus = ProcessingStatus.NORMALIZED;
+    }
+
+    public void markFailed() {
+        this.processingStatus = ProcessingStatus.FAILED;
+    }
+
+    public void markDuplicated() {
+        this.processingStatus = ProcessingStatus.DUPLICATED;
+    }
+
+    public enum ProcessingStatus {
+        PENDING, NORMALIZED, FAILED, DUPLICATED
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/RawNewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/RawNewsArticle.java
@@ -32,7 +32,7 @@ public class RawNewsArticle {
     @Column(name = "external_article_id", length = 255)
     private String externalArticleId;
 
-    @Column(name = "original_url", nullable = false)
+    @Column(name = "original_url", nullable = false, unique = true)
     private String originalUrl;
 
     @Column(name = "original_title", nullable = false)

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.news.repository;
+
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> {
+
+    boolean existsByDedupKey(String dedupKey);
+}

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleTagRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleTagRepository.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.news.repository;
+
+import com.solv.wefin.domain.news.entity.NewsArticleTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NewsArticleTagRepository extends JpaRepository<NewsArticleTag, Long> {
+
+    List<NewsArticleTag> findByNewsArticleId(Long newsArticleId);
+}

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsCollectBatchRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsCollectBatchRepository.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.news.repository;
+
+import com.solv.wefin.domain.news.entity.NewsCollectBatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsCollectBatchRepository extends JpaRepository<NewsCollectBatch, Long> {
+}

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsSourceRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsSourceRepository.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.news.repository;
+
+import com.solv.wefin.domain.news.entity.NewsSource;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NewsSourceRepository extends JpaRepository<NewsSource, Long> {
+
+    List<NewsSource> findByIsActiveTrue();
+
+    Optional<NewsSource> findBySourceName(String sourceName);
+}

--- a/src/main/java/com/solv/wefin/domain/news/repository/RawNewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/RawNewsArticleRepository.java
@@ -7,9 +7,7 @@ import java.util.List;
 
 public interface RawNewsArticleRepository extends JpaRepository<RawNewsArticle, Long> {
 
-    boolean existsByOriginalUrl(String originalUrl);
-
-    boolean existsByExternalArticleId(String externalArticleId);
+    boolean existsByOriginalUrlOrExternalArticleId(String originalUrl, String externalArticleId);
 
     List<RawNewsArticle> findByProcessingStatus(RawNewsArticle.ProcessingStatus processingStatus);
 }

--- a/src/main/java/com/solv/wefin/domain/news/repository/RawNewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/RawNewsArticleRepository.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.news.repository;
+
+import com.solv.wefin.domain.news.entity.RawNewsArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RawNewsArticleRepository extends JpaRepository<RawNewsArticle, Long> {
+
+    boolean existsByOriginalUrl(String originalUrl);
+
+    boolean existsByExternalArticleId(String externalArticleId);
+
+    List<RawNewsArticle> findByProcessingStatus(RawNewsArticle.ProcessingStatus processingStatus);
+}

--- a/src/main/java/com/solv/wefin/domain/news/repository/RawNewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/RawNewsArticleRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface RawNewsArticleRepository extends JpaRepository<RawNewsArticle, Long> {
 
-    boolean existsByOriginalUrlOrExternalArticleId(String originalUrl, String externalArticleId);
+    boolean existsByOriginalUrl(String originalUrl);
 
     List<RawNewsArticle> findByProcessingStatus(RawNewsArticle.ProcessingStatus processingStatus);
 }

--- a/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
@@ -6,14 +6,17 @@ import com.solv.wefin.domain.news.repository.NewsArticleRepository;
 import com.solv.wefin.domain.news.repository.RawNewsArticleRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Locale;
 
 @Slf4j
 @Service
@@ -25,8 +28,7 @@ public class ArticlePersistenceService {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processSingleArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
-        if (rawNewsArticleRepository.existsByOriginalUrlOrExternalArticleId(
-                dto.getOriginalUrl(), dto.getExternalArticleId())) {
+        if (rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())) {
             log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
             return;
         }
@@ -44,13 +46,55 @@ public class ArticlePersistenceService {
                 .build();
 
         try {
-            rawNewsArticleRepository.save(rawArticle);
+            rawNewsArticleRepository.saveAndFlush(rawArticle);
         } catch (DataIntegrityViolationException e) {
-            log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
-            return;
+            if (isDuplicateOriginalUrlViolation(e)) {
+                log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
+                return;
+            }
+            log.error("raw 기사 저장 실패 - url: {}", dto.getOriginalUrl(), e);
+            throw e;
         }
 
         normalizeAndSave(rawArticle, dto);
+    }
+
+    private boolean isDuplicateOriginalUrlViolation(DataIntegrityViolationException exception) {
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException constraintViolation) {
+                if (isOriginalUrlConstraintName(constraintViolation.getConstraintName())) {
+                    return true;
+                }
+                if (refersToOriginalUrlUniqueConstraint(constraintViolation.getSQLException())) {
+                    return true;
+                }
+            } else if (cause instanceof SQLException sqlException
+                    && refersToOriginalUrlUniqueConstraint(sqlException)) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    private boolean isOriginalUrlConstraintName(String constraintName) {
+        return "uk_raw_news_article_original_url".equalsIgnoreCase(constraintName);
+    }
+
+    private boolean refersToOriginalUrlUniqueConstraint(SQLException exception) {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            return false;
+        }
+
+        String normalized = message.toLowerCase(Locale.ROOT);
+        return normalized.contains("uk_raw_news_article_original_url")
+                || (normalized.contains("raw_news_article")
+                && normalized.contains("original_url")
+                && (normalized.contains("duplicate key")
+                || normalized.contains("unique constraint")
+                || normalized.contains("unique index")));
     }
 
     private void normalizeAndSave(RawNewsArticle rawArticle, CollectedNewsDto dto) {

--- a/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
@@ -1,0 +1,129 @@
+package com.solv.wefin.domain.news.service;
+
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
+import com.solv.wefin.domain.news.entity.*;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.repository.RawNewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ArticlePersistenceService {
+
+    private final RawNewsArticleRepository rawNewsArticleRepository;
+    private final NewsArticleRepository newsArticleRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void processSingleArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
+        if (rawNewsArticleRepository.existsByOriginalUrlOrExternalArticleId(
+                dto.getOriginalUrl(), dto.getExternalArticleId())) {
+            log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
+            return;
+        }
+
+        RawNewsArticle rawArticle = RawNewsArticle.builder()
+                .newsSource(source)
+                .newsCollectBatch(batch)
+                .externalArticleId(dto.getExternalArticleId())
+                .originalUrl(dto.getOriginalUrl())
+                .originalTitle(dto.getOriginalTitle())
+                .originalContent(dto.getOriginalContent())
+                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
+                .originalPublishedAt(dto.getOriginalPublishedAt())
+                .rawPayload(dto.getRawPayload())
+                .build();
+
+        try {
+            rawNewsArticleRepository.save(rawArticle);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
+            return;
+        }
+
+        normalizeAndSave(rawArticle, dto);
+    }
+
+    private void normalizeAndSave(RawNewsArticle rawArticle, CollectedNewsDto dto) {
+        String dedupKey = generateDedupKey(dto.getOriginalUrl());
+
+        if (newsArticleRepository.existsByDedupKey(dedupKey)) {
+            rawArticle.markDuplicated();
+            return;
+        }
+
+        try {
+            NewsArticle article = NewsArticle.builder()
+                    .rawNewsArticleId(rawArticle.getId())
+                    .publisherName(dto.getPublisherName())
+                    .title(cleanText(dto.getOriginalTitle()))
+                    .content(cleanHtml(dto.getOriginalContent()))
+                    .originalUrl(dto.getOriginalUrl())
+                    .thumbnailUrl(dto.getOriginalThumbnailUrl())
+                    .publishedAt(dto.getOriginalPublishedAt())
+                    .languageCode(detectLanguage(dto.getOriginalTitle()))
+                    .marketScope(detectMarketScope(dto.getOriginalTitle()))
+                    .dedupKey(dedupKey)
+                    .collectedAt(rawArticle.getCollectedAt())
+                    .build();
+
+            newsArticleRepository.save(article);
+            rawArticle.markNormalized();
+
+            log.debug("기사 정제 완료 - id: {}, title: {}", article.getId(), article.getTitle());
+
+        } catch (Exception e) {
+            rawArticle.markFailed();
+            throw e;
+        }
+    }
+
+    private String generateDedupKey(String url) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                    .digest(url.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return "url:" + hex;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
+    }
+
+    private String cleanText(String text) {
+        if (text == null) return null;
+        return text.trim();
+    }
+
+    private String cleanHtml(String content) {
+        if (content == null) return null;
+        return content
+                .replaceAll("<[^>]+>", "")
+                .replaceAll("&[a-zA-Z]+;", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    private String detectLanguage(String title) {
+        if (title == null) return "EN";
+        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+        return hasKorean ? "KO" : "EN";
+    }
+
+    private String detectMarketScope(String title) {
+        if (title == null) return "GLOBAL";
+        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+        return hasKorean ? "DOMESTIC" : "GLOBAL";
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
@@ -98,19 +98,13 @@ public class ArticlePersistenceService {
         }
 
         try {
-            NewsArticle article = NewsArticle.builder()
-                    .rawNewsArticleId(rawArticle.getId())
-                    .publisherName(dto.getPublisherName())
-                    .title(cleanText(dto.getOriginalTitle()))
-                    .content(cleanHtml(dto.getOriginalContent()))
-                    .originalUrl(dto.getOriginalUrl())
-                    .thumbnailUrl(dto.getOriginalThumbnailUrl())
-                    .publishedAt(dto.getOriginalPublishedAt())
-                    .languageCode(detectLanguage(dto.getOriginalTitle()))
-                    .marketScope(detectMarketScope(dto.getOriginalTitle()))
-                    .dedupKey(dedupKey)
-                    .collectedAt(rawArticle.getCollectedAt())
-                    .build();
+            NewsArticle article = NewsArticle.of(
+                    rawArticle, dto,
+                    cleanText(dto.getOriginalTitle()),
+                    cleanHtml(dto.getOriginalContent()),
+                    detectLanguage(dto.getOriginalTitle()),
+                    detectMarketScope(dto.getOriginalTitle()),
+                    dedupKey);
 
             newsArticleRepository.save(article);
             rawArticle.markNormalized();

--- a/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
@@ -28,11 +28,14 @@ public class ArticlePersistenceService {
     private final RawNewsArticleRepository rawNewsArticleRepository;
     private final NewsArticleRepository newsArticleRepository;
 
+    /**
+     * @return true if the article was saved, false if skipped (duplicate)
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void processSingleArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
+    public boolean processSingleArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
         if (rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())) {
             log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
-            return;
+            return false;
         }
 
         RawNewsArticle rawArticle = RawNewsArticle.of(dto, source, batch);
@@ -42,13 +45,14 @@ public class ArticlePersistenceService {
         } catch (DataIntegrityViolationException e) {
             if (isDuplicateOriginalUrlViolation(e)) {
                 log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
-                return;
+                return false;
             }
             log.error("raw 기사 저장 실패 - url: {}", dto.getOriginalUrl(), e);
             throw e;
         }
 
         normalizeAndSave(rawArticle, dto);
+        return true;
     }
 
     private boolean isDuplicateOriginalUrlViolation(DataIntegrityViolationException exception) {

--- a/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/ArticlePersistenceService.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.solv.wefin.global.util.StringUtils;
+
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.security.MessageDigest;
@@ -33,17 +35,7 @@ public class ArticlePersistenceService {
             return;
         }
 
-        RawNewsArticle rawArticle = RawNewsArticle.builder()
-                .newsSource(source)
-                .newsCollectBatch(batch)
-                .externalArticleId(dto.getExternalArticleId())
-                .originalUrl(dto.getOriginalUrl())
-                .originalTitle(dto.getOriginalTitle())
-                .originalContent(dto.getOriginalContent())
-                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
-                .originalPublishedAt(dto.getOriginalPublishedAt())
-                .rawPayload(dto.getRawPayload())
-                .build();
+        RawNewsArticle rawArticle = RawNewsArticle.of(dto, source, batch);
 
         try {
             rawNewsArticleRepository.saveAndFlush(rawArticle);
@@ -160,14 +152,10 @@ public class ArticlePersistenceService {
     }
 
     private String detectLanguage(String title) {
-        if (title == null) return "EN";
-        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
-        return hasKorean ? "KO" : "EN";
+        return StringUtils.containsKorean(title) ? "KO" : "EN";
     }
 
     private String detectMarketScope(String title) {
-        if (title == null) return "GLOBAL";
-        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
-        return hasKorean ? "DOMESTIC" : "GLOBAL";
+        return StringUtils.containsKorean(title) ? "DOMESTIC" : "GLOBAL";
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
@@ -1,14 +1,9 @@
 package com.solv.wefin.domain.news.service;
 
 import com.solv.wefin.domain.news.collector.NewsCollector;
-import com.solv.wefin.domain.news.dto.CollectedNewsDto;
-import com.solv.wefin.domain.news.entity.*;
-import com.solv.wefin.domain.news.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,169 +13,11 @@ import java.util.List;
 public class NewsCollectService {
 
     private final List<NewsCollector> newsCollectors;
-    private final NewsSourceRepository newsSourceRepository;
-    private final NewsCollectBatchRepository newsCollectBatchRepository;
-    private final RawNewsArticleRepository rawNewsArticleRepository;
-    private final NewsArticleRepository newsArticleRepository;
+    private final NewsSourceCollectService newsSourceCollectService;
 
-    @Transactional
     public void collectAll() {
         for (NewsCollector collector : newsCollectors) {
-            collectFromSource(collector, null);
+            newsSourceCollectService.collectFromSource(collector, null);
         }
-    }
-
-    @Transactional
-    public void collectFromSource(NewsCollector collector, String category) {
-        NewsSource source = getOrCreateSource(collector);
-        if (!source.getIsActive()) {
-            log.info("비활성 소스 스킵: {}", source.getSourceName());
-            return;
-        }
-
-        NewsCollectBatch batch = NewsCollectBatch.builder()
-                .newsSource(source)
-                .requestedCategory(category)
-                .build();
-        newsCollectBatchRepository.save(batch);
-
-        int collectedCount = 0;
-        int failedCount = 0;
-
-        try {
-            List<CollectedNewsDto> articles = collector.collect(category);
-
-            for (CollectedNewsDto dto : articles) {
-                try {
-                    processArticle(dto, source, batch);
-                    collectedCount++;
-                } catch (Exception e) {
-                    failedCount++;
-                    log.warn("기사 처리 실패 - url: {}, error: {}", dto.getOriginalUrl(), e.getMessage());
-                }
-            }
-
-            batch.success(collectedCount, failedCount);
-            log.info("뉴스 수집 배치 완료 - source: {}, collected: {}, failed: {}",
-                    source.getSourceName(), collectedCount, failedCount);
-
-        } catch (Exception e) {
-            batch.fail(e.getMessage(), collectedCount, failedCount);
-            log.error("뉴스 수집 배치 실패 - source: {}, error: {}", source.getSourceName(), e.getMessage());
-        }
-    }
-
-    private void processArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
-        // 중복 체크 (URL + externalArticleId)
-        if (rawNewsArticleRepository.existsByOriginalUrlOrExternalArticleId(
-                dto.getOriginalUrl(), dto.getExternalArticleId())) {
-            log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
-            return;
-        }
-
-        // Raw 저장
-        RawNewsArticle rawArticle = RawNewsArticle.builder()
-                .newsSource(source)
-                .newsCollectBatch(batch)
-                .externalArticleId(dto.getExternalArticleId())
-                .originalUrl(dto.getOriginalUrl())
-                .originalTitle(dto.getOriginalTitle())
-                .originalContent(dto.getOriginalContent())
-                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
-                .originalPublishedAt(dto.getOriginalPublishedAt())
-                .rawPayload(dto.getRawPayload())
-                .build();
-
-        try {
-            rawNewsArticleRepository.save(rawArticle);
-        } catch (DataIntegrityViolationException e) {
-            log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
-            return;
-        }
-
-        // 정제 및 NewsArticle 저장
-        normalizeAndSave(rawArticle, dto);
-    }
-
-    private void normalizeAndSave(RawNewsArticle rawArticle, CollectedNewsDto dto) {
-        String dedupKey = generateDedupKey(dto.getOriginalUrl());
-
-        if (newsArticleRepository.existsByDedupKey(dedupKey)) {
-            rawArticle.markDuplicated();
-            return;
-        }
-
-        try {
-            NewsArticle article = NewsArticle.builder()
-                    .rawNewsArticleId(rawArticle.getId())
-                    .publisherName(dto.getPublisherName())
-                    .title(cleanText(dto.getOriginalTitle()))
-                    .content(cleanHtml(dto.getOriginalContent()))
-                    .originalUrl(dto.getOriginalUrl())
-                    .thumbnailUrl(dto.getOriginalThumbnailUrl())
-                    .publishedAt(dto.getOriginalPublishedAt())
-                    .languageCode(detectLanguage(dto.getOriginalTitle()))
-                    .marketScope(detectMarketScope(dto.getOriginalTitle()))
-                    .dedupKey(dedupKey)
-                    .collectedAt(rawArticle.getCollectedAt())
-                    .build();
-
-            newsArticleRepository.save(article);
-            rawArticle.markNormalized();
-
-            log.debug("기사 정제 완료 - id: {}, title: {}", article.getId(), article.getTitle());
-
-        } catch (Exception e) {
-            rawArticle.markFailed();
-            throw e;
-        }
-    }
-
-    private NewsSource getOrCreateSource(NewsCollector collector) {
-        return newsSourceRepository.findBySourceName(collector.getSourceName())
-                .orElseGet(() -> {
-                    try {
-                        return newsSourceRepository.save(
-                                NewsSource.builder()
-                                        .sourceName(collector.getSourceName())
-                                        .sourceType(NewsSource.SourceType.API)
-                                        .isActive(true)
-                                        .build()
-                        );
-                    } catch (DataIntegrityViolationException e) {
-                        return newsSourceRepository.findBySourceName(collector.getSourceName())
-                                .orElseThrow(() -> e);
-                    }
-                });
-    }
-
-    private String generateDedupKey(String url) {
-        return "url:" + Math.abs(url.hashCode());
-    }
-
-    private String cleanText(String text) {
-        if (text == null) return null;
-        return text.trim();
-    }
-
-    private String cleanHtml(String content) {
-        if (content == null) return null;
-        return content
-                .replaceAll("<[^>]+>", "")
-                .replaceAll("&[a-zA-Z]+;", " ")
-                .replaceAll("\\s+", " ")
-                .trim();
-    }
-
-    private String detectLanguage(String title) {
-        if (title == null) return "EN";
-        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
-        return hasKorean ? "KO" : "EN";
-    }
-
-    private String detectMarketScope(String title) {
-        if (title == null) return "GLOBAL";
-        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
-        return hasKorean ? "DOMESTIC" : "GLOBAL";
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.news.entity.*;
 import com.solv.wefin.domain.news.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -70,8 +71,9 @@ public class NewsCollectService {
     }
 
     private void processArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
-        // 중복 체크 (URL 기준)
-        if (rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())) {
+        // 중복 체크 (URL + externalArticleId)
+        if (rawNewsArticleRepository.existsByOriginalUrlOrExternalArticleId(
+                dto.getOriginalUrl(), dto.getExternalArticleId())) {
             log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
             return;
         }
@@ -88,7 +90,13 @@ public class NewsCollectService {
                 .originalPublishedAt(dto.getOriginalPublishedAt())
                 .rawPayload(dto.getRawPayload())
                 .build();
-        rawNewsArticleRepository.save(rawArticle);
+
+        try {
+            rawNewsArticleRepository.save(rawArticle);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
+            return;
+        }
 
         // 정제 및 NewsArticle 저장
         normalizeAndSave(rawArticle, dto);
@@ -130,13 +138,20 @@ public class NewsCollectService {
 
     private NewsSource getOrCreateSource(NewsCollector collector) {
         return newsSourceRepository.findBySourceName(collector.getSourceName())
-                .orElseGet(() -> newsSourceRepository.save(
-                        NewsSource.builder()
-                                .sourceName(collector.getSourceName())
-                                .sourceType(NewsSource.SourceType.API)
-                                .isActive(true)
-                                .build()
-                ));
+                .orElseGet(() -> {
+                    try {
+                        return newsSourceRepository.save(
+                                NewsSource.builder()
+                                        .sourceName(collector.getSourceName())
+                                        .sourceType(NewsSource.SourceType.API)
+                                        .isActive(true)
+                                        .build()
+                        );
+                    } catch (DataIntegrityViolationException e) {
+                        return newsSourceRepository.findBySourceName(collector.getSourceName())
+                                .orElseThrow(() -> e);
+                    }
+                });
     }
 
     private String generateDedupKey(String url) {

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
@@ -1,0 +1,171 @@
+package com.solv.wefin.domain.news.service;
+
+import com.solv.wefin.domain.news.collector.NewsCollector;
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
+import com.solv.wefin.domain.news.entity.*;
+import com.solv.wefin.domain.news.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsCollectService {
+
+    private final List<NewsCollector> newsCollectors;
+    private final NewsSourceRepository newsSourceRepository;
+    private final NewsCollectBatchRepository newsCollectBatchRepository;
+    private final RawNewsArticleRepository rawNewsArticleRepository;
+    private final NewsArticleRepository newsArticleRepository;
+
+    @Transactional
+    public void collectAll() {
+        for (NewsCollector collector : newsCollectors) {
+            collectFromSource(collector, null);
+        }
+    }
+
+    @Transactional
+    public void collectFromSource(NewsCollector collector, String category) {
+        NewsSource source = getOrCreateSource(collector);
+        if (!source.getIsActive()) {
+            log.info("비활성 소스 스킵: {}", source.getSourceName());
+            return;
+        }
+
+        NewsCollectBatch batch = NewsCollectBatch.builder()
+                .newsSource(source)
+                .requestedCategory(category)
+                .build();
+        newsCollectBatchRepository.save(batch);
+
+        int collectedCount = 0;
+        int failedCount = 0;
+
+        try {
+            List<CollectedNewsDto> articles = collector.collect(category);
+
+            for (CollectedNewsDto dto : articles) {
+                try {
+                    processArticle(dto, source, batch);
+                    collectedCount++;
+                } catch (Exception e) {
+                    failedCount++;
+                    log.warn("기사 처리 실패 - url: {}, error: {}", dto.getOriginalUrl(), e.getMessage());
+                }
+            }
+
+            batch.success(collectedCount);
+            log.info("뉴스 수집 배치 완료 - source: {}, collected: {}, failed: {}",
+                    source.getSourceName(), collectedCount, failedCount);
+
+        } catch (Exception e) {
+            batch.fail(e.getMessage(), collectedCount, failedCount);
+            log.error("뉴스 수집 배치 실패 - source: {}, error: {}", source.getSourceName(), e.getMessage());
+        }
+    }
+
+    private void processArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
+        // 중복 체크 (URL 기준)
+        if (rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())) {
+            log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
+            return;
+        }
+
+        // Raw 저장
+        RawNewsArticle rawArticle = RawNewsArticle.builder()
+                .newsSource(source)
+                .newsCollectBatch(batch)
+                .externalArticleId(dto.getExternalArticleId())
+                .originalUrl(dto.getOriginalUrl())
+                .originalTitle(dto.getOriginalTitle())
+                .originalContent(dto.getOriginalContent())
+                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
+                .originalPublishedAt(dto.getOriginalPublishedAt())
+                .rawPayload(dto.getRawPayload())
+                .build();
+        rawNewsArticleRepository.save(rawArticle);
+
+        // 정제 및 NewsArticle 저장
+        normalizeAndSave(rawArticle, dto);
+    }
+
+    private void normalizeAndSave(RawNewsArticle rawArticle, CollectedNewsDto dto) {
+        String dedupKey = generateDedupKey(dto.getOriginalUrl());
+
+        if (newsArticleRepository.existsByDedupKey(dedupKey)) {
+            rawArticle.markDuplicated();
+            return;
+        }
+
+        try {
+            NewsArticle article = NewsArticle.builder()
+                    .rawNewsArticleId(rawArticle.getId())
+                    .publisherName(dto.getPublisherName())
+                    .title(cleanText(dto.getOriginalTitle()))
+                    .content(cleanHtml(dto.getOriginalContent()))
+                    .originalUrl(dto.getOriginalUrl())
+                    .thumbnailUrl(dto.getOriginalThumbnailUrl())
+                    .publishedAt(dto.getOriginalPublishedAt())
+                    .languageCode(detectLanguage(dto.getOriginalTitle()))
+                    .marketScope(detectMarketScope(dto.getOriginalTitle()))
+                    .dedupKey(dedupKey)
+                    .collectedAt(rawArticle.getCollectedAt())
+                    .build();
+
+            newsArticleRepository.save(article);
+            rawArticle.markNormalized();
+
+            log.debug("기사 정제 완료 - id: {}, title: {}", article.getId(), article.getTitle());
+
+        } catch (Exception e) {
+            rawArticle.markFailed();
+            throw e;
+        }
+    }
+
+    private NewsSource getOrCreateSource(NewsCollector collector) {
+        return newsSourceRepository.findBySourceName(collector.getSourceName())
+                .orElseGet(() -> newsSourceRepository.save(
+                        NewsSource.builder()
+                                .sourceName(collector.getSourceName())
+                                .sourceType(NewsSource.SourceType.API)
+                                .isActive(true)
+                                .build()
+                ));
+    }
+
+    private String generateDedupKey(String url) {
+        return "url:" + Math.abs(url.hashCode());
+    }
+
+    private String cleanText(String text) {
+        if (text == null) return null;
+        return text.trim();
+    }
+
+    private String cleanHtml(String content) {
+        if (content == null) return null;
+        return content
+                .replaceAll("<[^>]+>", "")
+                .replaceAll("&[a-zA-Z]+;", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    private String detectLanguage(String title) {
+        if (title == null) return "EN";
+        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+        return hasKorean ? "KO" : "EN";
+    }
+
+    private String detectMarketScope(String title) {
+        if (title == null) return "GLOBAL";
+        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+        return hasKorean ? "DOMESTIC" : "GLOBAL";
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsCollectService.java
@@ -59,7 +59,7 @@ public class NewsCollectService {
                 }
             }
 
-            batch.success(collectedCount);
+            batch.success(collectedCount, failedCount);
             log.info("뉴스 수집 배치 완료 - source: {}, collected: {}, failed: {}",
                     source.getSourceName(), collectedCount, failedCount);
 

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,7 +22,6 @@ public class NewsSourceCollectService {
     private final NewsCollectBatchRepository newsCollectBatchRepository;
     private final ArticlePersistenceService articlePersistenceService;
 
-    @Transactional
     public void collectFromSource(NewsCollector collector, String category) {
         NewsSource source = getOrCreateSource(collector);
         if (!source.getIsActive()) {
@@ -31,11 +29,12 @@ public class NewsSourceCollectService {
             return;
         }
 
+        // Each article is persisted in REQUIRES_NEW, so the batch row must be committed first.
         NewsCollectBatch batch = NewsCollectBatch.builder()
                 .newsSource(source)
                 .requestedCategory(category)
                 .build();
-        newsCollectBatchRepository.save(batch);
+        batch = newsCollectBatchRepository.saveAndFlush(batch);
 
         int collectedCount = 0;
         int failedCount = 0;
@@ -54,11 +53,13 @@ public class NewsSourceCollectService {
             }
 
             batch.success(collectedCount, failedCount);
+            newsCollectBatchRepository.save(batch);
             log.info("뉴스 수집 배치 완료 - source: {}, collected: {}, failed: {}",
                     source.getSourceName(), collectedCount, failedCount);
 
         } catch (Exception e) {
             batch.fail(e.getMessage(), collectedCount, failedCount);
+            newsCollectBatchRepository.save(batch);
             log.error("뉴스 수집 배치 실패 - source: {}, error: {}", source.getSourceName(), e.getMessage());
         }
     }

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
@@ -144,7 +144,17 @@ public class NewsSourceCollectService {
     }
 
     private String generateDedupKey(String url) {
-        return "url:" + Math.abs(url.hashCode());
+        try {
+            byte[] hash = java.security.MessageDigest.getInstance("SHA-256")
+                    .digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return "url:" + hex;
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-256 not available", e);
+        }
     }
 
     private String cleanText(String text) {

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
@@ -1,0 +1,175 @@
+package com.solv.wefin.domain.news.service;
+
+import com.solv.wefin.domain.news.collector.NewsCollector;
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
+import com.solv.wefin.domain.news.entity.*;
+import com.solv.wefin.domain.news.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsSourceCollectService {
+
+    private final NewsSourceRepository newsSourceRepository;
+    private final NewsCollectBatchRepository newsCollectBatchRepository;
+    private final RawNewsArticleRepository rawNewsArticleRepository;
+    private final NewsArticleRepository newsArticleRepository;
+
+    @Transactional
+    public void collectFromSource(NewsCollector collector, String category) {
+        NewsSource source = getOrCreateSource(collector);
+        if (!source.getIsActive()) {
+            log.info("비활성 소스 스킵: {}", source.getSourceName());
+            return;
+        }
+
+        NewsCollectBatch batch = NewsCollectBatch.builder()
+                .newsSource(source)
+                .requestedCategory(category)
+                .build();
+        newsCollectBatchRepository.save(batch);
+
+        int collectedCount = 0;
+        int failedCount = 0;
+
+        try {
+            List<CollectedNewsDto> articles = collector.collect(category);
+
+            for (CollectedNewsDto dto : articles) {
+                try {
+                    processArticle(dto, source, batch);
+                    collectedCount++;
+                } catch (Exception e) {
+                    failedCount++;
+                    log.warn("기사 처리 실패 - url: {}, error: {}", dto.getOriginalUrl(), e.getMessage());
+                }
+            }
+
+            batch.success(collectedCount, failedCount);
+            log.info("뉴스 수집 배치 완료 - source: {}, collected: {}, failed: {}",
+                    source.getSourceName(), collectedCount, failedCount);
+
+        } catch (Exception e) {
+            batch.fail(e.getMessage(), collectedCount, failedCount);
+            log.error("뉴스 수집 배치 실패 - source: {}, error: {}", source.getSourceName(), e.getMessage());
+        }
+    }
+
+    private void processArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
+        if (rawNewsArticleRepository.existsByOriginalUrlOrExternalArticleId(
+                dto.getOriginalUrl(), dto.getExternalArticleId())) {
+            log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
+            return;
+        }
+
+        RawNewsArticle rawArticle = RawNewsArticle.builder()
+                .newsSource(source)
+                .newsCollectBatch(batch)
+                .externalArticleId(dto.getExternalArticleId())
+                .originalUrl(dto.getOriginalUrl())
+                .originalTitle(dto.getOriginalTitle())
+                .originalContent(dto.getOriginalContent())
+                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
+                .originalPublishedAt(dto.getOriginalPublishedAt())
+                .rawPayload(dto.getRawPayload())
+                .build();
+
+        try {
+            rawNewsArticleRepository.save(rawArticle);
+        } catch (DataIntegrityViolationException e) {
+            log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
+            return;
+        }
+
+        normalizeAndSave(rawArticle, dto);
+    }
+
+    private void normalizeAndSave(RawNewsArticle rawArticle, CollectedNewsDto dto) {
+        String dedupKey = generateDedupKey(dto.getOriginalUrl());
+
+        if (newsArticleRepository.existsByDedupKey(dedupKey)) {
+            rawArticle.markDuplicated();
+            return;
+        }
+
+        try {
+            NewsArticle article = NewsArticle.builder()
+                    .rawNewsArticleId(rawArticle.getId())
+                    .publisherName(dto.getPublisherName())
+                    .title(cleanText(dto.getOriginalTitle()))
+                    .content(cleanHtml(dto.getOriginalContent()))
+                    .originalUrl(dto.getOriginalUrl())
+                    .thumbnailUrl(dto.getOriginalThumbnailUrl())
+                    .publishedAt(dto.getOriginalPublishedAt())
+                    .languageCode(detectLanguage(dto.getOriginalTitle()))
+                    .marketScope(detectMarketScope(dto.getOriginalTitle()))
+                    .dedupKey(dedupKey)
+                    .collectedAt(rawArticle.getCollectedAt())
+                    .build();
+
+            newsArticleRepository.save(article);
+            rawArticle.markNormalized();
+
+            log.debug("기사 정제 완료 - id: {}, title: {}", article.getId(), article.getTitle());
+
+        } catch (Exception e) {
+            rawArticle.markFailed();
+            throw e;
+        }
+    }
+
+    private NewsSource getOrCreateSource(NewsCollector collector) {
+        return newsSourceRepository.findBySourceName(collector.getSourceName())
+                .orElseGet(() -> {
+                    try {
+                        return newsSourceRepository.save(
+                                NewsSource.builder()
+                                        .sourceName(collector.getSourceName())
+                                        .sourceType(NewsSource.SourceType.API)
+                                        .isActive(true)
+                                        .build()
+                        );
+                    } catch (DataIntegrityViolationException e) {
+                        return newsSourceRepository.findBySourceName(collector.getSourceName())
+                                .orElseThrow(() -> e);
+                    }
+                });
+    }
+
+    private String generateDedupKey(String url) {
+        return "url:" + Math.abs(url.hashCode());
+    }
+
+    private String cleanText(String text) {
+        if (text == null) return null;
+        return text.trim();
+    }
+
+    private String cleanHtml(String content) {
+        if (content == null) return null;
+        return content
+                .replaceAll("<[^>]+>", "")
+                .replaceAll("&[a-zA-Z]+;", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+
+    private String detectLanguage(String title) {
+        if (title == null) return "EN";
+        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+        return hasKorean ? "KO" : "EN";
+    }
+
+    private String detectMarketScope(String title) {
+        if (title == null) return "GLOBAL";
+        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+        return hasKorean ? "DOMESTIC" : "GLOBAL";
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
@@ -36,7 +36,8 @@ public class NewsSourceCollectService {
                 .build();
         batch = newsCollectBatchRepository.saveAndFlush(batch);
 
-        int collectedCount = 0;
+        int savedCount = 0;
+        int skippedCount = 0;
         int failedCount = 0;
 
         try {
@@ -44,21 +45,22 @@ public class NewsSourceCollectService {
 
             for (CollectedNewsDto dto : articles) {
                 try {
-                    articlePersistenceService.processSingleArticle(dto, source, batch);
-                    collectedCount++;
+                    boolean saved = articlePersistenceService.processSingleArticle(dto, source, batch);
+                    if (saved) savedCount++;
+                    else skippedCount++;
                 } catch (Exception e) {
                     failedCount++;
                     log.warn("기사 처리 실패 - url: {}, error: {}", dto.getOriginalUrl(), e.getMessage());
                 }
             }
 
-            batch.success(collectedCount, failedCount);
+            batch.success(savedCount, failedCount);
             newsCollectBatchRepository.save(batch);
-            log.info("뉴스 수집 배치 완료 - source: {}, collected: {}, failed: {}",
-                    source.getSourceName(), collectedCount, failedCount);
+            log.info("뉴스 수집 배치 완료 - source: {}, saved: {}, skipped: {}, failed: {}",
+                    source.getSourceName(), savedCount, skippedCount, failedCount);
 
         } catch (Exception e) {
-            batch.fail(e.getMessage(), collectedCount, failedCount);
+            batch.fail(e.getMessage(), savedCount, failedCount);
             newsCollectBatchRepository.save(batch);
             log.error("뉴스 수집 배치 실패 - source: {}, error: {}", source.getSourceName(), e.getMessage());
         }

--- a/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/news/service/NewsSourceCollectService.java
@@ -2,8 +2,10 @@ package com.solv.wefin.domain.news.service;
 
 import com.solv.wefin.domain.news.collector.NewsCollector;
 import com.solv.wefin.domain.news.dto.CollectedNewsDto;
-import com.solv.wefin.domain.news.entity.*;
-import com.solv.wefin.domain.news.repository.*;
+import com.solv.wefin.domain.news.entity.NewsCollectBatch;
+import com.solv.wefin.domain.news.entity.NewsSource;
+import com.solv.wefin.domain.news.repository.NewsCollectBatchRepository;
+import com.solv.wefin.domain.news.repository.NewsSourceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -19,8 +21,7 @@ public class NewsSourceCollectService {
 
     private final NewsSourceRepository newsSourceRepository;
     private final NewsCollectBatchRepository newsCollectBatchRepository;
-    private final RawNewsArticleRepository rawNewsArticleRepository;
-    private final NewsArticleRepository newsArticleRepository;
+    private final ArticlePersistenceService articlePersistenceService;
 
     @Transactional
     public void collectFromSource(NewsCollector collector, String category) {
@@ -44,7 +45,7 @@ public class NewsSourceCollectService {
 
             for (CollectedNewsDto dto : articles) {
                 try {
-                    processArticle(dto, source, batch);
+                    articlePersistenceService.processSingleArticle(dto, source, batch);
                     collectedCount++;
                 } catch (Exception e) {
                     failedCount++;
@@ -59,69 +60,6 @@ public class NewsSourceCollectService {
         } catch (Exception e) {
             batch.fail(e.getMessage(), collectedCount, failedCount);
             log.error("뉴스 수집 배치 실패 - source: {}, error: {}", source.getSourceName(), e.getMessage());
-        }
-    }
-
-    private void processArticle(CollectedNewsDto dto, NewsSource source, NewsCollectBatch batch) {
-        if (rawNewsArticleRepository.existsByOriginalUrlOrExternalArticleId(
-                dto.getOriginalUrl(), dto.getExternalArticleId())) {
-            log.debug("중복 기사 스킵 - url: {}", dto.getOriginalUrl());
-            return;
-        }
-
-        RawNewsArticle rawArticle = RawNewsArticle.builder()
-                .newsSource(source)
-                .newsCollectBatch(batch)
-                .externalArticleId(dto.getExternalArticleId())
-                .originalUrl(dto.getOriginalUrl())
-                .originalTitle(dto.getOriginalTitle())
-                .originalContent(dto.getOriginalContent())
-                .originalThumbnailUrl(dto.getOriginalThumbnailUrl())
-                .originalPublishedAt(dto.getOriginalPublishedAt())
-                .rawPayload(dto.getRawPayload())
-                .build();
-
-        try {
-            rawNewsArticleRepository.save(rawArticle);
-        } catch (DataIntegrityViolationException e) {
-            log.debug("중복 기사 DB 제약 위반 스킵 - url: {}", dto.getOriginalUrl());
-            return;
-        }
-
-        normalizeAndSave(rawArticle, dto);
-    }
-
-    private void normalizeAndSave(RawNewsArticle rawArticle, CollectedNewsDto dto) {
-        String dedupKey = generateDedupKey(dto.getOriginalUrl());
-
-        if (newsArticleRepository.existsByDedupKey(dedupKey)) {
-            rawArticle.markDuplicated();
-            return;
-        }
-
-        try {
-            NewsArticle article = NewsArticle.builder()
-                    .rawNewsArticleId(rawArticle.getId())
-                    .publisherName(dto.getPublisherName())
-                    .title(cleanText(dto.getOriginalTitle()))
-                    .content(cleanHtml(dto.getOriginalContent()))
-                    .originalUrl(dto.getOriginalUrl())
-                    .thumbnailUrl(dto.getOriginalThumbnailUrl())
-                    .publishedAt(dto.getOriginalPublishedAt())
-                    .languageCode(detectLanguage(dto.getOriginalTitle()))
-                    .marketScope(detectMarketScope(dto.getOriginalTitle()))
-                    .dedupKey(dedupKey)
-                    .collectedAt(rawArticle.getCollectedAt())
-                    .build();
-
-            newsArticleRepository.save(article);
-            rawArticle.markNormalized();
-
-            log.debug("기사 정제 완료 - id: {}, title: {}", article.getId(), article.getTitle());
-
-        } catch (Exception e) {
-            rawArticle.markFailed();
-            throw e;
         }
     }
 
@@ -141,45 +79,5 @@ public class NewsSourceCollectService {
                                 .orElseThrow(() -> e);
                     }
                 });
-    }
-
-    private String generateDedupKey(String url) {
-        try {
-            byte[] hash = java.security.MessageDigest.getInstance("SHA-256")
-                    .digest(url.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-            StringBuilder hex = new StringBuilder();
-            for (byte b : hash) {
-                hex.append(String.format("%02x", b));
-            }
-            return "url:" + hex;
-        } catch (java.security.NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 not available", e);
-        }
-    }
-
-    private String cleanText(String text) {
-        if (text == null) return null;
-        return text.trim();
-    }
-
-    private String cleanHtml(String content) {
-        if (content == null) return null;
-        return content
-                .replaceAll("<[^>]+>", "")
-                .replaceAll("&[a-zA-Z]+;", " ")
-                .replaceAll("\\s+", " ")
-                .trim();
-    }
-
-    private String detectLanguage(String title) {
-        if (title == null) return "EN";
-        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
-        return hasKorean ? "KO" : "EN";
-    }
-
-    private String detectMarketScope(String title) {
-        if (title == null) return "GLOBAL";
-        boolean hasKorean = title.chars().anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
-        return hasKorean ? "DOMESTIC" : "GLOBAL";
     }
 }

--- a/src/main/java/com/solv/wefin/global/util/StringUtils.java
+++ b/src/main/java/com/solv/wefin/global/util/StringUtils.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.global.util;
+
+public class StringUtils {
+
+    private StringUtils() {
+    }
+
+    public static boolean containsKorean(String text) {
+        return text != null && text.chars()
+                .anyMatch(c -> Character.UnicodeScript.of(c) == Character.UnicodeScript.HANGUL);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
@@ -1,4 +1,4 @@
-package com.solv.wefin.domain.news.controller;
+package com.solv.wefin.web.news.controller;
 
 import com.solv.wefin.domain.news.service.NewsCollectService;
 import com.solv.wefin.global.common.ApiResponse;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -24,5 +24,13 @@ ai:
 jwt:
   secret: ${JWT_SECRET}
 
+news:
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    display: ${NAVER_NEWS_DISPLAY:100}
+  collect:
+    cron: "0 0 */2 * * *"
+
 server:
   forward-headers-strategy: native

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,3 +26,12 @@ ai:
 
 jwt:
   secret: ${JWT_SECRET:local-secret-key-change-me}
+
+news:
+  naver:
+    client-id: ${NAVER_CLIENT_ID:}
+    client-secret: ${NAVER_CLIENT_SECRET:}
+    display: ${NAVER_NEWS_DISPLAY:100}
+    base-url: ${NAVER_NEWS_BASE_URL:https://openapi.naver.com/v1/search/news.json}
+  collect:
+    cron: "0 0 */2 * * *"

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -21,5 +21,13 @@ ai:
 jwt:
   secret: ${JWT_SECRET}
 
+news:
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    display: ${NAVER_NEWS_DISPLAY:100}
+  collect:
+    cron: "0 0 */2 * * *"
+
 server:
   forward-headers-strategy: native

--- a/src/main/resources/db/migration/V2__add_unique_constraints.sql
+++ b/src/main/resources/db/migration/V2__add_unique_constraints.sql
@@ -1,0 +1,17 @@
+CREATE UNIQUE INDEX IF NOT EXISTS "uk_raw_news_article_original_url" ON "raw_news_article" ("original_url");
+CREATE UNIQUE INDEX IF NOT EXISTS "uk_news_source_source_name" ON "news_source" ("source_name");
+
+ALTER TABLE "users"
+    ADD CONSTRAINT "uk_users_email" UNIQUE ("email");
+ALTER TABLE "users"
+    ADD CONSTRAINT "uk_users_nickname" UNIQUE ("nickname");
+ALTER TABLE "payment"
+    ADD CONSTRAINT "uk_payment_order_id" UNIQUE ("order_id");
+CREATE UNIQUE INDEX "uk_payment_provider_payment_key"
+    ON "payment" ("provider_payment_key")
+    WHERE "provider_payment_key" IS NOT NULL;
+CREATE UNIQUE INDEX "uk_subscription_user_active"
+    ON "subscription" ("user_id")
+    WHERE "status" = 'ACTIVE';
+ALTER TABLE GAME_ROOM
+    ADD COLUMN started_at TIMESTAMPTZ NULL;

--- a/src/main/resources/db/migration/V3__add_updated_at_to_news_tables.sql
+++ b/src/main/resources/db/migration/V3__add_updated_at_to_news_tables.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "news_article" ADD COLUMN "updated_at" TIMESTAMP NULL;
+ALTER TABLE "news_source" ADD COLUMN "updated_at" TIMESTAMP NULL;
+
+COMMENT ON COLUMN "news_article"."updated_at" IS '수정 시각';
+COMMENT ON COLUMN "news_source"."updated_at" IS '수정 시각';

--- a/src/test/java/com/solv/wefin/domain/news/service/ArticlePersistenceServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/service/ArticlePersistenceServiceTest.java
@@ -1,0 +1,112 @@
+package com.solv.wefin.domain.news.service;
+
+import com.solv.wefin.domain.news.dto.CollectedNewsDto;
+import com.solv.wefin.domain.news.entity.NewsCollectBatch;
+import com.solv.wefin.domain.news.entity.NewsSource;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.repository.RawNewsArticleRepository;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArticlePersistenceServiceTest {
+
+    @Mock
+    private RawNewsArticleRepository rawNewsArticleRepository;
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+
+    @InjectMocks
+    private ArticlePersistenceService articlePersistenceService;
+
+    @Test
+    void processSingleArticle_checksDuplicateByOriginalUrlOnly() {
+        CollectedNewsDto dto = sampleDto();
+
+        when(rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())).thenReturn(true);
+
+        articlePersistenceService.processSingleArticle(dto, sampleSource(), sampleBatch());
+
+        verify(rawNewsArticleRepository).existsByOriginalUrl(dto.getOriginalUrl());
+        verify(rawNewsArticleRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void processSingleArticle_skipsOnlyOriginalUrlUniqueConstraintViolations() {
+        CollectedNewsDto dto = sampleDto();
+        SQLException sqlException = new SQLException(
+                "duplicate key value violates unique constraint \"uk_raw_news_article_original_url\"");
+        DataIntegrityViolationException exception = new DataIntegrityViolationException(
+                "duplicate original_url",
+                new ConstraintViolationException("duplicate original_url", sqlException, "uk_raw_news_article_original_url"));
+
+        when(rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())).thenReturn(false);
+        when(rawNewsArticleRepository.saveAndFlush(any())).thenThrow(exception);
+
+        assertDoesNotThrow(() ->
+                articlePersistenceService.processSingleArticle(dto, sampleSource(), sampleBatch()));
+
+        verify(rawNewsArticleRepository).saveAndFlush(any());
+        verify(newsArticleRepository, never()).save(any());
+    }
+
+    @Test
+    void processSingleArticle_rethrowsNonDuplicateConstraintViolations() {
+        CollectedNewsDto dto = sampleDto();
+        SQLException sqlException = new SQLException(
+                "insert or update on table \"raw_news_article\" violates foreign key constraint \"FK_news_collect_batch_TO_raw_news_article_1\"");
+        DataIntegrityViolationException exception = new DataIntegrityViolationException(
+                "foreign key violation",
+                new ConstraintViolationException(
+                        "foreign key violation",
+                        sqlException,
+                        "FK_news_collect_batch_TO_raw_news_article_1"));
+
+        when(rawNewsArticleRepository.existsByOriginalUrl(dto.getOriginalUrl())).thenReturn(false);
+        when(rawNewsArticleRepository.saveAndFlush(any())).thenThrow(exception);
+
+        assertThrows(DataIntegrityViolationException.class, () ->
+                articlePersistenceService.processSingleArticle(dto, sampleSource(), sampleBatch()));
+    }
+
+    private CollectedNewsDto sampleDto() {
+        return CollectedNewsDto.builder()
+                .externalArticleId("naver:123")
+                .originalUrl("https://example.com/news/123")
+                .originalTitle("sample title")
+                .originalContent("sample content")
+                .publisherName("example.com")
+                .rawPayload("{\"id\":123}")
+                .build();
+    }
+
+    private NewsSource sampleSource() {
+        return NewsSource.builder()
+                .sourceName("NaverNews")
+                .sourceType(NewsSource.SourceType.API)
+                .isActive(true)
+                .build();
+    }
+
+    private NewsCollectBatch sampleBatch() {
+        return NewsCollectBatch.builder()
+                .newsSource(sampleSource())
+                .requestedCategory(null)
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명                                         
네이버 뉴스 검색 API를 활용한 뉴스 수집 파이프라인을 구현합니다.              
외부 API 연동 → Raw 데이터 저장 → 정제 → NewsArticle 저장까지의 전체 흐름을 배치 기반으로 처리합니다.                                                     
<br>                                                                          
                                                                                
## ✅ 완료한 기능 명세                                
                                                                              
- [x] 뉴스 도메인 엔티티 생성 (NewsSource, NewsCollectBatch, RawNewsArticle, NewsArticle, NewsArticleTag)
- [x] 각 엔티티에 대한 JPA Repository 구현                                    
- [x] 뉴스 수집 어댑터 인터페이스 설계 (NewsCollector)
- [x] 네이버 뉴스 검색 API 수집기 구현 (NaverNewsCollector)                   
- [x] 카테고리별 한국어 검색 키워드 매핑 (경제, 주식, 금리, 환율 등)          
- [x] 뉴스 수집/중복체크/정제/저장 서비스 구현 (NewsCollectService)           
- [x] URL + dedupKey 기반 2단계 중복 저장 방지                                
- [x] HTML 태그/엔티티 제거 및 본문 클린 텍스트 생성                          
- [x] Spring Scheduler 기반 배치 스케줄러 (2시간 간격)                        
- [x] 로컬 수동 트리거 API (POST /api/admin/news/collect)                     
                                                                              
<br>         

## 💬 주요 파일 설명
1. `NewsCollectScheduler`: 일정 주기로 뉴스 수집 실행 (두 번 이상 실행 방지)
    - 2시간마다 뉴스 미리 수집
2.  `NewsArticle`: 정제된 뉴스 데이터를 저장하는 테이블
3. `NewsArticleTag`: 하나의 뉴스에 여러 태그를 붙이기 위한 매핑 테이블
4. `NewsCollectBatch`: 뉴스 수집 작업 실행에 대한 기록
   - `@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "{entity}_seq")`를 쓰려고 했으나 데이터가 많았을 때 개선 전 후 성능을 비교하기 위해 추후에 적용할 예정
5. `News Source`: 뉴스 수집 출처를 정의하는 설정 테이블
   - `isActive` : 수집 여부 (특정 출처 뉴스 수집 비활성화로 장애 대응 가능)
6. `RawNewsArticle`: 외부에서 가져온 뉴스 원본을 그대로 저장하는 테이블 

## 💭 고민과 해결과정

- 외부 API 선정
  NewsAPI, Finnhub, 직접 크롤링 중 네이버 뉴스 검색 API를 선택했습니다. 한국 금융 뉴스 커버리지가 가장 넓고, 무료 한도(25,000건/일)가 충분하며, 별도 인프라 없이 REST API로 바로 연동 가능합니다.                   
- 어댑터 패턴 적용
  향후 API 변경 또는 추가 소스 연동을 대비해 NewsCollector 인터페이스를 설계했습니다. 새로운 수집 소스는 인터페이스 구현체만 추가하면 서비스 계층 수정 없이 동작합니다.
- 중복 방지 전략
  Raw 저장 시 originalUrl 기준 1차 중복 체크, 정제 저장 시 dedupKey(URL 해시) 기준 2차 중복 체크로 이중 방어합니다.                     
- 배치 추적
  NewsCollectBatch 엔티티를 통해 수집 건수, 실패 건수, 에러 메시지를 기록하여 수집 이력을 추적할 수 있습니다.                             
                                                      
<br>                                                                          
                                                      
### 🔗 관련 이슈
Closes #19

  <br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Naver 뉴스 API 기반 자동 뉴스 수집 기능 추가
  * 2시간 주기(기본)로 실행되는 뉴스 수집 스케줄러 추가
  * 로컬 환경에서 사용할 수 있는 관리자용 수동 뉴스 수집 API 엔드포인트 추가

* **구성**
  * Naver 클라이언트 ID/시크릿 환경변수(NAVER_CLIENT_ID, NAVER_CLIENT_SECRET) 및 관련 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->