### PR TITLE
[WEF-337] 종목 검색 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,12 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter'
 	testImplementation 'org.testcontainers:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/solv/wefin/domain/trading/common/StockInfoProvider.java
+++ b/src/main/java/com/solv/wefin/domain/trading/common/StockInfoProvider.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.trading.common;
+
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+
+public interface StockInfoProvider {
+    boolean existsByCode(String stockCode);
+    Stock getStock(Long stockId);
+    String getStockName(String stockCode);
+    String getMarket(String stockCode);
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/dto/StockSearchResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/dto/StockSearchResponse.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.trading.stock.dto;
+
+public record StockSearchResponse(
+        String stockCode,
+        String stockName,
+        String market,
+        String sector
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/dto/StockSearchResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/dto/StockSearchResponse.java
@@ -1,9 +1,19 @@
 package com.solv.wefin.domain.trading.stock.dto;
 
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+
 public record StockSearchResponse(
         String stockCode,
         String stockName,
         String market,
         String sector
 ) {
+    public static StockSearchResponse from(Stock stock) {
+        return new StockSearchResponse(
+                stock.getStockCode(),
+                stock.getStockName(),
+                stock.getMarket(),
+                stock.getSector()
+        );
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/stock/entity/Stock.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/entity/Stock.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.domain.trading.stock.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "stock")
+public class Stock {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "stock_id")
+    private Long id;
+
+    @Column(name = "stock_code", nullable = false, unique = true)
+    private String stockCode;
+
+    @Column(name = "stock_name", nullable = false, length = 100)
+    private String stockName;
+
+    @Column(name = "market", nullable = false)
+    private String market;
+
+    @Column(name = "sector", nullable = false)
+    private String sector;
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepository.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepository.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.trading.stock.repository;
+
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface StockRepository extends JpaRepository<Stock, Long>, StockRepositoryCustom {
+    boolean existsByStockCode(String stockCode);
+    Optional<Stock> findByStockCode(String stockCode);
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryCustom.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.trading.stock.repository;
+
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+
+import java.util.List;
+
+public interface StockRepositoryCustom {
+    List<Stock> search(String keyword, String market);
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.solv.wefin.domain.trading.stock.repository;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.solv.wefin.domain.trading.stock.entity.QStock;
 import com.solv.wefin.domain.trading.stock.entity.Stock;
 import lombok.RequiredArgsConstructor;
 import org.springframework.util.StringUtils;
@@ -18,8 +17,6 @@ public class StockRepositoryImpl implements StockRepositoryCustom {
 
     @Override
     public List<Stock> search(String keyword, String market) {
-        QStock stock = QStock.stock;
-
         return queryFactory
                 .selectFrom(stock)
                 .where(

--- a/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.solv.wefin.domain.trading.stock.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.solv.wefin.domain.trading.stock.entity.QStock;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import lombok.RequiredArgsConstructor;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static com.solv.wefin.domain.trading.stock.entity.QStock.stock;
+
+@RequiredArgsConstructor
+public class StockRepositoryImpl implements StockRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Stock> search(String keyword, String market) {
+        QStock stock = QStock.stock;
+
+        return queryFactory
+                .selectFrom(stock)
+                .where(
+                        keywordContains(keyword),
+                        marketEq(market)
+                )
+                .orderBy(stock.stockName.asc())
+                .limit(20)
+                .fetch();
+    }
+
+    private BooleanExpression keywordContains(String keyword) {
+        if (!StringUtils.hasText(keyword)) return null;
+        return stock.stockName.contains(keyword)
+                .or(stock.stockCode.contains(keyword));
+    }
+
+    private BooleanExpression marketEq(String market) {
+        return StringUtils.hasText(market) ? stock.market.eq(market) : null;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepositoryImpl.java
@@ -33,8 +33,8 @@ public class StockRepositoryImpl implements StockRepositoryCustom {
 
     private BooleanExpression keywordContains(String keyword) {
         if (!StringUtils.hasText(keyword)) return null;
-        return stock.stockName.contains(keyword)
-                .or(stock.stockCode.contains(keyword));
+        return stock.stockName.containsIgnoreCase(keyword)
+                .or(stock.stockCode.containsIgnoreCase(keyword));
     }
 
     private BooleanExpression marketEq(String market) {

--- a/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
@@ -1,0 +1,52 @@
+package com.solv.wefin.domain.trading.stock.service;
+
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.stock.dto.StockSearchResponse;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.stock.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class StockService implements StockInfoProvider {
+    private final StockRepository stockRepository;
+
+    @Override
+    public boolean existsByCode(String stockCode) {
+        return stockRepository.existsByStockCode(stockCode);
+    }
+
+    @Override
+    public Stock getStock(Long stockId) {
+        return stockRepository.getReferenceById(stockId);
+    }
+
+    @Override
+    public String getStockName(String stockCode) {
+        return stockRepository.findByStockCode(stockCode)
+                .orElseThrow(() -> new RuntimeException("종목 없음"))
+                .getStockName();
+    }
+
+    @Override
+    public String getMarket(String stockCode) {
+        return stockRepository.findByStockCode(stockCode)
+                .orElseThrow(() -> new RuntimeException("종목 없음"))
+                .getMarket();
+    }
+
+    public List<StockSearchResponse> search(String keyword, String market) {
+        return stockRepository.search(keyword, market).stream()
+                .map(stock -> new StockSearchResponse(
+                        stock.getStockCode(),
+                        stock.getStockName(),
+                        stock.getMarket(),
+                        stock.getSector()
+                ))
+                .toList();
+    }
+
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
@@ -4,6 +4,8 @@ import com.solv.wefin.domain.trading.common.StockInfoProvider;
 import com.solv.wefin.domain.trading.stock.dto.StockSearchResponse;
 import com.solv.wefin.domain.trading.stock.entity.Stock;
 import com.solv.wefin.domain.trading.stock.repository.StockRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -26,27 +28,23 @@ public class StockService implements StockInfoProvider {
 
     @Override
     public String getStockName(String stockCode) {
-        return stockRepository.findByStockCode(stockCode)
-                .orElseThrow(() -> new RuntimeException("종목 없음"))
-                .getStockName();
+        return findByCodeOrThrow(stockCode).getStockName();
     }
 
     @Override
     public String getMarket(String stockCode) {
-        return stockRepository.findByStockCode(stockCode)
-                .orElseThrow(() -> new RuntimeException("종목 없음"))
-                .getMarket();
+        return findByCodeOrThrow(stockCode).getMarket();
     }
 
     public List<StockSearchResponse> search(String keyword, String market) {
         return stockRepository.search(keyword, market).stream()
-                .map(stock -> new StockSearchResponse(
-                        stock.getStockCode(),
-                        stock.getStockName(),
-                        stock.getMarket(),
-                        stock.getSector()
-                ))
+                .map(StockSearchResponse::from)
                 .toList();
+    }
+
+    private Stock findByCodeOrThrow(String stockCode) {
+        return stockRepository.findByStockCode(stockCode)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
@@ -23,7 +23,8 @@ public class StockService implements StockInfoProvider {
 
     @Override
     public Stock getStock(Long stockId) {
-        return stockRepository.getReferenceById(stockId);
+        return stockRepository.findById(stockId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/com/solv/wefin/global/config/QueryDslConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}
+

--- a/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
+++ b/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
@@ -3,9 +3,13 @@ package com.solv.wefin.web.trading.market;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.service.MarketService;
+import com.solv.wefin.domain.trading.stock.dto.StockSearchResponse;
+import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.*;
 public class MarketController {
 
     private final MarketService marketService;
+    private final StockService stockService;
 
     @GetMapping("/{code}/price")
     public ApiResponse<PriceResponse> getPrice(@PathVariable String code) {
@@ -23,5 +28,12 @@ public class MarketController {
     @GetMapping("/{code}/orderbook")
     public ApiResponse<OrderbookResponse> getOrderbook(@PathVariable String code) {
         return ApiResponse.success(marketService.getOrderbook(code));
+    }
+
+    @GetMapping("/search")
+    public ApiResponse<List<StockSearchResponse>> search(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String market) {
+        return ApiResponse.success(stockService.search(keyword, market));
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
Stock 엔티티 + QueryDSL 종목 검색 + StockInfoProvider 구현을 추가했습니다.
`StockInfoProvider` 인터페이스로 종목 정보를 조회할 수 있습니다.
<br>

## ✅ 완료한 기능 명세

- [x] Stock 엔티티 + StockRepository
- [x] QueryDslConfig 설정
- [x] StockRepositoryImpl — QueryDSL 검색 (keywordContains, marketEq)
- [x] StockInfoProvider 인터페이스 + StockService 구현체
- [x] GET `/api/stocks/search` 엔드포인트 (최대 20건)
- [x] StockSearchResponse DTO

<br>

## 📸 스크린샷
search 엔드포인트 응답 확인
<img width="470" height="258" alt="image" src="https://github.com/user-attachments/assets/3abddfb3-42b3-45e0-aa93-25794fad5d58" />
<img width="446" height="642" alt="image" src="https://github.com/user-attachments/assets/fbe25ce4-c0aa-422b-83f6-dad553636861" />


<br>

## 💭 고민과 해결과정
### 인터페이스 — 구현체 구조

```
domain/trading/common/
└── StockInfoProvider.java          ← 인터페이스 (/trading 개발자 간 공용 계약)

domain/trading/stock/
├── entity/Stock.java               ← JPA 엔티티
├── repository/
│   ├── StockRepository.java        ← Spring Data JPA (extends JpaRepository + StockRepositoryCustom)
│   ├── StockRepositoryCustom.java  ← QueryDSL 커스텀 인터페이스
│   └── StockRepositoryImpl.java    ← QueryDSL 구현체 (implements StockRepositoryCustom)
├── service/
│   └── StockService.java           ← 비즈니스 로직 (implements StockInfoProvider)
└── dto/
    └── StockSearchResponse.java    ← 검색 응답 DTO
```

- **StockInfoProvider** — `domain/trading/common/`에 위치. /trading 도메인 개발자들의 공용 인터페이스
- **StockService** — `StockInfoProvider`를 구현. @ochanhyeok는 인터페이스에만 의존하고, 구현 세부사항을 몰라도 됨
- **StockRepository** — `JpaRepository`(기본 CRUD) + `StockRepositoryCustom`(QueryDSL 검색) 두 인터페이스를 상속
- **StockRepositoryImpl** — Spring Data JPA 규칙에 따라 `StockRepository` + `Impl` 네이밍. `StockRepositoryCustom`을 구현

### QueryDSL 동적 쿼리
- `keywordContains()` — 종목명 또는 종목코드에 키워드 포함 (null이면 조건 무시)
- `marketEq()` — 시장 필터 KR/US (null이면 전체)
- 최대 20건 제한

<br>

### 🔗 관련 이슈
Closes #27 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 종목 검색 API 추가: 키워드·시장 필터로 최대 20건을 반환하며 종목 코드·이름·시장·섹터 정보를 제공합니다.
  * 종목 정보 조회 추가: 종목 존재 여부 확인 및 ID/코드 기준 세부 정보(이름·시장) 조회 지원.
* **업무 개선**
  * 검색 처리 성능·정확성 향상(쿼리 기반 검색 도입) 및 결과 정렬/응답 안정성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->