### PR TITLE
[WEF-310] 시장 지표 수집 파이프라인 구축

### DIFF
--- a/src/main/java/com/solv/wefin/domain/market/batch/MarketSnapshotScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/market/batch/MarketSnapshotScheduler.java
@@ -1,0 +1,55 @@
+package com.solv.wefin.domain.market.batch;
+
+import com.solv.wefin.domain.market.service.MarketSnapshotService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 시장 지표 수집 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarketSnapshotScheduler {
+
+    private final MarketSnapshotService marketSnapshotService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Scheduled(cron = "${market.collect.cron:0 */5 * * * *}")
+    public void collectMarketData() {
+        if (isWeekend()) {
+            log.debug("주말이므로 시장 지표 수집을 스킵합니다.");
+            return;
+        }
+
+        if (!running.compareAndSet(false, true)) {
+            log.info("시장 지표 수집이 이미 실행 중입니다. 스킵합니다.");
+            return;
+        }
+
+        log.info("=== 시장 지표 수집 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            marketSnapshotService.collectAndSave();
+        } catch (Exception e) {
+            log.error("시장 지표 수집 실패: {}", e.getMessage(), e);
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 시장 지표 수집 종료 ({}ms) ===", elapsed);
+        }
+    }
+
+    private boolean isWeekend() {
+        DayOfWeek day = LocalDate.now(ZoneId.of("Asia/Seoul")).getDayOfWeek();
+        return day == DayOfWeek.SATURDAY || day == DayOfWeek.SUNDAY;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
@@ -89,15 +89,21 @@ public class BokApiCollector implements MarketDataCollector {
             }
 
             JsonNode latest = rows.get(rows.size() - 1);
+            if (!latest.has("DATA_VALUE")) {
+                log.warn("한국은행 API 응답에 DATA_VALUE가 없습니다");
+                return Collections.emptyList();
+            }
             BigDecimal currentRate = new BigDecimal(latest.get("DATA_VALUE").asText());
 
             ChangeDirection direction = ChangeDirection.FLAT;
             BigDecimal changeValue = BigDecimal.ZERO;
             if (rows.size() >= 2) {
                 JsonNode previous = rows.get(rows.size() - 2);
-                BigDecimal previousRate = new BigDecimal(previous.get("DATA_VALUE").asText());
-                changeValue = currentRate.subtract(previousRate);
-                direction = resolveDirection(changeValue);
+                if (previous.has("DATA_VALUE")) {
+                    BigDecimal previousRate = new BigDecimal(previous.get("DATA_VALUE").asText());
+                    changeValue = currentRate.subtract(previousRate);
+                    direction = resolveDirection(changeValue);
+                }
             }
 
             CollectedMarketData data = CollectedMarketData.builder()

--- a/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
@@ -1,0 +1,135 @@
+package com.solv.wefin.domain.market.collector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.market.dto.CollectedMarketData;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.Unit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 한국은행 ECOS API에서 기준금리를 수집한다.
+ */
+@Slf4j
+@Component
+public class BokApiCollector implements MarketDataCollector {
+
+    private static final String SOURCE_NAME = "BOK"; // ECOS 기준금리 통계표 코드
+    private static final String STAT_CODE = "722Y001"; // COS 기준금리 통계표 코드기준금리 항목 코드
+    private static final String ITEM_CODE = "0101000"; // 기준금리 항목 코드
+    private static final String PERIOD_TYPE = "M"; // 월 단위 조회
+    private static final DateTimeFormatter MONTH_FORMAT = DateTimeFormatter.ofPattern("yyyyMM"); // ECOS 월 파라미터 포맷
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String baseUrl;
+
+    public BokApiCollector(@Qualifier("marketRestTemplate") RestTemplate restTemplate,
+                           ObjectMapper objectMapper,
+                           @Value("${market.bok.api-key:}") String apiKey,
+                           @Value("${market.bok.base-url:https://ecos.bok.or.kr/api}") String baseUrl) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.baseUrl = baseUrl;
+    }
+
+
+    /**
+     * 한국은행 ECOS API를 호출해 기준금리를 수집한다.
+     * 최근 2개월 데이터를 조회한 뒤 최신 값과 직전 값을 비교해 변동 방향 및 변동 값을 계산한다.
+     *
+     * @return 수집 결과가 있으면 1건의 리스트, 없으면 빈 리스트
+     */
+    @Override
+    public List<CollectedMarketData> collect() {
+        if (apiKey == null || apiKey.isBlank()) {
+            log.warn("BOK API 키가 설정되지 않아 기준금리 수집을 스킵합니다");
+            return Collections.emptyList();
+        }
+
+        try {
+            String endMonth = LocalDate.now().format(MONTH_FORMAT);
+            String startMonth = LocalDate.now().minusMonths(2).format(MONTH_FORMAT);
+
+            String url = String.format("%s/StatisticSearch/%s/json/kr/1/2/%s/%s/%s/%s/%s",
+                    baseUrl, apiKey, STAT_CODE, PERIOD_TYPE, startMonth, endMonth, ITEM_CODE);
+
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+            String body = response.getBody();
+            if (body == null || body.isBlank()) {
+                log.warn("한국은행 API 응답 body가 비어 있습니다");
+                return Collections.emptyList();
+            }
+            JsonNode root = objectMapper.readTree(body);
+
+            JsonNode statSearch = root.get("StatisticSearch");
+            if (statSearch == null) {
+                log.warn("한국은행 API 응답에 StatisticSearch가 없습니다: {}", response.getBody());
+                return Collections.emptyList();
+            }
+
+            JsonNode rows = statSearch.get("row");
+            if (rows == null || rows.isEmpty()) {
+                log.warn("한국은행 API 응답에 데이터가 없습니다");
+                return Collections.emptyList();
+            }
+
+            JsonNode latest = rows.get(rows.size() - 1);
+            BigDecimal currentRate = new BigDecimal(latest.get("DATA_VALUE").asText());
+
+            ChangeDirection direction = ChangeDirection.FLAT;
+            BigDecimal changeValue = BigDecimal.ZERO;
+            if (rows.size() >= 2) {
+                JsonNode previous = rows.get(rows.size() - 2);
+                BigDecimal previousRate = new BigDecimal(previous.get("DATA_VALUE").asText());
+                changeValue = currentRate.subtract(previousRate);
+                direction = resolveDirection(changeValue);
+            }
+
+            CollectedMarketData data = CollectedMarketData.builder()
+                    .metricType(MetricType.BASE_RATE)
+                    .label("한국 기준금리")
+                    .value(currentRate)
+                    .changeRate(BigDecimal.ZERO)
+                    .changeValue(changeValue)
+                    .unit(Unit.PERCENT)
+                    .changeDirection(direction)
+                    .build();
+
+            log.debug("기준금리 수집 완료: {}%", currentRate);
+            return List.of(data);
+        } catch (Exception e) {
+            log.error("기준금리 수집 실패: {}", e.getMessage(), e);
+            return Collections.emptyList();
+        }
+    }
+
+    @Override
+    public String getSourceName() {
+        return SOURCE_NAME;
+    }
+
+    /**
+     * 변동값의 부호에 따라 방향을 결정한다.
+     */
+    private ChangeDirection resolveDirection(BigDecimal changeValue) {
+        int cmp = changeValue.compareTo(BigDecimal.ZERO);
+        if (cmp > 0) return ChangeDirection.UP;
+        if (cmp < 0) return ChangeDirection.DOWN;
+        return ChangeDirection.FLAT;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
@@ -26,8 +26,8 @@ import java.util.List;
 @Component
 public class BokApiCollector implements MarketDataCollector {
 
-    private static final String SOURCE_NAME = "BOK"; // ECOS 기준금리 통계표 코드
-    private static final String STAT_CODE = "722Y001"; // COS 기준금리 통계표 코드기준금리 항목 코드
+    private static final String SOURCE_NAME = "BOK";
+    private static final String STAT_CODE = "722Y001"; // ECOS 기준금리 통계표 코드
     private static final String ITEM_CODE = "0101000"; // 기준금리 항목 코드
     private static final String PERIOD_TYPE = "M"; // 월 단위 조회
     private static final DateTimeFormatter MONTH_FORMAT = DateTimeFormatter.ofPattern("yyyyMM"); // ECOS 월 파라미터 포맷

--- a/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/BokApiCollector.java
@@ -129,13 +129,4 @@ public class BokApiCollector implements MarketDataCollector {
         return SOURCE_NAME;
     }
 
-    /**
-     * 변동값의 부호에 따라 방향을 결정한다.
-     */
-    private ChangeDirection resolveDirection(BigDecimal changeValue) {
-        int cmp = changeValue.compareTo(BigDecimal.ZERO);
-        if (cmp > 0) return ChangeDirection.UP;
-        if (cmp < 0) return ChangeDirection.DOWN;
-        return ChangeDirection.FLAT;
-    }
 }

--- a/src/main/java/com/solv/wefin/domain/market/collector/MarketDataCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/MarketDataCollector.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.domain.market.collector;
+
+import com.solv.wefin.domain.market.dto.CollectedMarketData;
+
+import java.util.List;
+
+/**
+ * 외부 API에서 시장 지표 데이터를 수집하는 인터페이스
+ */
+public interface MarketDataCollector {
+
+    /**
+     * 외부 API를 호출하여 시장 지표 데이터를 수집한다.
+     *
+     * @return 수집된 시장 지표 목록
+     */
+    List<CollectedMarketData> collect();
+
+    /**
+     * 데이터 소스 이름을 반환한다.
+     *
+     * @return 소스 이름 (ex. YahooFinance, BOK)
+     */
+    String getSourceName();
+}

--- a/src/main/java/com/solv/wefin/domain/market/collector/MarketDataCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/MarketDataCollector.java
@@ -1,7 +1,9 @@
 package com.solv.wefin.domain.market.collector;
 
 import com.solv.wefin.domain.market.dto.CollectedMarketData;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /**
@@ -22,4 +24,17 @@ public interface MarketDataCollector {
      * @return 소스 이름 (ex. YahooFinance, BOK)
      */
     String getSourceName();
+
+    /**
+     * 변동 값으로 변동 방향을 판단한다.
+     *
+     * @param changeValue 변동 값
+     * @return UP, DOWN, FLAT
+     */
+    default ChangeDirection resolveDirection(BigDecimal changeValue) {
+        int cmp = changeValue.compareTo(BigDecimal.ZERO);
+        if (cmp > 0) return ChangeDirection.UP;
+        if (cmp < 0) return ChangeDirection.DOWN;
+        return ChangeDirection.FLAT;
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/market/collector/YahooFinanceCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/YahooFinanceCollector.java
@@ -60,61 +60,27 @@ public class YahooFinanceCollector implements MarketDataCollector {
     }
 
     private void collectKospi(List<CollectedMarketData> results) {
-        try {
-            JsonNode meta = fetchChartMeta(KOSPI_SYMBOL);
-            if (meta == null) return;
-
-            BigDecimal price = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
-            BigDecimal previousClose = BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
-            BigDecimal changeValue = price.subtract(previousClose);
-            BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
-
-            results.add(CollectedMarketData.builder()
-                    .metricType(MetricType.KOSPI)
-                    .label("코스피")
-                    .value(price)
-                    .changeRate(changeRate)
-                    .changeValue(changeValue)
-                    .unit(Unit.POINT)
-                    .changeDirection(resolveDirection(changeValue))
-                    .build());
-
-            log.debug("KOSPI 수집 완료: {}", price);
-        } catch (Exception e) {
-            log.error("KOSPI 수집 실패: {}", e.getMessage(), e);
-        }
+        collectSymbol(results, KOSPI_SYMBOL, MetricType.KOSPI, "코스피", Unit.POINT);
     }
 
     private void collectNasdaq(List<CollectedMarketData> results) {
-        try {
-            JsonNode meta = fetchChartMeta(NASDAQ_SYMBOL);
-            if (meta == null) return;
-
-            BigDecimal price = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
-            BigDecimal previousClose = BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
-            BigDecimal changeValue = price.subtract(previousClose);
-            BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
-
-            results.add(CollectedMarketData.builder()
-                    .metricType(MetricType.NASDAQ)
-                    .label("나스닥")
-                    .value(price)
-                    .changeRate(changeRate)
-                    .changeValue(changeValue)
-                    .unit(Unit.POINT)
-                    .changeDirection(resolveDirection(changeValue))
-                    .build());
-
-            log.debug("NASDAQ 수집 완료: {}", price);
-        } catch (Exception e) {
-            log.error("NASDAQ 수집 실패: {}", e.getMessage(), e);
-        }
+        collectSymbol(results, NASDAQ_SYMBOL, MetricType.NASDAQ, "나스닥", Unit.POINT);
     }
 
     private void collectUsdKrw(List<CollectedMarketData> results) {
+        collectSymbol(results, USD_KRW_SYMBOL, MetricType.USD_KRW, "원/달러 환율", Unit.KRW);
+    }
+
+    private void collectSymbol(List<CollectedMarketData> results, String symbol,
+                                MetricType metricType, String label, Unit unit) {
         try {
-            JsonNode meta = fetchChartMeta(USD_KRW_SYMBOL);
+            JsonNode meta = fetchChartMeta(symbol);
             if (meta == null) return;
+
+            if (!meta.has("regularMarketPrice") || !meta.has("chartPreviousClose")) {
+                log.warn("{} 응답에 필수 필드가 없습니다: {}", symbol, meta);
+                return;
+            }
 
             BigDecimal price = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
             BigDecimal previousClose = BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
@@ -122,18 +88,18 @@ public class YahooFinanceCollector implements MarketDataCollector {
             BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
 
             results.add(CollectedMarketData.builder()
-                    .metricType(MetricType.USD_KRW)
-                    .label("원/달러 환율")
+                    .metricType(metricType)
+                    .label(label)
                     .value(price)
                     .changeRate(changeRate)
                     .changeValue(changeValue)
-                    .unit(Unit.KRW)
+                    .unit(unit)
                     .changeDirection(resolveDirection(changeValue))
                     .build());
 
-            log.debug("USD/KRW 수집 완료: {}", price);
+            log.debug("{} 수집 완료: {}", symbol, price);
         } catch (Exception e) {
-            log.error("USD/KRW 수집 실패: {}", e.getMessage(), e);
+            log.error("{} 수집 실패: {}", symbol, e.getMessage(), e);
         }
     }
 
@@ -167,7 +133,12 @@ public class YahooFinanceCollector implements MarketDataCollector {
                 return null;
             }
 
-            return results.get(0).get("meta");
+            JsonNode meta = results.path(0).path("meta");
+            if (meta.isMissingNode()) {
+                log.warn("Yahoo Finance {} 응답에 meta가 없습니다", symbol);
+                return null;
+            }
+            return meta;
         } catch (Exception e) {
             log.error("Yahoo Finance {} 응답 파싱 실패: {}", symbol, e.getMessage(), e);
             return null;

--- a/src/main/java/com/solv/wefin/domain/market/collector/YahooFinanceCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/YahooFinanceCollector.java
@@ -154,10 +154,4 @@ public class YahooFinanceCollector implements MarketDataCollector {
                 .setScale(2, RoundingMode.HALF_UP);
     }
 
-    private ChangeDirection resolveDirection(BigDecimal changeValue) {
-        int cmp = changeValue.compareTo(BigDecimal.ZERO);
-        if (cmp > 0) return ChangeDirection.UP;
-        if (cmp < 0) return ChangeDirection.DOWN;
-        return ChangeDirection.FLAT;
-    }
 }

--- a/src/main/java/com/solv/wefin/domain/market/collector/YahooFinanceCollector.java
+++ b/src/main/java/com/solv/wefin/domain/market/collector/YahooFinanceCollector.java
@@ -1,0 +1,192 @@
+package com.solv.wefin.domain.market.collector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.market.dto.CollectedMarketData;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.Unit;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Yahoo Finance API에서 NASDAQ Composite 지수와 USD/KRW 환율을 수집한다.
+ */
+@Slf4j
+@Component
+public class YahooFinanceCollector implements MarketDataCollector {
+
+    private static final String SOURCE_NAME = "YahooFinance";
+    private static final String BASE_URL = "https://query1.finance.yahoo.com/v8/finance/chart";
+    private static final String KOSPI_SYMBOL = "^KS11";
+    private static final String NASDAQ_SYMBOL = "^IXIC";
+    private static final String USD_KRW_SYMBOL = "KRW=X";
+    private static final String USER_AGENT = "Mozilla/5.0 (compatible; WefinBot/1.0)";
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public YahooFinanceCollector(@Qualifier("marketRestTemplate") RestTemplate restTemplate,
+                                 ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<CollectedMarketData> collect() {
+        List<CollectedMarketData> results = new ArrayList<>();
+
+        collectKospi(results);
+        collectNasdaq(results);
+        collectUsdKrw(results);
+
+        return results;
+    }
+
+    @Override
+    public String getSourceName() {
+        return SOURCE_NAME;
+    }
+
+    private void collectKospi(List<CollectedMarketData> results) {
+        try {
+            JsonNode meta = fetchChartMeta(KOSPI_SYMBOL);
+            if (meta == null) return;
+
+            BigDecimal price = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
+            BigDecimal previousClose = BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
+            BigDecimal changeValue = price.subtract(previousClose);
+            BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
+
+            results.add(CollectedMarketData.builder()
+                    .metricType(MetricType.KOSPI)
+                    .label("코스피")
+                    .value(price)
+                    .changeRate(changeRate)
+                    .changeValue(changeValue)
+                    .unit(Unit.POINT)
+                    .changeDirection(resolveDirection(changeValue))
+                    .build());
+
+            log.debug("KOSPI 수집 완료: {}", price);
+        } catch (Exception e) {
+            log.error("KOSPI 수집 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private void collectNasdaq(List<CollectedMarketData> results) {
+        try {
+            JsonNode meta = fetchChartMeta(NASDAQ_SYMBOL);
+            if (meta == null) return;
+
+            BigDecimal price = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
+            BigDecimal previousClose = BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
+            BigDecimal changeValue = price.subtract(previousClose);
+            BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
+
+            results.add(CollectedMarketData.builder()
+                    .metricType(MetricType.NASDAQ)
+                    .label("나스닥")
+                    .value(price)
+                    .changeRate(changeRate)
+                    .changeValue(changeValue)
+                    .unit(Unit.POINT)
+                    .changeDirection(resolveDirection(changeValue))
+                    .build());
+
+            log.debug("NASDAQ 수집 완료: {}", price);
+        } catch (Exception e) {
+            log.error("NASDAQ 수집 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    private void collectUsdKrw(List<CollectedMarketData> results) {
+        try {
+            JsonNode meta = fetchChartMeta(USD_KRW_SYMBOL);
+            if (meta == null) return;
+
+            BigDecimal price = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
+            BigDecimal previousClose = BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
+            BigDecimal changeValue = price.subtract(previousClose);
+            BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
+
+            results.add(CollectedMarketData.builder()
+                    .metricType(MetricType.USD_KRW)
+                    .label("원/달러 환율")
+                    .value(price)
+                    .changeRate(changeRate)
+                    .changeValue(changeValue)
+                    .unit(Unit.KRW)
+                    .changeDirection(resolveDirection(changeValue))
+                    .build());
+
+            log.debug("USD/KRW 수집 완료: {}", price);
+        } catch (Exception e) {
+            log.error("USD/KRW 수집 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Yahoo Finance chart API를 호출하여 meta 정보를 반환한다.
+     *
+     * @param symbol Yahoo Finance 심볼 (ex. ^IXIC, KRW=X)
+     * @return meta JSON 노드, 실패 시 null
+     */
+    private JsonNode fetchChartMeta(String symbol) {
+        String url = BASE_URL + "/" + symbol + "?interval=1d&range=2d";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("User-Agent", USER_AGENT);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                url, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+        String body = response.getBody();
+        if (body == null || body.isBlank()) {
+            log.warn("Yahoo Finance {} 응답 body가 비어 있습니다", symbol);
+            return null;
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode results = root.path("chart").path("result");
+
+            if (results.isMissingNode() || results.isEmpty()) {
+                log.warn("Yahoo Finance {} 응답에 데이터가 없습니다", symbol);
+                return null;
+            }
+
+            return results.get(0).get("meta");
+        } catch (Exception e) {
+            log.error("Yahoo Finance {} 응답 파싱 실패: {}", symbol, e.getMessage(), e);
+            return null;
+        }
+    }
+
+    private BigDecimal calculateChangeRate(BigDecimal changeValue, BigDecimal previousClose) {
+        if (previousClose.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return changeValue.divide(previousClose, 4, RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"))
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private ChangeDirection resolveDirection(BigDecimal changeValue) {
+        int cmp = changeValue.compareTo(BigDecimal.ZERO);
+        if (cmp > 0) return ChangeDirection.UP;
+        if (cmp < 0) return ChangeDirection.DOWN;
+        return ChangeDirection.FLAT;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/config/MarketConfig.java
+++ b/src/main/java/com/solv/wefin/domain/market/config/MarketConfig.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.domain.market.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class MarketConfig {
+
+    @Bean
+    public RestTemplate marketRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(10000);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/dto/CollectedMarketData.java
+++ b/src/main/java/com/solv/wefin/domain/market/dto/CollectedMarketData.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.domain.market.dto;
+
+import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.Unit;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+/**
+ * 시장 지표 데이터 DTO
+ */
+@Getter
+@Builder
+public class CollectedMarketData {
+
+    private final MetricType metricType; // 지표 타입
+    private final String label; // 화면 표시 이름
+    private final BigDecimal value; // 현재 값
+    private final BigDecimal changeRate; // 전일 대비 변동률
+    private final BigDecimal changeValue; // 전일 대비 변동 값
+    private final Unit unit; // 단위
+    private final ChangeDirection changeDirection; // 변동 방향
+}

--- a/src/main/java/com/solv/wefin/domain/market/entity/MarketSnapshot.java
+++ b/src/main/java/com/solv/wefin/domain/market/entity/MarketSnapshot.java
@@ -1,0 +1,90 @@
+package com.solv.wefin.domain.market.entity;
+
+import com.solv.wefin.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * 시장 지표 스냅샷 엔티티
+ */
+@Entity
+@Table(name = "market_snapshot")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MarketSnapshot extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "market_snapshot_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "metric_type", nullable = false, length = 30)
+    private MetricType metricType;
+
+    @Column(name = "label", nullable = false, length = 100)
+    private String label;
+
+    @Column(name = "value", nullable = false, precision = 18, scale = 4)
+    private BigDecimal value;
+
+    @Column(name = "change_rate", precision = 10, scale = 4)
+    private BigDecimal changeRate;
+
+    @Column(name = "change_value", precision = 18, scale = 4)
+    private BigDecimal changeValue;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "unit", nullable = false, length = 20)
+    private Unit unit;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "change_direction", nullable = false, length = 20)
+    private ChangeDirection changeDirection;
+
+    @Builder
+    public MarketSnapshot(MetricType metricType, String label, BigDecimal value,
+                          BigDecimal changeRate, BigDecimal changeValue,
+                          Unit unit, ChangeDirection changeDirection) {
+        this.metricType = metricType;
+        this.label = label;
+        this.value = value;
+        this.changeRate = changeRate;
+        this.changeValue = changeValue;
+        this.unit = unit;
+        this.changeDirection = changeDirection;
+    }
+
+    /**
+     * 시장 지표 수치를 최신 값으로 갱신한다.
+     *
+     * @param value 현재 값
+     * @param changeRate 전일 대비 변동률
+     * @param changeValue 전일 대비 변동 값
+     * @param changeDirection 변동 방향
+     */
+    public void updateValues(BigDecimal value, BigDecimal changeRate,
+                             BigDecimal changeValue, ChangeDirection changeDirection) {
+        this.value = value;
+        this.changeRate = changeRate;
+        this.changeValue = changeValue;
+        this.changeDirection = changeDirection;
+    }
+
+    public enum MetricType {
+        KOSPI, NASDAQ, BASE_RATE, USD_KRW
+    }
+
+    public enum Unit {
+        POINT, PERCENT, KRW
+    }
+
+    public enum ChangeDirection {
+        UP, DOWN, FLAT
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/repository/MarketSnapshotRepository.java
+++ b/src/main/java/com/solv/wefin/domain/market/repository/MarketSnapshotRepository.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.domain.market.repository;
+
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MarketSnapshotRepository extends JpaRepository<MarketSnapshot, Long> {
+
+    /**
+     * 지표 타입으로 스냅샷을 조회한다.
+     *
+     * @param metricType 조회할 지표 타입
+     * @return 해당 지표의 스냅샷
+     */
+    Optional<MarketSnapshot> findByMetricType(MetricType metricType);
+}

--- a/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotPersistenceService.java
@@ -1,0 +1,62 @@
+package com.solv.wefin.domain.market.service;
+
+import com.solv.wefin.domain.market.dto.CollectedMarketData;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 시장 지표 스냅샷의 DB 저장을 담당한다.
+ *MarketSnapshotService에서 외부 API 호출과 트랜잭션을 분리하기 위해
+ * self-invocation 방지 목적으로 별도 서비스로 분리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketSnapshotPersistenceService {
+
+    private final MarketSnapshotRepository marketSnapshotRepository;
+
+    /**
+     * 수집된 시장 지표를 DB에 upsert한다.
+     *
+     * @param allData 수집된 시장 지표 목록
+     */
+    @Transactional
+    public void saveSnapshots(List<CollectedMarketData> allData) {
+        for (CollectedMarketData data : allData) {
+            upsertSnapshot(data);
+        }
+        log.info("시장 지표 upsert 완료: {}건", allData.size());
+    }
+
+    private void upsertSnapshot(CollectedMarketData data) {
+        MarketSnapshot snapshot = marketSnapshotRepository
+                .findByMetricType(data.getMetricType())
+                .orElse(null);
+
+        if (snapshot != null) {
+            snapshot.updateValues(
+                    data.getValue(),
+                    data.getChangeRate(),
+                    data.getChangeValue(),
+                    data.getChangeDirection());
+        } else {
+            snapshot = MarketSnapshot.builder()
+                    .metricType(data.getMetricType())
+                    .label(data.getLabel())
+                    .value(data.getValue())
+                    .changeRate(data.getChangeRate())
+                    .changeValue(data.getChangeValue())
+                    .unit(data.getUnit())
+                    .changeDirection(data.getChangeDirection())
+                    .build();
+            marketSnapshotRepository.save(snapshot);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotService.java
+++ b/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotService.java
@@ -1,0 +1,85 @@
+package com.solv.wefin.domain.market.service;
+
+import com.solv.wefin.domain.market.collector.MarketDataCollector;
+import com.solv.wefin.domain.market.dto.CollectedMarketData;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 시장 지표 수집 전체 흐름을 관리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketSnapshotService {
+
+    private final List<MarketDataCollector> collectors;
+    private final MarketSnapshotRepository marketSnapshotRepository;
+
+    /**
+     * 모든 수집기에서 데이터를 수집하고 DB에 upsert한다.
+     */
+    @Transactional
+    public void collectAndSave() {
+        List<CollectedMarketData> allData = collectFromAllSources();
+
+        if (allData.isEmpty()) {
+            log.warn("수집된 시장 지표가 없습니다");
+            return;
+        }
+
+        for (CollectedMarketData data : allData) {
+            upsertSnapshot(data);
+        }
+
+        log.info("시장 지표 upsert 완료: {}건", allData.size());
+    }
+
+    private List<CollectedMarketData> collectFromAllSources() {
+        List<CollectedMarketData> allData = new ArrayList<>();
+
+        for (MarketDataCollector collector : collectors) {
+            try {
+                List<CollectedMarketData> collected = collector.collect();
+                allData.addAll(collected);
+                log.info("{} 수집 완료: {}건", collector.getSourceName(), collected.size());
+            } catch (Exception e) {
+                log.error("{} 수집 실패: {}", collector.getSourceName(), e.getMessage(), e);
+            }
+        }
+
+        return allData;
+    }
+
+    private void upsertSnapshot(CollectedMarketData data) {
+        MarketSnapshot snapshot = marketSnapshotRepository
+                .findByMetricType(data.getMetricType())
+                .orElse(null);
+
+        if (snapshot != null) {
+            snapshot.updateValues(
+                    data.getValue(),
+                    data.getChangeRate(),
+                    data.getChangeValue(),
+                    data.getChangeDirection());
+        } else {
+            snapshot = MarketSnapshot.builder()
+                    .metricType(data.getMetricType())
+                    .label(data.getLabel())
+                    .value(data.getValue())
+                    .changeRate(data.getChangeRate())
+                    .changeValue(data.getChangeValue())
+                    .unit(data.getUnit())
+                    .changeDirection(data.getChangeDirection())
+                    .build();
+            marketSnapshotRepository.save(snapshot);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotService.java
+++ b/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotService.java
@@ -21,6 +21,7 @@ import java.util.List;
 public class MarketSnapshotService {
 
     private final List<MarketDataCollector> collectors;
+    private final MarketSnapshotPersistenceService persistenceService;
     private final MarketSnapshotRepository marketSnapshotRepository;
 
     /**
@@ -35,8 +36,10 @@ public class MarketSnapshotService {
 
     /**
      * 모든 수집기에서 데이터를 수집하고 DB에 upsert한다.
+     *
+     * <p>외부 API 호출은 트랜잭션 밖에서 수행하고,
+     * DB 저장은 별도 서비스(MarketSnapshotPersistenceService)에서 트랜잭션으로 처리한다.</p>
      */
-    @Transactional
     public void collectAndSave() {
         List<CollectedMarketData> allData = collectFromAllSources();
 
@@ -45,11 +48,7 @@ public class MarketSnapshotService {
             return;
         }
 
-        for (CollectedMarketData data : allData) {
-            upsertSnapshot(data);
-        }
-
-        log.info("시장 지표 upsert 완료: {}건", allData.size());
+        persistenceService.saveSnapshots(allData);
     }
 
     private List<CollectedMarketData> collectFromAllSources() {
@@ -66,30 +65,5 @@ public class MarketSnapshotService {
         }
 
         return allData;
-    }
-
-    private void upsertSnapshot(CollectedMarketData data) {
-        MarketSnapshot snapshot = marketSnapshotRepository
-                .findByMetricType(data.getMetricType())
-                .orElse(null);
-
-        if (snapshot != null) {
-            snapshot.updateValues(
-                    data.getValue(),
-                    data.getChangeRate(),
-                    data.getChangeValue(),
-                    data.getChangeDirection());
-        } else {
-            snapshot = MarketSnapshot.builder()
-                    .metricType(data.getMetricType())
-                    .label(data.getLabel())
-                    .value(data.getValue())
-                    .changeRate(data.getChangeRate())
-                    .changeValue(data.getChangeValue())
-                    .unit(data.getUnit())
-                    .changeDirection(data.getChangeDirection())
-                    .build();
-            marketSnapshotRepository.save(snapshot);
-        }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotService.java
+++ b/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotService.java
@@ -24,6 +24,16 @@ public class MarketSnapshotService {
     private final MarketSnapshotRepository marketSnapshotRepository;
 
     /**
+     * 저장된 모든 시장 지표 스냅샷을 조회한다.
+     *
+     * @return 전체 스냅샷 목록
+     */
+    @Transactional(readOnly = true)
+    public List<MarketSnapshot> getAllSnapshots() {
+        return marketSnapshotRepository.findAll();
+    }
+
+    /**
      * 모든 수집기에서 데이터를 수집하고 DB에 upsert한다.
      */
     @Transactional

--- a/src/main/java/com/solv/wefin/web/market/MarketAdminController.java
+++ b/src/main/java/com/solv/wefin/web/market/MarketAdminController.java
@@ -1,0 +1,27 @@
+package com.solv.wefin.web.market;
+
+import com.solv.wefin.domain.market.service.MarketSnapshotService;
+import com.solv.wefin.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("local")
+@RestController
+@RequestMapping("/api/admin/market")
+@RequiredArgsConstructor
+public class MarketAdminController {
+
+    private final MarketSnapshotService marketSnapshotService;
+
+    /**
+     * 시장 지표를 수동으로 수집한다.
+     */
+    @PostMapping("/collect")
+    public ApiResponse<String> collectNow() {
+        marketSnapshotService.collectAndSave();
+        return ApiResponse.success("시장 지표 수집 완료");
+    }
+}

--- a/src/main/java/com/solv/wefin/web/market/MarketAdminController.java
+++ b/src/main/java/com/solv/wefin/web/market/MarketAdminController.java
@@ -2,19 +2,35 @@ package com.solv.wefin.web.market;
 
 import com.solv.wefin.domain.market.service.MarketSnapshotService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.market.dto.response.MarketSnapshotResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile("local")
+import java.util.List;
+
+@Profile({"local", "dev"})
 @RestController
 @RequestMapping("/api/admin/market")
 @RequiredArgsConstructor
 public class MarketAdminController {
 
     private final MarketSnapshotService marketSnapshotService;
+
+    /**
+     * 저장된 시장 지표 스냅샷 전체를 조회한다.
+     */
+    @GetMapping("/snapshots")
+    public ApiResponse<List<MarketSnapshotResponse>> getSnapshots() {
+        List<MarketSnapshotResponse> snapshots = marketSnapshotService.getAllSnapshots()
+                .stream()
+                .map(MarketSnapshotResponse::from)
+                .toList();
+        return ApiResponse.success(snapshots);
+    }
 
     /**
      * 시장 지표를 수동으로 수집한다.

--- a/src/main/java/com/solv/wefin/web/market/dto/response/MarketSnapshotResponse.java
+++ b/src/main/java/com/solv/wefin/web/market/dto/response/MarketSnapshotResponse.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.web.market.dto.response;
+
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class MarketSnapshotResponse {
+
+    private final String metricType;
+    private final String label;
+    private final BigDecimal value;
+    private final BigDecimal changeRate;
+    private final BigDecimal changeValue;
+    private final String unit;
+    private final String changeDirection;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+
+    public static MarketSnapshotResponse from(MarketSnapshot snapshot) {
+        return MarketSnapshotResponse.builder()
+                .metricType(snapshot.getMetricType().name())
+                .label(snapshot.getLabel())
+                .value(snapshot.getValue())
+                .changeRate(snapshot.getChangeRate())
+                .changeValue(snapshot.getChangeValue())
+                .unit(snapshot.getUnit().name())
+                .changeDirection(snapshot.getChangeDirection().name())
+                .createdAt(snapshot.getCreatedAt())
+                .updatedAt(snapshot.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile("local")
+@Profile({"local", "dev"})
 @RestController
 @RequestMapping("/api/admin/news")
 @RequiredArgsConstructor

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,6 +35,13 @@ news:
 server:
   forward-headers-strategy: native
 
+market:
+  bok:
+    api-key: ${BOK_API_KEY:}
+    base-url: ${BOK_BASE_URL:https://ecos.bok.or.kr/api}
+  collect:
+    cron: "0 */5 * * * *"
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -36,6 +36,13 @@ news:
   collect:
     cron: "0 0 */2 * * *"
 
+market:
+  bok:
+    api-key: ${BOK_API_KEY:}
+    base-url: ${BOK_BASE_URL:https://ecos.bok.or.kr/api}
+  collect:
+    cron: "0 */5 * * * *"
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -32,6 +32,13 @@ news:
 server:
   forward-headers-strategy: native
 
+market:
+  bok:
+    api-key: ${BOK_API_KEY:}
+    base-url: ${BOK_BASE_URL:https://ecos.bok.or.kr/api}
+  collect:
+    cron: "0 */5 * * * *"
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/main/resources/db/migration/V6__decouple_market_snapshot_from_trend.sql
+++ b/src/main/resources/db/migration/V6__decouple_market_snapshot_from_trend.sql
@@ -1,0 +1,30 @@
+-- market_snapshot을 market_trend에서 분리
+-- 수집 단계에서는 MarketSnapshot을 독립 저장
+-- MarketTrend는 세션별 요약/인사이트 그룹 용도로만 사용
+
+-- 기존 FK 제약조건 제거
+ALTER TABLE "market_snapshot"
+    DROP CONSTRAINT IF EXISTS "FK_market_trend_TO_market_snapshot_1";
+
+-- 기존 unique 제약조건 제거 (market_trend_id 포함)
+ALTER TABLE "market_snapshot"
+    DROP CONSTRAINT IF EXISTS "uk_market_snapshot_metric_type";
+
+ALTER TABLE "market_snapshot"
+    DROP CONSTRAINT IF EXISTS "uk_market_snapshot_display_order";
+
+-- market_trend_id 컬럼 제거
+ALTER TABLE "market_snapshot"
+    DROP COLUMN "market_trend_id";
+
+-- metric_type 단독 unique 제약조건 추가 (지표별 최신 값 1건 유지)
+ALTER TABLE "market_snapshot"
+    ADD CONSTRAINT "uk_market_snapshot_metric_type" UNIQUE ("metric_type");
+
+-- display_order 컬럼 제거 (화면 순서는 프론트에서 metricType으로 결정)
+ALTER TABLE "market_snapshot"
+    DROP COLUMN "display_order";
+
+-- updated_at 컬럼 추가
+ALTER TABLE "market_snapshot"
+    ADD COLUMN "updated_at" TIMESTAMPTZ;

--- a/src/main/resources/db/migration/V6__decouple_market_snapshot_from_trend.sql
+++ b/src/main/resources/db/migration/V6__decouple_market_snapshot_from_trend.sql
@@ -17,6 +17,12 @@ ALTER TABLE "market_snapshot"
 ALTER TABLE "market_snapshot"
     DROP COLUMN "market_trend_id";
 
+-- metric_type별 중복 데이터 정리 (최신 1건만 보존)
+DELETE FROM "market_snapshot" a
+    USING "market_snapshot" b
+WHERE a.market_snapshot_id < b.market_snapshot_id
+  AND a.metric_type = b.metric_type;
+
 -- metric_type 단독 unique 제약조건 추가 (지표별 최신 값 1건 유지)
 ALTER TABLE "market_snapshot"
     ADD CONSTRAINT "uk_market_snapshot_metric_type" UNIQUE ("metric_type");

--- a/src/test/java/com/solv/wefin/domain/market/repository/MarketSnapshotRepositoryIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/repository/MarketSnapshotRepositoryIntegrationTest.java
@@ -1,0 +1,113 @@
+package com.solv.wefin.domain.market.repository;
+
+import com.solv.wefin.common.IntegrationTestBase;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.Unit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MarketSnapshotRepositoryIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MarketSnapshotRepository marketSnapshotRepository;
+
+    @Test
+    @DisplayName("MarketSnapshot INSERT — 신규 지표가 정상 저장된다")
+    void insert_snapshot() {
+        // Given
+        MarketSnapshot snapshot = MarketSnapshot.builder()
+                .metricType(MetricType.NASDAQ)
+                .label("나스닥")
+                .value(new BigDecimal("20948.3600"))
+                .changeRate(new BigDecimal("-4.47"))
+                .changeValue(new BigDecimal("-981.4600"))
+                .unit(Unit.POINT)
+                .changeDirection(ChangeDirection.DOWN)
+                .build();
+
+        // When
+        marketSnapshotRepository.save(snapshot);
+
+        // Then
+        Optional<MarketSnapshot> found = marketSnapshotRepository.findByMetricType(MetricType.NASDAQ);
+        assertThat(found).isPresent();
+        assertThat(found.get().getValue()).isEqualByComparingTo("20948.36");
+        assertThat(found.get().getLabel()).isEqualTo("나스닥");
+        assertThat(found.get().getChangeDirection()).isEqualTo(ChangeDirection.DOWN);
+    }
+
+    @Test
+    @DisplayName("MarketSnapshot UPDATE — 기존 지표가 최신 값으로 갱신된다")
+    void upsert_snapshot() {
+        // Given — 기존 데이터 저장
+        MarketSnapshot snapshot = MarketSnapshot.builder()
+                .metricType(MetricType.USD_KRW)
+                .label("원/달러 환율")
+                .value(new BigDecimal("1500.0000"))
+                .changeRate(new BigDecimal("0.50"))
+                .changeValue(new BigDecimal("7.0000"))
+                .unit(Unit.KRW)
+                .changeDirection(ChangeDirection.UP)
+                .build();
+        marketSnapshotRepository.save(snapshot);
+
+        // When — 값 갱신
+        MarketSnapshot existing = marketSnapshotRepository
+                .findByMetricType(MetricType.USD_KRW).orElseThrow();
+        existing.updateValues(
+                new BigDecimal("1508.0000"),
+                new BigDecimal("1.03"),
+                new BigDecimal("15.0000"),
+                ChangeDirection.UP);
+        marketSnapshotRepository.flush();
+
+        // Then
+        MarketSnapshot updated = marketSnapshotRepository
+                .findByMetricType(MetricType.USD_KRW).orElseThrow();
+        assertThat(updated.getValue()).isEqualByComparingTo("1508.00");
+        assertThat(updated.getChangeRate()).isEqualByComparingTo("1.03");
+        assertThat(updated.getChangeValue()).isEqualByComparingTo("15.00");
+    }
+
+    @Test
+    @DisplayName("metric_type unique 제약 — 동일 지표 타입 중복 INSERT 시 예외 발생")
+    void unique_constraint() {
+        // Given
+        MarketSnapshot first = MarketSnapshot.builder()
+                .metricType(MetricType.KOSPI)
+                .label("코스피")
+                .value(new BigDecimal("2700.0000"))
+                .changeRate(BigDecimal.ZERO)
+                .changeValue(BigDecimal.ZERO)
+                .unit(Unit.POINT)
+                .changeDirection(ChangeDirection.FLAT)
+                .build();
+        marketSnapshotRepository.save(first);
+        marketSnapshotRepository.flush();
+
+        // When & Then
+        MarketSnapshot duplicate = MarketSnapshot.builder()
+                .metricType(MetricType.KOSPI)
+                .label("코스피")
+                .value(new BigDecimal("2750.0000"))
+                .changeRate(BigDecimal.ZERO)
+                .changeValue(BigDecimal.ZERO)
+                .unit(Unit.POINT)
+                .changeDirection(ChangeDirection.FLAT)
+                .build();
+
+        assertThatThrownBy(() -> {
+            marketSnapshotRepository.save(duplicate);
+            marketSnapshotRepository.flush();
+        }).isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/market/service/MarketSnapshotServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/service/MarketSnapshotServiceTest.java
@@ -2,7 +2,6 @@ package com.solv.wefin.domain.market.service;
 
 import com.solv.wefin.domain.market.collector.MarketDataCollector;
 import com.solv.wefin.domain.market.dto.CollectedMarketData;
-import com.solv.wefin.domain.market.entity.MarketSnapshot;
 import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
 import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
 import com.solv.wefin.domain.market.entity.MarketSnapshot.Unit;
@@ -15,9 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -25,6 +24,9 @@ import static org.mockito.Mockito.*;
 class MarketSnapshotServiceTest {
 
     private MarketSnapshotService marketSnapshotService;
+
+    @Mock
+    private MarketSnapshotPersistenceService persistenceService;
 
     @Mock
     private MarketSnapshotRepository marketSnapshotRepository;
@@ -36,72 +38,39 @@ class MarketSnapshotServiceTest {
     private MarketDataCollector bokCollector;
 
     @Test
-    @DisplayName("수집 성공 — 신규 지표는 INSERT된다")
-    void collectAndSave_insert() {
+    @DisplayName("수집 성공 — persistenceService에 저장을 위임한다")
+    void collectAndSave_success() {
         // Given
         marketSnapshotService = new MarketSnapshotService(
-                List.of(yahooCollector), marketSnapshotRepository);
+                List.of(yahooCollector), persistenceService, marketSnapshotRepository);
 
         given(yahooCollector.collect()).willReturn(List.of(createNasdaqData()));
         given(yahooCollector.getSourceName()).willReturn("YahooFinance");
-        given(marketSnapshotRepository.findByMetricType(MetricType.NASDAQ))
-                .willReturn(Optional.empty());
 
         // When
         marketSnapshotService.collectAndSave();
 
         // Then
-        verify(marketSnapshotRepository).save(any(MarketSnapshot.class));
+        verify(persistenceService).saveSnapshots(anyList());
     }
 
     @Test
-    @DisplayName("수집 성공 — 기존 지표는 UPDATE된다")
-    void collectAndSave_update() {
-        // Given
-        marketSnapshotService = new MarketSnapshotService(
-                List.of(yahooCollector), marketSnapshotRepository);
-
-        MarketSnapshot existing = MarketSnapshot.builder()
-                .metricType(MetricType.NASDAQ)
-                .label("나스닥")
-                .value(new BigDecimal("20000"))
-                .changeRate(BigDecimal.ZERO)
-                .changeValue(BigDecimal.ZERO)
-                .unit(Unit.POINT)
-                .changeDirection(ChangeDirection.FLAT)
-                .build();
-
-        given(yahooCollector.collect()).willReturn(List.of(createNasdaqData()));
-        given(yahooCollector.getSourceName()).willReturn("YahooFinance");
-        given(marketSnapshotRepository.findByMetricType(MetricType.NASDAQ))
-                .willReturn(Optional.of(existing));
-
-        // When
-        marketSnapshotService.collectAndSave();
-
-        // Then — UPDATE이므로 save를 호출하지 않는다.
-        verify(marketSnapshotRepository, never()).save(any(MarketSnapshot.class));
-    }
-
-    @Test
-    @DisplayName("부분 실패 — 한 수집기 실패해도 다른 수집기는 정상 동작한다")
+    @DisplayName("부분 실패 — 한 수집기 실패해도 다른 수집기 결과는 저장된다")
     void collectAndSave_partialFailure() {
         // Given
         marketSnapshotService = new MarketSnapshotService(
-                List.of(yahooCollector, bokCollector), marketSnapshotRepository);
+                List.of(yahooCollector, bokCollector), persistenceService, marketSnapshotRepository);
 
         given(yahooCollector.collect()).willThrow(new RuntimeException("Yahoo 장애"));
         given(yahooCollector.getSourceName()).willReturn("YahooFinance");
         given(bokCollector.collect()).willReturn(List.of(createBaseRateData()));
         given(bokCollector.getSourceName()).willReturn("BOK");
-        given(marketSnapshotRepository.findByMetricType(MetricType.BASE_RATE))
-                .willReturn(Optional.empty());
 
         // When
         marketSnapshotService.collectAndSave();
 
-        // Then — BOK 데이터만 저장
-        verify(marketSnapshotRepository).save(any(MarketSnapshot.class));
+        // Then — BOK 데이터만 저장 위임
+        verify(persistenceService).saveSnapshots(anyList());
     }
 
     @Test
@@ -109,7 +78,7 @@ class MarketSnapshotServiceTest {
     void collectAndSave_allFailure() {
         // Given
         marketSnapshotService = new MarketSnapshotService(
-                List.of(yahooCollector, bokCollector), marketSnapshotRepository);
+                List.of(yahooCollector, bokCollector), persistenceService, marketSnapshotRepository);
 
         given(yahooCollector.collect()).willThrow(new RuntimeException("Yahoo 장애"));
         given(yahooCollector.getSourceName()).willReturn("YahooFinance");
@@ -120,7 +89,7 @@ class MarketSnapshotServiceTest {
         marketSnapshotService.collectAndSave();
 
         // Then
-        verify(marketSnapshotRepository, never()).save(any());
+        verify(persistenceService, never()).saveSnapshots(anyList());
     }
 
     @Test
@@ -128,7 +97,7 @@ class MarketSnapshotServiceTest {
     void collectAndSave_emptyResult() {
         // Given
         marketSnapshotService = new MarketSnapshotService(
-                List.of(yahooCollector), marketSnapshotRepository);
+                List.of(yahooCollector), persistenceService, marketSnapshotRepository);
 
         given(yahooCollector.collect()).willReturn(List.of());
         given(yahooCollector.getSourceName()).willReturn("YahooFinance");
@@ -137,8 +106,7 @@ class MarketSnapshotServiceTest {
         marketSnapshotService.collectAndSave();
 
         // Then
-        verify(marketSnapshotRepository, never()).save(any());
-        verify(marketSnapshotRepository, never()).findByMetricType(any());
+        verify(persistenceService, never()).saveSnapshots(anyList());
     }
 
     private CollectedMarketData createNasdaqData() {

--- a/src/test/java/com/solv/wefin/domain/market/service/MarketSnapshotServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/service/MarketSnapshotServiceTest.java
@@ -10,7 +10,6 @@ import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -25,7 +24,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class MarketSnapshotServiceTest {
 
-    @InjectMocks
     private MarketSnapshotService marketSnapshotService;
 
     @Mock

--- a/src/test/java/com/solv/wefin/domain/market/service/MarketSnapshotServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/service/MarketSnapshotServiceTest.java
@@ -1,0 +1,169 @@
+package com.solv.wefin.domain.market.service;
+
+import com.solv.wefin.domain.market.collector.MarketDataCollector;
+import com.solv.wefin.domain.market.dto.CollectedMarketData;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.ChangeDirection;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
+import com.solv.wefin.domain.market.entity.MarketSnapshot.Unit;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MarketSnapshotServiceTest {
+
+    @InjectMocks
+    private MarketSnapshotService marketSnapshotService;
+
+    @Mock
+    private MarketSnapshotRepository marketSnapshotRepository;
+
+    @Mock
+    private MarketDataCollector yahooCollector;
+
+    @Mock
+    private MarketDataCollector bokCollector;
+
+    @Test
+    @DisplayName("수집 성공 — 신규 지표는 INSERT된다")
+    void collectAndSave_insert() {
+        // Given
+        marketSnapshotService = new MarketSnapshotService(
+                List.of(yahooCollector), marketSnapshotRepository);
+
+        given(yahooCollector.collect()).willReturn(List.of(createNasdaqData()));
+        given(yahooCollector.getSourceName()).willReturn("YahooFinance");
+        given(marketSnapshotRepository.findByMetricType(MetricType.NASDAQ))
+                .willReturn(Optional.empty());
+
+        // When
+        marketSnapshotService.collectAndSave();
+
+        // Then
+        verify(marketSnapshotRepository).save(any(MarketSnapshot.class));
+    }
+
+    @Test
+    @DisplayName("수집 성공 — 기존 지표는 UPDATE된다")
+    void collectAndSave_update() {
+        // Given
+        marketSnapshotService = new MarketSnapshotService(
+                List.of(yahooCollector), marketSnapshotRepository);
+
+        MarketSnapshot existing = MarketSnapshot.builder()
+                .metricType(MetricType.NASDAQ)
+                .label("나스닥")
+                .value(new BigDecimal("20000"))
+                .changeRate(BigDecimal.ZERO)
+                .changeValue(BigDecimal.ZERO)
+                .unit(Unit.POINT)
+                .changeDirection(ChangeDirection.FLAT)
+                .build();
+
+        given(yahooCollector.collect()).willReturn(List.of(createNasdaqData()));
+        given(yahooCollector.getSourceName()).willReturn("YahooFinance");
+        given(marketSnapshotRepository.findByMetricType(MetricType.NASDAQ))
+                .willReturn(Optional.of(existing));
+
+        // When
+        marketSnapshotService.collectAndSave();
+
+        // Then — UPDATE이므로 save를 호출하지 않는다.
+        verify(marketSnapshotRepository, never()).save(any(MarketSnapshot.class));
+    }
+
+    @Test
+    @DisplayName("부분 실패 — 한 수집기 실패해도 다른 수집기는 정상 동작한다")
+    void collectAndSave_partialFailure() {
+        // Given
+        marketSnapshotService = new MarketSnapshotService(
+                List.of(yahooCollector, bokCollector), marketSnapshotRepository);
+
+        given(yahooCollector.collect()).willThrow(new RuntimeException("Yahoo 장애"));
+        given(yahooCollector.getSourceName()).willReturn("YahooFinance");
+        given(bokCollector.collect()).willReturn(List.of(createBaseRateData()));
+        given(bokCollector.getSourceName()).willReturn("BOK");
+        given(marketSnapshotRepository.findByMetricType(MetricType.BASE_RATE))
+                .willReturn(Optional.empty());
+
+        // When
+        marketSnapshotService.collectAndSave();
+
+        // Then — BOK 데이터만 저장
+        verify(marketSnapshotRepository).save(any(MarketSnapshot.class));
+    }
+
+    @Test
+    @DisplayName("전체 실패 — 모든 수집기가 실패하면 저장하지 않는다")
+    void collectAndSave_allFailure() {
+        // Given
+        marketSnapshotService = new MarketSnapshotService(
+                List.of(yahooCollector, bokCollector), marketSnapshotRepository);
+
+        given(yahooCollector.collect()).willThrow(new RuntimeException("Yahoo 장애"));
+        given(yahooCollector.getSourceName()).willReturn("YahooFinance");
+        given(bokCollector.collect()).willThrow(new RuntimeException("BOK 장애"));
+        given(bokCollector.getSourceName()).willReturn("BOK");
+
+        // When
+        marketSnapshotService.collectAndSave();
+
+        // Then
+        verify(marketSnapshotRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("빈 수집 결과 — 수집기가 빈 리스트 반환 시 저장하지 않는다")
+    void collectAndSave_emptyResult() {
+        // Given
+        marketSnapshotService = new MarketSnapshotService(
+                List.of(yahooCollector), marketSnapshotRepository);
+
+        given(yahooCollector.collect()).willReturn(List.of());
+        given(yahooCollector.getSourceName()).willReturn("YahooFinance");
+
+        // When
+        marketSnapshotService.collectAndSave();
+
+        // Then
+        verify(marketSnapshotRepository, never()).save(any());
+        verify(marketSnapshotRepository, never()).findByMetricType(any());
+    }
+
+    private CollectedMarketData createNasdaqData() {
+        return CollectedMarketData.builder()
+                .metricType(MetricType.NASDAQ)
+                .label("나스닥")
+                .value(new BigDecimal("20948.36"))
+                .changeRate(new BigDecimal("-4.47"))
+                .changeValue(new BigDecimal("-981.46"))
+                .unit(Unit.POINT)
+                .changeDirection(ChangeDirection.DOWN)
+                .build();
+    }
+
+    private CollectedMarketData createBaseRateData() {
+        return CollectedMarketData.builder()
+                .metricType(MetricType.BASE_RATE)
+                .label("한국 기준금리")
+                .value(new BigDecimal("3.50"))
+                .changeRate(BigDecimal.ZERO)
+                .changeValue(BigDecimal.ZERO)
+                .unit(Unit.PERCENT)
+                .changeDirection(ChangeDirection.FLAT)
+                .build();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,3 +25,10 @@ news:
     display: 10
   collect:
     cron: "-"
+
+market:
+  bok:
+    api-key: test-bok-key
+    base-url: https://ecos.bok.or.kr/api
+  collect:
+    cron: "-"


### PR DESCRIPTION
## 📌 PR 설명
시장 지표 수집 파이프라인을 구축했습니다.

* Yahoo Finance(비공식) + 한국은행 ECOS API를 기반으로 주요 시장 지표를 수집합니다.
* 수집된 데이터는 `MarketSnapshot`에 metric_type 기준으로 upsert 되어 항상 최신 값을 유지합니다.
* `MarketSnapshot`과 `MarketTrend`를 분리하여, 수집 단계와 요약/인사이트 단계를 명확히 구분했습니다.
* 스케줄러를 통해 5분 간격으로 자동 수집되며, local 환경에서는 수동 트리거 API도 제공합니다.

<br>

## ✅ 완료한 기능 명세

* [x] 시장 지표 수집 파이프라인 구축 (Collector 패턴 적용)
* [x] Yahoo Finance 기반 지표 수집 (KOSPI, NASDAQ, USD/KRW)
* [x] 한국은행 ECOS API 기반 기준금리 수집
* [x] `MarketSnapshot` 엔티티 및 metric_type 기준 upsert 로직 구현
* [x] 스케줄러 기반 5분 주기 자동 수집
* [x] 수동 수집 API (`POST /api/admin/market/collect`) 구현 (local)
* [x] 수집기별 예외 격리 처리 (부분 실패 허용)
* [x] 설정 분리 (API Key env, base-url default)

<br>

## 📸 스크린샷
<img width="1266" height="144" alt="image" src="https://github.com/user-attachments/assets/6e1b1346-2c64-4a76-b31d-420705523976" />

<br>

## 💭 고민과 해결과정

### 1. MarketSnapshot vs MarketTrend 분리

초기에는 `MarketTrend`에 snapshot을 포함시키는 구조를 고려했지만,

* MarketSnapshot → “현재 시세 (5분 단위 갱신)”
* MarketTrend → “세션 기반 요약/인사이트”

로 성격이 완전히 다르다고 판단하여 분리했습니다.

→ 수집 단계에서는 snapshot만 관리하고,
→ 이후 AI 요약 단계에서 trend를 생성하는 구조로 변경했습니다.


### 2. 외부 API 구조 설계 (Collector 패턴)

뉴스 수집과 동일하게 `MarketDataCollector` 인터페이스를 도입했습니다.

* API 추가 시 구현체만 추가하면 확장 가능
* Service는 Collector 목록을 순회하며 수집 → 변경 없이 확장 가능


### 3. 설정 관리 기준 정리

* API Key → env (민감 정보)
* base URL → default 값 (변경 가능성 낮음)

설정 누락 시에도 애플리케이션이 정상 동작하도록 기본값 전략을 적용했습니다.


### 4. 안정성 (실패 격리)

* Collector 단위 try-catch 적용
* 일부 API 실패 시 나머지 데이터는 정상 저장
* 전체 실패 시 기존 snapshot 유지



###  5. 트랜잭션과 외부 API 호출 분리

#### 1. 문제 상황

시장 지표 수집 로직은 다음 두 작업을 함께 수행합니다.

* 외부 API 호출 (Yahoo Finance, 한국은행)
* DB 저장

이 두 작업이 하나의 `@Transactional` 안에 존재할 경우,
외부 API 응답이 느릴 때 DB 커넥션을 불필요하게 오래 점유하는 문제가 발생합니다.

```java
// Bad: 외부 호출이 트랜잭션 내부에 포함된 경우
@Transactional
public void collectAndSave() {
    List<Data> data = callExternalAPIs();  // 3~5초 소요 (DB 커넥션 점유)
    saveToDb(data);                        // 실제 DB 작업은 수십 ms
}
```

#### 2. 해결 방법

외부 API 호출과 DB 저장을 분리하여,

* 외부 호출 → 트랜잭션 밖에서 수행
* DB 저장 → 별도 서비스에서 @Transactional로 처리

하도록 구조를 개선했습니다.

```
MarketSnapshotService (트랜잭션 없음)
│
├── 1. collectFromAllSources()
│   ├── YahooFinanceCollector.collect()   // 외부 API 호출 (DB 커넥션 미사용)
│   └── BokApiCollector.collect()         // 외부 API 호출 (DB 커넥션 미사용)
│
└── 2. persistenceService.saveSnapshots() // @Transactional (DB 저장 전용)
```


#### 3. 별도 서비스로 분리한 이유

Spring에서는 같은 클래스 내부에서 `@Transactional` 메서드를 호출할 경우
프록시를 거치지 않아 트랜잭션이 적용되지 않는 self-invocation 문제가 발생합니다.

```java
// Bad: self-invocation (트랜잭션 미적용)
public void collectAndSave() {
    List<Data> data = callExternalAPIs();
    saveSnapshots(data);  // 같은 클래스 내부 호출 → 프록시 우회
}

@Transactional
private void saveSnapshots(List<Data> data) { ... }
```

이를 방지하기 위해,

* DB 저장 로직을 `MarketSnapshotPersistenceService`로 분리하고
* 프록시를 통해 `@Transactional`이 정상적으로 적용되도록 구성했습니다.

#### 4. 설계 의도

* DB 커넥션 점유 시간 최소화 → 성능 및 안정성 개선
* 트랜잭션 범위 명확화 → 책임 분리
* Spring 프록시 기반 트랜잭션 동작 보장 → 예측 가능한 동작

<br>


### 🔗 관련 이슈
 #23


<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 5분 주기 시장 데이터 스케줄러 추가(주말 생략, 중복 실행 방지)
  * KOSPI, NASDAQ, USD/KRW 및 한국 기준금리 수집기 추가
  * 관리자용 API: 스냅샷 조회 및 수동 수집 트리거 추가

* **설정**
  * 마켓 관련 설정(API 키, 엔드포인트, 수집 크론) 및 HTTP 타임아웃 추가

* **데이터베이스**
  * market_snapshot 테이블 분리, 고유 제약 재정의 및 updated_at 컬럼 추가

* **테스트**
  * 리포지토리 통합 테스트 및 서비스 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->