### PR TITLE
[WEF-440] 방 상세정보 및 참여자 상세정보 연결

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -5,10 +5,16 @@ import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface GameParticipantRepository extends JpaRepository<GameParticipant, UUID> {
 
+    // 참가자 수 카운트
     int countByGameRoomAndStatus(GameRoom gameRoom, ParticipantStatus status);
+
+    List<GameParticipant> findByGameRoomOrderByJoinedAtAsc(GameRoom gameRoom);
+
+
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -10,6 +10,8 @@ import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.ParticipantDetailDto;
+import com.solv.wefin.web.game.room.dto.response.RoomDetailResponse;
 import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -96,6 +98,21 @@ public class GameRoomService {
                 .collect(Collectors.toList());
     }
 
+    //방 상세 정보
+    public RoomDetailResponse getRoomDetail(UUID roomId) {
+
+        // 방 조회
+        GameRoom gameRoom= gameRoomRepository.findById(roomId).orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        //참가자 상세
+        List<ParticipantDetailDto> participants = gameParticipantRepository
+                .findByGameRoomOrderByJoinedAtAsc(gameRoom)
+                .stream()
+                .map(p->ParticipantDetailDto.from(p,"유저묵데이터"))
+                .collect(Collectors.toList());
+        //참가자 상세 + 방 상세 저보
+        return RoomDetailResponse.from(gameRoom, participants);
+    }
 
 
 }
@@ -124,6 +141,10 @@ gameParticipant.builder()
  progress , wating / finished
 
  과거 게임 이력 = finished + 유저아이디 ( 내 Id)
+
+ 방정보 + 참가자 목록
+ RoomDetailResponse
+ 참가자 정보 -> participantDetailDto로 변환
 
  */
 /**cancel room

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.RoomDetailResponse;
 import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -44,6 +45,13 @@ public class GameRoomController {
     public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms() {
 
         List<RoomListResponse> response = gameRoomService.getRooms(TEMP_GROUP_ID, TEMP_USER_ID);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse<RoomDetailResponse>> getRoomDetail(@PathVariable UUID roomId){
+        RoomDetailResponse response = gameRoomService.getRoomDetail(roomId);
+
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/ParticipantDetailDto.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/ParticipantDetailDto.java
@@ -1,0 +1,35 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class ParticipantDetailDto {
+
+    private UUID participantId;
+    private UUID userId;
+    private String userName;
+    private Boolean isLeader;
+    private ParticipantStatus status;
+    private OffsetDateTime joinedAt;
+
+    public static ParticipantDetailDto from (GameParticipant participant, String userName) {
+        return new ParticipantDetailDto(
+                participant.getParticipantId(),
+                participant.getUserId(),
+                userName,
+                participant.getIsLeader(),
+                participant.getStatus(),
+                participant.getJoinedAt()
+
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
@@ -1,0 +1,41 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class RoomDetailResponse {
+
+    private UUID roomId;
+    private UUID hostId;
+    private Long seed;
+    private Integer periodMonths;
+    private Integer moveDays;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private RoomStatus status;
+    private List<ParticipantDetailDto> participants;
+
+    public static RoomDetailResponse from (GameRoom room, List<ParticipantDetailDto> participants) {
+        return new RoomDetailResponse(
+                room.getRoomId(),
+                room.getUserId(),
+                room.getSeed(),
+                room.getPeriodMonth(),
+                room.getMoveDays(),
+                room.getStartDate(),
+                room.getEndDate(),
+                room.getStatus(),
+                participants
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
@@ -25,7 +25,7 @@ public class RoomDetailResponse {
     private RoomStatus status;
     private List<ParticipantDetailDto> participants;
 
-    public static RoomDetailResponse from (GameRoom room, List<ParticipantDetailDto> participants) {
+    public static RoomDetailResponse from(GameRoom room, List<ParticipantDetailDto> participants) {
         return new RoomDetailResponse(
                 room.getRoomId(),
                 room.getUserId(),

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -21,6 +21,7 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -142,6 +143,27 @@ class GameRoomServiceTest {
         // Then — 빈 리스트 (에러 아님)
         assertThat(result).isEmpty();
     }
+
+    @Test
+    @DisplayName("게임방 상세 조회 실패 — 존재하지 않는 방이면 ROOM_NOT_FOUND")
+    void getRoomDetail_notFound() {
+        // Given — 존재하지 않는 roomId
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findById(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.getRoomDetail(fakeRoomId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        // 방을 못 찾았으니 참가자 조회는 호출되면 안 된다
+        verify(gameParticipantRepository, never()).findByGameRoomOrderByJoinedAtAsc(any());
+    }
+
 
     // === 헬퍼 메서드 ===
 


### PR DESCRIPTION
## 📌 PR 설명
<br>
게임방 상세정보와 참여자 상세정보를 컨트롤러와 연결

## ✅ 완료한 기능 명세

- [x] 게임방 상세 정보 연결 
- [x] 게임방  참가자 목록 조회
- [x] 참가자 상세정보 dto 정적 팩토리 메소드 구현
- [x] 참가사 상세정보 response 내부 리스트 dto 파일
- [x] 컨트롤러 연결

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
dto를 중첩 사용하여 RoomDetails 내부에 List<ParticipantDetailDto>를 넣어둠
user entity가 없어도 api 응답 구조를 먼저 만들어둬 from() 메서드의 파라미터로 userName 받아 교체 하기 쉽게 구현함
<br>

### 🔗 관련 이슈
Closes #62 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게임룸 상세 정보를 반환하는 신규 GET API 추가
  * 상세 응답에 호스트·기간·상태 등 룸 정보와 참가자 목록(참가자 ID, 사용자명, 리더 여부, 상태, 합류 시간) 포함

* **개선사항**
  * 참가자 목록을 합류 시간(오름차순)으로 정렬하여 반환
  * 존재하지 않는 게임룸 조회 시 명확한 에러 응답 처리 강화

* **테스트**
  * 조회 실패 경로에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->