### PR TITLE
[WEF-128] 로비 페이지 방 목록 조회 api 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -8,7 +8,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
+
+import static com.solv.wefin.domain.game.participant.entity.ParticipantStatus.ACTIVE;
+import static com.solv.wefin.domain.game.participant.entity.ParticipantStatus.LEFT;
 
 @Entity
 @Table(name = "game_participant", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "room_id" }))
@@ -34,17 +38,18 @@ public class GameParticipant {
     @Column(name="seed")
     private Long seed;
 
+    @Enumerated(EnumType.STRING)
     @Column(name="status", nullable = false)
-    private String status;
+    private ParticipantStatus status;
 
     @Column(name="joined_at", nullable = false, updatable = false)
-    private LocalDateTime joinedAt;
+    private OffsetDateTime joinedAt;
 
     @PrePersist
     protected void onCreate() {
-        this.joinedAt = LocalDateTime.now();
+        this.joinedAt = OffsetDateTime.now();
         if (this.status == null) {
-            this.status = "ACTIVE";
+            this.status = ACTIVE;
         }
         if(this.isLeader == null) {
             this.isLeader = false;
@@ -55,7 +60,14 @@ public class GameParticipant {
         this.gameRoom = gameRoom;
         this.userId = userId;
         this.isLeader = isLeader != null ? isLeader : false;
-        this.status = "ACTIVE";
+        this.status = ACTIVE;
+    }
+    public static GameParticipant createLeader(GameRoom gameRoom, UUID userId) {
+        return GameParticipant.builder()
+                .gameRoom(gameRoom)
+                .userId(userId)
+                .isLeader(true)
+                .build();
     }
 
     public void assignSeed(Long seed) {
@@ -63,7 +75,7 @@ public class GameParticipant {
     }
 
     public void leave() {
-        this.status = "LEFT";
+        this.status = LEFT;
     }
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/ParticipantStatus.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/ParticipantStatus.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.game.participant.entity;
+
+public enum ParticipantStatus {
+    ACTIVE,
+    LEFT
+}

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.game.participant.repository;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,6 +9,6 @@ import java.util.UUID;
 
 public interface GameParticipantRepository extends JpaRepository<GameParticipant, UUID> {
 
-    int countByGameRoomAndStatus(GameRoom gameRoom, String status);
+    int countByGameRoomAndStatus(GameRoom gameRoom, ParticipantStatus status);
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -1,10 +1,13 @@
 package com.solv.wefin.domain.game.participant.repository;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface GameParticipantRepository extends JpaRepository<GameParticipant, UUID> {
+
+    int countByGameRoomAndStatus(GameRoom gameRoom, String status);
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/entity/GameRoom.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/entity/GameRoom.java
@@ -1,6 +1,6 @@
 package com.solv.wefin.domain.game.room.entity;
 
-
+import static com.solv.wefin.domain.game.room.entity.RoomStatus.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Entity
@@ -43,20 +44,21 @@ public class GameRoom {
     @Column(name ="end_date", nullable = false)
     private LocalDate endDate;
 
+    @Enumerated(EnumType.STRING)
     @Column(name ="status", nullable = false)
-    private String status;
+    private RoomStatus status;
 
     @Column(name ="created_at", nullable = false)
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
     @Column(name ="started_at")
-    private LocalDateTime startedAt;
+    private OffsetDateTime startedAt;
 
     @PrePersist
     protected  void oncCreated() {
-        this.createdAt = LocalDateTime.now();
+        this.createdAt = OffsetDateTime.now();
         if(this.status==null) {
-            this.status="WAITING";
+            this.status=WAITING;
         }
     }
 
@@ -69,15 +71,28 @@ public class GameRoom {
       this.moveDays = moveDays;
       this.startDate = startDate;
       this.endDate = endDate;
-      this.status = "WAITING";
+      this.status = WAITING;
     }
 
+    public static GameRoom create(Long groupId, UUID userId, Long seed, Integer periodMonth, Integer moveDays, LocalDate startDate, LocalDate endDate) {
+        return GameRoom.builder()
+                .groupId(groupId)
+                .userId(userId)
+                .seed(seed)
+                .periodMonth(periodMonth)
+                .moveDays(moveDays)
+                .startDate(startDate)
+                .endDate(endDate)
+                .build();
+    }
+
+
     public void start() {
-        this.status = "IN_PROGRESS";
-        this.startedAt = LocalDateTime.now();
+        this.status = IN_PROGRESS;
+        this.startedAt = OffsetDateTime.now();
     }
 
     public void finish() {
-        this.status = "FINISHED";
+        this.status = FINISHED;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/entity/GameRoom.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/entity/GameRoom.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -55,7 +54,7 @@ public class GameRoom {
     private OffsetDateTime startedAt;
 
     @PrePersist
-    protected  void oncCreated() {
+    protected  void onCreated() {
         this.createdAt = OffsetDateTime.now();
         if(this.status==null) {
             this.status=WAITING;

--- a/src/main/java/com/solv/wefin/domain/game/room/entity/RoomStatus.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/entity/RoomStatus.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.game.room.entity;
+
+public enum RoomStatus {
+    WAITING,
+    IN_PROGRESS,
+    FINISHED
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
@@ -1,24 +1,28 @@
 package com.solv.wefin.domain.game.room.repository;
 
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
 public interface GameRoomRepository extends JpaRepository<GameRoom, UUID> {
-    boolean existsByUserIdAndStartedAtBetween(UUID userId, LocalDateTime from, LocalDateTime to);
+    // 방장 1일 1회 제한
+    boolean existsByUserIdAndStartedAtBetween(UUID userId, OffsetDateTime from, OffsetDateTime to);
+
     //만들어진 방 체크
-    boolean existsByGroupIdAndStatusIn(Long groupId, List<String> statuses);
+    boolean existsByGroupIdAndStatusIn(Long groupId, List<RoomStatus> statuses);
 
     //중복 방 방지
-    boolean existsByUserIdAndStatusIn(UUID userId, List<String> statuses);
+    boolean existsByUserIdAndStatusIn(UUID userId, List<RoomStatus> statuses);
 
     // 목록 조회용바
-    List<GameRoom> findByGroupIdAndStatusIn(Long groupId, List<String> statuses);
+    List<GameRoom> findByGroupIdAndStatusIn(Long groupId, List<RoomStatus> statuses);
     @Query("SELECT r FROM GameRoom r JOIN GameParticipant p ON p.gameRoom = r "
             + "WHERE r.groupId = :groupId AND r.status = 'FINISHED' AND p.userId = :userId "
             + "ORDER BY r.createdAt DESC")

--- a/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
@@ -14,4 +14,8 @@ public interface GameRoomRepository extends JpaRepository<GameRoom, UUID> {
 
     //중복 방 방지
     boolean existsByUserIdAndStatusIn(UUID userId, List<String> statuses);
+
+    // 목록 조회용
+    List<GameRoom> findByGroupId(Long groupId);
+    List<GameRoom> findByGroupIdAndStatus(Long groupId, String status);
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
@@ -2,6 +2,8 @@ package com.solv.wefin.domain.game.room.repository;
 
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,7 +17,12 @@ public interface GameRoomRepository extends JpaRepository<GameRoom, UUID> {
     //중복 방 방지
     boolean existsByUserIdAndStatusIn(UUID userId, List<String> statuses);
 
-    // 목록 조회용
-    List<GameRoom> findByGroupId(Long groupId);
-    List<GameRoom> findByGroupIdAndStatus(Long groupId, String status);
+    // 목록 조회용바
+    List<GameRoom> findByGroupIdAndStatusIn(Long groupId, List<String> statuses);
+    @Query("SELECT r FROM GameRoom r JOIN GameParticipant p ON p.gameRoom = r "
+            + "WHERE r.groupId = :groupId AND r.status = 'FINISHED' AND p.userId = :userId "
+            + "ORDER BY r.createdAt DESC")
+    List<GameRoom> findFinishedRoomsByGroupIdAndUserId(
+            @Param("groupId") Long groupId, @Param("userId") UUID userId);
+
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -82,14 +83,14 @@ public class GameRoomService {
         return CreateRoomResponse.from(gameRoom);
     }
 
-    public List<RoomListResponse> getRooms(Long groupId, String status) {
+    public List<RoomListResponse> getRooms(Long groupId, UUID userId) {
+        List<GameRoom> activeRooms = gameRoomRepository.findByGroupIdAndStatusIn(groupId, List.of("WAITING", "IN_PROGRESS"));
 
-        List<GameRoom> rooms;
-        if(status != null && !status.isBlank()) {
-            rooms = gameRoomRepository.findByGroupIdAndStatus(groupId, status);
-        } else {
-            rooms = gameRoomRepository.findByGroupId(groupId);
-        }
+        List<GameRoom> myFinishedRooms = gameRoomRepository.findFinishedRoomsByGroupIdAndUserId((groupId), userId);
+
+        List<GameRoom> rooms = new ArrayList<>();
+        rooms.addAll(activeRooms);
+        rooms.addAll(myFinishedRooms);
 
         return rooms.stream().map(room -> {
             int playerCount = gameParticipantRepository.countByGameRoomAndStatus(room, "ACTIVE");

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -8,6 +8,7 @@ import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +79,23 @@ public class GameRoomService {
 
         gameParticipantRepository.save(host);
 
-        return new CreateRoomResponse(gameRoom.getRoomId(), gameRoom.getStatus());
+        return CreateRoomResponse.from(gameRoom);
+    }
+
+    public List<RoomListResponse> getRooms(Long groupId, String status) {
+
+        List<GameRoom> rooms;
+        if(status != null && !status.isBlank()) {
+            rooms = gameRoomRepository.findByGroupIdAndStatus(groupId, status);
+        } else {
+            rooms = gameRoomRepository.findByGroupId(groupId);
+        }
+
+        return rooms.stream().map(room -> {
+            int playerCount = gameParticipantRepository.countByGameRoomAndStatus(room, "ACTIVE");
+            return RoomListResponse.from(room, playerCount);
+        })
+        .collect(Collectors.toList());
     }
 
 

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -1,8 +1,10 @@
 package com.solv.wefin.domain.game.room.service;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -15,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
@@ -34,17 +38,18 @@ public class GameRoomService {
     @Transactional //트랜잭션으로 방생성과 방장유저 지정 동시에 이루어짐
     public CreateRoomResponse createRoom(UUID userId, Long groupId, CreateRoomRequest request) {
         //그룹 게임방 있으면 차단
-        if (gameRoomRepository.existsByGroupIdAndStatusIn(groupId, List.of("WAITING", "IN_PROGRESS"))) {
+        List<RoomStatus> activeStatuses = List.of(RoomStatus.WAITING, RoomStatus.IN_PROGRESS);
+        if (gameRoomRepository.existsByGroupIdAndStatusIn(groupId, activeStatuses)) {
             throw new BusinessException(ErrorCode.ROOM_ALREADY_EXISTS);
         }
         // 방장 방 동시 생성 방지
-        if (gameRoomRepository.existsByUserIdAndStatusIn(userId, List.of("WAITING", "IN_PROGRESS"))) {
+        if (gameRoomRepository.existsByUserIdAndStatusIn(userId, activeStatuses)) {
             throw new BusinessException(ErrorCode.ROOM_HOST_ALREADY_EXISTS);
         }
 
             // 방장 횟수 제한 1일 1회
-        LocalDateTime todayStart = LocalDate.now().atStartOfDay();;
-        LocalDateTime todayEnd = todayStart.plusDays(1);
+        OffsetDateTime todayStart = LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime();
+        OffsetDateTime todayEnd = todayStart.plusDays(1);
 
         if(gameRoomRepository.existsByUserIdAndStartedAtBetween(userId, todayStart, todayEnd)) {
             throw new BusinessException(ErrorCode.ROOM_HOST_DAILY_LIMIT);
@@ -59,24 +64,12 @@ public class GameRoomService {
         LocalDate endDate = startDate.plusMonths(request.getPeriodMonths());
 
         //게임룸 저장
-        GameRoom gameRoom =  GameRoom.builder()
-                .groupId(groupId)
-                .userId(userId)
-                .seed(request.getSeedMoney())
-                .periodMonth(request.getPeriodMonths())
-                .moveDays(request.getMoveDays())
-                .startDate(startDate)
-                .endDate(endDate)
-                .build();
-
+        GameRoom gameRoom = GameRoom.create(groupId, userId, request.getSeedMoney(), request.getPeriodMonths(),
+                request.getMoveDays(), startDate, endDate);
         gameRoomRepository.save(gameRoom);
 
         //첫 번째 참가자 = 방장
-        GameParticipant host = GameParticipant.builder()
-                .gameRoom(gameRoom)
-                .userId(userId)
-                .isLeader(true)
-                .build();
+        GameParticipant host = GameParticipant.createLeader(gameRoom, userId);
 
         gameParticipantRepository.save(host);
 
@@ -84,19 +77,23 @@ public class GameRoomService {
     }
 
     public List<RoomListResponse> getRooms(Long groupId, UUID userId) {
-        List<GameRoom> activeRooms = gameRoomRepository.findByGroupIdAndStatusIn(groupId, List.of("WAITING", "IN_PROGRESS"));
+        //그룹 활성화된 방
+        List<RoomStatus> activeStatuses = List.of(RoomStatus.WAITING, RoomStatus.IN_PROGRESS);
+        List<GameRoom> activeRooms = gameRoomRepository.findByGroupIdAndStatusIn(groupId, activeStatuses);
 
+        // 내 과거 기록
         List<GameRoom> myFinishedRooms = gameRoomRepository.findFinishedRoomsByGroupIdAndUserId((groupId), userId);
 
         List<GameRoom> rooms = new ArrayList<>();
         rooms.addAll(activeRooms);
         rooms.addAll(myFinishedRooms);
 
+        //참가자 수 count
         return rooms.stream().map(room -> {
-            int playerCount = gameParticipantRepository.countByGameRoomAndStatus(room, "ACTIVE");
-            return RoomListResponse.from(room, playerCount);
-        })
-        .collect(Collectors.toList());
+                    int playerCount = gameParticipantRepository.countByGameRoomAndStatus(room, ParticipantStatus.ACTIVE);
+                    return RoomListResponse.from(room, playerCount);
+                })
+                .collect(Collectors.toList());
     }
 
 
@@ -122,6 +119,11 @@ gameParticipant.builder()
 
  jpa 코드로 생성된 방 있으면 추가 생성 + 방장 방 동시 생성 차단
  유니크로 2차 차단그 아
+
+ 방 목록 조회 그룹아이디 + status
+ progress , wating / finished
+
+ 과거 게임 이력 = finished + 유저아이디 ( 내 Id)
 
  */
 /**cancel room

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -22,7 +22,7 @@ public class GameRoomController {
     private final GameRoomService gameRoomService;
 
     //로그인 구현 전 묵데이터
-    private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEMP_GROUP_ID = 1L;
 
     @PostMapping
@@ -63,4 +63,6 @@ public class GameRoomController {
 조회 = get 요청
  서비스에서 그룹 id , status
  List roomListRespones
+
+ -> status는 ㄴ클라이언트가 아닌 서버에서 처리 프론트에서는 화면에 맞게 필터링 해서 사용
  */

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -4,15 +4,14 @@ import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -36,14 +35,34 @@ public class GameRoomController {
 
     }
 
+    /**
+     게임방 목록 조회
+     get /api/rooms
+     get /api/rooms?status=WAITING or in_progress or finished
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms(
+            @RequestParam(required = false) String status) {
+
+        List<RoomListResponse> response = gameRoomService.getRooms(TEMP_GROUP_ID, status);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
 
 }
 
 /**
+ 1. 방 생성 컨트롤러
  클라이언트에서 입력
  서비스 처리
  출력값 클라이언트 리턴
 
  그룹아이디, 유저아이디 묵데이터 입력 post요청
  createRoomRequest입력값 -> createRoom 서비스 출력값으로 응답 dto 클라이언트 리턴
+
+ 2. 게임방 목록 조회 컨트롤러
+그룹 방 조회 -> 상태로 필터
+조회 = get 요청
+ 서비스에서 그룹 id , status
+ List roomListRespones
  */

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -41,11 +41,9 @@ public class GameRoomController {
      get /api/rooms?status=WAITING or in_progress or finished
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms(
-            @RequestParam(required = false) String status) {
+    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms() {
 
-        List<RoomListResponse> response = gameRoomService.getRooms(TEMP_GROUP_ID, status);
-
+        List<RoomListResponse> response = gameRoomService.getRooms(TEMP_GROUP_ID, TEMP_USER_ID);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/CreateRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/CreateRoomResponse.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.web.game.room.dto.response;
 
+import com.solv.wefin.domain.game.room.entity.GameRoom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,4 +12,7 @@ public class CreateRoomResponse {
 
     private UUID roomId;
     private String status;
+    public static CreateRoomResponse from(GameRoom room) {
+        return new CreateRoomResponse(room.getRoomId(), room.getStatus());
+    }
 }

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/CreateRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/CreateRoomResponse.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.web.game.room.dto.response;
 
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -11,7 +12,7 @@ import java.util.UUID;
 public class CreateRoomResponse {
 
     private UUID roomId;
-    private String status;
+    private RoomStatus status;
     public static CreateRoomResponse from(GameRoom room) {
         return new CreateRoomResponse(room.getRoomId(), room.getStatus());
     }

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
@@ -1,11 +1,13 @@
 package com.solv.wefin.web.game.room.dto.response;
 
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Getter
@@ -19,9 +21,9 @@ public class RoomListResponse {
     private Integer moveDays;
     private LocalDate startDate;
     private LocalDate endDate;
-    private String status;
+    private RoomStatus status;
     private int currentPlayers;
-    private LocalDateTime createdAt;
+    private OffsetDateTime createdAt;
 
     public static RoomListResponse from(GameRoom room, int currentPlayers) {
         return new RoomListResponse(

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
@@ -1,0 +1,41 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class RoomListResponse {
+
+    private UUID roomId;
+    private UUID hostUserId;
+    private Long seedMoney;
+    private Integer periodMonths;
+    private Integer moveDays;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String status;
+    private int currentPlayers;
+    private LocalDateTime createdAt;
+
+    public static RoomListResponse from(GameRoom room, int currentPlayers) {
+        return new RoomListResponse(
+                room.getRoomId(),
+                room.getUserId(),
+                room.getSeed(),
+                room.getPeriodMonth(),
+                room.getMoveDays(),
+                room.getStartDate(),
+                room.getEndDate(),
+                room.getStatus(),
+                currentPlayers,
+                room.getCreatedAt()
+        );
+    }
+}
+

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -7,6 +7,7 @@ import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,12 +15,16 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -42,7 +47,11 @@ class GameRoomServiceTest {
     @Test
     @DisplayName("게임방 생성 성공 — 정상적으로 방과 참가자가 저장된다")
     void createRoom_success() {
-        // Given — 오늘 게임 시작 이력 없음
+        // Given — 그룹에 활성 방 없음, 방장 활성 방 없음, 오늘 게임 시작 이력 없음
+        given(gameRoomRepository.existsByGroupIdAndStatusIn(any(Long.class), any(List.class)))
+                .willReturn(false);
+        given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
+                .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
                 any(UUID.class), any(LocalDateTime.class), any(LocalDateTime.class)))
                 .willReturn(false);
@@ -65,7 +74,11 @@ class GameRoomServiceTest {
     @Test
     @DisplayName("게임방 생성 실패 — 방장 1일 1회 제한 위반 시 예외 발생")
     void createRoom_dailyLimitExceeded() {
-        // Given — 오늘 이미 게임 시작 이력 있음
+        // Given — 그룹/방장 활성 방 없음, 오늘 이미 게임 시작 이력 있음
+        given(gameRoomRepository.existsByGroupIdAndStatusIn(any(Long.class), any(List.class)))
+                .willReturn(false);
+        given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
+                .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
                 any(UUID.class), any(LocalDateTime.class), any(LocalDateTime.class)))
                 .willReturn(true);
@@ -86,9 +99,81 @@ class GameRoomServiceTest {
         verify(gameParticipantRepository, never()).save(any());
     }
 
+    // ===  게임방 목록 조회 테스트 ===
 
-    // 테스트용 Request 생성 헬퍼 메서드
+    @Test
+    @DisplayName("게임방 목록 조회 — status 없으면 그룹 전체 방 조회")
+    void getRooms_withoutStatus() {
+        // Given — 그룹에 방 2개 존재
+        GameRoom room1 = createGameRoom();
+        GameRoom room2 = createGameRoom();
+        given(gameRoomRepository.findByGroupId(TEST_GROUP_ID))
+                .willReturn(List.of(room1, room2));
+        given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq("ACTIVE")))
+                .willReturn(1);
+
+        // When — status 없이 조회
+        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, null);
+
+        // Then — 2개 반환
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getStatus()).isEqualTo("WAITING");
+        assertThat(result.get(0).getCurrentPlayers()).isEqualTo(1);
+
+        // findByGroupId가 호출됐는지 확인
+        verify(gameRoomRepository).findByGroupId(TEST_GROUP_ID);
+    }
+
+    @Test
+    @DisplayName("게임방 목록 조회 — status 있으면 해당 상태만 필터링")
+    void getRooms_withStatus() {
+        // Given — WAITING 방 1개
+        GameRoom room = createGameRoom();
+        given(gameRoomRepository.findByGroupIdAndStatus(TEST_GROUP_ID, "WAITING"))
+                .willReturn(List.of(room));
+        given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq("ACTIVE")))
+                .willReturn(3);
+
+        // When — status=WAITING으로 조회
+        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, "WAITING");
+
+        // Then — 1개 반환, 참가자 3명
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCurrentPlayers()).isEqualTo(3);
+
+        // findByGroupIdAndStatus가 호출됐는지 확인
+        verify(gameRoomRepository).findByGroupIdAndStatus(TEST_GROUP_ID, "WAITING");
+    }
+
+    @Test
+    @DisplayName("게임방 목록 조회 — 결과 없으면 빈 리스트 반환")
+    void getRooms_empty() {
+        // Given — 그룹에 방 없음
+        given(gameRoomRepository.findByGroupId(TEST_GROUP_ID))
+                .willReturn(Collections.emptyList());
+
+        // When
+        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, null);
+
+        // Then — 빈 리스트 (에러 아님)
+        assertThat(result).isEmpty();
+    }
+
+    // === 헬퍼 메서드 ===
+
     private CreateRoomRequest createRequest() {
         return new CreateRoomRequest(10000000L, 6, 7);
+    }
+
+    private GameRoom createGameRoom() {
+        return GameRoom.builder()
+                .groupId(TEST_GROUP_ID)
+                .userId(TEST_USER_ID)
+                .seed(10000000L)
+                .periodMonth(6)
+                .moveDays(7)
+                .startDate(LocalDate.of(2020, 1, 2))
+                .endDate(LocalDate.of(2020, 7, 2))
+                .build();
     }
 }

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -1,7 +1,9 @@
 package com.solv.wefin.domain.game.room.service;
 
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -16,7 +18,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -42,7 +44,7 @@ class GameRoomServiceTest {
     @Mock
     private GameParticipantRepository gameParticipantRepository;
 
-    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
 
     @Test
@@ -54,7 +56,7 @@ class GameRoomServiceTest {
         given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
                 .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
-                any(UUID.class), any(LocalDateTime.class), any(LocalDateTime.class)))
+                any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(false);
 
         CreateRoomRequest request = createRequest();
@@ -63,7 +65,7 @@ class GameRoomServiceTest {
         CreateRoomResponse response = gameRoomService.createRoom(TEST_USER_ID, TEST_GROUP_ID, request);
 
         // Then — 결과 검증
-        assertThat(response.getStatus()).isEqualTo("WAITING");
+        assertThat(response.getStatus()).isEqualTo(RoomStatus.WAITING);
 
         // GameRoom이 저장됐는지 확인
         verify(gameRoomRepository).save(any(GameRoom.class));
@@ -81,7 +83,7 @@ class GameRoomServiceTest {
         given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
                 .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
-                any(UUID.class), any(LocalDateTime.class), any(LocalDateTime.class)))
+                any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(true);
 
         CreateRoomRequest request = createRequest();
@@ -112,7 +114,7 @@ class GameRoomServiceTest {
                 .willReturn(List.of(activeRoom));
         given(gameRoomRepository.findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID))
                 .willReturn(List.of(finishedRoom));
-        given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq("ACTIVE")))
+        given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq(ParticipantStatus.ACTIVE)))
                 .willReturn(1);
 
         // When
@@ -148,14 +150,7 @@ class GameRoomServiceTest {
     }
 
     private GameRoom createGameRoom() {
-        return GameRoom.builder()
-                .groupId(TEST_GROUP_ID)
-                .userId(TEST_USER_ID)
-                .seed(10000000L)
-                .periodMonth(6)
-                .moveDays(7)
-                .startDate(LocalDate.of(2020, 1, 2))
-                .endDate(LocalDate.of(2020, 7, 2))
-                .build();
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,
+                6, 7, LocalDate.of(2020, 1, 2), LocalDate.of(2020, 7, 2));
     }
 }

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -99,61 +100,42 @@ class GameRoomServiceTest {
         verify(gameParticipantRepository, never()).save(any());
     }
 
-    // ===  게임방 목록 조회 테스트 ===
+    // === API 2: 게임방 목록 조회 테스트 ===
 
     @Test
-    @DisplayName("게임방 목록 조회 — status 없으면 그룹 전체 방 조회")
-    void getRooms_withoutStatus() {
-        // Given — 그룹에 방 2개 존재
-        GameRoom room1 = createGameRoom();
-        GameRoom room2 = createGameRoom();
-        given(gameRoomRepository.findByGroupId(TEST_GROUP_ID))
-                .willReturn(List.of(room1, room2));
+    @DisplayName("게임방 목록 조회 — 활성방 + 내 완료방 조회")
+    void getRooms() {
+        // Given — 활성방 1개, 내 완료방 1개
+        GameRoom activeRoom = createGameRoom();
+        GameRoom finishedRoom = createGameRoom();
+        given(gameRoomRepository.findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList()))
+                .willReturn(List.of(activeRoom));
+        given(gameRoomRepository.findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID))
+                .willReturn(List.of(finishedRoom));
         given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq("ACTIVE")))
                 .willReturn(1);
 
-        // When — status 없이 조회
-        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, null);
+        // When
+        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
 
-        // Then — 2개 반환
+        // Then — 2개 반환 (활성 1 + 완료 1)
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).getStatus()).isEqualTo("WAITING");
-        assertThat(result.get(0).getCurrentPlayers()).isEqualTo(1);
 
-        // findByGroupId가 호출됐는지 확인
-        verify(gameRoomRepository).findByGroupId(TEST_GROUP_ID);
-    }
-
-    @Test
-    @DisplayName("게임방 목록 조회 — status 있으면 해당 상태만 필터링")
-    void getRooms_withStatus() {
-        // Given — WAITING 방 1개
-        GameRoom room = createGameRoom();
-        given(gameRoomRepository.findByGroupIdAndStatus(TEST_GROUP_ID, "WAITING"))
-                .willReturn(List.of(room));
-        given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq("ACTIVE")))
-                .willReturn(3);
-
-        // When — status=WAITING으로 조회
-        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, "WAITING");
-
-        // Then — 1개 반환, 참가자 3명
-        assertThat(result).hasSize(1);
-        assertThat(result.get(0).getCurrentPlayers()).isEqualTo(3);
-
-        // findByGroupIdAndStatus가 호출됐는지 확인
-        verify(gameRoomRepository).findByGroupIdAndStatus(TEST_GROUP_ID, "WAITING");
+        verify(gameRoomRepository).findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList());
+        verify(gameRoomRepository).findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID);
     }
 
     @Test
     @DisplayName("게임방 목록 조회 — 결과 없으면 빈 리스트 반환")
     void getRooms_empty() {
-        // Given — 그룹에 방 없음
-        given(gameRoomRepository.findByGroupId(TEST_GROUP_ID))
+        // Given — 활성방 없음, 완료방 없음
+        given(gameRoomRepository.findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList()))
+                .willReturn(Collections.emptyList());
+        given(gameRoomRepository.findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID))
                 .willReturn(Collections.emptyList());
 
         // When
-        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, null);
+        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
 
         // Then — 빈 리스트 (에러 아님)
         assertThat(result).isEmpty();


### PR DESCRIPTION
## 📌 PR 설명
<br>
로비 페이지에서 방 목록을 조회할 수 있는 api
<br>

##  ✅ 완료한 기능 명세

- [x] 로비 페이지 방 목록 조회
- [x] 상태별 필터링 만들어진 방 있으면 방 만들기 버튼 비활성화, 입장하기 버튼 활성화
- [x] status를 프론트가 아닌 서버에서 처리하도록 변경

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
현재 쿼리에선 방 조회시 n+1문제 생길 수 있지만 기능 구현 완료 후 최적화 예정

<br>

### 🔗 관련 이슈
Closes #32 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게임 룸 목록 조회 API 추가 (GET /api/rooms) — 그룹의 활성 룸과 사용자의 종료된 룸을 함께 반환
  * 룸 리스트 응답에 현재 활성 플레이어 수(currentPlayers) 포함

* **리팩터**
  * 룸/참가자 상태를 문자열에서 enum으로 전환(RoomStatus, ParticipantStatus)하여 응답 일관성 강화
  * 생성/시작/생성일 타임스탬프를 OffsetDateTime으로 변경하여 시간대 신뢰성 향상
  * 생성 응답 구조를 팩토리 메서드로 통일

* **테스트**
  * 목록 조회 및 룸 생성 관련 단위 테스트 보강 (getRooms 케이스 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->