### PR TITLE
[WEF-319] 한투 API 인증 및 토큰 관리 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,6 @@ AI_SERVER_URL=http://localhost:8000
 
 NAVER_CLIENT_ID=your-naver-client-id
 NAVER_CLIENT_SECRET=your-naver-client-secret
+
+HANTU_APPKEY=your-hantu-appkey
+HANTU_APPSECRET=your-hantu-appsecret

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
@@ -44,7 +44,7 @@ public class HantuTokenManager {
      * 실패 시 최대 3회 재시도.
      */
     private void fetchToken() {
-        HantuTokenResponse response = null;
+        HantuTokenResponse response;
 
         for (int tries = 1; tries <= 3; tries++) {
             try {
@@ -59,7 +59,7 @@ public class HantuTokenManager {
                 this.tokenExpiresAt = LocalDateTime.parse(response.access_token_token_expired(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
                 return;
             } catch (Exception e) {
-                log.error("한투 토큰 발급 실패 ({}/3)", tries);
+                log.error("한투 토큰 발급 실패 ({}/3)", tries, e);
                 if (tries == 3) throw e;
                 try {
                     Thread.sleep(1000);

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
@@ -1,0 +1,75 @@
+package com.solv.wefin.domain.trading.market.client;
+
+import com.solv.wefin.domain.trading.market.dto.HantuTokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class HantuTokenManager {
+
+    @Value("${hantu.api.appkey}")
+    private String appKey;
+
+    @Value("${hantu.api.appsecret}")
+    private String appSecret;
+
+    private final RestClient hantuRestClient;
+    private String accessToken;
+    private LocalDateTime tokenExpiresAt;
+
+    /**
+     * 토큰을 반환합니다. (만료됐으면 자동 갱신)
+     * @return 액세스 토큰 문자열
+     */
+    public String getAccessToken() {
+        if (accessToken == null || tokenExpiresAt == null || tokenExpiresAt.isBefore(LocalDateTime.now())) {
+            fetchToken();
+        }
+
+        return accessToken;
+    }
+
+    /**
+     * 한투 API에 POST 요청으로 토큰을 발급합니다.
+     * 실패 시 최대 3회 재시도.
+     */
+    private void fetchToken() {
+        HantuTokenResponse response = null;
+
+        for (int tries = 1; tries <= 3; tries++) {
+            try {
+                response = hantuRestClient.post()
+                        .uri("/oauth2/tokenP")
+                        .body(Map.of("grant_type", "client_credentials", "appkey", appKey, "appsecret",
+                                appSecret))
+                        .retrieve()
+                        .body(HantuTokenResponse.class);
+
+                this.accessToken = response.access_token();
+                this.tokenExpiresAt = LocalDateTime.parse(response.access_token_token_expired(), DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+                return;
+            } catch (Exception e) {
+                log.error("한투 토큰 발급 실패 ({}/3)", tries);
+                if (tries == 3) throw e;
+            }
+        }
+    }
+
+    /**
+     * 6시간 주기로 토큰을 갱신합니다.
+     */
+    @Scheduled(fixedRate = 1000 * 60 * 60 * 6)
+    private void refreshToken() {
+        fetchToken();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
@@ -28,11 +28,11 @@ public class HantuTokenManager {
     private LocalDateTime tokenExpiresAt;
 
     /**
-     * 토큰을 반환합니다. (만료됐으면 자동 갱신)
+     * 토큰을 반환합니다. (만료됐거나 만료 5분 이내이면 자동 갱신)
      * @return 액세스 토큰 문자열
      */
     public String getAccessToken() {
-        if (accessToken == null || tokenExpiresAt == null || tokenExpiresAt.isBefore(LocalDateTime.now())) {
+        if (accessToken == null || tokenExpiresAt == null || tokenExpiresAt.isBefore(LocalDateTime.now().plusMinutes(5))) {
             fetchToken();
         }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
@@ -61,6 +61,11 @@ public class HantuTokenManager {
             } catch (Exception e) {
                 log.error("한투 토큰 발급 실패 ({}/3)", tries);
                 if (tries == 3) throw e;
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }
@@ -69,7 +74,7 @@ public class HantuTokenManager {
      * 6시간 주기로 토큰을 갱신합니다.
      */
     @Scheduled(fixedRate = 1000 * 60 * 60 * 6)
-    private void refreshToken() {
+    public void refreshToken() {
         fetchToken();
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/config/RestClientConfig.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/config/RestClientConfig.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.domain.trading.market.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.time.Duration;
+
+@Configuration
+public class RestClientConfig {
+
+    @Value("${hantu.api.baseUrl}")
+    private String baseUrl;
+
+    @Bean
+    public RestClient hantuRestClient() {
+        return RestClient.builder()
+                .requestFactory(clientHttpRequestFactory())
+                .baseUrl(baseUrl)
+                .build();
+    }
+
+    private ClientHttpRequestFactory clientHttpRequestFactory() {
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory();
+        factory.setReadTimeout(Duration.ofSeconds(5));
+
+        return factory;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/HantuTokenResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/HantuTokenResponse.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+public record HantuTokenResponse(
+        String access_token,
+        String access_token_token_expired
+) {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,9 @@ spring:
 websocket:
   allowed-origins:
     - http://localhost:5173
+
+hantu:
+  api:
+    baseUrl: https://openapivts.koreainvestment.com:29443
+    appkey: ${HANTU_APPKEY}
+    appsecret: ${HANTU_APPSECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,5 +16,5 @@ websocket:
 hantu:
   api:
     baseUrl: https://openapivts.koreainvestment.com:29443
-    appkey: ${HANTU_APPKEY}
-    appsecret: ${HANTU_APPSECRET}
+    appkey: ${HANTU_APPKEY:}
+    appsecret: ${HANTU_APPSECRET:}


### PR DESCRIPTION
## 📌 PR 설명
한투 Open API 인증 토큰 발급/캐싱/자동 갱신/재시도 로직을 구현했습니다.
<br>

## ✅ 완료한 기능 명세

- [x] HantuTokenManager 클래스 구현 (토큰 발급 POST /oauth2/tokenP)
- [x] 토큰 서버 캐싱 (만료 전 자동 갱신)
- [x] @Scheduled 6시간 주기 갱신 스케줄러
- [x] 토큰 발급 실패 시 재시도 로직

<br>

## 💭 고민과 해결과정
### RestClient vs RestTemplate
- Spring Boot 3.5에서 RestTemplate은 유지보수 모드
- RestClient(fluent API) 채택, JdkClientHttpRequestFactory로 타임아웃 설정

### 토큰 캐싱 전략
- 서버 1대 구조이므로 Redis 대신 클래스 필드에 캐싱
- getAccessToken() 호출 시 만료 여부 확인 후 자동 갱신

### 재시도 로직
- 외부 라이브러리(Spring Retry 등) 대신 for문 3회 재시도로 단순하게 구현
- 3회 실패 시 예외 전파

<br>

### 🔗 관련 이슈
Closes #38 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API 인증 토큰의 자동 취득·캐싱 및 6시간 주기 자동 갱신이 추가되었습니다.
  * 토큰 요청 시 재시도 및 실패 로깅이 적용되어 안정성이 개선되었습니다.
  * 전용 HTTP 클라이언트 설정(읽기 타임아웃 등)이 도입되었습니다.

* **설정**
  * 환경 변수 HANTU_APPKEY, HANTU_APPSECRET 추가 지원.
  * 애플리케이션 구성에 hantu.api 관련 base URL 및 자격증명 바인딩이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->