### PR TITLE
[WEF-431] 뉴스 기사 본문 크롤링 파이프라인 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
+	implementation 'org.jsoup:jsoup:1.18.3'
 	developmentOnly 'me.paulschwarz:springboot3-dotenv:5.1.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/solv/wefin/domain/news/batch/NewsCollectScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/batch/NewsCollectScheduler.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.news.batch;
 
+import com.solv.wefin.domain.news.crawl.ArticleCrawlService;
 import com.solv.wefin.domain.news.service.NewsCollectService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,26 +15,33 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class NewsCollectScheduler {
 
     private final NewsCollectService newsCollectService;
+    private final ArticleCrawlService articleCrawlService;
     private final AtomicBoolean running = new AtomicBoolean(false);
 
     @Scheduled(cron = "${news.collect.cron:0 0 */2 * * *}")
-    public void collectNews() {
+    public void collectAndCrawlNews() {
         if (!running.compareAndSet(false, true)) {
-            log.info("뉴스 수집 배치가 이미 실행 중입니다. 스킵합니다.");
+            log.info("뉴스 수집/크롤링 배치가 이미 실행 중입니다. 스킵합니다.");
             return;
         }
 
-        log.info("=== 뉴스 수집 배치 시작 ===");
+        log.info("=== 뉴스 수집/크롤링 배치 시작 ===");
         long start = System.currentTimeMillis();
 
         try {
             newsCollectService.collectAll();
         } catch (Exception e) {
-            log.error("뉴스 수집 배치 실패: {}", e.getMessage(), e);
+            log.error("뉴스 수집 실패: {}", e.getMessage(), e);
+        }
+
+        try {
+            articleCrawlService.crawlPendingArticles();
+        } catch (Exception e) {
+            log.error("뉴스 크롤링 실패: {}", e.getMessage(), e);
         } finally {
             running.set(false);
             long elapsed = System.currentTimeMillis() - start;
-            log.info("=== 뉴스 수집 배치 종료 ({}ms) ===", elapsed);
+            log.info("=== 뉴스 수집/크롤링 배치 종료 ({}ms) ===", elapsed);
         }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/collector/NaverNewsCollector.java
+++ b/src/main/java/com/solv/wefin/domain/news/collector/NaverNewsCollector.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.news.dto.CollectedNewsDto;
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -150,15 +151,7 @@ public class NaverNewsCollector implements NewsCollector {
 
     private String stripHtml(String text) {
         if (text == null || text.isBlank()) return text;
-        return text
-                .replaceAll("<[^>]+>", "")
-                .replace("&amp;", "&")
-                .replace("&lt;", "<")
-                .replace("&gt;", ">")
-                .replace("&quot;", "\"")
-                .replace("&#039;", "'")
-                .replace("&#39;", "'")
-                .trim();
+        return Jsoup.parse(text).text().trim();
     }
 
     private LocalDateTime parseNaverDate(String pubDate) {

--- a/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceService.java
@@ -1,0 +1,44 @@
+package com.solv.wefin.domain.news.crawl;
+
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 크롤링 결과를 DB에 반영하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ArticleCrawlPersistenceService {
+
+    private final NewsArticleRepository newsArticleRepository;
+
+    /**
+     * 크롤링 성공 결과를 저장한다. 본문과 썸네일을 업데이트하고 상태를 SUCCESS로 변경한다.
+     *
+     * @param articleId 대상 기사 ID
+     * @param content 크롤링된 본문 텍스트
+     * @param thumbnailUrl og:image에서 추출한 썸네일 URL (없으면 null)
+     */
+    @Transactional
+    public void saveCrawlSuccess(Long articleId, String content, String thumbnailUrl) {
+        NewsArticle article = newsArticleRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalStateException("기사를 찾을 수 없습니다: " + articleId));
+        article.updateCrawledContent(content, thumbnailUrl);
+    }
+
+    /**
+     * 크롤링 실패를 기록한다. 상태를 FAILED로 변경하고 retryCount를 증가시킨다.
+     *
+     * @param articleId 대상 기사 ID
+     * @param errorMessage 실패 원인 메시지
+     */
+    @Transactional
+    public void saveCrawlFailure(Long articleId, String errorMessage) {
+        NewsArticle article = newsArticleRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalStateException("기사를 찾을 수 없습니다: " + articleId));
+        article.markCrawlFailed(errorMessage);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceService.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.news.entity.NewsArticle;
 import com.solv.wefin.domain.news.repository.NewsArticleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -22,7 +23,7 @@ public class ArticleCrawlPersistenceService {
      * @param content 크롤링된 본문 텍스트
      * @param thumbnailUrl og:image에서 추출한 썸네일 URL (없으면 null)
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveCrawlSuccess(Long articleId, String content, String thumbnailUrl) {
         NewsArticle article = newsArticleRepository.findById(articleId)
                 .orElseThrow(() -> new IllegalStateException("기사를 찾을 수 없습니다: " + articleId));
@@ -35,7 +36,7 @@ public class ArticleCrawlPersistenceService {
      * @param articleId 대상 기사 ID
      * @param errorMessage 실패 원인 메시지
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void saveCrawlFailure(Long articleId, String errorMessage) {
         NewsArticle article = newsArticleRepository.findById(articleId)
                 .orElseThrow(() -> new IllegalStateException("기사를 찾을 수 없습니다: " + articleId));

--- a/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlService.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlService.java
@@ -1,0 +1,141 @@
+package com.solv.wefin.domain.news.crawl;
+
+import com.solv.wefin.domain.news.crawl.extractor.ArticleContentExtractor;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ArticleCrawlService {
+
+    private static final String USER_AGENT = "Mozilla/5.0 (compatible; WefinBot/1.0)";
+    private static final int ERROR_MESSAGE_MAX_LENGTH = 500;
+    private static final int MAX_RETRY = 3;
+    private static final int CRAWL_BATCH_SIZE = 500;
+
+    private final NewsArticleRepository newsArticleRepository;
+    private final ArticleCrawlPersistenceService persistenceService;
+    private final List<ArticleContentExtractor> extractors;
+    private final RestTemplate newsRestTemplate;
+
+    /**
+     * PENDING/FAILED 상태의 기사를 조회하여 원문 HTML을 크롤링하고 본문/썸네일을 저장한다.
+     */
+    public void crawlPendingArticles() {
+        List<NewsArticle> targets = findCrawlTargets();
+        log.info("크롤링 대상 기사 수: {}", targets.size());
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (NewsArticle article : targets) {
+            if (crawlSingleArticle(article)) {
+                successCount++;
+            } else {
+                failCount++;
+            }
+        }
+
+        log.info("크롤링 완료 - 성공: {}, 실패: {}", successCount, failCount);
+    }
+
+    private List<NewsArticle> findCrawlTargets() {
+        return newsArticleRepository
+                .findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(
+                        List.of(CrawlStatus.PENDING, CrawlStatus.FAILED),
+                        MAX_RETRY,
+                        PageRequest.of(0, CRAWL_BATCH_SIZE));
+    }
+
+    private boolean crawlSingleArticle(NewsArticle article) {
+        try {
+            String html = fetchHtml(article.getOriginalUrl());
+            if (html == null || html.isBlank()) {
+                persistenceService.saveCrawlFailure(article.getId(), "Empty HTML response");
+                return false;
+            }
+
+            Document doc = Jsoup.parse(html, article.getOriginalUrl());
+            return extractAndSave(article, doc);
+
+        } catch (Exception e) {
+            handleCrawlException(article, e);
+            return false;
+        }
+    }
+
+    private boolean extractAndSave(NewsArticle article, Document doc) {
+        Optional<String> content = extractContent(article.getOriginalUrl(), doc);
+        if (content.isEmpty()) {
+            persistenceService.saveCrawlFailure(article.getId(), "Content extraction returned empty");
+            return false;
+        }
+
+        String thumbnailUrl = extractOgImage(doc).orElse(null);
+        persistenceService.saveCrawlSuccess(article.getId(), content.get(), thumbnailUrl);
+        log.debug("크롤링 성공 - id: {}, contentLength: {}", article.getId(), content.get().length());
+        return true;
+    }
+
+    private void handleCrawlException(NewsArticle article, Exception e) {
+        String errorMessage = truncateErrorMessage(e);
+        persistenceService.saveCrawlFailure(article.getId(), errorMessage);
+        log.warn("크롤링 실패 - id: {}, url: {}, error: {}",
+                article.getId(), article.getOriginalUrl(), e.getMessage());
+    }
+
+    private String truncateErrorMessage(Exception e) {
+        if (e.getMessage() == null) {
+            return "Unknown error";
+        }
+        return e.getMessage().substring(0, Math.min(e.getMessage().length(), ERROR_MESSAGE_MAX_LENGTH));
+    }
+
+    private String fetchHtml(String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("User-Agent", USER_AGENT);
+        ResponseEntity<String> response = newsRestTemplate.exchange(
+                url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+        return response.getBody();
+    }
+
+    private Optional<String> extractOgImage(Document doc) {
+        Element ogImage = doc.selectFirst("meta[property=og:image]");
+        if (ogImage == null) {
+            return Optional.empty();
+        }
+        String content = ogImage.attr("content");
+        return content.isBlank() ? Optional.empty() : Optional.of(content);
+    }
+
+    private Optional<String> extractContent(String url, Document doc) {
+        for (ArticleContentExtractor extractor : extractors) {
+            if (extractor.supports(url)) {
+                String content = extractor.extract(doc);
+                if (content != null && !content.isBlank()) {
+                    return Optional.of(content);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlService.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/ArticleCrawlService.java
@@ -19,8 +19,12 @@ import org.springframework.web.client.RestTemplate;
 
 import org.springframework.data.domain.PageRequest;
 
+import java.net.InetAddress;
+import java.net.URI;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -31,6 +35,7 @@ public class ArticleCrawlService {
     private static final int ERROR_MESSAGE_MAX_LENGTH = 500;
     private static final int MAX_RETRY = 3;
     private static final int CRAWL_BATCH_SIZE = 500;
+    private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
 
     private final NewsArticleRepository newsArticleRepository;
     private final ArticleCrawlPersistenceService persistenceService;
@@ -111,11 +116,38 @@ public class ArticleCrawlService {
     }
 
     private String fetchHtml(String url) {
+        validateUrl(url);
         HttpHeaders headers = new HttpHeaders();
         headers.set("User-Agent", USER_AGENT);
         ResponseEntity<String> response = newsRestTemplate.exchange(
                 url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
         return response.getBody();
+    }
+
+    /**
+     * SSRF 방지를 위해 URL 스킴과 호스트를 검증한다.
+     * http/https만 허용하고, 내부망/루프백/링크로컬 대역은 차단한다.
+     */
+    private void validateUrl(String url) {
+        URI uri = URI.create(url);
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        if (!ALLOWED_SCHEMES.contains(scheme) || uri.getHost() == null) {
+            throw new IllegalArgumentException("Unsupported crawl URL scheme: " + url);
+        }
+
+        try {
+            InetAddress[] addresses = InetAddress.getAllByName(uri.getHost());
+            for (InetAddress addr : addresses) {
+                if (addr.isLoopbackAddress() || addr.isAnyLocalAddress()
+                        || addr.isSiteLocalAddress() || addr.isLinkLocalAddress()) {
+                    throw new IllegalArgumentException("Blocked internal network URL: " + url);
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to resolve crawl URL: " + url, e);
+        }
     }
 
     private Optional<String> extractOgImage(Document doc) {

--- a/src/main/java/com/solv/wefin/domain/news/crawl/extractor/ArticleContentExtractor.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/extractor/ArticleContentExtractor.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.domain.news.crawl.extractor;
+
+import org.jsoup.nodes.Document;
+
+public interface ArticleContentExtractor {
+
+    /**
+     * 주어진 URL을 이 extractor로 처리할 수 있는지 판단한다.
+     *
+     * @param url 기사 원문 URL
+     * @return 처리 가능하면 true, 아니면 false
+     */
+    boolean supports(String url);
+
+    /**
+     * HTML Document에서 기사 본문 텍스트를 추출한다.
+     *
+     * @param document Jsoup으로 파싱된 HTML Document
+     * @return 추출된 본문 텍스트, 추출 실패 시 null
+     */
+    String extract(Document document);
+}

--- a/src/main/java/com/solv/wefin/domain/news/crawl/extractor/DefaultArticleContentExtractor.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/extractor/DefaultArticleContentExtractor.java
@@ -1,0 +1,97 @@
+package com.solv.wefin.domain.news.crawl.extractor;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class DefaultArticleContentExtractor implements ArticleContentExtractor {
+
+    private static final int MIN_CONTENT_LENGTH = 200;
+
+    private static final String[] CONTENT_SELECTORS = {
+            "article",
+            "div.article_body", "div.article-body",
+            "div#articleBody", "div#article-body",
+            "div.news_body", "div.story-body",
+            "div[itemprop=articleBody]",
+            "div.article_txt", "div.article-txt",
+            "div#newsContent", "div.news-content",
+            "div.view_article", "div.view-article"
+    };
+
+    private static final String NOISE_SELECTORS =
+            "script, style, nav, aside, footer, .ad, .advertisement, .related";
+
+    private static final Set<String> SKIP_TAGS = Set.of("nav", "aside", "footer");
+
+    @Override
+    public boolean supports(String url) {
+        return true;
+    }
+
+    @Override
+    public String extract(Document document) {
+        // 1. 공통 CSS 셀렉터로 본문 탐색
+        String content = extractBySelectors(document);
+        if (content != null) {
+            return content;
+        }
+
+        // 2. 가장 큰 텍스트 블록 탐색
+        content = findLargestTextBlock(document);
+        if (content != null && content.length() >= MIN_CONTENT_LENGTH) {
+            return content;
+        }
+
+        // 3. og:description 폴백
+        return extractOgDescription(document);
+    }
+
+    private String extractBySelectors(Document document) {
+        for (String selector : CONTENT_SELECTORS) {
+            Elements elements = document.select(selector);
+            if (!elements.isEmpty()) {
+                elements.select(NOISE_SELECTORS).remove();
+                String text = elements.first().text().trim();
+                if (text.length() >= MIN_CONTENT_LENGTH) {
+                    return text;
+                }
+            }
+        }
+        return null;
+    }
+
+    private String findLargestTextBlock(Document document) {
+        String longest = "";
+        for (Element div : document.select("div")) {
+            if (isSkipElement(div)) {
+                continue;
+            }
+            String text = div.text().trim();
+            if (text.length() > longest.length()) {
+                longest = text;
+            }
+        }
+        return longest.isEmpty() ? null : longest;
+    }
+
+    private boolean isSkipElement(Element element) {
+        if (SKIP_TAGS.contains(element.tagName())) {
+            return true;
+        }
+        Element parent = element.parent();
+        return parent != null && SKIP_TAGS.contains(parent.tagName());
+    }
+
+    private String extractOgDescription(Document document) {
+        String ogDesc = document.select("meta[property=og:description]").attr("content");
+        return ogDesc.isBlank() ? null : ogDesc;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/crawl/extractor/NaverNewsContentExtractor.java
+++ b/src/main/java/com/solv/wefin/domain/news/crawl/extractor/NaverNewsContentExtractor.java
@@ -1,0 +1,51 @@
+package com.solv.wefin.domain.news.crawl.extractor;
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class NaverNewsContentExtractor implements ArticleContentExtractor {
+
+    private static final int MIN_CONTENT_LENGTH = 50;
+    private static final String NAVER_NEWS_HOST = "n.news.naver.com";
+
+    private static final String[] BODY_SELECTORS = {
+            "div#newsct_article",
+            "div#articeBody",
+            "div._article_body"
+    };
+
+    private static final String NOISE_SELECTORS =
+            "script, style, .reporter_area, .byline, .copyright, .source";
+
+    @Override
+    public boolean supports(String url) {
+        return url != null && url.contains(NAVER_NEWS_HOST);
+    }
+
+    @Override
+    public String extract(Document document) {
+        Elements body = findArticleBody(document);
+        if (body.isEmpty()) {
+            return null;
+        }
+
+        body.select(NOISE_SELECTORS).remove();
+        String text = body.text().trim();
+        return text.length() > MIN_CONTENT_LENGTH ? text : null;
+    }
+
+    private Elements findArticleBody(Document document) {
+        for (String selector : BODY_SELECTORS) {
+            Elements body = document.select(selector);
+            if (!body.isEmpty()) {
+                return body;
+            }
+        }
+        return new Elements();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -107,7 +107,8 @@ public class NewsArticle extends BaseEntity {
      */
     public void updateCrawledContent(String crawledContent, String thumbnailUrl) {
         this.content = crawledContent;
-        if (this.thumbnailUrl == null && thumbnailUrl != null) {
+        if ((this.thumbnailUrl == null || this.thumbnailUrl.isBlank())
+                && thumbnailUrl != null && !thumbnailUrl.isBlank()) {
             this.thumbnailUrl = thumbnailUrl;
         }
         this.crawlStatus = CrawlStatus.SUCCESS;
@@ -131,6 +132,7 @@ public class NewsArticle extends BaseEntity {
     public void markCrawlSkipped() {
         this.crawlStatus = CrawlStatus.SKIPPED;
         this.crawlAttemptedAt = LocalDateTime.now();
+        this.crawlErrorMessage = null;
     }
 
     public enum CrawlStatus {

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -60,6 +60,19 @@ public class NewsArticle extends BaseEntity {
     @Column(name = "collected_at")
     private LocalDateTime collectedAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "crawl_status", nullable = false, length = 30)
+    private CrawlStatus crawlStatus = CrawlStatus.PENDING;
+
+    @Column(name = "crawl_attempted_at")
+    private LocalDateTime crawlAttemptedAt;
+
+    @Column(name = "crawl_retry_count", nullable = false)
+    private int crawlRetryCount = 0;
+
+    @Column(name = "crawl_error_message")
+    private String crawlErrorMessage;
+
     @Builder
     private NewsArticle(Long rawNewsArticleId, String publisherName, String title,
                         String summary, String content, String originalUrl,
@@ -79,6 +92,49 @@ public class NewsArticle extends BaseEntity {
         this.languageCode = languageCode;
         this.dedupKey = dedupKey;
         this.collectedAt = collectedAt;
+        this.crawlStatus = CrawlStatus.PENDING;
+    }
+
+    /**
+     * 크롤링 성공 시 본문과 썸네일을 업데이트한다.
+     *
+     * <p>본문은 항상 최신 크롤링 결과로 덮어쓴다 (재크롤링 시 최신 본문 반영).
+     * 썸네일은 최초 1회만 저장하고 이후 덮어쓰지 않는다
+     * (원본 사이트의 og:image가 광고/기본 이미지로 변경되는 경우 방지).</p>
+     *
+     * @param crawledContent 크롤링된 본문 텍스트
+     * @param thumbnailUrl og:image 썸네일 URL (없으면 null)
+     */
+    public void updateCrawledContent(String crawledContent, String thumbnailUrl) {
+        this.content = crawledContent;
+        if (this.thumbnailUrl == null && thumbnailUrl != null) {
+            this.thumbnailUrl = thumbnailUrl;
+        }
+        this.crawlStatus = CrawlStatus.SUCCESS;
+        this.crawlAttemptedAt = LocalDateTime.now();
+        this.crawlErrorMessage = null;
+    }
+
+    /**
+     * 크롤링 실패를 기록한다. retryCount를 증가시키고 상태를 FAILED로 변경한다.
+     *
+     * @param errorMessage 실패 원인 메시지 (최대 500자)
+     */
+    public void markCrawlFailed(String errorMessage) {
+        this.crawlRetryCount++;
+        this.crawlStatus = CrawlStatus.FAILED;
+        this.crawlAttemptedAt = LocalDateTime.now();
+        this.crawlErrorMessage = errorMessage;
+    }
+
+    /** 크롤링 대상에서 제외한다. 상태를 SKIPPED로 변경한다. */
+    public void markCrawlSkipped() {
+        this.crawlStatus = CrawlStatus.SKIPPED;
+        this.crawlAttemptedAt = LocalDateTime.now();
+    }
+
+    public enum CrawlStatus {
+        PENDING, SUCCESS, FAILED, SKIPPED
     }
 
     public static NewsArticle of(RawNewsArticle rawArticle, CollectedNewsDto dto,

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
@@ -1,9 +1,15 @@
 package com.solv.wefin.domain.news.repository;
 
 import com.solv.wefin.domain.news.entity.NewsArticle;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> {
 
     boolean existsByDedupKey(String dedupKey);
+
+    List<NewsArticle> findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(
+            List<NewsArticle.CrawlStatus> statuses, int maxRetryCount, Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.web.news.controller;
 
+import com.solv.wefin.domain.news.crawl.ArticleCrawlService;
 import com.solv.wefin.domain.news.service.NewsCollectService;
 import com.solv.wefin.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,10 +16,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class NewsCollectController {
 
     private final NewsCollectService newsCollectService;
+    private final ArticleCrawlService articleCrawlService;
 
     @PostMapping("/collect")
     public ApiResponse<String> collectNow() {
         newsCollectService.collectAll();
         return ApiResponse.success("뉴스 수집 완료");
+    }
+
+    @PostMapping("/crawl")
+    public ApiResponse<String> crawlNow() {
+        articleCrawlService.crawlPendingArticles();
+        return ApiResponse.success("뉴스 크롤링 완료");
     }
 }

--- a/src/main/resources/db/migration/V4__add_crawl_status_to_news_article.sql
+++ b/src/main/resources/db/migration/V4__add_crawl_status_to_news_article.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "news_article" ADD COLUMN "crawl_status" VARCHAR(30) NOT NULL DEFAULT 'PENDING';
+ALTER TABLE "news_article" ADD COLUMN "crawl_attempted_at" TIMESTAMP NULL;
+ALTER TABLE "news_article" ADD COLUMN "crawl_retry_count" INT NOT NULL DEFAULT 0;
+ALTER TABLE "news_article" ADD COLUMN "crawl_error_message" TEXT NULL;
+
+COMMENT ON COLUMN "news_article"."crawl_status" IS 'PENDING / SUCCESS / FAILED / SKIPPED';
+COMMENT ON COLUMN "news_article"."crawl_attempted_at" IS '마지막 크롤링 시도 시각';
+COMMENT ON COLUMN "news_article"."crawl_retry_count" IS '크롤링 재시도 횟수';
+COMMENT ON COLUMN "news_article"."crawl_error_message" IS '크롤링 실패 메시지';

--- a/src/test/java/com/solv/wefin/common/IntegrationTestBase.java
+++ b/src/test/java/com/solv/wefin/common/IntegrationTestBase.java
@@ -1,22 +1,18 @@
 package com.solv.wefin.common;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 @SpringBootTest
 @ActiveProfiles("test")
-@Testcontainers
 @Transactional
 public abstract class IntegrationTestBase {
 
-    @Container
+    @ServiceConnection
     static final PostgreSQLContainer<?> postgres =
             new PostgreSQLContainer<>(
                     DockerImageName.parse("pgvector/pgvector:pg16")
@@ -25,11 +21,7 @@ public abstract class IntegrationTestBase {
                     .withUsername("test")
                     .withPassword("test");
 
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", postgres::getJdbcUrl);
-        registry.add("spring.datasource.username", postgres::getUsername);
-        registry.add("spring.datasource.password", postgres::getPassword);
-        registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+    static {
+        postgres.start();
     }
 }

--- a/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceServiceIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceServiceIntegrationTest.java
@@ -5,11 +5,14 @@ import com.solv.wefin.domain.news.entity.NewsArticle;
 import com.solv.wefin.domain.news.entity.NewsArticle.CrawlStatus;
 import com.solv.wefin.domain.news.repository.NewsArticleRepository;
 import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Transactional(propagation = org.springframework.transaction.annotation.Propagation.NOT_SUPPORTED)
 class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase {
 
     @Autowired
@@ -21,6 +24,11 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
     @Autowired
     private EntityManager entityManager;
 
+    @AfterEach
+    void cleanup() {
+        newsArticleRepository.deleteAll();
+    }
+
     @Test
     void 크롤링_성공시_본문과_썸네일이_DB에_반영된다() {
         // given
@@ -28,7 +36,6 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
 
         // when
         persistenceService.saveCrawlSuccess(article.getId(), "크롤링된 본문 내용", "https://example.com/thumb.jpg");
-        flushAndClear();
 
         // then
         NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
@@ -45,11 +52,9 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
         // given — 이미 썸네일이 저장된 기사
         NewsArticle article = createAndSavePendingArticle("https://example.com/2");
         persistenceService.saveCrawlSuccess(article.getId(), "첫 번째 본문", "https://example.com/original.jpg");
-        flushAndClear();
 
         // when — 다른 썸네일로 다시 저장 시도
         persistenceService.saveCrawlSuccess(article.getId(), "두 번째 본문", "https://example.com/new.jpg");
-        flushAndClear();
 
         // then — 기존 썸네일 유지, 본문은 갱신
         NewsArticle result = newsArticleRepository.findById(article.getId()).orElseThrow();
@@ -62,11 +67,9 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
         // given — 이미 성공한 기사
         NewsArticle article = createAndSavePendingArticle("https://example.com/2-1");
         persistenceService.saveCrawlSuccess(article.getId(), "첫 번째 본문", "https://example.com/thumb.jpg");
-        flushAndClear();
 
         // when — 다시 성공
         persistenceService.saveCrawlSuccess(article.getId(), "두 번째 본문", null);
-        flushAndClear();
 
         // then
         NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
@@ -81,7 +84,6 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
 
         // when
         persistenceService.saveCrawlFailure(article.getId(), "Connection refused");
-        flushAndClear();
 
         // then
         NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
@@ -100,7 +102,6 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
         persistenceService.saveCrawlFailure(article.getId(), "1차 실패");
         persistenceService.saveCrawlFailure(article.getId(), "2차 실패");
         persistenceService.saveCrawlFailure(article.getId(), "3차 실패");
-        flushAndClear();
 
         // then
         NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
@@ -113,11 +114,9 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
         // given — 먼저 실패
         NewsArticle article = createAndSavePendingArticle("https://example.com/5");
         persistenceService.saveCrawlFailure(article.getId(), "Connection refused");
-        flushAndClear();
 
         // when — 재시도 후 성공
         persistenceService.saveCrawlSuccess(article.getId(), "크롤링 성공 본문", "https://example.com/thumb.jpg");
-        flushAndClear();
 
         // then — 에러 정보 초기화, retryCount는 유지
         NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
@@ -137,10 +136,5 @@ class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase 
                 .dedupKey("url:" + url)
                 .build();
         return newsArticleRepository.saveAndFlush(article);
-    }
-
-    private void flushAndClear() {
-        entityManager.flush();
-        entityManager.clear();
     }
 }

--- a/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceServiceIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlPersistenceServiceIntegrationTest.java
@@ -1,0 +1,146 @@
+package com.solv.wefin.domain.news.crawl;
+
+import com.solv.wefin.common.IntegrationTestBase;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArticleCrawlPersistenceServiceIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private ArticleCrawlPersistenceService persistenceService;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void 크롤링_성공시_본문과_썸네일이_DB에_반영된다() {
+        // given
+        NewsArticle article = createAndSavePendingArticle("https://example.com/1");
+
+        // when
+        persistenceService.saveCrawlSuccess(article.getId(), "크롤링된 본문 내용", "https://example.com/thumb.jpg");
+        flushAndClear();
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getCrawlStatus()).isEqualTo(CrawlStatus.SUCCESS);
+        assertThat(updated.getContent()).isEqualTo("크롤링된 본문 내용");
+        assertThat(updated.getThumbnailUrl()).isEqualTo("https://example.com/thumb.jpg");
+        assertThat(updated.getCrawlAttemptedAt()).isNotNull();
+        assertThat(updated.getCrawlErrorMessage()).isNull();
+        assertThat(updated.getCrawlRetryCount()).isEqualTo(0);
+    }
+
+    @Test
+    void 크롤링_성공시_기존_썸네일이_있으면_덮어쓰지_않는다() {
+        // given — 이미 썸네일이 저장된 기사
+        NewsArticle article = createAndSavePendingArticle("https://example.com/2");
+        persistenceService.saveCrawlSuccess(article.getId(), "첫 번째 본문", "https://example.com/original.jpg");
+        flushAndClear();
+
+        // when — 다른 썸네일로 다시 저장 시도
+        persistenceService.saveCrawlSuccess(article.getId(), "두 번째 본문", "https://example.com/new.jpg");
+        flushAndClear();
+
+        // then — 기존 썸네일 유지, 본문은 갱신
+        NewsArticle result = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(result.getThumbnailUrl()).isEqualTo("https://example.com/original.jpg");
+        assertThat(result.getContent()).isEqualTo("두 번째 본문");
+    }
+
+    @Test
+    void 성공했던_기사가_다시_성공하면_retryCount는_증가하지_않는다() {
+        // given — 이미 성공한 기사
+        NewsArticle article = createAndSavePendingArticle("https://example.com/2-1");
+        persistenceService.saveCrawlSuccess(article.getId(), "첫 번째 본문", "https://example.com/thumb.jpg");
+        flushAndClear();
+
+        // when — 다시 성공
+        persistenceService.saveCrawlSuccess(article.getId(), "두 번째 본문", null);
+        flushAndClear();
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getCrawlRetryCount()).isEqualTo(0);
+        assertThat(updated.getCrawlStatus()).isEqualTo(CrawlStatus.SUCCESS);
+    }
+
+    @Test
+    void 크롤링_실패시_실패_상태와_에러메시지가_DB에_반영된다() {
+        // given
+        NewsArticle article = createAndSavePendingArticle("https://example.com/3");
+
+        // when
+        persistenceService.saveCrawlFailure(article.getId(), "Connection refused");
+        flushAndClear();
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getCrawlStatus()).isEqualTo(CrawlStatus.FAILED);
+        assertThat(updated.getCrawlRetryCount()).isEqualTo(1);
+        assertThat(updated.getCrawlErrorMessage()).isEqualTo("Connection refused");
+        assertThat(updated.getCrawlAttemptedAt()).isNotNull();
+    }
+
+    @Test
+    void 크롤링_실패시_재시도마다_retryCount가_증가한다() {
+        // given
+        NewsArticle article = createAndSavePendingArticle("https://example.com/4");
+
+        // when
+        persistenceService.saveCrawlFailure(article.getId(), "1차 실패");
+        persistenceService.saveCrawlFailure(article.getId(), "2차 실패");
+        persistenceService.saveCrawlFailure(article.getId(), "3차 실패");
+        flushAndClear();
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getCrawlRetryCount()).isEqualTo(3);
+        assertThat(updated.getCrawlErrorMessage()).isEqualTo("3차 실패");
+    }
+
+    @Test
+    void 실패했던_기사가_성공하면_에러메시지는_초기화되고_상태는_SUCCESS가_된다() {
+        // given — 먼저 실패
+        NewsArticle article = createAndSavePendingArticle("https://example.com/5");
+        persistenceService.saveCrawlFailure(article.getId(), "Connection refused");
+        flushAndClear();
+
+        // when — 재시도 후 성공
+        persistenceService.saveCrawlSuccess(article.getId(), "크롤링 성공 본문", "https://example.com/thumb.jpg");
+        flushAndClear();
+
+        // then — 에러 정보 초기화, retryCount는 유지
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getCrawlStatus()).isEqualTo(CrawlStatus.SUCCESS);
+        assertThat(updated.getContent()).isEqualTo("크롤링 성공 본문");
+        assertThat(updated.getCrawlErrorMessage()).isNull();
+        assertThat(updated.getCrawlRetryCount()).isEqualTo(1);
+    }
+
+    private NewsArticle createAndSavePendingArticle(String url) {
+        NewsArticle article = NewsArticle.builder()
+                .rawNewsArticleId(null)
+                .publisherName("example.com")
+                .title("테스트 기사")
+                .content("요약")
+                .originalUrl(url)
+                .dedupKey("url:" + url)
+                .build();
+        return newsArticleRepository.saveAndFlush(article);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlServiceTest.java
@@ -1,0 +1,273 @@
+package com.solv.wefin.domain.news.crawl;
+
+import com.solv.wefin.domain.news.crawl.extractor.ArticleContentExtractor;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ArticleCrawlServiceTest {
+
+    private static final String SAMPLE_HTML_WITH_THUMBNAIL = """
+            <html>
+            <head>
+                <meta property="og:image" content="https://example.com/thumb/%d.jpg"/>
+            </head>
+            <body>
+                <article>%s</article>
+            </body>
+            </html>
+            """;
+    private static final String SAMPLE_HTML_WITHOUT_THUMBNAIL = """
+            <html>
+            <head></head>
+            <body>
+                <article>%s</article>
+            </body>
+            </html>
+            """;
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+    @Mock
+    private ArticleCrawlPersistenceService persistenceService;
+    @Mock
+    private RestTemplate newsRestTemplate;
+    @Mock
+    private ArticleContentExtractor extractor;
+    @Captor
+    private ArgumentCaptor<Long> articleIdCaptor;
+    @Captor
+    private ArgumentCaptor<String> contentCaptor;
+    @Captor
+    private ArgumentCaptor<String> thumbnailCaptor;
+    private ArticleCrawlService articleCrawlService;
+
+    @BeforeEach
+    void setUp() {
+        articleCrawlService = new ArticleCrawlService(
+                newsArticleRepository,
+                persistenceService,
+                List.of(extractor),
+                newsRestTemplate
+        );
+    }
+
+    @Test
+    void 수집된_10건_기사를_크롤링하면_올바른_본문과_썸네일이_저장된다() {
+        // given
+        List<NewsArticle> articles = createPendingArticles(10);
+        stubFindCrawlTargets(articles);
+        when(extractor.supports(anyString())).thenReturn(true);
+
+        for (int i = 0; i < 10; i++) {
+            String body = "본문 내용 기사번호=" + i;
+            String html = String.format(SAMPLE_HTML_WITH_THUMBNAIL, i, body);
+            stubHtmlResponse("https://example.com/news/" + i, html);
+        }
+        // thenAnswer로 URL별 다른 본문 반환
+        when(extractor.extract(any(Document.class))).thenAnswer(invocation -> {
+            Document doc = invocation.getArgument(0);
+            return doc.select("article").text();
+        });
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then — 호출 횟수 + id-content 매핑으로 순서 무관 검증
+        verify(persistenceService, times(10))
+                .saveCrawlSuccess(articleIdCaptor.capture(), contentCaptor.capture(), thumbnailCaptor.capture());
+        verify(persistenceService, never()).saveCrawlFailure(anyLong(), anyString());
+
+        Map<Long, String> savedContentMap = IntStream.range(0, 10).boxed()
+                .collect(Collectors.toMap(
+                        i -> articleIdCaptor.getAllValues().get(i),
+                        i -> contentCaptor.getAllValues().get(i)));
+
+        Map<Long, String> savedThumbnailMap = IntStream.range(0, 10).boxed()
+                .collect(Collectors.toMap(
+                        i -> articleIdCaptor.getAllValues().get(i),
+                        i -> thumbnailCaptor.getAllValues().get(i)));
+
+        for (int i = 0; i < 10; i++) {
+            long expectedId = i + 1;
+            assertThat(savedContentMap.get(expectedId)).contains("기사번호=" + i);
+            assertThat(savedThumbnailMap.get(expectedId)).isEqualTo("https://example.com/thumb/" + i + ".jpg");
+        }
+    }
+
+    @Test
+    void 수집된_10건_중_5건의_HTML_응답이_비어있으면_5건은_성공하고_5건은_실패로_저장된다() {
+        // given
+        List<NewsArticle> articles = createPendingArticles(10);
+        stubFindCrawlTargets(articles);
+        when(extractor.supports(anyString())).thenReturn(true);
+        when(extractor.extract(any(Document.class))).thenAnswer(invocation -> {
+            Document doc = invocation.getArgument(0);
+            return doc.select("article").text();
+        });
+
+        for (int i = 0; i < 10; i++) {
+            if (i < 5) {
+                String body = "본문 내용 " + i;
+                String html = String.format(SAMPLE_HTML_WITH_THUMBNAIL, i, body);
+                stubHtmlResponse("https://example.com/news/" + i, html);
+            } else {
+                stubHtmlResponse("https://example.com/news/" + i, "");
+            }
+        }
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then
+        verify(persistenceService, times(5)).saveCrawlSuccess(anyLong(), anyString(), anyString());
+        verify(persistenceService, times(5)).saveCrawlFailure(anyLong(), eq("Empty HTML response"));
+    }
+
+    @Test
+    void 본문_추출에_실패하면_실패_상태를_저장한다() {
+        // given
+        List<NewsArticle> articles = createPendingArticles(10);
+        stubFindCrawlTargets(articles);
+        when(extractor.supports(anyString())).thenReturn(true);
+        when(extractor.extract(any(Document.class))).thenReturn(null);
+
+        for (int i = 0; i < 10; i++) {
+            stubHtmlResponse("https://example.com/news/" + i, "<html><body>no article</body></html>");
+        }
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then
+        verify(persistenceService, never()).saveCrawlSuccess(anyLong(), anyString(), anyString());
+        verify(persistenceService, times(10)).saveCrawlFailure(anyLong(), eq("Content extraction returned empty"));
+    }
+
+    @Test
+    void 네트워크_예외_발생_시_에러메시지와_함께_실패_저장된다() {
+        // given
+        List<NewsArticle> articles = createPendingArticles(10);
+        stubFindCrawlTargets(articles);
+
+        for (int i = 0; i < 10; i++) {
+            when(newsRestTemplate.exchange(
+                    eq("https://example.com/news/" + i),
+                    eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                    .thenThrow(new RuntimeException("Connection refused"));
+        }
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then
+        verify(persistenceService, never()).saveCrawlSuccess(anyLong(), anyString(), anyString());
+        verify(persistenceService, times(10)).saveCrawlFailure(anyLong(), eq("Connection refused"));
+    }
+
+    @Test
+    void PENDING_기사가_없으면_HTTP_호출과_추출을_건너뛴다() {
+        // given
+        stubFindCrawlTargets(List.of());
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then
+        verify(persistenceService, never()).saveCrawlSuccess(anyLong(), anyString(), anyString());
+        verify(persistenceService, never()).saveCrawlFailure(anyLong(), anyString());
+        verifyNoInteractions(newsRestTemplate);
+        verifyNoInteractions(extractor);
+    }
+
+    @Test
+    void 지원하는_extractor가_없으면_실패_상태를_저장한다() {
+        // given
+        List<NewsArticle> articles = createPendingArticles(3);
+        stubFindCrawlTargets(articles);
+        when(extractor.supports(anyString())).thenReturn(false);
+
+        for (int i = 0; i < 3; i++) {
+            stubHtmlResponse("https://example.com/news/" + i, "<html><body>content</body></html>");
+        }
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then
+        verify(extractor, never()).extract(any());
+        verify(persistenceService, times(3)).saveCrawlFailure(anyLong(), eq("Content extraction returned empty"));
+    }
+
+    @Test
+    void 썸네일이_없는_HTML이면_null_썸네일로_성공_저장된다() {
+        // given
+        List<NewsArticle> articles = createPendingArticles(1);
+        stubFindCrawlTargets(articles);
+        when(extractor.supports(anyString())).thenReturn(true);
+        when(extractor.extract(any(Document.class))).thenReturn("본문 내용");
+
+        String html = String.format(SAMPLE_HTML_WITHOUT_THUMBNAIL, "본문 내용");
+        stubHtmlResponse("https://example.com/news/0", html);
+
+        // when
+        articleCrawlService.crawlPendingArticles();
+
+        // then
+        verify(persistenceService).saveCrawlSuccess(eq(1L), eq("본문 내용"), isNull());
+    }
+
+    private void stubFindCrawlTargets(List<NewsArticle> articles) {
+        when(newsArticleRepository.findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(
+                eq(List.of(CrawlStatus.PENDING, CrawlStatus.FAILED)), eq(3), any()))
+                .thenReturn(articles);
+    }
+
+    private void stubHtmlResponse(String url, String html) {
+        when(newsRestTemplate.exchange(
+                eq(url), eq(HttpMethod.GET), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(html));
+    }
+
+    private List<NewsArticle> createPendingArticles(int count) {
+        List<NewsArticle> articles = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            NewsArticle article = NewsArticle.builder()
+                    .rawNewsArticleId((long) i)
+                    .publisherName("example.com")
+                    .title("테스트 기사 " + i)
+                    .content("요약 " + i)
+                    .originalUrl("https://example.com/news/" + i)
+                    .dedupKey("url:hash" + i)
+                    .build();
+
+            ReflectionTestUtils.setField(article, "id", (long) (i + 1));
+            ReflectionTestUtils.setField(article, "crawlStatus", CrawlStatus.PENDING);
+            articles.add(article);
+        }
+        return articles;
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
뉴스 기사 본문 크롤링 파이프라인을 구축했습니다.

* 수집 이후 `crawlStatus=PENDING` 기사들을 대상으로 원문 HTML을 크롤링하여 본문과 썸네일을 저장합니다.
* 수집 → 크롤링을 하나의 스케줄러에서 순차 실행하여 backlog 누적을 방지했습니다.
* HTTP 호출과 DB 트랜잭션을 분리하고, Extractor 전략 패턴을 적용해 안정성과 확장성을 고려했습니다.
* 테스트 안정성 개선 (Testcontainers + Spring Boot)
  - 문제 상황
    - 기존에는 Testcontainers를 `@Testcontainers`, `@Container`, `@DynamicPropertySource` 조합으로 사용하고 있었는데, 테스트 클래스 단위로 컨테이너가 생성/종료되고 Spring 테스트 컨텍스트는 캐싱되어 재사용되면서 컨테이너와 Spring/Hikari lifecycle이 어긋나는 문제가 있었습니다. 
    - 오류 로그:`This connection has been closed` - `ConnectException`
  - 변경 내용
    - Testcontainers lifecycle을 JUnit이 아닌 static initializer로 직접 관리
    - `@ServiceConnection` 도입으로 datasource 설정 자동화
    - `@Testcontainers`, `@Container`, `@DynamicPropertySource` 제거
  - 결과
    - 테스트 간 컨테이너 재생성 제거 → lifecycle 일치
    - DB 커넥션 오류 해결 → 테스트 안정성 확보
    - 설정 코드 단순화 및 유지보수성 향상
 
<br>

## ✅ 완료한 기능 명세

* [x] 크롤링 파이프라인 구축
* [x] PENDING / FAILED 대상 처리
* [x] 본문 / 썸네일 저장
* [x] 재시도 정책 (최대 3회)
* [x] Extractor 전략 패턴 적용
* [x] 스케줄러 통합
* [x] 수동 트리거 API 추가
* [x] 테스트 코드 작성

<br>

## 🏛️설계

* **수집 / 크롤링 분리**
  → 크롤링 실패가 수집 결과에 영향 없도록 설계

* **트랜잭션 분리**
  → HTTP 호출은 트랜잭션 밖, DB 저장만 `@Transactional`

* **기사 단위 처리 (`REQUIRES_NEW`)**
  → 일부 실패가 전체 롤백으로 이어지지 않도록 처리

* **Extractor 전략 패턴**
  → 뉴스 소스별 파싱 로직 분리 (확장 용이)<br>

<br>

## 📐 처리 정책
* 대상: `PENDING`, `FAILED`
* 조건: `retry < 3`
* 정렬: 최신 기사 우선 (`collectedAt DESC`)
* 배치: 최대 500건

→ 미처리/일시 실패 데이터를 안정적으로 재처리

<br>

## 🔄 흐름
### 상태 전이
<img width="450"  alt="Alice Bob Message Flow-2026-03-28-131417" src="https://github.com/user-attachments/assets/cd61764a-8784-42eb-9765-959241ca9c7a" />

### 파이프라인
<img width="450" alt="Alice Bob Message Flow-2026-03-28-131217" src="https://github.com/user-attachments/assets/d9ff4467-1f91-48e6-9be7-121cce5307cf" />


<br>

## 📸 스크린샷
수집 결과
<img width="873" height="474" alt="image" src="https://github.com/user-attachments/assets/06b57d86-3919-4089-9657-0538e936995d" />

<br>

## 💭 고민과 해결과정
* **트랜잭션 + 외부 호출 분리**
  → long transaction 및 장애 전파 방지

* **스케줄러 통합**
  → 수집/크롤링 처리량 불균형으로 인한 backlog 방지

* **배치 제한**
  → 메모리 사용 및 실행 시간 안정화

<br>

### 🔗 관련 이슈
Closes #34

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 뉴스 기사 자동 크롤링 워크플로우와 관리자용 수동 크롤링 API 추가
  * 다중 전략 글 내용 추출기(기본 및 네이버 전용) 및 크롤링 상태 추적/갱신 기능 추가
  * 크롤링 결과 영속화 서비스 추가

* **개선 사항**
  * HTML 파싱에 Jsoup 도입으로 추출 정확도 및 엔티티 디코딩 향상
  * 수집 스케줄러가 수집과 크롤링을 연속 실행하도록 로그·오류 분리

* **테스트**
  * 크롤링 서비스 및 영속성 관련 통합/단위 테스트 추가
  * 통합테스트 컨테이너 초기화 방식 개선 (테스트 인프라 변경)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->