### PR TITLE
[WEF-288] 시장가 매수 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
@@ -95,6 +95,9 @@ public class Order extends BaseEntity {
 		if (this.status != OrderStatus.PENDING) {
 			throw new BusinessException(ErrorCode.ORDER_ALREADY_FILLED);
 		}
+		if (filledQuantity == null || filledQuantity <= 0 || filledQuantity > this.quantity) {
+			throw new BusinessException(ErrorCode.ORDER_INVALID_QUANTITY);
+		}
 		this.status = OrderStatus.FILLED;
 		this.filledQuantity = filledQuantity;
 	}

--- a/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
@@ -87,4 +87,10 @@ public class Order extends BaseEntity {
 		this.fee = fee;
 		this.tax = tax;
 	}
+
+	// == 비즈니스 메서드 ==
+	public void fill(Integer filledQuantity) {
+		this.status = OrderStatus.FILLED;
+		this.filledQuantity = filledQuantity;
+	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
@@ -6,6 +6,8 @@ import java.util.UUID;
 
 import com.solv.wefin.domain.trading.portfolio.entity.Currency;
 import com.solv.wefin.global.common.BaseEntity;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -90,6 +92,9 @@ public class Order extends BaseEntity {
 
 	// == 비즈니스 메서드 ==
 	public void fill(Integer filledQuantity) {
+		if (this.status != OrderStatus.PENDING) {
+			throw new BusinessException(ErrorCode.ORDER_ALREADY_FILLED);
+		}
 		this.status = OrderStatus.FILLED;
 		this.filledQuantity = filledQuantity;
 	}

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -1,0 +1,72 @@
+package com.solv.wefin.domain.trading.order.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.portfolio.entity.Currency;
+import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+import com.solv.wefin.domain.trading.trade.repository.TradeRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+
+	private static final BigDecimal FEE_RATE = new BigDecimal("0.00015");
+
+	private final OrderRepository orderRepository;
+	private final TradeRepository tradeRepository;
+	private final PortfolioService portfolioService;
+	private final VirtualAccountService virtualAccountService;
+	private final MarketPriceProvider marketPriceProvider;
+
+
+	@Transactional
+	public Order buyMarket(Long virtualAccountId, Long stockId, String stockCode, Integer quantity) {
+		// 1. 수량 검증
+		if (quantity == null || quantity <= 0) {
+			throw new BusinessException(ErrorCode.ORDER_INVALID_QUANTITY);
+		}
+
+		// 2. 현재가 조회
+		BigDecimal currentPrice = marketPriceProvider.getCurrentPrice(stockCode);
+
+		// 3. 금액 계산
+		BigDecimal totalAmount = currentPrice.multiply(BigDecimal.valueOf(quantity));
+
+		// 4. 수수료 계산 (totalAmount x 0.00015, 절사)
+		BigDecimal fee = totalAmount.multiply(FEE_RATE).setScale(0, RoundingMode.DOWN);
+
+		// 5. 예수금 차감 (totalAmount + fee)
+		virtualAccountService.deductBalance(virtualAccountId, totalAmount.add(fee));
+
+		// 6. Order 생성 + 저장
+		Order order = orderRepository.save(new Order(virtualAccountId, stockId, OrderType.MARKET, OrderSide.BUY, quantity,
+			null, Currency.KRW, null, fee, BigDecimal.ZERO));
+
+		// 7. Trade 생성 + 저장
+		Trade trade = tradeRepository.save(Trade.createBuyTrade(order.getOrderId(), virtualAccountId, stockId,
+			quantity, currentPrice, totalAmount, fee, Currency.KRW, null));
+		order.fill(quantity);
+
+		// 8. 포트폴리오 갱신
+		portfolioService.addHolding(virtualAccountId, stockId, quantity, currentPrice, Currency.KRW);
+
+		// 9. 반환
+		return order;
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/trade/entity/Trade.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/entity/Trade.java
@@ -94,4 +94,11 @@ public class Trade {
 		this.currency = currency;
 		this.exchangeRate = exchangeRate;
 	}
+
+	public static Trade createBuyTrade(Long orderId, Long virtualAccountId, Long stockId,
+									   Integer quantity, BigDecimal price, BigDecimal totalAmount, BigDecimal fee,
+									   Currency currency, BigDecimal exchangeRate) {
+		return new Trade(orderId, virtualAccountId, stockId, OrderSide.BUY, quantity, price, totalAmount, fee,
+			BigDecimal.ZERO, null, currency, exchangeRate);
+	}
 }

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -1,0 +1,81 @@
+package com.solv.wefin.domain.trading.order.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
+import com.solv.wefin.domain.trading.trade.repository.TradeRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class OrderServiceTest {
+
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private TradeRepository tradeRepository;
+	@Mock
+	private MarketPriceProvider marketPriceProvider;
+	@Mock
+	private VirtualAccountService virtualAccountService;
+	@Mock
+	private PortfolioService portfolioService;
+
+	@InjectMocks
+	private OrderService orderService;
+
+	@Test
+	void 매수_성공() {
+		// given
+		when(marketPriceProvider.getCurrentPrice("005930"))
+			.thenReturn(new BigDecimal("170000"));
+		when(virtualAccountService.deductBalance(eq(1L), any()))
+			.thenReturn(new VirtualAccount(UUID.randomUUID()));
+		when(orderRepository.save(any()))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+		when(tradeRepository.save(any()))
+			.thenAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		orderService.buyMarket(1L, 1L, "005930", 20);
+
+		// then
+		verify(orderRepository).save(any());
+		verify(tradeRepository).save(any());
+		verify(portfolioService).addHolding(eq(1L), eq(1L), eq(20), any(), any());
+	}
+
+	@Test
+	void 수량_0_이하() {
+		// when & then
+		assertThatThrownBy(() -> orderService.buyMarket(1L, 1L, "005930", 0))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	void 예수금_부족() {
+		// given
+		when(marketPriceProvider.getCurrentPrice("005930"))
+			.thenReturn(new BigDecimal("178000"));
+		when(virtualAccountService.deductBalance(any(), any()))
+			.thenThrow(new BusinessException(ErrorCode.ORDER_INSUFFICIENT_BALANCE));
+
+		// when & then
+		assertThatThrownBy(() -> orderService.buyMarket(1L, 1L, "005930", 20))
+			.isInstanceOf(BusinessException.class);
+	}
+}


### PR DESCRIPTION
  ## 📌 PR 설명
  시장가 매수 주문의 전체 흐름을 구현했습니다.
  주문 접수 → 현재가 조회 → 수수료 계산 → 예수금 차감 → Order/Trade 생성 → 포트폴리오 갱신.
  <br>

  ## ✅ 완료한 기능 명세

  - [x] OrderService.buyMarket() 구현 (시장가 매수 전체 흐름)
  - [x] Order.fill() 비즈니스 메서드 (체결 시 상태 변경)
  - [x] Trade.createBuyTrade() 정적 팩토리 메서드
  - [x] 수수료 계산 (totalAmount × 0.015%, 절사)
  - [x] 기존 Service 연동 (VirtualAccountService 예수금 차감, PortfolioService 보유종목 갱신)
  - [x] 단위 테스트 (매수 성공 / 수량 0 이하 / 예수금 부족)

  <br>

  ## 💭 고민과 해결과정
  - 수수료율을 상수(FEE_RATE)로 추출 — 매직 넘버 제거, 나중에 매도에서도 재사용 가능
  - Trade 생성자 파라미터가 12개라 가독성이 떨어져서 정적 팩토리 메서드(createBuyTrade)로 개선 — 매수 시 고정값(side=BUY, tax=ZERO,
  realizedProfit=null)을 내부에서 처리
  - 빌더 대신 정적 팩토리를 선택한 이유: Trade는 불변 객체이고 필드 대부분이 필수값이라 빌더로 하면 필수값 누락을 컴파일 타임에 잡을 수 없음
  - StockInfoProvider가 아직 머지 전이라 stockCode를 파라미터로 직접 받는 구조 — 머지 후 stockId 기반으로 변경 예정

  <br>

  ### 🔗 관련 이슈
  Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 시장가 매수 주문 기능을 추가했습니다: 현재가 조회, 수수료 계산, 자금 차감, 주문 생성·체결 및 포트폴리오 반영이 자동 처리됩니다.
  * 매수 거래 생성 로직을 추가해 거래 기록이 일관되게 생성됩니다.
* **버그 수정**
  * 이미 체결된 주문의 중복 체결을 방지하도록 주문 체결 검증을 강화했습니다.
* **테스트**
  * 시장가 매수 흐름과 수량/예수금 예외 상황을 검증하는 단위 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->