### PR TITLE
[WEF-439] 뉴스 기사 임베딩 생성 파이프라인 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,5 @@ NAVER_CLIENT_SECRET=your-naver-client-secret
 
 HANTU_APPKEY=your-hantu-appkey
 HANTU_APPSECRET=your-hantu-appsecret
+
+OPENAI_API_KEY=your-openai-api-key

--- a/src/main/java/com/solv/wefin/domain/market/repository/MarketSnapshotRepository.java
+++ b/src/main/java/com/solv/wefin/domain/market/repository/MarketSnapshotRepository.java
@@ -3,7 +3,11 @@ package com.solv.wefin.domain.market.repository;
 import com.solv.wefin.domain.market.entity.MarketSnapshot;
 import com.solv.wefin.domain.market.entity.MarketSnapshot.MetricType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.util.Optional;
 
 public interface MarketSnapshotRepository extends JpaRepository<MarketSnapshot, Long> {
@@ -15,4 +19,23 @@ public interface MarketSnapshotRepository extends JpaRepository<MarketSnapshot, 
      * @return 해당 지표의 스냅샷
      */
     Optional<MarketSnapshot> findByMetricType(MetricType metricType);
+
+    /**
+     * 시장 지표를 race-safe하게 upsert한다.
+     * PostgreSQL ON CONFLICT를 사용하여 동시 호출 시에도 unique constraint 충돌 없이 처리한다.
+     */
+    @Modifying
+    @Query(value = "INSERT INTO market_snapshot (metric_type, label, value, change_rate, change_value, unit, change_direction, created_at, updated_at) " +
+            "VALUES (:metricType, :label, :value, :changeRate, :changeValue, :unit, :changeDirection, now(), now()) " +
+            "ON CONFLICT (metric_type) DO UPDATE SET " +
+            "value = :value, change_rate = :changeRate, change_value = :changeValue, " +
+            "change_direction = :changeDirection, updated_at = now()",
+            nativeQuery = true)
+    void upsert(@Param("metricType") String metricType,
+                @Param("label") String label,
+                @Param("value") BigDecimal value,
+                @Param("changeRate") BigDecimal changeRate,
+                @Param("changeValue") BigDecimal changeValue,
+                @Param("unit") String unit,
+                @Param("changeDirection") String changeDirection);
 }

--- a/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/market/service/MarketSnapshotPersistenceService.java
@@ -1,7 +1,6 @@
 package com.solv.wefin.domain.market.service;
 
 import com.solv.wefin.domain.market.dto.CollectedMarketData;
-import com.solv.wefin.domain.market.entity.MarketSnapshot;
 import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,39 +23,22 @@ public class MarketSnapshotPersistenceService {
 
     /**
      * 수집된 시장 지표를 DB에 upsert한다.
+     * PostgreSQL ON CONFLICT를 사용하여 동시 호출 시에도 안전하게 처리한다.
      *
      * @param allData 수집된 시장 지표 목록
      */
     @Transactional
     public void saveSnapshots(List<CollectedMarketData> allData) {
         for (CollectedMarketData data : allData) {
-            upsertSnapshot(data);
-        }
-        log.info("시장 지표 upsert 완료: {}건", allData.size());
-    }
-
-    private void upsertSnapshot(CollectedMarketData data) {
-        MarketSnapshot snapshot = marketSnapshotRepository
-                .findByMetricType(data.getMetricType())
-                .orElse(null);
-
-        if (snapshot != null) {
-            snapshot.updateValues(
+            marketSnapshotRepository.upsert(
+                    data.getMetricType().name(),
+                    data.getLabel(),
                     data.getValue(),
                     data.getChangeRate(),
                     data.getChangeValue(),
-                    data.getChangeDirection());
-        } else {
-            snapshot = MarketSnapshot.builder()
-                    .metricType(data.getMetricType())
-                    .label(data.getLabel())
-                    .value(data.getValue())
-                    .changeRate(data.getChangeRate())
-                    .changeValue(data.getChangeValue())
-                    .unit(data.getUnit())
-                    .changeDirection(data.getChangeDirection())
-                    .build();
-            marketSnapshotRepository.save(snapshot);
+                    data.getUnit().name(),
+                    data.getChangeDirection().name());
         }
+        log.info("시장 지표 upsert 완료: {}건", allData.size());
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/embedding/batch/EmbeddingScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/batch/EmbeddingScheduler.java
@@ -1,0 +1,56 @@
+package com.solv.wefin.domain.news.embedding.batch;
+
+import com.solv.wefin.domain.news.embedding.service.EmbeddingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 임베딩 생성 스케줄러
+ *
+ * 30분 간격으로 크롤링 완료 기사의 임베딩을 생성한다.
+ * AtomicBoolean으로 수동 트리거와의 동시 실행을 방지한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmbeddingScheduler {
+
+    private final EmbeddingService embeddingService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Scheduled(cron = "${embedding.collect.cron:0 */30 * * * *}")
+    public void generateEmbeddings() {
+        execute();
+    }
+
+    /**
+     * 임베딩 생성을 실행한다.
+     *
+     * @return 실행 여부 (이미 실행 중이면 false)
+     */
+    public boolean execute() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("임베딩 생성이 이미 실행 중입니다. 스킵합니다.");
+            return false;
+        }
+
+        log.info("=== 임베딩 생성 배치 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            embeddingService.generatePendingEmbeddings();
+            return true;
+        } catch (Exception e) {
+            log.error("임베딩 생성 실패: {}", e.getMessage(), e);
+            return false;
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 임베딩 생성 배치 종료 ({}ms) ===", elapsed);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/client/OpenAiEmbeddingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/client/OpenAiEmbeddingClient.java
@@ -1,0 +1,78 @@
+package com.solv.wefin.domain.news.embedding.client;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI Embedding API를 호출하여 텍스트를 벡터로 변환한다.
+ * 배열 입력을 지원하므로, 기사 1건의 청크들을 한 번에 요청할 수 있다.
+ */
+@Slf4j
+@Component
+public class OpenAiEmbeddingClient {
+
+    private static final String OPENAI_EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
+
+    private final RestTemplate restTemplate;
+    private final String apiKey;
+    private final String model;
+
+    public OpenAiEmbeddingClient(@Qualifier("embeddingRestTemplate") RestTemplate restTemplate,
+                                 @Value("${openai.api-key}") String apiKey,
+                                 @Value("${openai.embedding.model}") String model) {
+        this.restTemplate = restTemplate;
+        this.apiKey = apiKey;
+        this.model = model;
+    }
+
+    /**
+     * 여러 텍스트를 한 번에 임베딩으로 변환한다.
+     *
+     * @param texts 임베딩할 텍스트 목록
+     * @return 입력 순서와 동일한 순서의 임베딩 벡터 목록
+     */
+    public List<float[]> getEmbeddings(List<String> texts) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "input", texts
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+        EmbeddingResponse response = restTemplate.postForObject(
+                OPENAI_EMBEDDING_URL, request, EmbeddingResponse.class);
+
+        if (response == null || response.getData() == null) {
+            throw new IllegalStateException("OpenAI Embedding API 응답이 비어있습니다");
+        }
+
+        return response.getData().stream()
+                .sorted((a, b) -> Integer.compare(a.getIndex(), b.getIndex()))
+                .map(EmbeddingData::getEmbedding)
+                .toList();
+    }
+
+    @Getter
+    private static class EmbeddingResponse {
+        private List<EmbeddingData> data;
+    }
+
+    @Getter
+    private static class EmbeddingData {
+        private int index;
+        private float[] embedding;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/client/OpenAiEmbeddingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/client/OpenAiEmbeddingClient.java
@@ -59,6 +59,11 @@ public class OpenAiEmbeddingClient {
             throw new IllegalStateException("OpenAI Embedding API 응답이 비어있습니다");
         }
 
+        if (response.getData().size() != texts.size()) {
+            throw new IllegalStateException(
+                    "OpenAI Embedding API 응답 개수 불일치: 요청=" + texts.size() + ", 응답=" + response.getData().size());
+        }
+
         return response.getData().stream()
                 .sorted((a, b) -> Integer.compare(a.getIndex(), b.getIndex()))
                 .map(EmbeddingData::getEmbedding)

--- a/src/main/java/com/solv/wefin/domain/news/embedding/config/EmbeddingConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/config/EmbeddingConfig.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.domain.news.embedding.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class EmbeddingConfig {
+
+    @Bean
+    public RestTemplate embeddingRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000);
+        factory.setReadTimeout(30000);
+        return new RestTemplate(factory);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/entity/ArticleEmbedding.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/entity/ArticleEmbedding.java
@@ -1,0 +1,56 @@
+package com.solv.wefin.domain.news.embedding.entity;
+
+import com.solv.wefin.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "article_embedding",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_article_embedding_article_model_chunk",
+                columnNames = {"news_article_id", "embedding_model", "chunk_index"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleEmbedding extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_embedding_id")
+    private Long id;
+
+    @Column(name = "news_article_id", nullable = false)
+    private Long newsArticleId;
+
+    @Column(name = "embedding_model", nullable = false, length = 50)
+    private String embeddingModel;
+
+    @Column(name = "embedding_version", nullable = false, length = 20)
+    private String embeddingVersion;
+
+    @Column(name = "chunk_index", nullable = false)
+    private int chunkIndex;
+
+    @Column(name = "chunk_text", nullable = false, columnDefinition = "TEXT")
+    private String chunkText;
+
+    @Column(name = "token_count", nullable = false)
+    private int tokenCount;
+
+    @Column(name = "embedding", nullable = false, columnDefinition = "vector(1536)")
+    private float[] embedding;
+
+    @Builder
+    private ArticleEmbedding(Long newsArticleId, String embeddingModel, String embeddingVersion,
+                             int chunkIndex, String chunkText, int tokenCount, float[] embedding) {
+        this.newsArticleId = newsArticleId;
+        this.embeddingModel = embeddingModel;
+        this.embeddingVersion = embeddingVersion;
+        this.chunkIndex = chunkIndex;
+        this.chunkText = chunkText;
+        this.tokenCount = tokenCount;
+        this.embedding = embedding;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/repository/ArticleEmbeddingRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/repository/ArticleEmbeddingRepository.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.news.embedding.repository;
+
+import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ArticleEmbeddingRepository extends JpaRepository<ArticleEmbedding, Long> {
+
+    /**
+     * 특정 기사의 특정 모델로 생성된 청크별 임베딩을 조회한다.
+     *
+     * @param newsArticleId 기사 ID
+     * @param embeddingModel 임베딩 모델명 (예: "text-embedding-3-small")
+     * @return 해당 기사의 청크별 임베딩 목록
+     */
+    List<ArticleEmbedding> findByNewsArticleIdAndEmbeddingModel(Long newsArticleId, String embeddingModel);
+
+    /**
+     * 특정 기사의 특정 모델로 생성된 임베딩을 전부 삭제한다.
+     * 모델 교체나 재임베딩 시 기존 데이터를 정리하기 위해 사용한다.
+     *
+     * @param newsArticleId 기사 ID
+     * @param embeddingModel 임베딩 모델명
+     */
+    void deleteByNewsArticleIdAndEmbeddingModel(Long newsArticleId, String embeddingModel);
+
+    /**
+     * 특정 기사에 대해 특정 모델의 임베딩이 존재하는지 확인한다.
+     * 중복 생성 방지 시 사용한다.
+     *
+     * @param newsArticleId 기사 ID
+     * @param embeddingModel 임베딩 모델명
+     * @return 임베딩이 존재하면 true
+     */
+    boolean existsByNewsArticleIdAndEmbeddingModel(Long newsArticleId, String embeddingModel);
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/ArticleChunker.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/ArticleChunker.java
@@ -1,0 +1,177 @@
+package com.solv.wefin.domain.news.embedding.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * 기사 본문을 토큰 기준으로 청크 분할한다.
+ * RAG 근거 문단 추적을 위해 기사 전체를 하나의 벡터로 만들지 않고,
+ * 약 500토큰 단위로 문장 경계에서 나누어 청크별 임베딩을 생성할 수 있도록 한다.
+ * 첫 번째 청크에는 제목을 포함시켜 기사의 맥락을 유지한다.
+ */
+@Component
+public class ArticleChunker {
+
+    private static final int TARGET_CHUNK_TOKENS = 500;
+    private static final double KOREAN_CHARS_PER_TOKEN = 2.0;
+    private static final double NON_KOREAN_CHARS_PER_TOKEN = 4.0;
+
+    /**
+     * 제목과 본문을 결합하여 토큰 기준 청크로 분할한다.
+     *
+     * @param title   기사 제목
+     * @param content 기사 본문
+     * @return 분할된 청크 목록 (최소 1개)
+     */
+    public List<Chunk> chunk(String title, String content) {
+        String fullText = buildFullText(title, content);
+
+        if (fullText.isBlank()) {
+            return List.of();
+        }
+
+        int estimatedTokens = estimateTokenCount(fullText);
+        if (estimatedTokens <= TARGET_CHUNK_TOKENS) {
+            return List.of(createChunk(0, fullText, estimatedTokens));
+        }
+
+        return splitBySentenceBoundary(fullText);
+    }
+
+    /**
+     * 제목과 본문을 하나의 텍스트로 결합한다.
+     * 제목이 있으면 본문 앞에 줄바꿈 2개로 구분하여 붙인다.
+     */
+    private String buildFullText(String title, String content) {
+        String normalizedTitle = normalize(title);
+        String normalizedContent = normalize(content);
+
+        if (normalizedTitle.isEmpty()) {
+            return normalizedContent;
+        }
+        if (normalizedContent.isEmpty()) {
+            return normalizedTitle;
+        }
+        return normalizedTitle + "\n\n" + normalizedContent;
+    }
+
+    /** null/blank 문자열을 빈 문자열로 정규화한다. */
+    private String normalize(String text) {
+        return text == null ? "" : text.strip();
+    }
+
+    /**
+     * 텍스트를 문장 경계에서 나누어 ~500토큰 단위 청크로 분할한다.
+     * 현재 청크에 문장을 추가했을 때 목표 토큰 수를 초과하면 새 청크를 시작한다.
+     */
+    private List<Chunk> splitBySentenceBoundary(String text) {
+        List<String> sentences = splitIntoSentences(text);
+        List<Chunk> chunks = new ArrayList<>();
+
+        StringBuilder currentChunk = new StringBuilder();
+        int currentTokens = 0;
+        int chunkIndex = 0;
+
+        for (String sentence : sentences) {
+            int sentenceTokens = estimateTokenCount(sentence);
+
+            if (currentTokens + sentenceTokens > TARGET_CHUNK_TOKENS && currentTokens > 0) {
+                chunks.add(createChunk(chunkIndex++, currentChunk.toString(), currentTokens));
+                currentChunk = new StringBuilder();
+                currentTokens = 0;
+            }
+
+            currentChunk.append(sentence);
+            currentTokens += sentenceTokens;
+        }
+
+        if (currentTokens > 0) {
+            chunks.add(createChunk(chunkIndex, currentChunk.toString(), currentTokens));
+        }
+
+        return chunks;
+    }
+
+    /**
+     * 텍스트를 문장 단위로 분리한다.
+     * Java의 BreakIterator(한국어)를 사용하여 마침표, 물음표 등 문장 경계를 감지한다.
+     * 문장 분리 실패 시 원문 전체를 1문장으로 취급한다.
+     */
+    private List<String> splitIntoSentences(String text) {
+        List<String> sentences = new ArrayList<>();
+        BreakIterator iterator = BreakIterator.getSentenceInstance(Locale.KOREAN);
+        iterator.setText(text);
+
+        int start = iterator.first();
+        for (int end = iterator.next(); end != BreakIterator.DONE; end = iterator.next()) {
+            String sentence = text.substring(start, end).strip();
+            if (!sentence.isEmpty()) {
+                sentences.add(sentence);
+            }
+            start = end;
+        }
+
+        if (sentences.isEmpty() && !text.isBlank()) {
+            return List.of(text.strip());
+        }
+
+        return sentences;
+    }
+
+    /**
+     * 텍스트의 토큰 수를 근사 추정한다.
+     * 한글은 약 2자당 1토큰, 영문/숫자/기호는 약 4자당 1토큰으로 계산한다.
+     *
+     * @param text 대상 텍스트
+     * @return 추정 토큰 수
+     */
+    public int estimateTokenCount(String text) {
+        if (text == null || text.isEmpty()) {
+            return 0;
+        }
+
+        int koreanChars = 0;
+        int otherChars = 0;
+
+        for (char c : text.toCharArray()) {
+            if (isKorean(c)) {
+                koreanChars++;
+            } else if (!Character.isWhitespace(c)) {
+                otherChars++;
+            }
+        }
+
+        return (int) Math.ceil(koreanChars / KOREAN_CHARS_PER_TOKEN + otherChars / NON_KOREAN_CHARS_PER_TOKEN);
+    }
+
+    /** 한글 음절/자모인지 판별한다. */
+    private boolean isKorean(char c) {
+        Character.UnicodeBlock block = Character.UnicodeBlock.of(c);
+        return block == Character.UnicodeBlock.HANGUL_SYLLABLES
+                || block == Character.UnicodeBlock.HANGUL_JAMO
+                || block == Character.UnicodeBlock.HANGUL_COMPATIBILITY_JAMO;
+    }
+
+    /** 청크 객체를 생성한다. strip() 처리를 한 곳에서 담당한다. */
+    private Chunk createChunk(int chunkIndex, String text, int tokenCount) {
+        return Chunk.builder()
+                .chunkIndex(chunkIndex)
+                .chunkText(text.strip())
+                .tokenCount(tokenCount)
+                .build();
+    }
+
+    @Getter
+    @Builder
+    public static class Chunk {
+        private final int chunkIndex;
+        private final String chunkText;
+        private final int tokenCount;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/ArticleChunker.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/ArticleChunker.java
@@ -87,8 +87,14 @@ public class ArticleChunker {
                 currentTokens = 0;
             }
 
-            currentChunk.append(sentence);
-            currentTokens += sentenceTokens;
+            if (sentenceTokens > TARGET_CHUNK_TOKENS) {
+                chunkIndex = hardSplit(sentence, chunks, currentChunk, currentTokens, chunkIndex);
+                currentChunk = new StringBuilder();
+                currentTokens = 0;
+            } else {
+                currentChunk.append(sentence);
+                currentTokens += sentenceTokens;
+            }
         }
 
         if (currentTokens > 0) {
@@ -156,6 +162,40 @@ public class ArticleChunker {
         return block == Character.UnicodeBlock.HANGUL_SYLLABLES
                 || block == Character.UnicodeBlock.HANGUL_JAMO
                 || block == Character.UnicodeBlock.HANGUL_COMPATIBILITY_JAMO;
+    }
+
+    /**
+     * 단일 문장이 TARGET_CHUNK_TOKENS를 초과할 때 문자 단위로 강제 분할한다.
+     * 앞에 쌓인 currentChunk가 있으면 먼저 flush한 뒤, 긴 문장을 토큰 한도 내로 잘라 청크를 생성한다.
+     *
+     * @return 갱신된 chunkIndex
+     */
+    private int hardSplit(String sentence, List<Chunk> chunks, StringBuilder currentChunk,
+                          int currentTokens, int chunkIndex) {
+        if (currentTokens > 0) {
+            chunks.add(createChunk(chunkIndex++, currentChunk.toString(), currentTokens));
+        }
+
+        int estimatedCharsPerToken = 3;
+        int charsPerChunk = TARGET_CHUNK_TOKENS * estimatedCharsPerToken;
+        int start = 0;
+
+        while (start < sentence.length()) {
+            int end = Math.min(start + charsPerChunk, sentence.length());
+            String part = sentence.substring(start, end);
+            int partTokens = estimateTokenCount(part);
+
+            while (partTokens > TARGET_CHUNK_TOKENS && end > start + 1) {
+                end--;
+                part = sentence.substring(start, end);
+                partTokens = estimateTokenCount(part);
+            }
+
+            chunks.add(createChunk(chunkIndex++, part, partTokens));
+            start = end;
+        }
+
+        return chunkIndex;
     }
 
     /** 청크 객체를 생성한다. strip() 처리를 한 곳에서 담당한다. */

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceService.java
@@ -34,6 +34,7 @@ public class EmbeddingPersistenceService {
         for (NewsArticle article : articles) {
             article.markEmbeddingProcessing();
         }
+        newsArticleRepository.saveAll(articles);
     }
 
     /**
@@ -48,6 +49,7 @@ public class EmbeddingPersistenceService {
         for (NewsArticle article : articles) {
             article.markEmbeddingSuccess();
         }
+        newsArticleRepository.saveAll(articles);
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceService.java
@@ -1,0 +1,72 @@
+package com.solv.wefin.domain.news.embedding.service;
+
+import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
+import com.solv.wefin.domain.news.embedding.repository.ArticleEmbeddingRepository;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 임베딩 결과를 DB에 반영하는 서비스
+ *
+ * 외부 API 호출과 트랜잭션을 분리하기 위해 별도 서비스로 구성한다.
+ * 정상 흐름은 묶음 트랜잭션으로 처리하고, 실패 건은 개별 REQUIRES_NEW로 격리한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class EmbeddingPersistenceService {
+
+    private final ArticleEmbeddingRepository articleEmbeddingRepository;
+    private final NewsArticleRepository newsArticleRepository;
+
+    /**
+     * 임베딩 대상 기사들의 상태를 PROCESSING으로 일괄 전환한다.
+     *
+     * @param articles 대상 기사 목록
+     */
+    @Transactional
+    public void markProcessing(List<NewsArticle> articles) {
+        for (NewsArticle article : articles) {
+            article.markEmbeddingProcessing();
+        }
+    }
+
+    /**
+     * 여러 기사의 임베딩을 한 트랜잭션으로 저장하고 상태를 SUCCESS로 변경한다.
+     *
+     * @param embeddings 저장할 임베딩 목록
+     * @param articles   대상 기사 목록 (상태 변경용)
+     */
+    @Transactional
+    public void saveEmbeddingsBatch(List<ArticleEmbedding> embeddings, List<NewsArticle> articles) {
+        articleEmbeddingRepository.saveAll(embeddings);
+        for (NewsArticle article : articles) {
+            article.markEmbeddingSuccess();
+        }
+    }
+
+    /**
+     * 임베딩 생성 실패를 기록한다. 개별 트랜잭션으로 격리하여 다른 건에 영향을 주지 않는다.
+     *
+     * @param articleId    실패한 기사 ID
+     * @param errorMessage 실패 원인 메시지
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long articleId, String errorMessage) {
+        NewsArticle article = newsArticleRepository.findById(articleId)
+                .orElseThrow(() -> new IllegalStateException("기사를 찾을 수 없습니다: " + articleId));
+        article.markEmbeddingFailed(truncate(errorMessage, 500));
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) {
+            return "Unknown error";
+        }
+        return text.length() <= maxLength ? text : text.substring(0, maxLength);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceService.java
@@ -4,6 +4,8 @@ import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
 import com.solv.wefin.domain.news.embedding.repository.ArticleEmbeddingRepository;
 import com.solv.wefin.domain.news.entity.NewsArticle;
 import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -61,7 +63,7 @@ public class EmbeddingPersistenceService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markFailed(Long articleId, String errorMessage) {
         NewsArticle article = newsArticleRepository.findById(articleId)
-                .orElseThrow(() -> new IllegalStateException("기사를 찾을 수 없습니다: " + articleId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.EMBEDDING_ARTICLE_NOT_FOUND));
         article.markEmbeddingFailed(truncate(errorMessage, 500));
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -30,6 +31,7 @@ public class EmbeddingService {
     private static final int BATCH_SIZE = 500;
     private static final int PROCESS_CHUNK_SIZE = 20;
     private static final int MAX_RETRY = 3;
+    private static final int STALE_PROCESSING_MINUTES = 30;
 
     private final NewsArticleRepository newsArticleRepository;
     private final OpenAiEmbeddingClient openAiEmbeddingClient;
@@ -73,10 +75,12 @@ public class EmbeddingService {
     }
 
     private List<NewsArticle> findEmbeddingTargets() {
+        LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
         return newsArticleRepository.findEmbeddingTargets(
                 CrawlStatus.SUCCESS,
                 List.of(EmbeddingStatus.PENDING, EmbeddingStatus.FAILED),
                 MAX_RETRY,
+                staleBefore,
                 PageRequest.of(0, BATCH_SIZE));
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
@@ -1,0 +1,156 @@
+package com.solv.wefin.domain.news.embedding.service;
+
+import com.solv.wefin.domain.news.embedding.client.OpenAiEmbeddingClient;
+import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.entity.NewsArticle.EmbeddingStatus;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 임베딩 생성 전체 흐름을 관리하는 서비스
+ *
+ * 외부 API 호출은 트랜잭션 밖에서 수행하고,
+ * DB 저장은 EmbeddingPersistenceService에서 트랜잭션으로 처리한다.
+ * 20건 단위로 묶어서 배치 트랜잭션을 실행하고, 실패 건은 개별 fallback으로 격리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmbeddingService {
+
+    private static final int BATCH_SIZE = 500;
+    private static final int PROCESS_CHUNK_SIZE = 20;
+    private static final int MAX_RETRY = 3;
+
+    private final NewsArticleRepository newsArticleRepository;
+    private final OpenAiEmbeddingClient openAiEmbeddingClient;
+    private final ArticleChunker articleChunker;
+    private final EmbeddingPersistenceService persistenceService;
+
+    @Value("${openai.embedding.model}")
+    private String embeddingModel;
+
+    @Value("${openai.embedding.version:v1}")
+    private String embeddingVersion;
+
+    /**
+     * 크롤링 완료 + 임베딩 미생성 기사를 조회하여 임베딩을 생성한다.
+     *
+     * 500건씩 조회한 뒤 20건 단위로 묶어 처리한다.
+     * 기사별로 청크 분할 → OpenAI API 호출 → DB 저장 순서로 진행하며,
+     * 개별 기사 실패는 다른 기사에 영향을 주지 않도록 격리한다.
+     */
+    public void generatePendingEmbeddings() {
+        List<NewsArticle> targets = findEmbeddingTargets();
+        log.info("임베딩 대상 기사 수: {}", targets.size());
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        persistenceService.markProcessing(targets);
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (int i = 0; i < targets.size(); i += PROCESS_CHUNK_SIZE) {
+            List<NewsArticle> chunk = targets.subList(i, Math.min(i + PROCESS_CHUNK_SIZE, targets.size()));
+            int[] result = processChunk(chunk);
+            successCount += result[0];
+            failCount += result[1];
+        }
+
+        log.info("임베딩 생성 완료 - 성공: {}, 실패: {}", successCount, failCount);
+    }
+
+    private List<NewsArticle> findEmbeddingTargets() {
+        return newsArticleRepository.findEmbeddingTargets(
+                CrawlStatus.SUCCESS,
+                List.of(EmbeddingStatus.PENDING, EmbeddingStatus.FAILED),
+                MAX_RETRY,
+                PageRequest.of(0, BATCH_SIZE));
+    }
+
+    private int[] processChunk(List<NewsArticle> articles) {
+        List<ArticleEmbedding> allEmbeddings = new ArrayList<>();
+        List<NewsArticle> successArticles = new ArrayList<>();
+        int failCount = 0;
+
+        for (NewsArticle article : articles) {
+            try {
+                List<ArticleEmbedding> embeddings = generateEmbeddingsForArticle(article);
+                allEmbeddings.addAll(embeddings);
+                successArticles.add(article);
+            } catch (Exception e) {
+                log.warn("임베딩 생성 실패 - articleId: {}, error: {}", article.getId(), e.getMessage());
+                persistenceService.markFailed(article.getId(), e.getMessage());
+                failCount++;
+            }
+        }
+
+        if (!allEmbeddings.isEmpty()) {
+            try {
+                persistenceService.saveEmbeddingsBatch(allEmbeddings, successArticles);
+            } catch (Exception e) {
+                log.error("임베딩 배치 저장 실패, 개별 fallback 시도: {}", e.getMessage());
+                failCount += handleBatchSaveFailure(successArticles, e.getMessage());
+                return new int[]{0, failCount};
+            }
+        }
+
+        return new int[]{successArticles.size(), failCount};
+    }
+
+    private List<ArticleEmbedding> generateEmbeddingsForArticle(NewsArticle article) {
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk(article.getTitle(), article.getContent());
+
+        if (chunks.isEmpty()) {
+            throw new IllegalStateException("청크 분할 결과가 비어있습니다");
+        }
+
+        List<String> chunkTexts = chunks.stream()
+                .map(ArticleChunker.Chunk::getChunkText)
+                .toList();
+
+        List<float[]> vectors = openAiEmbeddingClient.getEmbeddings(chunkTexts);
+
+        List<ArticleEmbedding> embeddings = new ArrayList<>();
+        for (int i = 0; i < chunks.size(); i++) {
+            ArticleChunker.Chunk chunk = chunks.get(i);
+            embeddings.add(ArticleEmbedding.builder()
+                    .newsArticleId(article.getId())
+                    .embeddingModel(embeddingModel)
+                    .embeddingVersion(embeddingVersion)
+                    .chunkIndex(chunk.getChunkIndex())
+                    .chunkText(chunk.getChunkText())
+                    .tokenCount(chunk.getTokenCount())
+                    .embedding(vectors.get(i))
+                    .build());
+        }
+
+        return embeddings;
+    }
+
+    private int handleBatchSaveFailure(List<NewsArticle> articles, String errorMessage) {
+        int failCount = 0;
+        for (NewsArticle article : articles) {
+            try {
+                persistenceService.markFailed(article.getId(), "배치 저장 실패: " + errorMessage);
+                failCount++;
+            } catch (Exception e) {
+                log.error("개별 실패 마킹도 실패 - articleId: {}, error: {}", article.getId(), e.getMessage());
+                failCount++;
+            }
+        }
+        return failCount;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -73,6 +73,19 @@ public class NewsArticle extends BaseEntity {
     @Column(name = "crawl_error_message")
     private String crawlErrorMessage;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "embedding_status", nullable = false, length = 30)
+    private EmbeddingStatus embeddingStatus = EmbeddingStatus.PENDING;
+
+    @Column(name = "embedding_retry_count", nullable = false)
+    private int embeddingRetryCount = 0;
+
+    @Column(name = "embedding_attempted_at")
+    private LocalDateTime embeddingAttemptedAt;
+
+    @Column(name = "embedding_error_message")
+    private String embeddingErrorMessage;
+
     @Builder
     private NewsArticle(Long rawNewsArticleId, String publisherName, String title,
                         String summary, String content, String originalUrl,
@@ -95,12 +108,19 @@ public class NewsArticle extends BaseEntity {
         this.crawlStatus = CrawlStatus.PENDING;
     }
 
+    public enum CrawlStatus {
+        PENDING, SUCCESS, FAILED, SKIPPED
+    }
+
+    public enum EmbeddingStatus {
+        PENDING, PROCESSING, SUCCESS, FAILED
+    }
+
     /**
      * 크롤링 성공 시 본문과 썸네일을 업데이트한다.
      *
-     * <p>본문은 항상 최신 크롤링 결과로 덮어쓴다 (재크롤링 시 최신 본문 반영).
      * 썸네일은 최초 1회만 저장하고 이후 덮어쓰지 않는다
-     * (원본 사이트의 og:image가 광고/기본 이미지로 변경되는 경우 방지).</p>
+     * (원본 사이트의 og:image가 광고/기본 이미지로 변경되는 경우 방지).
      *
      * @param crawledContent 크롤링된 본문 텍스트
      * @param thumbnailUrl og:image 썸네일 URL (없으면 null)
@@ -117,7 +137,8 @@ public class NewsArticle extends BaseEntity {
     }
 
     /**
-     * 크롤링 실패를 기록한다. retryCount를 증가시키고 상태를 FAILED로 변경한다.
+     * 크롤링 실패를 기록한다.
+     * retryCount를 증가시키고 상태를 FAILED로 변경한다.
      *
      * @param errorMessage 실패 원인 메시지 (최대 500자)
      */
@@ -128,15 +149,46 @@ public class NewsArticle extends BaseEntity {
         this.crawlErrorMessage = errorMessage;
     }
 
-    /** 크롤링 대상에서 제외한다. 상태를 SKIPPED로 변경한다. */
+    /**
+     * 크롤링 대상에서 제외한다.
+     * 상태를 SKIPPED로 변경한다.
+     */
     public void markCrawlSkipped() {
         this.crawlStatus = CrawlStatus.SKIPPED;
         this.crawlAttemptedAt = LocalDateTime.now();
         this.crawlErrorMessage = null;
     }
 
-    public enum CrawlStatus {
-        PENDING, SUCCESS, FAILED, SKIPPED
+    /**
+     * 임베딩 처리 시작을 기록한다.
+     * 상태를 PROCESSING으로 변경한다.
+     */
+    public void markEmbeddingProcessing() {
+        this.embeddingStatus = EmbeddingStatus.PROCESSING;
+        this.embeddingAttemptedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 임베딩 생성 성공을 기록한다.
+     * 상태를 SUCCESS로 변경하고 에러 메시지를 초기화한다.
+     */
+    public void markEmbeddingSuccess() {
+        this.embeddingStatus = EmbeddingStatus.SUCCESS;
+        this.embeddingAttemptedAt = LocalDateTime.now();
+        this.embeddingErrorMessage = null;
+    }
+
+    /**
+     * 임베딩 생성 실패를 기록한다.
+     * retryCount를 증가시키고 상태를 FAILED로 변경한다.
+     *
+     * @param errorMessage 실패 원인 메시지
+     */
+    public void markEmbeddingFailed(String errorMessage) {
+        this.embeddingRetryCount++;
+        this.embeddingStatus = EmbeddingStatus.FAILED;
+        this.embeddingAttemptedAt = LocalDateTime.now();
+        this.embeddingErrorMessage = errorMessage;
     }
 
     public static NewsArticle of(RawNewsArticle rawArticle, CollectedNewsDto dto,

--- a/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/entity/NewsArticle.java
@@ -166,6 +166,7 @@ public class NewsArticle extends BaseEntity {
     public void markEmbeddingProcessing() {
         this.embeddingStatus = EmbeddingStatus.PROCESSING;
         this.embeddingAttemptedAt = LocalDateTime.now();
+        this.embeddingErrorMessage = null;
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> {
@@ -15,14 +16,20 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
     List<NewsArticle> findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(
             List<NewsArticle.CrawlStatus> statuses, int maxRetryCount, Pageable pageable);
 
+    /**
+     * 임베딩 대상 기사를 조회한다.
+     * PENDING/FAILED 상태이거나, PROCESSING 상태에서 staleBefore 이전에 시도된 기사(크래시로 방치된 건)를 포함한다.
+     */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.crawlStatus = :crawlStatus " +
-            "AND a.embeddingStatus IN :embeddingStatuses " +
             "AND a.embeddingRetryCount < :maxRetryCount " +
+            "AND (a.embeddingStatus IN :embeddingStatuses " +
+            "     OR (a.embeddingStatus = 'PROCESSING' AND a.embeddingAttemptedAt < :staleBefore)) " +
             "ORDER BY a.collectedAt DESC")
     List<NewsArticle> findEmbeddingTargets(
             @Param("crawlStatus") NewsArticle.CrawlStatus crawlStatus,
             @Param("embeddingStatuses") List<NewsArticle.EmbeddingStatus> embeddingStatuses,
             @Param("maxRetryCount") int maxRetryCount,
+            @Param("staleBefore") LocalDateTime staleBefore,
             Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/repository/NewsArticleRepository.java
@@ -3,6 +3,8 @@ package com.solv.wefin.domain.news.repository;
 import com.solv.wefin.domain.news.entity.NewsArticle;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -12,4 +14,15 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
 
     List<NewsArticle> findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(
             List<NewsArticle.CrawlStatus> statuses, int maxRetryCount, Pageable pageable);
+
+    @Query("SELECT a FROM NewsArticle a " +
+            "WHERE a.crawlStatus = :crawlStatus " +
+            "AND a.embeddingStatus IN :embeddingStatuses " +
+            "AND a.embeddingRetryCount < :maxRetryCount " +
+            "ORDER BY a.collectedAt DESC")
+    List<NewsArticle> findEmbeddingTargets(
+            @Param("crawlStatus") NewsArticle.CrawlStatus crawlStatus,
+            @Param("embeddingStatuses") List<NewsArticle.EmbeddingStatus> embeddingStatuses,
+            @Param("maxRetryCount") int maxRetryCount,
+            Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -48,6 +48,9 @@ public enum ErrorCode {
     INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심종목입니다."),
     INTEREST_LIMIT_EXCEEDED(400, "관심종목은 최대 10개까지 등록할 수 있습니다."),
 
+    // Embedding
+    EMBEDDING_ARTICLE_NOT_FOUND(500, "임베딩 대상 기사를 찾을 수 없습니다."),
+
     // GameRoom
     ROOM_NOT_FOUND(404,"게임장을 찾을 수 없습니다."),
     ROOM_ALREADY_EXISTS(409, "이미 진행 중이거나 대기 중인 게임방이 있습니다."),

--- a/src/main/java/com/solv/wefin/web/news/EmbeddingAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/EmbeddingAdminController.java
@@ -25,6 +25,6 @@ public class EmbeddingAdminController {
         if (executed) {
             return ApiResponse.success("임베딩 생성 완료");
         }
-        return ApiResponse.success("임베딩 생성이 이미 실행 중입니다");
+        return ApiResponse.success("임베딩 생성을 건너뜁니다 (이미 실행 중이거나 오류 발생)");
     }
 }

--- a/src/main/java/com/solv/wefin/web/news/EmbeddingAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/EmbeddingAdminController.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.web.news;
+
+import com.solv.wefin.domain.news.embedding.batch.EmbeddingScheduler;
+import com.solv.wefin.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/api/admin/news/embeddings")
+@RequiredArgsConstructor
+public class EmbeddingAdminController {
+
+    private final EmbeddingScheduler embeddingScheduler;
+
+    /**
+     * 임베딩 생성을 수동으로 트리거한다.
+     */
+    @PostMapping("/generate")
+    public ApiResponse<String> generateNow() {
+        boolean executed = embeddingScheduler.execute();
+        if (executed) {
+            return ApiResponse.success("임베딩 생성 완료");
+        }
+        return ApiResponse.success("임베딩 생성이 이미 실행 중입니다");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -42,6 +42,10 @@ market:
   collect:
     cron: "0 */5 * * * *"
 
+embedding:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -43,6 +43,10 @@ market:
   collect:
     cron: "0 */5 * * * *"
 
+embedding:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -39,6 +39,10 @@ market:
   collect:
     cron: "0 */5 * * * *"
 
+embedding:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,16 @@ spring:
     enabled: true
     locations: classpath:db/migration
 
+openai:
+  api-key: ${OPENAI_API_KEY:}
+  embedding:
+    model: text-embedding-3-small
+    version: v1
+
+embedding:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/db/migration/V8__add_article_embedding.sql
+++ b/src/main/resources/db/migration/V8__add_article_embedding.sql
@@ -1,0 +1,27 @@
+-- 기존 V1에서 만든 article_embedding 테이블 제거 (컬럼 구조 변경)
+-- CASCADE로 참조하는 FK 제약조건만 제거됨 (참조 테이블 자체는 유지)
+DROP TABLE IF EXISTS article_embedding CASCADE;
+
+-- 청크별 임베딩 벡터 저장 테이블 (재생성)
+CREATE TABLE article_embedding (
+    article_embedding_id BIGSERIAL PRIMARY KEY,
+    news_article_id      BIGINT       NOT NULL REFERENCES news_article(news_article_id),
+    embedding_model      VARCHAR(50)  NOT NULL,
+    embedding_version    VARCHAR(20)  NOT NULL,
+    chunk_index          INT          NOT NULL,
+    chunk_text           TEXT         NOT NULL,
+    token_count          INT          NOT NULL,
+    embedding            vector(1536) NOT NULL,
+    created_at           TIMESTAMPTZ    NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ    NOT NULL DEFAULT now(),
+
+    CONSTRAINT uk_article_embedding_article_model_chunk
+        UNIQUE (news_article_id, embedding_model, chunk_index)
+);
+
+-- news_article에 임베딩 처리 상태 추적 컬럼 추가
+ALTER TABLE news_article
+    ADD COLUMN IF NOT EXISTS embedding_status        VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN IF NOT EXISTS embedding_retry_count   INT         NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS embedding_attempted_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS embedding_error_message TEXT;

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/ArticleChunkerTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/ArticleChunkerTest.java
@@ -1,0 +1,152 @@
+package com.solv.wefin.domain.news.embedding.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArticleChunkerTest {
+
+    private ArticleChunker articleChunker;
+
+    @BeforeEach
+    void setUp() {
+        articleChunker = new ArticleChunker();
+    }
+
+    @Test
+    @DisplayName("짧은 기사는 청크 1개로 반환된다")
+    void shortArticle_singleChunk() {
+        // given
+        String title = "테스트 제목";
+        String content = "짧은 본문입니다.";
+
+        // when
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk(title, content);
+
+        // then
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).getChunkIndex()).isZero();
+        assertThat(chunks.get(0).getChunkText()).contains("테스트 제목");
+        assertThat(chunks.get(0).getChunkText()).contains("짧은 본문입니다.");
+        assertThat(chunks.get(0).getTokenCount()).isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("긴 기사는 여러 청크로 분할된다")
+    void longArticle_multipleChunks() {
+        // given
+        String title = "긴 기사 제목";
+        StringBuilder contentBuilder = new StringBuilder();
+        for (int i = 0; i < 200; i++) {
+            contentBuilder.append("이것은 테스트 문장 번호 ").append(i).append("입니다. ");
+        }
+        String content = contentBuilder.toString();
+
+        // when
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk(title, content);
+
+        // then
+        assertThat(chunks.size()).isGreaterThan(1);
+        assertThat(chunks.get(0).getChunkIndex()).isZero();
+        assertThat(chunks.get(0).getChunkText()).contains("긴 기사 제목");
+
+        for (int i = 0; i < chunks.size(); i++) {
+            assertThat(chunks.get(i).getChunkIndex()).isEqualTo(i);
+            assertThat(chunks.get(i).getChunkText()).isNotBlank();
+            assertThat(chunks.get(i).getTokenCount()).isGreaterThan(0);
+        }
+    }
+
+    @Test
+    @DisplayName("청크 인덱스는 0부터 연속적으로 증가한다")
+    void chunkIndex_sequential() {
+        // given
+        StringBuilder contentBuilder = new StringBuilder();
+        for (int i = 0; i < 300; i++) {
+            contentBuilder.append("반복 문장입니다. ");
+        }
+
+        // when
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk("제목", contentBuilder.toString());
+
+        // then
+        for (int i = 0; i < chunks.size(); i++) {
+            assertThat(chunks.get(i).getChunkIndex()).isEqualTo(i);
+        }
+    }
+
+    @Test
+    @DisplayName("title이 null이면 content만으로 청크를 생성한다")
+    void nullTitle_contentOnly() {
+        // given
+        String content = "본문만 있는 기사입니다.";
+
+        // when
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk(null, content);
+
+        // then
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).getChunkText()).isEqualTo("본문만 있는 기사입니다.");
+    }
+
+    @Test
+    @DisplayName("content가 null이면 title만으로 청크를 생성한다")
+    void nullContent_titleOnly() {
+        // given
+        String title = "제목만 있는 기사";
+
+        // when
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk(title, null);
+
+        // then
+        assertThat(chunks).hasSize(1);
+        assertThat(chunks.get(0).getChunkText()).isEqualTo("제목만 있는 기사");
+    }
+
+    @Test
+    @DisplayName("title과 content가 모두 빈 문자열이면 빈 리스트를 반환한다")
+    void emptyTitleAndContent_emptyList() {
+        // when
+        List<ArticleChunker.Chunk> chunks = articleChunker.chunk("", "");
+
+        // then
+        assertThat(chunks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("한글 텍스트의 토큰 수를 근사 추정한다")
+    void estimateTokenCount_korean() {
+        // given — 한글 10자 → 약 5토큰
+        String korean = "가나다라마바사아자차";
+
+        // when
+        int tokens = articleChunker.estimateTokenCount(korean);
+
+        // then
+        assertThat(tokens).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("영문 텍스트의 토큰 수를 근사 추정한다")
+    void estimateTokenCount_english() {
+        // given — 영문 12자 → 약 3토큰
+        String english = "abcdefghijkl";
+
+        // when
+        int tokens = articleChunker.estimateTokenCount(english);
+
+        // then
+        assertThat(tokens).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("빈 문자열의 토큰 수는 0이다")
+    void estimateTokenCount_empty() {
+        assertThat(articleChunker.estimateTokenCount("")).isZero();
+        assertThat(articleChunker.estimateTokenCount(null)).isZero();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceServiceIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingPersistenceServiceIntegrationTest.java
@@ -1,0 +1,121 @@
+package com.solv.wefin.domain.news.embedding.service;
+
+import com.solv.wefin.common.IntegrationTestBase;
+import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
+import com.solv.wefin.domain.news.embedding.repository.ArticleEmbeddingRepository;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.entity.NewsArticle.EmbeddingStatus;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EmbeddingPersistenceServiceIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private EmbeddingPersistenceService persistenceService;
+
+    @Autowired
+    private ArticleEmbeddingRepository articleEmbeddingRepository;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Test
+    @DisplayName("임베딩 배치 저장 시 ArticleEmbedding이 저장되고 기사 상태가 SUCCESS로 변경된다")
+    void saveEmbeddingsBatch_success() {
+        // given
+        NewsArticle article = createAndSaveArticle();
+        article.markEmbeddingProcessing();
+        newsArticleRepository.flush();
+
+        float[] vector = new float[1536];
+        ArticleEmbedding embedding = ArticleEmbedding.builder()
+                .newsArticleId(article.getId())
+                .embeddingModel("text-embedding-3-small")
+                .embeddingVersion("v1")
+                .chunkIndex(0)
+                .chunkText("테스트 청크 텍스트")
+                .tokenCount(10)
+                .embedding(vector)
+                .build();
+
+        // when
+        persistenceService.saveEmbeddingsBatch(List.of(embedding), List.of(article));
+
+        // then
+        List<ArticleEmbedding> saved = articleEmbeddingRepository
+                .findByNewsArticleIdAndEmbeddingModel(article.getId(), "text-embedding-3-small");
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getChunkIndex()).isZero();
+        assertThat(saved.get(0).getTokenCount()).isEqualTo(10);
+
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getEmbeddingStatus()).isEqualTo(EmbeddingStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("markEmbeddingFailed 호출 시 상태가 FAILED로 변경되고 에러 메시지와 retryCount가 저장된다")
+    void markEmbeddingFailed_updatesStatus() {
+        // given
+        NewsArticle article = createAndSaveArticle();
+        article.markEmbeddingProcessing();
+
+        // when
+        article.markEmbeddingFailed("API 호출 실패");
+        newsArticleRepository.flush();
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getEmbeddingStatus()).isEqualTo(EmbeddingStatus.FAILED);
+        assertThat(updated.getEmbeddingErrorMessage()).isEqualTo("API 호출 실패");
+        assertThat(updated.getEmbeddingRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("여러 청크 임베딩을 한 번에 저장할 수 있다")
+    void saveEmbeddingsBatch_multipleChunks() {
+        // given
+        NewsArticle article = createAndSaveArticle();
+        article.markEmbeddingProcessing();
+        newsArticleRepository.flush();
+
+        float[] vector = new float[1536];
+        List<ArticleEmbedding> embeddings = List.of(
+                ArticleEmbedding.builder()
+                        .newsArticleId(article.getId())
+                        .embeddingModel("text-embedding-3-small")
+                        .embeddingVersion("v1")
+                        .chunkIndex(0).chunkText("첫 번째 청크").tokenCount(10).embedding(vector).build(),
+                ArticleEmbedding.builder()
+                        .newsArticleId(article.getId())
+                        .embeddingModel("text-embedding-3-small")
+                        .embeddingVersion("v1")
+                        .chunkIndex(1).chunkText("두 번째 청크").tokenCount(15).embedding(vector).build()
+        );
+
+        // when
+        persistenceService.saveEmbeddingsBatch(embeddings, List.of(article));
+
+        // then
+        List<ArticleEmbedding> saved = articleEmbeddingRepository
+                .findByNewsArticleIdAndEmbeddingModel(article.getId(), "text-embedding-3-small");
+        assertThat(saved).hasSize(2);
+    }
+
+    private NewsArticle createAndSaveArticle() {
+        NewsArticle article = NewsArticle.builder()
+                .rawNewsArticleId(null)
+                .publisherName("test")
+                .title("테스트 기사")
+                .content("테스트 본문")
+                .originalUrl("https://example.com/test-" + System.nanoTime())
+                .dedupKey("key-" + System.nanoTime())
+                .build();
+        return newsArticleRepository.save(article);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
@@ -165,7 +165,7 @@ class EmbeddingServiceTest {
         given(newsArticleRepository.findEmbeddingTargets(
                         eq(CrawlStatus.SUCCESS),
                         eq(List.of(EmbeddingStatus.PENDING, EmbeddingStatus.FAILED)),
-                        eq(3), any()))
+                        eq(3), any(), any()))
                 .willReturn(articles);
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
@@ -1,0 +1,190 @@
+package com.solv.wefin.domain.news.embedding.service;
+
+import com.solv.wefin.domain.news.embedding.client.OpenAiEmbeddingClient;
+import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
+import com.solv.wefin.domain.news.entity.NewsArticle;
+import com.solv.wefin.domain.news.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.entity.NewsArticle.EmbeddingStatus;
+import com.solv.wefin.domain.news.repository.NewsArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmbeddingServiceTest {
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+    @Mock
+    private OpenAiEmbeddingClient openAiEmbeddingClient;
+    @Mock
+    private ArticleChunker articleChunker;
+    @Mock
+    private EmbeddingPersistenceService persistenceService;
+    @Captor
+    private ArgumentCaptor<List<ArticleEmbedding>> embeddingsCaptor;
+    @Captor
+    private ArgumentCaptor<List<NewsArticle>> articlesCaptor;
+
+    private EmbeddingService embeddingService;
+
+    @BeforeEach
+    void setUp() {
+        embeddingService = new EmbeddingService(
+                newsArticleRepository, openAiEmbeddingClient, articleChunker, persistenceService);
+        ReflectionTestUtils.setField(embeddingService, "embeddingModel", "text-embedding-3-small");
+        ReflectionTestUtils.setField(embeddingService, "embeddingVersion", "v1");
+    }
+
+    @Test
+    @DisplayName("대상 기사 3건이 있으면 청킹 → API 호출 → 저장을 수행한다")
+    void generatePendingEmbeddings_success() {
+        // given
+        List<NewsArticle> articles = createArticles(3);
+        stubFindTargets(articles);
+
+        List<ArticleChunker.Chunk> singleChunk = List.of(
+                ArticleChunker.Chunk.builder().chunkIndex(0).chunkText("테스트 텍스트").tokenCount(10).build());
+        given(articleChunker.chunk(anyString(), anyString())).willReturn(singleChunk);
+
+        float[] vector = new float[1536];
+        given(openAiEmbeddingClient.getEmbeddings(anyList())).willReturn(List.of(vector));
+
+        // when
+        embeddingService.generatePendingEmbeddings();
+
+        // then
+        verify(persistenceService).markProcessing(articles);
+        verify(persistenceService).saveEmbeddingsBatch(embeddingsCaptor.capture(), articlesCaptor.capture());
+        assertThat(embeddingsCaptor.getValue()).hasSize(3);
+        assertThat(articlesCaptor.getValue()).hasSize(3);
+        verify(persistenceService, never()).markFailed(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("대상 기사가 없으면 아무 작업도 하지 않는다")
+    void generatePendingEmbeddings_noTargets() {
+        // given
+        stubFindTargets(List.of());
+
+        // when
+        embeddingService.generatePendingEmbeddings();
+
+        // then
+        verifyNoInteractions(openAiEmbeddingClient);
+        verifyNoInteractions(articleChunker);
+        verify(persistenceService, never()).markProcessing(anyList());
+    }
+
+    @Test
+    @DisplayName("OpenAI API 실패 시 해당 기사만 FAILED로 마킹하고 나머지는 진행한다")
+    void generatePendingEmbeddings_partialFailure() {
+        // given
+        List<NewsArticle> articles = createArticles(3);
+        stubFindTargets(articles);
+
+        List<ArticleChunker.Chunk> singleChunk = List.of(
+                ArticleChunker.Chunk.builder().chunkIndex(0).chunkText("텍스트").tokenCount(5).build());
+        given(articleChunker.chunk(anyString(), anyString())).willReturn(singleChunk);
+
+        float[] vector = new float[1536];
+        given(openAiEmbeddingClient.getEmbeddings(anyList()))
+                .willReturn(List.of(vector))
+                .willThrow(new RuntimeException("API 오류"))
+                .willReturn(List.of(vector));
+
+        // when
+        embeddingService.generatePendingEmbeddings();
+
+        // then — 1건 실패, 2건 성공
+        verify(persistenceService).markFailed(eq(2L), contains("API 오류"));
+        verify(persistenceService).saveEmbeddingsBatch(embeddingsCaptor.capture(), articlesCaptor.capture());
+        assertThat(embeddingsCaptor.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("청크 분할 결과가 비어있으면 해당 기사를 FAILED로 마킹한다")
+    void generatePendingEmbeddings_emptyChunks() {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        given(articleChunker.chunk(anyString(), anyString())).willReturn(List.of());
+
+        // when
+        embeddingService.generatePendingEmbeddings();
+
+        // then
+        verify(persistenceService).markFailed(eq(1L), contains("청크 분할 결과가 비어있습니다"));
+        verify(openAiEmbeddingClient, never()).getEmbeddings(anyList());
+    }
+
+    @Test
+    @DisplayName("여러 청크가 있는 기사는 청크 수만큼 임베딩을 생성한다")
+    void generatePendingEmbeddings_multipleChunks() {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        List<ArticleChunker.Chunk> threeChunks = List.of(
+                ArticleChunker.Chunk.builder().chunkIndex(0).chunkText("첫 번째").tokenCount(10).build(),
+                ArticleChunker.Chunk.builder().chunkIndex(1).chunkText("두 번째").tokenCount(10).build(),
+                ArticleChunker.Chunk.builder().chunkIndex(2).chunkText("세 번째").tokenCount(10).build());
+        given(articleChunker.chunk(anyString(), anyString())).willReturn(threeChunks);
+
+        float[] vector = new float[1536];
+        given(openAiEmbeddingClient.getEmbeddings(anyList()))
+                .willReturn(List.of(vector, vector, vector));
+
+        // when
+        embeddingService.generatePendingEmbeddings();
+
+        // then
+        verify(persistenceService).saveEmbeddingsBatch(embeddingsCaptor.capture(), articlesCaptor.capture());
+        assertThat(embeddingsCaptor.getValue()).hasSize(3);
+        assertThat(embeddingsCaptor.getValue().get(0).getChunkIndex()).isZero();
+        assertThat(embeddingsCaptor.getValue().get(1).getChunkIndex()).isEqualTo(1);
+        assertThat(embeddingsCaptor.getValue().get(2).getChunkIndex()).isEqualTo(2);
+    }
+
+    private void stubFindTargets(List<NewsArticle> articles) {
+        given(newsArticleRepository.findEmbeddingTargets(
+                        eq(CrawlStatus.SUCCESS),
+                        eq(List.of(EmbeddingStatus.PENDING, EmbeddingStatus.FAILED)),
+                        eq(3), any()))
+                .willReturn(articles);
+    }
+
+    private List<NewsArticle> createArticles(int count) {
+        List<NewsArticle> articles = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            NewsArticle article = NewsArticle.builder()
+                    .rawNewsArticleId((long) i)
+                    .publisherName("test")
+                    .title("테스트 기사 " + i)
+                    .content("본문 내용 " + i)
+                    .originalUrl("https://example.com/" + i)
+                    .dedupKey("key" + i)
+                    .build();
+            ReflectionTestUtils.setField(article, "id", (long) (i + 1));
+            ReflectionTestUtils.setField(article, "crawlStatus", CrawlStatus.SUCCESS);
+            ReflectionTestUtils.setField(article, "embeddingStatus", EmbeddingStatus.PENDING);
+            articles.add(article);
+        }
+        return articles;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,3 +32,13 @@ market:
     base-url: https://ecos.bok.or.kr/api
   collect:
     cron: "-"
+
+openai:
+  api-key: test-openai-key
+  embedding:
+    model: text-embedding-3-small
+    version: v1
+
+embedding:
+  collect:
+    cron: "-"


### PR DESCRIPTION

## 📌 PR 설명

크롤링이 완료된 뉴스 기사(SUCCESS)를 대상으로 OpenAI Embedding API를 이용한 벡터 임베딩 생성 파이프라인을 구축했습니다. 

RAG 기반 기능(브리핑, 추천, 유사도 검색)을 고려하여 아래와 같이 설계했습니다.

* 기사 본문을 토큰 기준 청크로 분할
* 청크 단위 임베딩 생성 및 저장 (문단 단위 출처 추적 가능)
* pgvector 기반 PostgreSQL에 벡터 저장
* 배치 처리 + 상태 관리 + 재시도 구조 포함

스케줄러와 수동 트리거가 동시에 실행되는 상황을 고려하여 동시성/중복 방지 구조를 함께 적용했습니다.

<br>

## ✅ 완료한 기능 명세

* [x] pgvector 기반 article_embedding 테이블 설계 및 마이그레이션
* [x] 뉴스 기사 Embedding 상태 관리 (PENDING / PROCESSING / SUCCESS / FAILED)
* [x] ArticleChunker 구현 (토큰 기준 약 500토큰 단위 분할)
* [x] OpenAI Embedding API 연동 클라이언트 구현
* [x] 20건 단위 배치 트랜잭션 처리 + 실패 건 개별 fallback
* [x] EmbeddingScheduler (30분 주기 배치)
* [x] EmbeddingAdminController (수동 실행 API)
* [x] stale PROCESSING (30분 초과) 자동 재수거 로직
* [x] UNIQUE 제약으로 중복 임베딩 방지
* [x] 단위 테스트 및 통합 테스트 작성

<br>

## 📸 스크린샷

<img width="1832" height="507" alt="image" src="https://github.com/user-attachments/assets/e256befb-c8fd-4d42-8d6a-4fc07951a1af" />


<br>

## 💭 고민과 해결과정

### 1. 기사 단위 vs 청크 단위 임베딩

처음에는 기사 전체를 하나의 벡터로 저장하는 방식도 고려했지만,
RAG 기반 서비스에서 어떤 문단이 근거인지 추적이 필요하기 때문에 청크 단위로 설계했습니다.
결과적으로 출처 추적 가능, 긴 기사에서 문맥 손실 방지를 동시에 만족할 수 있도록 했습니다.


### 2. 상태 관리 방식

단순히 임베딩 row 존재 여부로 처리 여부를 판단하면 실패 이력 관리 불가, 재시도 로직 불가능, 스케줄러/수동 트리거 충돌 발생 문제가 발생하여

기존 크롤링 구조와 동일하게

* status
* retry_count
* error_message

를 도입하여 운영 가능한 배치 구조로 설계했습니다.



### 3. 트랜잭션 전략

전략 후보:

* 건별 REQUIRES_NEW → 안정성 높지만 성능 비용 큼
* 일괄 처리 → 성능 좋지만 일부 실패 시 문제

최종
* 20건 단위 1 트랜잭션
* 실패 건만 개별 fallback 처리

→ 성능과 안정성 확보


### 4. 동시성 및 중복 방지

스케줄러 + 수동 트리거 동시 실행 상황을 고려하여 실제 운영 환경에서도 안전하게 동작하도록 설계하였습니다.

* AtomicBoolean으로 실행 중복 방지
* PROCESSING 상태 선점
* stale PROCESSING 재수거

### 5. UNIQUE 제약 설계

`news_article_id` 단일 키 고려하였지만 다음 상황을 고려하여 모델 변경, 재임베딩, 청크 단위 저장 등을 고려하여 `(news_article_id, embedding_model, chunk_index)` 복합 UNIQUE 적용하였습니다.


### 🔗 관련 이슈
Closes #58

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 뉴스 기사 임베딩 자동 생성 배치(30분 간격) 및 수동 트리거 엔드포인트 추가
  * 기사 임베딩 생성 파이프라인(청크 분할, 외부 임베딩 호출, 일괄 저장) 도입
  * 임베딩 상태 추적(대기/진행/성공/실패) 및 실패 기록/재시도 로직 추가

* **성능/안정성**
  * 시장 스냅샷 upsert로 동시성 및 성능 개선

* **설정 추가**
  * OpenAI 임베딩 관련 설정 및 API 키 템플릿(.env.example) 추가

* **데이터베이스**
  * 기사 임베딩 저장용 테이블 및 마이그레이션 적용

* **테스트**
  * 임베딩 관련 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->