### PR TITLE
[WEF-432] PR 2명 승인 시 디스코드 알림 워크플로우 추가

### DIFF
--- a/.github/workflows/discord-pr-approved.yml
+++ b/.github/workflows/discord-pr-approved.yml
@@ -13,13 +13,12 @@ jobs:
       - name: Check approval count and notify
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+          URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+          AUTHOR: ${{ github.event.pull_request.user.login }}
         run: |
-          PR_NUM=${{ github.event.pull_request.number }}
-          TITLE="${{ github.event.pull_request.title }}"
-          URL="${{ github.event.pull_request.html_url }}"
-          REPO="${{ github.repository }}"
-          AUTHOR="${{ github.event.pull_request.user.login }}"
-
           # 현재 PR의 approved 리뷰 수 카운트
           APPROVAL_COUNT=$(curl -sS \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/discord-pr-approved.yml
+++ b/.github/workflows/discord-pr-approved.yml
@@ -1,0 +1,51 @@
+name: Discord Notify - PR Approved x2
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check approval count and notify
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          PR_NUM=${{ github.event.pull_request.number }}
+          TITLE="${{ github.event.pull_request.title }}"
+          URL="${{ github.event.pull_request.html_url }}"
+          REPO="${{ github.repository }}"
+          AUTHOR="${{ github.event.pull_request.user.login }}"
+
+          # 현재 PR의 approved 리뷰 수 카운트
+          APPROVAL_COUNT=$(curl -sS \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/$REPO/pulls/$PR_NUM/reviews" \
+            | jq '[.[] | select(.state == "APPROVED")] | length')
+
+          echo "Current approvals: $APPROVAL_COUNT"
+
+          # 정확히 2개가 됐을 때만 알림 (중복 방지)
+          if [ "$APPROVAL_COUNT" -eq 2 ]; then
+
+            # GitHub 유저네임 → Discord ID 매핑
+            case "$AUTHOR" in
+              "kkhhmm3103")    DISCORD_MENTION="<@1355211300501717145>" ;;
+              "minseokim0113") DISCORD_MENTION="<@759420067980509225>" ;;
+              "cl-o-lc")       DISCORD_MENTION="<@1348158110488858628>" ;;
+              "ochanhyeok")    DISCORD_MENTION="<@396531387764834304>" ;;
+              "gaeunnlee")     DISCORD_MENTION="<@1061932517441163337>" ;;
+              "hjh79gw")       DISCORD_MENTION="<@947477999085813810>" ;;
+              *)               DISCORD_MENTION="@$AUTHOR" ;;
+            esac
+
+            MSG="✅ **PR 승인 2개 완료!** $DISCORD_MENTION\n\n**#$PR_NUM $TITLE**\n$URL\n\n👉 머지 가능 상태입니다."
+
+            curl -sS -X POST \
+              -H "Content-Type: application/json" \
+              -d "{\"content\":\"$MSG\"}" \
+              "$DISCORD_WEBHOOK_URL"
+          fi


### PR DESCRIPTION
## 📌 PR 설명
PR 승인이 2개 완료되면 Discord 채널에 PR 작성자를 멘션하여 머지 가능 상태를 알리는 GitHub Actions 워크플로우를 추가합니다.
<br>

## ✅ 완료한 기능 명세

- pull_request_review 이벤트에서 approved 리뷰 수를 카운트
- 승인 수가 정확히 2개가 됐을 때 Discord 웹훅으로 알림 전송
- GitHub 유저네임 → Discord ID 매핑을 통해 PR 작성자 직접 멘션

<br>

## 참고
- 알림 중복 방지를 위해 승인 수가 2 초과일 때는 알림을 보내지 않음
- 매핑되지 않은 유저의 경우 GitHub 유저네임 텍스트로 fallback 처리

<br>

### 🔗 관련 이슈
Closes #45 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 풀 리퀘스트가 정확히 2건 승인될 때 자동으로 Discord 알림을 전송합니다.
  * 알림에 PR 번호, 제목, URL 및 "병합 가능" 메시지가 포함됩니다.
  * GitHub 사용자명에 매핑된 Discord 멘션을 사용하며, 매핑이 없을 경우 작성자 언급으로 대체됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->