### PR TITLE
[WEF-136] 게임방 입장 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -29,20 +29,20 @@ public class GameParticipant {
     @JoinColumn(name = "room_id", nullable = false)
     private GameRoom gameRoom;
 
-    @Column(name="user_id", nullable = false)
+    @Column(name = "user_id", nullable = false)
     private UUID userId;
 
-    @Column(name="is_leader", nullable = false)
+    @Column(name = "is_leader", nullable = false)
     private Boolean isLeader;
 
-    @Column(name="seed")
+    @Column(name = "seed")
     private Long seed;
 
     @Enumerated(EnumType.STRING)
-    @Column(name="status", nullable = false)
+    @Column(name = "status", nullable = false)
     private ParticipantStatus status;
 
-    @Column(name="joined_at", nullable = false, updatable = false)
+    @Column(name = "joined_at", nullable = false, updatable = false)
     private OffsetDateTime joinedAt;
 
     @PrePersist
@@ -51,10 +51,11 @@ public class GameParticipant {
         if (this.status == null) {
             this.status = ACTIVE;
         }
-        if(this.isLeader == null) {
+        if (this.isLeader == null) {
             this.isLeader = false;
         }
     }
+
     @Builder
     public GameParticipant(GameRoom gameRoom, UUID userId, Boolean isLeader) {
         this.gameRoom = gameRoom;
@@ -62,6 +63,7 @@ public class GameParticipant {
         this.isLeader = isLeader != null ? isLeader : false;
         this.status = ACTIVE;
     }
+
     public static GameParticipant createLeader(GameRoom gameRoom, UUID userId) {
         return GameParticipant.builder()
                 .gameRoom(gameRoom)
@@ -79,11 +81,17 @@ public class GameParticipant {
     }
 
     public void assignSeed(Long seed) {
+
         this.seed = seed;
     }
 
     public void leave() {
+
         this.status = LEFT;
     }
 
+    public void rejoin() {
+        this.status = ACTIVE;
+    }
 }
+

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -70,6 +70,14 @@ public class GameParticipant {
                 .build();
     }
 
+    public static GameParticipant createMember(GameRoom gameRoom, UUID userId) {
+        return GameParticipant.builder()
+                .gameRoom(gameRoom)
+                .userId(userId)
+                .isLeader(false)
+                .build();
+    }
+
     public void assignSeed(Long seed) {
         this.seed = seed;
     }

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.game.room.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface GameParticipantRepository extends JpaRepository<GameParticipant, UUID> {
@@ -15,7 +16,10 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
 
     List<GameParticipant> findByGameRoomOrderByJoinedAtAsc(GameRoom gameRoom);
 
-    //게임 참가
+    //게임 참가 확인 - 중복 방지
     Boolean existsByGameRoomAndUserId(GameRoom gameRoom, UUID userId);
+
+    // 유저 참가 이력 조회 - 재참가 때 사용
+    Optional<GameParticipant> findByGameRoomAndUserId(GameRoom gameRoom, UUID userId);
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -15,6 +15,7 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
 
     List<GameParticipant> findByGameRoomOrderByJoinedAtAsc(GameRoom gameRoom);
 
-
+    //게임 참가
+    Boolean existsByGameRoomAndUserId(GameRoom gameRoom, UUID userId);
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/dto/CreateRoomCommand.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/dto/CreateRoomCommand.java
@@ -1,0 +1,4 @@
+package com.solv.wefin.domain.game.room.dto;
+
+public record CreateRoomCommand(Long seedMoney, Integer periodMonths, Integer moveDays) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/dto/RoomDetailInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/dto/RoomDetailInfo.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.game.room.dto;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+
+import java.util.List;
+
+public record RoomDetailInfo(GameRoom room, List<GameParticipant> participants) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/dto/RoomListInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/dto/RoomListInfo.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.game.room.dto;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+
+public record RoomListInfo(GameRoom room, int playerCount) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
@@ -2,13 +2,16 @@ package com.solv.wefin.domain.game.room.repository;
 
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface GameRoomRepository extends JpaRepository<GameRoom, UUID> {
@@ -28,5 +31,11 @@ public interface GameRoomRepository extends JpaRepository<GameRoom, UUID> {
             + "ORDER BY r.createdAt DESC")
     List<GameRoom> findFinishedRoomsByGroupIdAndUserId(
             @Param("groupId") Long groupId, @Param("userId") UUID userId);
+
+    //게임방 조회, 비관적 락 -> 동시성 제어
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM GameRoom r WHERE r.roomId = :roomId")
+    Optional<GameRoom> findByIdForUpdate(@Param("roomId") UUID roomId);
+
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -9,10 +9,7 @@ import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
-import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
-import com.solv.wefin.web.game.room.dto.response.ParticipantDetailDto;
-import com.solv.wefin.web.game.room.dto.response.RoomDetailResponse;
-import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
+import com.solv.wefin.web.game.room.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -114,6 +111,41 @@ public class GameRoomService {
         return RoomDetailResponse.from(gameRoom, participants);
     }
 
+    /**
+     게임 입장
+     비관적 락으로 동시 입장 동시성 제어
+     *
+     */
+    @Transactional
+    public JoinRoomResponse joinRoom(UUID roomId, UUID userId) {
+
+        // 방 조회 + 락 시작
+        GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 종료된 방인지 확인
+        if (gameRoom.getStatus() == RoomStatus.FINISHED) {
+            throw new BusinessException(ErrorCode.ROOM_FINISHED);
+        }
+
+        // 이미 참가한 유저인지 확인
+        if (gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, userId)) {
+            throw new BusinessException(ErrorCode.ROOM_ALREADY_JOINED);
+        }
+
+        // 인원 초과 검사 (최대 6명)
+        int currentPlayers = gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+        if (currentPlayers >= 6) {
+            throw new BusinessException(ErrorCode.ROOM_FULL);
+        }
+
+        // 5. 참가자 저장
+        GameParticipant member = GameParticipant.createMember(gameRoom, userId);
+        gameParticipantRepository.save(member);
+
+        return JoinRoomResponse.from(member);
+    }
+
 
 }
 
@@ -128,24 +160,28 @@ public class GameRoomService {
 
 
 */
-/**participant로 처음 create 방 생성한 사람 = 방장
+/**
+  1.participant로 처음 create 방 생성한 사람 = 방장
  방 생성과 방장 지정 동시에 이루어지게 트랜잭션
 gameParticipant.builder()
 
  return 응답dto = createRoomResponse
 
- jpa 코드로 생성된 방 있으면 추가 생성 + 방장 방 동시 생성 차단
+ 2. jpa 코드로 생성된 방 있으면 추가 생성 + 방장 방 동시 생성 차단
  유니크로 2차 차단그 아
 
- 방 목록 조회 그룹아이디 + status
+ 3. 방 목록 조회 그룹아이디 + status
  progress , wating / finished
 
- 과거 게임 이력 = finished + 유저아이디 ( 내 Id)
+ 4. 과거 게임 이력 = finished + 유저아이디 ( 내 Id)
 
- 방정보 + 참가자 목록
+ 5. 방정보 + 참가자 목록
  RoomDetailResponse
  참가자 정보 -> participantDetailDto로 변환
 
+
+ 6. 게임 입장
+ 조회 -> 방 상태 체크 -> 참가 여부 체크 -> 인원체 -> 입장
  */
 /**cancel room
  *

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -2,6 +2,9 @@ package com.solv.wefin.domain.game.room.service;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
+import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
+import com.solv.wefin.domain.game.room.dto.RoomListInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
@@ -15,7 +18,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -36,7 +38,7 @@ public class GameRoomService {
 
     //게임방 생성
     @Transactional //트랜잭션으로 방생성과 방장유저 지정 동시에 이루어짐
-    public CreateRoomResponse createRoom(UUID userId, Long groupId, CreateRoomRequest request) {
+    public GameRoom createRoom(UUID userId, Long groupId, CreateRoomCommand command) {
         //그룹 게임방 있으면 차단
         List<RoomStatus> activeStatuses = List.of(RoomStatus.WAITING, RoomStatus.IN_PROGRESS);
         if (gameRoomRepository.existsByGroupIdAndStatusIn(groupId, activeStatuses)) {
@@ -57,15 +59,15 @@ public class GameRoomService {
 
         //endDate 계산
         LocalDate rangeStart = LocalDate.of(2020,1,1);
-        LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(request.getPeriodMonths());
+        LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(command.periodMonths());
         long daysBetween = ChronoUnit.DAYS.between(rangeStart, rangeEnd);
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
         LocalDate startDate = rangeStart.plusDays(randomDays);
-        LocalDate endDate = startDate.plusMonths(request.getPeriodMonths());
+        LocalDate endDate = startDate.plusMonths(command.periodMonths());
 
         //게임룸 저장
-        GameRoom gameRoom = GameRoom.create(groupId, userId, request.getSeedMoney(), request.getPeriodMonths(),
-                request.getMoveDays(), startDate, endDate);
+        GameRoom gameRoom = GameRoom.create(groupId, userId, command.seedMoney(), command.periodMonths(),
+                command.moveDays(), startDate, endDate);
         gameRoomRepository.save(gameRoom);
 
         //첫 번째 참가자 = 방장
@@ -73,10 +75,10 @@ public class GameRoomService {
 
         gameParticipantRepository.save(host);
 
-        return CreateRoomResponse.from(gameRoom);
+        return gameRoom;
     }
 
-    public List<RoomListResponse> getRooms(Long groupId, UUID userId) {
+    public List<RoomListInfo> getRooms(Long groupId, UUID userId) {
         //그룹 활성화된 방
         List<RoomStatus> activeStatuses = List.of(RoomStatus.WAITING, RoomStatus.IN_PROGRESS);
         List<GameRoom> activeRooms = gameRoomRepository.findByGroupIdAndStatusIn(groupId, activeStatuses);
@@ -91,25 +93,22 @@ public class GameRoomService {
         //참가자 수 count
         return rooms.stream().map(room -> {
                     int playerCount = gameParticipantRepository.countByGameRoomAndStatus(room, ParticipantStatus.ACTIVE);
-                    return RoomListResponse.from(room, playerCount);
+                    return new RoomListInfo(room, playerCount);
                 })
                 .collect(Collectors.toList());
     }
 
     //방 상세 정보
-    public RoomDetailResponse getRoomDetail(UUID roomId) {
+    public RoomDetailInfo getRoomDetail(UUID roomId) {
 
         // 방 조회
         GameRoom gameRoom= gameRoomRepository.findById(roomId).orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
         //참가자 상세
-        List<ParticipantDetailDto> participants = gameParticipantRepository
-                .findByGameRoomOrderByJoinedAtAsc(gameRoom)
-                .stream()
-                .map(p->ParticipantDetailDto.from(p,"유저묵데이터"))
-                .collect(Collectors.toList());
+        List<GameParticipant> participants = gameParticipantRepository.findByGameRoomOrderByJoinedAtAsc(gameRoom);
+
         //참가자 상세 + 방 상세 저보
-        return RoomDetailResponse.from(gameRoom, participants);
+        return new RoomDetailInfo(gameRoom, participants);
     }
 
     /**
@@ -118,7 +117,7 @@ public class GameRoomService {
      *
      */
     @Transactional
-    public JoinRoomResponse joinRoom(UUID roomId, UUID userId) {
+    public GameParticipant joinRoom(UUID roomId, UUID userId) {
 
         // 방 조회 + 락 시작
         GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
@@ -142,11 +141,11 @@ public class GameRoomService {
                 throw new BusinessException(ErrorCode.ROOM_FULL);
             }
             participant.rejoin();
-            return JoinRoomResponse.from(participant);
+            return participant;
         }
 
 
-        // 인원 초과 검사 (신규만, 최대 6명)
+        // 인원 초과 검사 (신규만, 근데 지금 최대 6명)
         int currentPlayers = gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
         if (currentPlayers >= 6) {
             throw new BusinessException(ErrorCode.ROOM_FULL);
@@ -156,7 +155,7 @@ public class GameRoomService {
         GameParticipant member = GameParticipant.createMember(gameRoom, userId);
         gameParticipantRepository.save(member);
 
-        return JoinRoomResponse.from(member);
+        return member;
     }
 
 

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -21,6 +21,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -129,11 +130,23 @@ public class GameRoomService {
         }
 
         // 이미 참가한 유저인지 확인
-        if (gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, userId)) {
-            throw new BusinessException(ErrorCode.ROOM_ALREADY_JOINED);
+        Optional<GameParticipant> existing = gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId);
+        if (existing.isPresent()) {
+            GameParticipant participant = existing.get();
+
+            if(participant.getStatus() == ParticipantStatus.ACTIVE){
+                throw new BusinessException(ErrorCode.ROOM_ALREADY_JOINED);
+            }
+            int currentPlayers = gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+            if (currentPlayers >= 6) {
+                throw new BusinessException(ErrorCode.ROOM_FULL);
+            }
+            participant.rejoin();
+            return JoinRoomResponse.from(participant);
         }
 
-        // 인원 초과 검사 (최대 6명)
+
+        // 인원 초과 검사 (신규만, 최대 6명)
         int currentPlayers = gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
         if (currentPlayers >= 6) {
             throw new BusinessException(ErrorCode.ROOM_FULL);
@@ -182,6 +195,9 @@ gameParticipant.builder()
 
  6. 게임 입장
  조회 -> 방 상태 체크 -> 참가 여부 체크 -> 인원체 -> 입장
+
+ 재참가로 로직 변경
+ 조회 - 방 상태 체크 - 참가 기록 확인 (기록 있으면 인워 수 체크 후 재참가 로직 )- 인원체크 입장
  */
 /**cancel room
  *

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -49,7 +49,10 @@ public enum ErrorCode {
     ROOM_NOT_FOUND(404,"게임장을 찾을 수 없습니다."),
     ROOM_ALREADY_EXISTS(409, "이미 진행 중이거나 대기 중인 게임방이 있습니다."),
     ROOM_HOST_ALREADY_EXISTS(409, "이미 방장으로 참여 중인 게임방이 있습니다."),
-    ROOM_HOST_DAILY_LIMIT(409, "하루 방 생성 가능 횟수 초과");
+    ROOM_HOST_DAILY_LIMIT(409, "하루 방 생성 가능 횟수 초과"),
+    ROOM_ALREADY_JOINED(409, "이미 참가 중인 방입니다."),
+    ROOM_FULL(400, "인원 초과"),
+    ROOM_FINISHED(400, "종료된 방입니다,");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -52,7 +52,7 @@ public enum ErrorCode {
     ROOM_HOST_DAILY_LIMIT(409, "하루 방 생성 가능 횟수 초과"),
     ROOM_ALREADY_JOINED(409, "이미 참가 중인 방입니다."),
     ROOM_FULL(400, "인원 초과"),
-    ROOM_FINISHED(400, "종료된 방입니다,");
+    ROOM_FINISHED(400, "종료된 방입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.JoinRoomResponse;
 import com.solv.wefin.web.game.room.dto.response.RoomDetailResponse;
 import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import jakarta.validation.Valid;
@@ -51,6 +52,15 @@ public class GameRoomController {
     @GetMapping("/{roomId}")
     public ResponseEntity<ApiResponse<RoomDetailResponse>> getRoomDetail(@PathVariable UUID roomId){
         RoomDetailResponse response = gameRoomService.getRoomDetail(roomId);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // 게임방 입장
+    @PostMapping("/{roomId}/join")
+    public ResponseEntity<ApiResponse<JoinRoomResponse>> joinRoom(@PathVariable UUID roomId) {
+
+        JoinRoomResponse response = gameRoomService.joinRoom(roomId, TEMP_USER_ID);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -1,12 +1,14 @@
 package com.solv.wefin.web.game.room;
 
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
+import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
+import com.solv.wefin.domain.game.room.dto.RoomListInfo;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
-import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
-import com.solv.wefin.web.game.room.dto.response.JoinRoomResponse;
-import com.solv.wefin.web.game.room.dto.response.RoomDetailResponse;
-import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
+import com.solv.wefin.web.game.room.dto.response.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -15,6 +17,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/rooms")
@@ -31,7 +35,10 @@ public class GameRoomController {
     public ResponseEntity<ApiResponse<CreateRoomResponse>> createRoom(
             @Valid @RequestBody CreateRoomRequest request) {
 
-        CreateRoomResponse response = gameRoomService.createRoom(TEMP_USER_ID, TEMP_GROUP_ID, request);
+        CreateRoomCommand command = new CreateRoomCommand(
+                request.getSeedMoney(), request.getPeriodMonths(), request.getMoveDays());
+        GameRoom gameRoom = gameRoomService.createRoom(TEMP_USER_ID, TEMP_GROUP_ID, command);
+        CreateRoomResponse response = CreateRoomResponse.from(gameRoom);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, response));
 
@@ -45,14 +52,22 @@ public class GameRoomController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms() {
 
-        List<RoomListResponse> response = gameRoomService.getRooms(TEMP_GROUP_ID, TEMP_USER_ID);
+        List<RoomListInfo> rooms = gameRoomService.getRooms(TEMP_GROUP_ID, TEMP_USER_ID);
+        List<RoomListResponse> response = rooms.stream().map(
+                r -> RoomListResponse.from(r.room(), r.playerCount())).collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{roomId}")
     public ResponseEntity<ApiResponse<RoomDetailResponse>> getRoomDetail(@PathVariable UUID roomId){
-        RoomDetailResponse response = gameRoomService.getRoomDetail(roomId);
 
+        RoomDetailInfo detail = gameRoomService.getRoomDetail(roomId);
+
+        List<ParticipantDetailDto> participantDtos = detail.participants().stream().map(
+                p -> ParticipantDetailDto.from(p, "묵데이터유저")
+        ).collect(Collectors.toList());
+
+        RoomDetailResponse response = RoomDetailResponse.from(detail.room(), participantDtos);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -60,7 +75,8 @@ public class GameRoomController {
     @PostMapping("/{roomId}/join")
     public ResponseEntity<ApiResponse<JoinRoomResponse>> joinRoom(@PathVariable UUID roomId) {
 
-        JoinRoomResponse response = gameRoomService.joinRoom(roomId, TEMP_USER_ID);
+        GameParticipant participant = gameRoomService.joinRoom(roomId, TEMP_USER_ID);
+        JoinRoomResponse response = JoinRoomResponse.from(participant);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/JoinRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/JoinRoomResponse.java
@@ -1,0 +1,26 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class JoinRoomResponse {
+
+    private UUID participantId;
+    private UUID roomId;
+    private RoomStatus roomStatus;
+
+    public static JoinRoomResponse from(GameParticipant participant) {
+        return new JoinRoomResponse(
+                participant.getParticipantId(),
+                participant.getGameRoom().getRoomId(),
+                participant.getGameRoom().getStatus()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.game.room.service;
 
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
@@ -9,6 +10,7 @@ import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
+import com.solv.wefin.web.game.room.dto.response.JoinRoomResponse;
 import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -164,6 +166,146 @@ class GameRoomServiceTest {
         verify(gameParticipantRepository, never()).findByGameRoomOrderByJoinedAtAsc(any());
     }
 
+
+    // === API 4: 게임방 참가 테스트 ===
+
+    private static final UUID OTHER_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+
+    @Test
+    @DisplayName("게임방 참가 성공 — WAITING 방에 참가")
+    void joinRoom_success_waiting() {
+        // Given — WAITING 방이 존재, 중복 참가 아님, 인원 여유 있음
+        GameRoom gameRoom = createGameRoom(); // status = WAITING
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(false);
+        given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(1); // 방장 1명만 있음
+
+        // When
+        JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
+
+        // Then
+        assertThat(response.getRoomId()).isEqualTo(roomId);
+        assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.WAITING);
+        verify(gameParticipantRepository).save(any(GameParticipant.class));
+    }
+
+    @Test
+    @DisplayName("게임방 참가 성공 — IN_PROGRESS 방에도 참가 가능")
+    void joinRoom_success_inProgress() {
+        // Given — IN_PROGRESS 방
+        GameRoom gameRoom = createGameRoom();
+        gameRoom.start(); // WAITING → IN_PROGRESS
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(false);
+        given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(3);
+
+        // When
+        JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
+
+        // Then — IN_PROGRESS 상태로 응답 (프론트에서 게임 화면으로 라우팅)
+        assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
+        verify(gameParticipantRepository).save(any(GameParticipant.class));
+    }
+
+    @Test
+    @DisplayName("게임방 참가 실패 — 존재하지 않는 방")
+    void joinRoom_notFound() {
+        // Given
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findByIdForUpdate(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.joinRoom(fakeRoomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        verify(gameParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("게임방 참가 실패 — 종료된 방")
+    void joinRoom_finished() {
+        // Given — FINISHED 방
+        GameRoom gameRoom = createGameRoom();
+        gameRoom.start();
+        gameRoom.finish(); // → FINISHED
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.joinRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_FINISHED);
+                });
+
+        verify(gameParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("게임방 참가 실패 — 이미 참가 중")
+    void joinRoom_alreadyJoined() {
+        // Given — 이미 참가한 유저
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(true); // 이미 참가함
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.joinRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_ALREADY_JOINED);
+                });
+
+        verify(gameParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("게임방 참가 실패 — 인원 초과 (최대 6명)")
+    void joinRoom_full() {
+        // Given — 이미 6명
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(false);
+        given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(6); // 꽉 참
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.joinRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_FULL);
+                });
+
+        verify(gameParticipantRepository, never()).save(any());
+    }
 
     // === 헬퍼 메서드 ===
 

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -1,17 +1,17 @@
 package com.solv.wefin.domain.game.room.service;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
+import com.solv.wefin.domain.game.room.dto.RoomListInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
-import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
-import com.solv.wefin.web.game.room.dto.response.CreateRoomResponse;
-import com.solv.wefin.web.game.room.dto.response.JoinRoomResponse;
-import com.solv.wefin.web.game.room.dto.response.RoomListResponse;
+import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -50,6 +50,8 @@ class GameRoomServiceTest {
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
 
+    // === API 1: 게임방 생성 테스트 ===
+
     @Test
     @DisplayName("게임방 생성 성공 — 정상적으로 방과 참가자가 저장된다")
     void createRoom_success() {
@@ -62,13 +64,13 @@ class GameRoomServiceTest {
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(false);
 
-        CreateRoomRequest request = createRequest();
+        CreateRoomCommand request = createCommand();
 
         // When — 방 생성 호출
-        CreateRoomResponse response = gameRoomService.createRoom(TEST_USER_ID, TEST_GROUP_ID, request);
+        GameRoom result = gameRoomService.createRoom(TEST_USER_ID, TEST_GROUP_ID, request);
 
         // Then — 결과 검증
-        assertThat(response.getStatus()).isEqualTo(RoomStatus.WAITING);
+        assertThat(result.getStatus()).isEqualTo(RoomStatus.WAITING);
 
         // GameRoom이 저장됐는지 확인
         verify(gameRoomRepository).save(any(GameRoom.class));
@@ -89,7 +91,7 @@ class GameRoomServiceTest {
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(true);
 
-        CreateRoomRequest request = createRequest();
+        CreateRoomCommand request = createCommand();
 
         // When & Then — BusinessException이 발생해야 한다
         assertThatThrownBy(() ->
@@ -121,10 +123,12 @@ class GameRoomServiceTest {
                 .willReturn(1);
 
         // When
-        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
+        List<RoomListInfo> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
 
         // Then — 2개 반환 (활성 1 + 완료 1)
         assertThat(result).hasSize(2);
+        assertThat(result.get(0).room()).isEqualTo(activeRoom);
+        assertThat(result.get(0).playerCount()).isEqualTo(1);
 
         verify(gameRoomRepository).findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList());
         verify(gameRoomRepository).findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID);
@@ -140,10 +144,42 @@ class GameRoomServiceTest {
                 .willReturn(Collections.emptyList());
 
         // When
-        List<RoomListResponse> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
+        List<RoomListInfo> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
 
         // Then — 빈 리스트 (에러 아님)
         assertThat(result).isEmpty();
+    }
+
+    // === API 3: 게임방 상세 조회 테스트 ===
+
+    @Test
+    @DisplayName("게임방 상세 조회 성공 — 방 정보 + 참가자 목록 반환")
+    void getRoomDetail_success() {
+        // Given — 방이 존재하고 참가자 1명(방장)이 있다
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomOrderByJoinedAtAsc(gameRoom))
+                .willReturn(List.of(leader));
+
+        // When
+        RoomDetailInfo result = gameRoomService.getRoomDetail(roomId);
+
+        // Then — 방 정보 검증
+        assertThat(result.room().getRoomId()).isEqualTo(roomId);
+        assertThat(result.room().getStatus()).isEqualTo(RoomStatus.WAITING);
+        assertThat(result.room().getSeed()).isEqualTo(10000000L);
+
+        // Then — 참가자 목록 검증
+        assertThat(result.participants()).hasSize(1);
+        assertThat(result.participants().get(0).getIsLeader()).isTrue();
+        assertThat(result.participants().get(0).getUserId()).isEqualTo(TEST_USER_ID);
+
+        verify(gameRoomRepository).findById(roomId);
+        verify(gameParticipantRepository).findByGameRoomOrderByJoinedAtAsc(gameRoom);
     }
 
     @Test
@@ -166,7 +202,6 @@ class GameRoomServiceTest {
         verify(gameParticipantRepository, never()).findByGameRoomOrderByJoinedAtAsc(any());
     }
 
-
     // === API 4: 게임방 참가 테스트 ===
 
     private static final UUID OTHER_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
@@ -186,11 +221,11 @@ class GameRoomServiceTest {
                 .willReturn(1);
 
         // When
-        JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
+        GameParticipant result = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
 
         // Then
-        assertThat(response.getRoomId()).isEqualTo(roomId);
-        assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.WAITING);
+        assertThat(result.getGameRoom().getRoomId()).isEqualTo(roomId);
+        assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.WAITING);
         verify(gameParticipantRepository).save(any(GameParticipant.class));
     }
 
@@ -210,10 +245,10 @@ class GameRoomServiceTest {
                 .willReturn(3);
 
         // When
-        JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
+        GameParticipant result = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
 
         // Then
-        assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
+        assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
         verify(gameParticipantRepository).save(any(GameParticipant.class));
     }
 
@@ -234,11 +269,11 @@ class GameRoomServiceTest {
                 .willReturn(3);
 
         // When
-        JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
+        GameParticipant result = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
 
         // Then — 기존 레코드 재활용, save() 호출 안 함 (더티 체킹)
-        assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.WAITING);
-        assertThat(leftParticipant.getStatus()).isEqualTo(ParticipantStatus.ACTIVE); // LEFT → ACTIVE
+        assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.WAITING);
+        assertThat(result.getStatus()).isEqualTo(ParticipantStatus.ACTIVE); // LEFT → ACTIVE
         verify(gameParticipantRepository, never()).save(any()); // 더티 체킹이니까 save 안 부름
     }
 
@@ -335,9 +370,10 @@ class GameRoomServiceTest {
 
     // === 헬퍼 메서드 ===
 
-    private CreateRoomRequest createRequest() {
-        return new CreateRoomRequest(10000000L, 6, 7);
+    private CreateRoomCommand createCommand() {
+        return new CreateRoomCommand(10000000L, 6, 7);
     }
+
 
     private GameRoom createGameRoom() {
         return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -172,18 +172,18 @@ class GameRoomServiceTest {
     private static final UUID OTHER_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
 
     @Test
-    @DisplayName("게임방 참가 성공 — WAITING 방에 참가")
+    @DisplayName("게임방 참가 성공 — WAITING 방에 신규 참가")
     void joinRoom_success_waiting() {
-        // Given — WAITING 방이 존재, 중복 참가 아님, 인원 여유 있음
-        GameRoom gameRoom = createGameRoom(); // status = WAITING
+        // Given — WAITING 방, 참가 이력 없음, 인원 여유 있음
+        GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
 
         given(gameRoomRepository.findByIdForUpdate(roomId))
                 .willReturn(Optional.of(gameRoom));
-        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
-                .willReturn(false);
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.empty()); // 이력 없음
         given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
-                .willReturn(1); // 방장 1명만 있음
+                .willReturn(1);
 
         // When
         JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
@@ -197,24 +197,49 @@ class GameRoomServiceTest {
     @Test
     @DisplayName("게임방 참가 성공 — IN_PROGRESS 방에도 참가 가능")
     void joinRoom_success_inProgress() {
-        // Given — IN_PROGRESS 방
+        // Given — IN_PROGRESS 방, 참가 이력 없음
         GameRoom gameRoom = createGameRoom();
-        gameRoom.start(); // WAITING → IN_PROGRESS
+        gameRoom.start();
         UUID roomId = gameRoom.getRoomId();
 
         given(gameRoomRepository.findByIdForUpdate(roomId))
                 .willReturn(Optional.of(gameRoom));
-        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
-                .willReturn(false);
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.empty());
         given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
                 .willReturn(3);
 
         // When
         JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
 
-        // Then — IN_PROGRESS 상태로 응답 (프론트에서 게임 화면으로 라우팅)
+        // Then
         assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
         verify(gameParticipantRepository).save(any(GameParticipant.class));
+    }
+
+    @Test
+    @DisplayName("게임방 참가 성공 — 퇴장 후 재참가 (LEFT → ACTIVE)")
+    void joinRoom_success_rejoin() {
+        // Given — LEFT 상태의 기존 참가 이력
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leftParticipant = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
+        leftParticipant.leave(); // ACTIVE → LEFT
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.of(leftParticipant)); // LEFT 상태로 존재
+        given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(3);
+
+        // When
+        JoinRoomResponse response = gameRoomService.joinRoom(roomId, OTHER_USER_ID);
+
+        // Then — 기존 레코드 재활용, save() 호출 안 함 (더티 체킹)
+        assertThat(response.getRoomStatus()).isEqualTo(RoomStatus.WAITING);
+        assertThat(leftParticipant.getStatus()).isEqualTo(ParticipantStatus.ACTIVE); // LEFT → ACTIVE
+        verify(gameParticipantRepository, never()).save(any()); // 더티 체킹이니까 save 안 부름
     }
 
     @Test
@@ -260,16 +285,17 @@ class GameRoomServiceTest {
     }
 
     @Test
-    @DisplayName("게임방 참가 실패 — 이미 참가 중")
+    @DisplayName("게임방 참가 실패 — 이미 ACTIVE 상태로 참가 중")
     void joinRoom_alreadyJoined() {
-        // Given — 이미 참가한 유저
+        // Given — ACTIVE 상태의 기존 참가자
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
+        GameParticipant activeParticipant = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
 
         given(gameRoomRepository.findByIdForUpdate(roomId))
                 .willReturn(Optional.of(gameRoom));
-        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
-                .willReturn(true); // 이미 참가함
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.of(activeParticipant)); // ACTIVE 상태로 존재
 
         // When & Then
         assertThatThrownBy(() -> gameRoomService.joinRoom(roomId, OTHER_USER_ID))
@@ -285,14 +311,14 @@ class GameRoomServiceTest {
     @Test
     @DisplayName("게임방 참가 실패 — 인원 초과 (최대 6명)")
     void joinRoom_full() {
-        // Given — 이미 6명
+        // Given — 이력 없는 신규 유저, 이미 6명
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
 
         given(gameRoomRepository.findByIdForUpdate(roomId))
                 .willReturn(Optional.of(gameRoom));
-        given(gameParticipantRepository.existsByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
-                .willReturn(false);
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.empty()); // 이력 없음
         given(gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
                 .willReturn(6); // 꽉 참
 


### PR DESCRIPTION
## 📌 PR 설명
<br>
게임방 입장 / 퇴장 구현
동시성 제어 및 조건 검사로 오류 사전에 방지

## ✅ 완료한 기능 명세

- [x] 게임방 입장
- [x] 게임방 입장 테스트 코드
- [x] 동시정 제어 - 비관적 락으로 초과 입장 방지
- [x] 조회 시작 시락
- [x] 방 상태 체크
- [x] 방 인원 체크
- [x] 모두 통과 시 입장
- [x] 재입장 로직 추가

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
5/6 과 같은 상황에서 여러명이 동시에 입장시 초과 입장의 상황을 비관적 락으로 사전에 방지함.
 @Lock(PESSIMISTIC_WRITE)를 통해 jpa 가 for update를 붙여줌 for update로 조회 + 잠금 상태가 됐으므로
이후 방 상태, 인원 체크 후 모두 통과하면 save로 참가자를 저장하는 과정이 하나의 트랜잭션으로 작동하여 트랜잭션 종료시 까지 다른 유저들은 대기 상태로 들어가 동시성 제어가 가능.

============================
기존의 도메인 계층의 서비스 파일이 웹 계층의 dto를 의존하고 있어, 웹과 도메인 계층의 의존이 역전될 수 있는 구조를 도메인 계층에 dto를 추가하여 서비스 계층이 웹계층에 의존하지 않도록 변경했습니다.
<br>

### 🔗 관련 이슈
Closes #64 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 방 참가 API 추가 — 참가·재입장 흐름 처리 및 참여자 정보(참여자Id/방Id/방상태) 반환.
  * 참여자 생성용 팩토리 메서드와 재입장 상태 전환 지원.

* **동시성/저장소**
  * 방 조회 시 잠금 기반 조회 도입 및 참여 여부 확인/조회 메서드 추가로 기존 참여 재사용 지원.

* **오류 응답**
  * 중복 참가, 방 가득참(최대 6명), 종료된 방 등 명확한 오류 코드 추가.

* **테스트**
  * 다양한 참가 성공/실패와 재입장 시나리오에 대한 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->