### PR TITLE
[WEF-55] 회원가입 입력값 검증 (#54)

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/solv/wefin/domain/auth/repository/UserRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
-    boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -82,7 +82,6 @@ public class AuthService {
                     if (UK_USERS_NICKNAME.equals(constraint)) {
                         throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
                     }
-                }
                 cause = cause.getCause();
             }
 

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -70,23 +70,28 @@ public class AuthService {
                     .build();
 
         } catch (DataIntegrityViolationException e) {
-            Throwable cause = e;
-
-            while (cause != null) {
-                if (cause instanceof ConstraintViolationException cve) {
-                    String constraint = cve.getConstraintName();
-
-                    if (UK_USERS_EMAIL.equals(constraint)) {
-                        throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
-                    }
-                    if (UK_USERS_NICKNAME.equals(constraint)) {
-                        throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
-                    }
-                }
-                cause = cause.getCause();
-            }
-
-            throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
+            throw mapConstraintViolation(e);
         }
+    }
+
+    // unique 제약 위반 예외를 도메인 에러 코드로 변환
+    private BusinessException mapConstraintViolation(DataIntegrityViolationException e) {
+        Throwable cause = e;
+
+        while (cause != null) {
+            if (cause instanceof ConstraintViolationException cve) {
+                String constraint = cve.getConstraintName();
+
+                if (UK_USERS_EMAIL.equals(constraint)) {
+                    return new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
+                }
+                if (UK_USERS_NICKNAME.equals(constraint)) {
+                    return new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
+                }
+            }
+            cause = cause.getCause();
+        }
+
+        return new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -7,7 +7,6 @@ import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.auth.dto.SignupResponse;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.exception.ConstraintViolationException;
-import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -68,9 +67,9 @@ public class AuthService {
                     .build();
 
         } catch (DataIntegrityViolationException e) {
-            Throwable root = NestedExceptionUtils.getMostSpecificCause(e);
+            Throwable cause = e.getCause();
 
-            if (root instanceof ConstraintViolationException cve) {
+            if (cause instanceof ConstraintViolationException cve) {
                 String constraint = cve.getConstraintName();
 
                 if (UK_USERS_EMAIL.equals(constraint)) {

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -82,6 +82,7 @@ public class AuthService {
                     if (UK_USERS_NICKNAME.equals(constraint)) {
                         throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
                     }
+                }
                 cause = cause.getCause();
             }
 

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -70,17 +70,20 @@ public class AuthService {
                     .build();
 
         } catch (DataIntegrityViolationException e) {
-            Throwable cause = e.getCause();
+            Throwable cause = e;
 
-            if (cause instanceof ConstraintViolationException cve) {
-                String constraint = cve.getConstraintName();
+            while (cause != null) {
+                if (cause instanceof ConstraintViolationException cve) {
+                    String constraint = cve.getConstraintName();
 
-                if (UK_USERS_EMAIL.equals(constraint)) {
-                    throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
+                    if (UK_USERS_EMAIL.equals(constraint)) {
+                        throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
+                    }
+                    if (UK_USERS_NICKNAME.equals(constraint)) {
+                        throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
+                    }
                 }
-                if (UK_USERS_NICKNAME.equals(constraint)) {
-                    throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
-                }
+                cause = cause.getCause();
             }
 
             throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -13,17 +13,43 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Locale;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
-        private final UserRepository userRepository;
-        private final PasswordEncoder passwordEncoder;
+
+    private static final String UK_USERS_EMAIL = "uk_users_email";
+    private static final String UK_USERS_NICKNAME = "uk_users_nickname";
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public SignupResponse signup(String email, String nickname, String password) {
+        // null 처리
+        if (email == null || nickname == null || password == null) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        // 입력값 정규화
+        email = email.trim().toLowerCase(Locale.ROOT);
+        nickname = nickname.trim();
+        // 비밀번호 앞뒤 공백은 허용하지 않으므로 trim 처리
+        password = password.trim();
+
+        // 빈 값 처리
+        if (email.isBlank() || nickname.isBlank() || password.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        // 중복 처리
         if (userRepository.existsByEmail(email)) {
-            throw new BusinessException(ErrorCode.EMAIL_DUPLICATED);
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
+        }
+        if (userRepository.existsByNickname(nickname)) {
+            throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
         }
 
         try {
@@ -47,8 +73,11 @@ public class AuthService {
             if (root instanceof ConstraintViolationException cve) {
                 String constraint = cve.getConstraintName();
 
-                if ("uk_users_email".equals(constraint)) {
-                    throw new BusinessException(ErrorCode.EMAIL_DUPLICATED);
+                if (UK_USERS_EMAIL.equals(constraint)) {
+                    throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
+                }
+                if (UK_USERS_NICKNAME.equals(constraint)) {
+                    throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
                 }
             }
 

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -35,11 +35,14 @@ public class AuthService {
         // 입력값 정규화
         email = email.trim().toLowerCase(Locale.ROOT);
         nickname = nickname.trim();
-        // 비밀번호 앞뒤 공백은 허용하지 않으므로 trim 처리
-        password = password.trim();
 
         // 빈 값 처리
         if (email.isBlank() || nickname.isBlank() || password.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        // 비밀번호 앞뒤 공백 비허용
+        if (!password.equals(password.trim())) {
             throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
         }
 

--- a/src/main/java/com/solv/wefin/domain/group/entity/Group.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/Group.java
@@ -1,0 +1,5 @@
+package com.solv.wefin.domain.group.entity;
+
+public class Group {
+    @Column(nullable = false, )
+}

--- a/src/main/java/com/solv/wefin/domain/group/entity/Group.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/Group.java
@@ -1,5 +1,0 @@
-package com.solv.wefin.domain.group.entity;
-
-public class Group {
-    @Column(nullable = false, )
-}

--- a/src/main/java/com/solv/wefin/global/common/ApiResponse.java
+++ b/src/main/java/com/solv/wefin/global/common/ApiResponse.java
@@ -26,4 +26,8 @@ public class ApiResponse<T> {
     public static <T> ApiResponse<T> error(ErrorCode code) {
         return new ApiResponse<>(code.getStatus(), code.name(), code.getMessage(), null);
     }
+
+    public static <T> ApiResponse<T> error(ErrorCode code, String message) {
+        return new ApiResponse<>(code.getStatus(), code.name(), message, null);
+    }
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -19,8 +19,10 @@ public enum ErrorCode {
     DUPLICATE_RESOURCE(409,"중복된 리소스입니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
 
-    // Auth
-    EMAIL_DUPLICATED(409, "이미 사용 중인 이메일입니다."),
+    // Auth - SIGNUP
+    AUTH_EMAIL_DUPLICATED(409, "이미 사용 중인 이메일입니다."),
+    AUTH_NICKNAME_DUPLICATED(409, "이미 사용 중인 닉네임입니다."),
+    AUTH_VALIDATION_FAILED(400, "잘못된 입력입니다."),
 
     // Order - BUY
     ORDER_INSUFFICIENT_BALANCE(400, "예수금이 부족합니다."),

--- a/src/main/java/com/solv/wefin/web/auth/AuthExceptionHandler.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthExceptionHandler.java
@@ -4,6 +4,7 @@ import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.error.ErrorCode;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -18,8 +19,7 @@ import java.util.Map;
 public class AuthExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ApiResponse<?> handleValidationException(MethodArgumentNotValidException e) {
-
+    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
         // 에러 순서 유지
         Map<String, String> errors = new LinkedHashMap<>();
 
@@ -27,11 +27,13 @@ public class AuthExceptionHandler {
             errors.put(error.getField(), error.getDefaultMessage());
         });
 
-        return new ApiResponse<>(
+        ApiResponse<Map<String, String>> response = new ApiResponse<>(
                 ErrorCode.AUTH_VALIDATION_FAILED.getStatus(),
                 ErrorCode.AUTH_VALIDATION_FAILED.name(),
                 ErrorCode.AUTH_VALIDATION_FAILED.getMessage(),
                 errors
         );
+
+        return ResponseEntity.badRequest().body(response);
     }
 }

--- a/src/main/java/com/solv/wefin/web/auth/AuthExceptionHandler.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthExceptionHandler.java
@@ -24,7 +24,7 @@ public class AuthExceptionHandler {
         Map<String, String> errors = new LinkedHashMap<>();
 
         e.getBindingResult().getFieldErrors().forEach(error -> {
-            errors.put(error.getField(), error.getDefaultMessage());
+            errors.putIfAbsent(error.getField(), error.getDefaultMessage());
         });
 
         ApiResponse<Map<String, String>> response = new ApiResponse<>(

--- a/src/main/java/com/solv/wefin/web/auth/AuthExceptionHandler.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.web.auth;
+
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.ErrorCode;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+// global 보다 먼저 실행
+@Order(Ordered.HIGHEST_PRECEDENCE)
+// AuthController에서 발생한 예외에만 적용
+@RestControllerAdvice(assignableTypes = AuthController.class)
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleValidationException(MethodArgumentNotValidException e) {
+
+        // 에러 순서 유지
+        Map<String, String> errors = new LinkedHashMap<>();
+
+        e.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(error.getField(), error.getDefaultMessage());
+        });
+
+        return new ApiResponse<>(
+                ErrorCode.AUTH_VALIDATION_FAILED.getStatus(),
+                ErrorCode.AUTH_VALIDATION_FAILED.name(),
+                ErrorCode.AUTH_VALIDATION_FAILED.getMessage(),
+                errors
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/auth/dto/SignupRequest.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/SignupRequest.java
@@ -13,7 +13,7 @@ public class SignupRequest {
     @Email(message = "올바른 이메일 형식이 아닙니다.")
     private String email;
 
-    @NotBlank(message = " 비밀번호는 필수입니다.")
+    @NotBlank(message = "비밀번호는 필수입니다.")
     @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
     @Pattern(
             regexp = "^(?=.*[A-Za-z])(?=.*\\d).+$",

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,202 @@
+package com.solv.wefin.domain.auth.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.auth.dto.SignupResponse;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Nested
+    @DisplayName("signup")
+    class SignupTest {
+
+        @Test
+        @DisplayName("회원가입에 성공한다")
+        void signup_success() {
+            // given
+            String rawEmail = "  TEST@Example.com  ";
+            String rawNickname = "  testuser  ";
+            String rawPassword = "  pass1234  ";
+
+            UUID userId = UUID.randomUUID();
+
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("testuser")).thenReturn(false);
+            when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
+
+            User savedUser = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            setUserId(savedUser, userId);
+
+            when(userRepository.save(any(User.class))).thenReturn(savedUser);
+
+            // when
+            SignupResponse response = authService.signup(rawEmail, rawNickname, rawPassword);
+
+            // then
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(captor.capture());
+            User user = captor.getValue();
+
+            assertAll(
+                    () -> assertThat(user.getEmail()).isEqualTo("test@example.com"),
+                    () -> assertThat(user.getNickname()).isEqualTo("testuser"),
+                    () -> assertThat(user.getPassword()).isEqualTo("encoded-password"),
+                    () -> assertThat(response.getUserId()).isEqualTo(userId),
+                    () -> assertThat(response.getEmail()).isEqualTo("test@example.com"),
+                    () -> assertThat(response.getNickname()).isEqualTo("testuser")
+            );
+        }
+
+        @Test
+        @DisplayName("이메일이 중복되면 예외가 발생한다")
+        void signup_fail_when_email_duplicated() {
+            // given
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(true);
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.signup("test@example.com", "nickname", "pass1234")
+            );
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_EMAIL_DUPLICATED);
+            verify(userRepository, never()).existsByNickname(anyString());
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void signup_fail_when_nickname_duplicated() {
+            // given
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("nickname")).thenReturn(true);
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.signup("test@example.com", "nickname", "pass1234")
+            );
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_NICKNAME_DUPLICATED);
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("입력값이 null 또는 blank면 validation 예외가 발생한다")
+        void signup_fail_when_input_invalid() {
+            BusinessException nullException = assertThrows(
+                    BusinessException.class,
+                    () -> authService.signup(null, "nickname", "pass1234")
+            );
+
+            BusinessException blankException = assertThrows(
+                    BusinessException.class,
+                    () -> authService.signup("   ", "nickname", "pass1234")
+            );
+
+            assertAll(
+                    () -> assertThat(nullException.getErrorCode()).isEqualTo(ErrorCode.AUTH_VALIDATION_FAILED),
+                    () -> assertThat(blankException.getErrorCode()).isEqualTo(ErrorCode.AUTH_VALIDATION_FAILED)
+            );
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("DB 이메일 unique 제약 위반 시 이메일 중복 예외로 변환한다")
+        void signup_fail_when_email_constraint_violated() {
+            // given
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("nickname")).thenReturn(false);
+            when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
+
+            ConstraintViolationException cause =
+                    new ConstraintViolationException("constraint violated", new SQLException(), "uk_users_email");
+
+            when(userRepository.save(any(User.class)))
+                    .thenThrow(new DataIntegrityViolationException("db error", cause));
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.signup("test@example.com", "nickname", "pass1234")
+            );
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_EMAIL_DUPLICATED);
+        }
+
+        @Test
+        @DisplayName("DB 닉네임 unique 제약 위반 시 닉네임 중복 예외로 변환한다")
+        void signup_fail_when_nickname_constraint_violated() {
+            // given
+            when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("nickname")).thenReturn(false);
+            when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
+
+            ConstraintViolationException cause =
+                    new ConstraintViolationException("constraint violated", new SQLException(), "uk_users_nickname");
+
+            when(userRepository.save(any(User.class)))
+                    .thenThrow(new DataIntegrityViolationException("db error", cause));
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.signup("test@example.com", "nickname", "pass1234")
+            );
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_NICKNAME_DUPLICATED);
+        }
+    }
+
+    private void setUserId(User user, UUID userId) {
+        try {
+            var field = User.class.getDeclaredField("userId");
+            field.setAccessible(true);
+            field.set(user, userId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -48,7 +48,7 @@ class AuthServiceTest {
             // given
             String rawEmail = "  TEST@Example.com  ";
             String rawNickname = "  testuser  ";
-            String rawPassword = "  pass1234  ";
+            String rawPassword = "pass1234";
 
             UUID userId = UUID.randomUUID();
 

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.sql.SQLException;
 import java.util.UUID;
@@ -62,7 +63,7 @@ class AuthServiceTest {
                     .password("encoded-password")
                     .build();
 
-            setUserId(savedUser, userId);
+            ReflectionTestUtils.setField(savedUser, "userId", userId);
 
             when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
@@ -187,16 +188,6 @@ class AuthServiceTest {
 
             // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_NICKNAME_DUPLICATED);
-        }
-    }
-
-    private void setUserId(User user, UUID userId) {
-        try {
-            var field = User.class.getDeclaredField("userId");
-            field.setAccessible(true);
-            field.set(user, userId);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
@@ -1,0 +1,179 @@
+package com.solv.wefin.web.auth;
+
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.auth.dto.SignupResponse;
+import com.solv.wefin.domain.auth.service.AuthService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+@Import(AuthExceptionHandler.class)
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Nested
+    @DisplayName("POST /api/auth/signup")
+    class SignupTest {
+
+        private String signupRequest(String email, String password, String nickname) {
+            return """
+            {
+              "email": "%s",
+              "password": "%s",
+              "nickname": "%s"
+            }
+            """.formatted(email, password, nickname);
+        }
+
+        @Test
+        @DisplayName("회원가입 성공 시 200과 응답 데이터를 반환한다")
+        void signup_success() throws Exception {
+            UUID userId = UUID.randomUUID();
+
+            SignupResponse response = SignupResponse.builder()
+                    .userId(userId)
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .build();
+
+            when(authService.signup(
+                    eq("test@example.com"),
+                    eq("testuser"),
+                    eq("pass1234")
+            )).thenReturn(response);
+
+            String requestBody = signupRequest("test@example.com", "pass1234", "testuser");
+
+            mockMvc.perform(post("/api/auth/signup")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                    .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                    .andExpect(jsonPath("$.data.nickname").value("testuser"));
+
+            verify(authService).signup("test@example.com", "testuser", "pass1234");
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 잘못되면 validation 에러를 반환한다")
+        void signup_fail_when_email_invalid() throws Exception {
+            String requestBody = """
+                    {
+                      "email": "invalid-email",
+                      "password": "pass1234",
+                      "nickname": "testuser"
+                    }
+                    """;
+
+            mockMvc.perform(post("/api/auth/signup")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.code").value("AUTH_VALIDATION_FAILED"))
+                    .andExpect(jsonPath("$.data.email").value("올바른 이메일 형식이 아닙니다."));
+        }
+
+        @Test
+        @DisplayName("여러 필드가 동시에 잘못되면 필드별 에러 메시지를 모두 반환한다")
+        void signup_fail_when_multiple_fields_invalid() throws Exception {
+            String requestBody = """
+                    {
+                      "email": "wrong-email",
+                      "password": "1234",
+                      "nickname": ""
+                    }
+                    """;
+
+            mockMvc.perform(post("/api/auth/signup")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.code").value("AUTH_VALIDATION_FAILED"))
+                    .andExpect(jsonPath("$.data.email").value("올바른 이메일 형식이 아닙니다."))
+                    .andExpect(jsonPath("$.data.password").exists())
+                    .andExpect(jsonPath("$.data.nickname").value("닉네임은 필수입니다."));
+        }
+
+        @Test
+        @DisplayName("이메일이 이미 존재하면 409와 에러 응답을 반환한다")
+        void signup_fail_when_email_duplicated() throws Exception {
+            // given
+            when(authService.signup(
+                    eq("test@example.com"),
+                    eq("testuser"),
+                    eq("pass1234")
+            )).thenThrow(new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED));
+
+            String requestBody = signupRequest("test@example.com", "pass1234", "testuser");
+
+            // when & then
+            mockMvc.perform(post("/api/auth/signup")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value(409))
+                    .andExpect(jsonPath("$.code").value("AUTH_EMAIL_DUPLICATED"))
+                    .andExpect(jsonPath("$.message").value("이미 사용 중인 이메일입니다."));
+        }
+
+        @Test
+        @DisplayName("닉네임이 이미 존재하면 409와 에러 응답을 반환한다")
+        void signup_fail_when_nickname_duplicated() throws Exception {
+            // given
+            when(authService.signup(
+                    eq("test@example.com"),
+                    eq("testuser"),
+                    eq("pass1234")
+            )).thenThrow(new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED));
+
+            String requestBody = signupRequest("test@example.com", "pass1234", "testuser");
+
+            // when & then
+            mockMvc.perform(post("/api/auth/signup")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.status").value(409))
+                    .andExpect(jsonPath("$.code").value("AUTH_NICKNAME_DUPLICATED"))
+                    .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
+        }
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
회원가입 요청값 검증 및 Auth 전용 예외 처리 로직을 구현

<br>

## ✅ 완료한 기능 명세

- [x] WEF-56: 회원가입 요청값 Validation 규칙 정의
- [x] WEF-57: 이메일 형식 검증 구현
- [x] WEF-58: 비밀번호 정책 검증 구현
- [x] WEF-59: 닉네임 검증 구현
- [x] WEF-60: Validation 실패 응답 포맷 구현

- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

### 💭 고민과 해결과정

- 특히 Global에서는 validation 에러를 단일 메시지(`INVALID_INPUT`)로 처리하고 있어, 회원가입에서 요구되는 필드별 상세 메시지를 내려주기 어려웠음

- 이를 해결하기 위해 Auth 도메인에 한정된 AuthExceptionHandler를 별도로 구성
  - @Order(Ordered.HIGHEST_PRECEDENCE)를 설정하여 GlobalExceptionHandler보다 먼저 실행되도록 함

- 에러 순서를 유지하기 위해 LinkedHashMap을 사용하여 사용자 입력 흐름과 일치하도록 함

<br>

### 🔗 관련 이슈
Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 회원가입 입력 강화: 이메일 소문자/공백 정규화, 닉네임·비밀번호 공백 검사 및 비밀번호 양끝 공백 금지
  * 사용자 중복 검사에 닉네임 추가 및 관련 리포지토리 메서드 복원
  * 인증 전용 예외 핸들러 추가: 필드별 순서 보장된 상세 검증 오류 응답
  * 에러 응답 생성 오버로드로 메시지 지정 가능

* **버그 픽스**
  * 중복 에러 코드 세분화 및 검증 실패 코드 추가

* **테스트**
  * 회원가입 서비스·컨트롤러에 대한 단위/웹 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->