### PR TITLE
[WEF-41] 전체 채팅 메시지 송수신 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	developmentOnly 'me.paulschwarz:springboot3-dotenv:5.1.0'

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.chat.globalChat.service;
+
+import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
+import com.solv.wefin.web.chat.globalChat.dto.request.GlobalChatSendRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GlobalChatService {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void sendMessage(GlobalChatSendRequest request, String sender) {
+        System.out.println("controller 진입");
+        validateMessage(request.getContent());
+
+        GlobalChatMessageResponse response = GlobalChatMessageResponse.builder()
+                .messageId(null)
+                .sender(sender)
+                .content(request.getContent())
+                .build();
+
+        messagingTemplate.convertAndSend("/topic/chat/global", response);
+    }
+
+    private void validateMessage(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("메시지 내용은 비어있을 수 없습니다.");
+        }
+
+        if (content.length() > 1000) {
+            throw new IllegalArgumentException("메시지는 1000자를 초과할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
@@ -15,13 +15,15 @@ public class GlobalChatService {
     private final SimpMessagingTemplate messagingTemplate;
 
     public void sendMessage(GlobalChatSendRequest request, String sender) {
-        System.out.println("controller 진입");
-        validateMessage(request.getContent());
+
+        String content = (request != null) ? request.getContent() : null;
+
+        validateMessage(content);
 
         GlobalChatMessageResponse response = GlobalChatMessageResponse.builder()
                 .messageId(null)
                 .sender(sender)
-                .content(request.getContent())
+                .content(content)
                 .build();
 
         messagingTemplate.convertAndSend("/topic/chat/global", response);
@@ -33,7 +35,7 @@ public class GlobalChatService {
         }
 
         if (content.length() > 1000) {
-            throw new BusinessException(ErrorCode.CHAT_MESSAGE_EMPTY);
+            throw new BusinessException(ErrorCode.CHAT_MESSAGE_TOO_LONG);
         }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.chat.globalChat.service;
 
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
 import com.solv.wefin.web.chat.globalChat.dto.request.GlobalChatSendRequest;
 import lombok.RequiredArgsConstructor;
@@ -27,11 +29,11 @@ public class GlobalChatService {
 
     private void validateMessage(String content) {
         if (content == null || content.isBlank()) {
-            throw new IllegalArgumentException("메시지 내용은 비어있을 수 없습니다.");
+            throw new BusinessException(ErrorCode.CHAT_MESSAGE_EMPTY);
         }
 
         if (content.length() > 1000) {
-            throw new IllegalArgumentException("메시지는 1000자를 초과할 수 없습니다.");
+            throw new BusinessException(ErrorCode.CHAT_MESSAGE_EMPTY);
         }
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
@@ -1,0 +1,58 @@
+package com.solv.wefin.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    // 메시지가 채널로 보내지기 직전 호출 -> 조건에 안맞으면 차단(지금은 안함), 사용자 정보 넣기
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor =
+                MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if(accessor == null) {
+            return message;
+        }
+
+        // CONNECT 일때 nickname을 웹소켓 사용자로 저장
+        if(StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String nickname = accessor.getFirstNativeHeader("nickname");
+
+            // jwt 토큰 검증
+//            String token = accessor.getFirstNativeHeader("Authorization");
+            if (nickname == null || nickname.isBlank()) {
+                nickname = "anonymous";
+            }
+
+            accessor.setUser(
+                    new UsernamePasswordAuthenticationToken(nickname, null)
+            );
+
+            log.info("WebSocket CONNECT nickname={}", nickname);
+        }
+
+        // SUBSCRIBE 일때 구독 destination 로그 출력
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            log.info("WebSocket SUBSCRIBE destination={}", accessor.getDestination());
+        }
+
+        // SEnD 일때 전송 destination 로그 출력
+        if (StompCommand.SEND.equals(accessor.getCommand())) {
+            log.info("WebSocket SEND destination={}", accessor.getDestination());
+        }
+
+        return message;
+
+
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.global.config;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -10,10 +11,12 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@EnableConfigurationProperties(WebSocketProperties.class)
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+    private final WebSocketProperties webSocketProperties;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -24,7 +27,9 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("http://localhost:5173")
+                .setAllowedOriginPatterns(
+                        webSocketProperties.getAllowedOrigins().toArray(String[]::new)
+                )
                 .withSockJS();
     }
 

--- a/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
@@ -24,7 +24,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns("http://localhost:5173")
                 .withSockJS();
     }
 

--- a/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
@@ -1,0 +1,35 @@
+package com.solv.wefin.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic"); // 구독
+        config.setApplicationDestinationPrefixes("/app"); // 송신
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/WebSocketEventListener.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketEventListener.java
@@ -1,0 +1,39 @@
+package com.solv.wefin.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Session;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+@Slf4j
+@Component
+public class WebSocketEventListener {
+
+    @EventListener
+    public void handleWebSocketConnectListener(SessionConnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Object user = accessor.getUser();
+
+        if (user instanceof Authentication auth) {
+            log.info("WebSocket connected user={}", auth.getName());
+        } else {
+            log.info("WebSocket connected");
+        }
+    }
+
+    @EventListener
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        Object user = accessor.getUser();
+
+        if (user instanceof Authentication auth) {
+            log.info("WebSocket disconnected user={}", auth.getName());
+        } else {
+            log.info("WebSocket disconnected");
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/WebSocketEventListener.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketEventListener.java
@@ -1,7 +1,6 @@
 package com.solv.wefin.global.config;
 
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.Session;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/solv/wefin/global/config/WebSocketProperties.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketProperties.java
@@ -1,0 +1,16 @@
+package com.solv.wefin.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "websocket")
+public class WebSocketProperties {
+
+    private List<String> allowedOrigins = new ArrayList<>();
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -7,6 +7,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    // Chat
+    CHAT_MESSAGE_EMPTY(400, "메시지 내용은 비어 있을 수 없습니다."),
+    CHAT_MESSAGE_TOO_LONG(400, "메시지는 1000자를 초과할 수 없습니다."),
+
     // Common
     INVALID_INPUT(400, "잘못된 입력입니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.web.chat.globalChat;
+
+import com.solv.wefin.domain.chat.globalChat.service.GlobalChatService;
+import com.solv.wefin.web.chat.globalChat.dto.request.GlobalChatSendRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+@Controller
+@RequiredArgsConstructor
+public class GlobalChatController {
+
+    private final GlobalChatService globalChatService;
+
+    @MessageMapping("/chat/global/send")
+    public void sendMessage(GlobalChatSendRequest request, Principal principal) {
+        String sender = (principal != null) ? principal.getName() : "anonymous";
+        globalChatService.sendMessage(request, sender);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/dto/request/GlobalChatSendRequest.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/dto/request/GlobalChatSendRequest.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.web.chat.globalChat.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GlobalChatSendRequest {
+    private String content;
+}

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/dto/response/GlobalChatMessageResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/dto/response/GlobalChatMessageResponse.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.web.chat.globalChat.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GlobalChatMessageResponse {
+    private Long messageId;
+    private String sender;
+    private String content;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,3 +26,7 @@ jwt:
 
 server:
   forward-headers-strategy: native
+
+websocket:
+  allowed-origins:
+    - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -26,3 +26,7 @@ ai:
 
 jwt:
   secret: ${JWT_SECRET:local-secret-key-change-me}
+
+websocket:
+  allowed-origins:
+    - http://localhost:5173

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,3 +36,6 @@ news:
   collect:
     cron: "0 0 */2 * * *"
 
+websocket:
+  allowed-origins:
+    - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,3 +23,7 @@ jwt:
 
 server:
   forward-headers-strategy: native
+
+websocket:
+  allowed-origins:
+    - https://wefin.ai.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,3 +8,7 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+
+websocket:
+  allowed-origins:
+    - http://localhost:5173

--- a/src/test/java/com/solv/wefin/common/WebSocketIntegrationTestBase.java
+++ b/src/test/java/com/solv/wefin/common/WebSocketIntegrationTestBase.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.common;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class WebSocketIntegrationTestBase extends IntegrationTestBase{
+}

--- a/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.chat.globalChat.service;
 
+import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
 import com.solv.wefin.web.chat.globalChat.dto.request.GlobalChatSendRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,11 +39,11 @@ public class GlobalChatServiceTest {
 
     @Test
     @DisplayName("메시지가 비어있으면 예외가 발생한다")
-    void sendMessage_fail_blink() {
+    void sendMessage_fail_blank() {
         GlobalChatSendRequest request = new GlobalChatSendRequest();
         ReflectionTestUtils.setField(request, "content", " ");
 
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(BusinessException.class,
                 () -> globalChatService.sendMessage(request, "tico"));
     }
 
@@ -53,7 +54,7 @@ public class GlobalChatServiceTest {
         String longMessage = "a".repeat(1001);
         ReflectionTestUtils.setField(request, "content", longMessage);
 
-        assertThrows(IllegalArgumentException.class,
+        assertThrows(BusinessException.class,
                 () -> globalChatService.sendMessage(request, "tico"));
     }
 }

--- a/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
@@ -1,0 +1,59 @@
+package com.solv.wefin.domain.chat.globalChat.service;
+
+import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
+import com.solv.wefin.web.chat.globalChat.dto.request.GlobalChatSendRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class GlobalChatServiceTest {
+
+    private SimpMessagingTemplate messagingTemplate;
+    private GlobalChatService globalChatService;
+
+    @BeforeEach
+    void setUp() {
+        messagingTemplate = mock(SimpMessagingTemplate.class);
+        globalChatService = new GlobalChatService(messagingTemplate);
+    }
+
+    @Test
+    @DisplayName("전체 채팅 메시지 전송 시 브로드캐스트된다")
+    void sendMessage_success() {
+        GlobalChatSendRequest request = new GlobalChatSendRequest();
+        ReflectionTestUtils.setField(request, "content", "안녕하세요");
+
+        globalChatService.sendMessage(request, "tico");
+
+        verify(messagingTemplate, times(1))
+                .convertAndSend(eq("/topic/chat/global"), any(GlobalChatMessageResponse.class));
+
+    }
+
+    @Test
+    @DisplayName("메시지가 비어있으면 예외가 발생한다")
+    void sendMessage_fail_blink() {
+        GlobalChatSendRequest request = new GlobalChatSendRequest();
+        ReflectionTestUtils.setField(request, "content", " ");
+
+        assertThrows(IllegalArgumentException.class,
+                () -> globalChatService.sendMessage(request, "tico"));
+    }
+
+    @Test
+    @DisplayName("메시지가 1000자를 초과하면 예외가 발생한다")
+    void sendMessage_fail_tooLong() {
+        GlobalChatSendRequest request = new GlobalChatSendRequest();
+        String longMessage = "a".repeat(1001);
+        ReflectionTestUtils.setField(request, "content", longMessage);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> globalChatService.sendMessage(request, "tico"));
+    }
+}

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
@@ -1,9 +1,9 @@
 package com.solv.wefin.web.chat.globalChat;
 
+import com.solv.wefin.common.WebSocketIntegrationTestBase;
 import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
@@ -16,7 +16,6 @@ import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 import java.lang.reflect.Type;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
@@ -26,8 +25,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class GlobalChatWebSocketTest {
+class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
 
     @LocalServerPort
     private int port;

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
@@ -21,9 +21,9 @@ import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
 
@@ -45,6 +45,7 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
 
         // 서버에서 오는 메시지를 담을 큐
         BlockingQueue<GlobalChatMessageResponse> queue = new LinkedBlockingQueue<>();
+        AtomicReference<Throwable> asyncError = new AtomicReference<>();
 
         // CONNECT 시 nickname 해더 전달 (서버에서 Principal로 사용됨)
         StompHeaders connectHeaders = new StompHeaders();
@@ -62,13 +63,13 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
                             @Override
                             public void handleException(StompSession session, StompCommand command,
                                                         StompHeaders headers, byte[] payload, Throwable exception) {
-                                exception.printStackTrace();
+                                asyncError.compareAndSet(null, exception);
                             }
 
                             // 연결 자체 문제 발생 시 로그 출력
                             @Override
                             public void handleTransportError(StompSession session, Throwable exception) {
-                                exception.printStackTrace();
+                                asyncError.compareAndSet(null, exception);
                             }
                         }
                 )
@@ -111,6 +112,7 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
         GlobalChatMessageResponse response = queue.poll(5, TimeUnit.SECONDS);
 
         // 결과 검증
+        assertNull(asyncError.get(), "비동기 처리 중 예외가 발생했습니다: " + asyncError.get());
         assertNotNull(response, "구독 메시지를 받지 못했습니다.");
         assertEquals("testUser", response.getSender());
         assertEquals("테스트 메시지", response.getContent());

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
@@ -1,0 +1,120 @@
+package com.solv.wefin.web.chat.globalChat;
+
+import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.simp.stomp.*;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+import org.springframework.web.socket.sockjs.client.SockJsClient;
+import org.springframework.web.socket.sockjs.client.Transport;
+import org.springframework.web.socket.sockjs.client.WebSocketTransport;
+
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GlobalChatWebSocketTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    @DisplayName("SockJS 기반 전체 채팅 송수신 테스트")
+    void globalChat_sockJs_sendAndReceive() throws Exception {
+
+        // SockJS + WebSocket 기반 STOMP 클라이언트 생성
+        List<Transport> transports = List.of(
+                new WebSocketTransport(new StandardWebSocketClient())
+        );
+        SockJsClient sockJsClient = new SockJsClient(transports);
+
+        WebSocketStompClient stompClient = new WebSocketStompClient(sockJsClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+
+        // 서버에서 오는 메시지를 담을 큐
+        BlockingQueue<GlobalChatMessageResponse> queue = new LinkedBlockingQueue<>();
+
+        // CONNECT 시 nickname 해더 전달 (서버에서 Principal로 사용됨)
+        StompHeaders connectHeaders = new StompHeaders();
+        connectHeaders.add("nickname", "testUser");
+
+        // WebSocket 연결
+        StompSession session = stompClient
+                .connectAsync(
+                        "http://localhost:" + port + "/ws",
+                        new WebSocketHttpHeaders(),
+                        connectHeaders,
+                        new StompSessionHandlerAdapter() {
+
+                            // STOMP 처리 중 예외 발생 시 로그 출력
+                            @Override
+                            public void handleException(StompSession session, StompCommand command,
+                                                        StompHeaders headers, byte[] payload, Throwable exception) {
+                                exception.printStackTrace();
+                            }
+
+                            // 연결 자체 문제 발생 시 로그 출력
+                            @Override
+                            public void handleTransportError(StompSession session, Throwable exception) {
+                                exception.printStackTrace();
+                            }
+                        }
+                )
+                .get(5, TimeUnit.SECONDS);
+
+        // 채팅 메시지 구독
+        session.subscribe("/topic/chat/global", new StompFrameHandler() {
+
+            // 서버에서 받은 메시지를 어떤 타입으로 변환할지 지정
+            @Override
+            public Type getPayloadType(StompHeaders headers) {
+                return GlobalChatMessageResponse.class;
+            }
+
+            // 메시지 수신 시 실행되는 콜백
+            @Override
+            public void handleFrame(StompHeaders headers, Object payload) {
+                System.out.println("받은 payload = " + payload);
+
+                // 큐에 메시지 저장 (offer 반환값은 항상 true라 무시 가능)
+                queue.offer((GlobalChatMessageResponse) payload);
+            }
+        });
+
+        // 구독 완료 대기
+        Thread.sleep(300);
+
+        // 메시지 전송 설정
+        StompHeaders sendHeaders = new StompHeaders();
+        sendHeaders.setDestination("/app/chat/global/send");
+        sendHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        // JSON payload 생성
+        Map<String, String> payload = Map.of("content", "테스트 메시지");
+
+        // 메시지 전송
+        session.send(sendHeaders, payload);
+
+        // 메시지 수신 대기
+        GlobalChatMessageResponse response = queue.poll(5, TimeUnit.SECONDS);
+
+        // 결과 검증
+        assertNotNull(response, "구독 메시지를 받지 못했습니다.");
+        assertEquals("testUser", response.getSender());
+        assertEquals("테스트 메시지", response.getContent());
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
WebSocket(STOMP) 기반 전체 채팅 송수신 기능을 구현했습니다.
클라이언트가 메시지를 전송하면 서버에서 처리 후 broadcast하여 구독자에게 실시간 전달되도록 구성했습니다.

<br>

## ✅ 완료한 기능 명세

- [X] WebSocket/STOMP 설정 구성
- [X] @MessageMapping 기반 메시지 수신 처리
- [X] STOMP Interceptor를 통한 사용자 식별
- [X] WebSocket 연결/해제 이벤트 처리
- [X] DTO 기반 메시지 역직렬화 처리
- [X] 메시지 브로드캐스트 처리

<br>

## 💬 주요 파일 설명

### 🔹 WebSocketConfig
- STOMP endpoint(`/ws`) 설정
- broker(`/topic`) 및 application prefix(`/app`) 설정

### 🔹 StompAuthChannelInterceptor
- CONNECT 시 nickname 기반 사용자 식별 처리
- STOMP 메시지 흐름 로깅

### 🔹 WebSocketEventListener
- WebSocket 연결/해제 이벤트 로그 처리

### 🔹 GlobalChatController
- `/app/chat/global/send` 메시지 수신 처리 (`@MessageMapping`)

### 🔹 GlobalChatService
- 메시지 검증 및 `/topic/chat/global`로 broadcast 처리

### 🔹 DTO
- `GlobalChatSendRequest`: 메시지 요청 구조
- `GlobalChatMessageResponse`: 메시지 응답 구조

### 🔹 테스트 코드
- WebSocket 통합 테스트를 통해 송수신 흐름 검증
- 서비스 단위 테스트 추가

<br>

## 💭 고민과 해결과정

### 1. WebSocket 메시지 수신 실패 문제
- 초기에는 컨트롤러 진입이 되지 않는 문제가 발생
- Spring Security와 MessageConverter(Content-Type) 설정을 점검하여 해결

### 2. STOMP 테스트에서 메시지 수신 실패 문제
- subscribe 직후 send 시 메시지가 유실되는 문제 발생
- subscribe 이후 일정 시간 대기하여 해결

### 3. JSON 직렬화 문제
- 테스트 코드에서 `byte[]`로 메시지를 전송할 경우 DTO 변환이 실패하는 문제 발생
- String 기반 JSON payload로 전송하도록 수정하여 해결

<br>

### 🔗 관련 이슈
Closes #49 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 글로벌 채팅 추가: WebSocket/STOMP 브로드캐스트, 닉네임 기반 식별 및 익명 처리, 클라이언트 엔드포인트(/ws) 및 SockJS 지원과 메시지 브로커/경로 구성, STOMP 인바운드 인터셉터 및 연결/연결해제 이벤트 로깅 추가.

* **버그 수정 / 유효성 검사**
  * 채팅 메시지 유효성 검사 도입(빈 내용 차단, 최대 1000자 제한) 및 관련 오류 코드 추가.

* **테스트**
  * 서비스 단위 테스트 및 WebSocket 통합(연결·전송·수신) 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->