### PR TITLE
[WEF-297] 시장가 매도 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -94,7 +94,7 @@ public class OrderService {
 		}
 
 		// 4. 보유 종목 확인
-		Portfolio portfolio = portfolioService.getPortfolio(virtualAccountId, stockId);
+		Portfolio portfolio = portfolioService.getPortfolioForUpdate(virtualAccountId, stockId);
 		if (portfolio.getQuantity() < quantity) {
 			throw new BusinessException(ErrorCode.ORDER_INSUFFICIENT_HOLDINGS);
 		}

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -8,14 +8,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
 import com.solv.wefin.domain.trading.order.entity.Order;
 import com.solv.wefin.domain.trading.order.entity.OrderSide;
 import com.solv.wefin.domain.trading.order.entity.OrderType;
 import com.solv.wefin.domain.trading.order.repository.OrderRepository;
 import com.solv.wefin.domain.trading.portfolio.entity.Currency;
+import com.solv.wefin.domain.trading.portfolio.entity.Portfolio;
 import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
-import com.solv.wefin.domain.trading.trade.entity.Trade;
-import com.solv.wefin.domain.trading.trade.repository.TradeRepository;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.trade.service.TradeService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 
@@ -27,23 +29,28 @@ import lombok.RequiredArgsConstructor;
 public class OrderService {
 
 	private static final BigDecimal FEE_RATE = new BigDecimal("0.00015");
+	private static final BigDecimal TAX_RATE = new BigDecimal("0.0018");
 
 	private final OrderRepository orderRepository;
-	private final TradeRepository tradeRepository;
 	private final PortfolioService portfolioService;
 	private final VirtualAccountService virtualAccountService;
 	private final MarketPriceProvider marketPriceProvider;
-
+	private final StockInfoProvider stockInfoProvider;
+	private final TradeService tradeService;
 
 	@Transactional
-	public Order buyMarket(Long virtualAccountId, Long stockId, String stockCode, Integer quantity) {
+	public Order buyMarket(Long virtualAccountId, Long stockId, Integer quantity) {
 		// 1. 수량 검증
 		if (quantity == null || quantity <= 0) {
 			throw new BusinessException(ErrorCode.ORDER_INVALID_QUANTITY);
 		}
 
 		// 2. 현재가 조회
-		BigDecimal currentPrice = marketPriceProvider.getCurrentPrice(stockCode);
+		Stock stock = stockInfoProvider.getStock(stockId);
+		BigDecimal currentPrice = marketPriceProvider.getCurrentPrice(stock.getStockCode());
+		if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
+			throw new BusinessException(ErrorCode.ORDER_STOCK_NOT_FOUND);
+		}
 
 		// 3. 금액 계산
 		BigDecimal totalAmount = currentPrice.multiply(BigDecimal.valueOf(quantity));
@@ -59,14 +66,73 @@ public class OrderService {
 			null, Currency.KRW, null, fee, BigDecimal.ZERO));
 
 		// 7. Trade 생성 + 저장
-		Trade trade = tradeRepository.save(Trade.createBuyTrade(order.getOrderId(), virtualAccountId, stockId,
-			quantity, currentPrice, totalAmount, fee, Currency.KRW, null));
+		tradeService.createBuyTrade(order.getOrderId(), virtualAccountId, stockId,
+			quantity, currentPrice, totalAmount, fee, Currency.KRW, null);
 		order.fill(quantity);
 
 		// 8. 포트폴리오 갱신
 		portfolioService.addHolding(virtualAccountId, stockId, quantity, currentPrice, Currency.KRW);
 
 		// 9. 반환
+		return order;
+	}
+
+	@Transactional
+	public Order sellMarket(Long virtualAccountId, Long stockId, Integer quantity) {
+		// 1. 수량 검증
+		if (quantity == null || quantity <= 0) {
+			throw new BusinessException(ErrorCode.ORDER_INVALID_QUANTITY);
+		}
+
+		// 2. 종목 조회
+		Stock stock = stockInfoProvider.getStock(stockId);
+
+		// 3. 현재가 조회
+		BigDecimal currentPrice = marketPriceProvider.getCurrentPrice(stock.getStockCode());
+		if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
+			throw new BusinessException(ErrorCode.ORDER_STOCK_NOT_FOUND);
+		}
+
+		// 4. 보유 종목 확인
+		Portfolio portfolio = portfolioService.getPortfolio(virtualAccountId, stockId);
+		if (portfolio.getQuantity() < quantity) {
+			throw new BusinessException(ErrorCode.ORDER_INSUFFICIENT_HOLDINGS);
+		}
+		BigDecimal avgPrice = portfolio.getAvgPrice();
+
+		// 5. 금액 계산
+		BigDecimal totalAmount = currentPrice.multiply(BigDecimal.valueOf(quantity));
+
+		// 6. 수수료 계산
+		BigDecimal fee = totalAmount.multiply(FEE_RATE).setScale(0, RoundingMode.DOWN);
+
+		// 7. 매도 세금 계산
+		BigDecimal tax = totalAmount.multiply(TAX_RATE).setScale(0, RoundingMode.DOWN);
+
+		// 8. 실현손익 계산
+		BigDecimal realizedAmount = currentPrice.subtract(avgPrice).multiply(BigDecimal.valueOf(quantity));
+
+		// 9. Order 생성 + 저장
+		Order order = orderRepository.save(
+			new Order(virtualAccountId, stockId, OrderType.MARKET, OrderSide.SELL, quantity
+				, null, Currency.KRW, null, fee, tax));
+
+		// 10. Trade 생성 + 저장
+		tradeService.createSellTrade(order.getOrderId(), virtualAccountId, stockId, quantity, currentPrice,
+			totalAmount, fee, tax, realizedAmount, Currency.KRW, null);
+
+		// 11. Order 상태 변경
+		order.fill(quantity);
+
+		// 12. 포트폴리오 수량 차감
+		portfolioService.deductQuantity(virtualAccountId, stockId, quantity);
+
+		// 13. 예수금 입금
+		virtualAccountService.depositBalance(virtualAccountId, totalAmount.subtract(fee).subtract(tax));
+
+		// 14. 실현손익 누적
+		virtualAccountService.addRealizedProfit(virtualAccountId, realizedAmount);
+
 		return order;
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/portfolio/service/PortfolioService.java
@@ -24,7 +24,7 @@ public class PortfolioService {
 
 	@Transactional
 	public void addHolding(Long virtualAccountId, Long stockId, Integer quantity, BigDecimal price, Currency currency) {
-		Optional<Portfolio> portfolio = getPortfolioForUpdate(virtualAccountId, stockId);
+		Optional<Portfolio> portfolio = findPortfolioForUpdate(virtualAccountId, stockId);
 
 		if (portfolio.isPresent()) {
 			portfolio.get().addQuantity(quantity, price);
@@ -35,7 +35,7 @@ public class PortfolioService {
 
 	@Transactional
 	public void deductQuantity(Long virtualAccountId, Long stockId, Integer quantity) {
-		Optional<Portfolio> portfolio = getPortfolioForUpdate(virtualAccountId, stockId);
+		Optional<Portfolio> portfolio = findPortfolioForUpdate(virtualAccountId, stockId);
 
 		if (portfolio.isEmpty()) {
 			throw new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD);
@@ -57,9 +57,17 @@ public class PortfolioService {
 	}
 
 	/**
-	 * 비관적 락으로 포트폴리오 조회
+	 * 비관적 락으로 포트폴리오 조회 - 없으면 예외
 	 */
-	private Optional<Portfolio> getPortfolioForUpdate(Long virtualAccountId, Long stockId) {
+	public Portfolio getPortfolioForUpdate(Long virtualAccountId, Long stockId) {
+		return portfolioRepository.findByVirtualAccountIdAndStockIdForUpdate(virtualAccountId, stockId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD));
+	}
+
+	/**
+	 * 비관적 락으로 포트폴리오 조회 - Optional 반환
+	 */
+	private Optional<Portfolio> findPortfolioForUpdate(Long virtualAccountId, Long stockId) {
 		return portfolioRepository.findByVirtualAccountIdAndStockIdForUpdate(virtualAccountId, stockId);
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/portfolio/service/PortfolioService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/portfolio/service/PortfolioService.java
@@ -47,6 +47,11 @@ public class PortfolioService {
 		}
 	}
 
+	public Portfolio getPortfolio(Long virtualAccountId, Long stockId) {
+		return portfolioRepository.findByVirtualAccountIdAndStockId(virtualAccountId, stockId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD));
+	}
+
 	public List<Portfolio> getPortfolios(Long virtualAccountId) {
 		return portfolioRepository.findByVirtualAccountId(virtualAccountId);
 	}

--- a/src/main/java/com/solv/wefin/domain/trading/trade/entity/Trade.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/entity/Trade.java
@@ -96,9 +96,17 @@ public class Trade {
 	}
 
 	public static Trade createBuyTrade(Long orderId, Long virtualAccountId, Long stockId,
-									   Integer quantity, BigDecimal price, BigDecimal totalAmount, BigDecimal fee,
-									   Currency currency, BigDecimal exchangeRate) {
-		return new Trade(orderId, virtualAccountId, stockId, OrderSide.BUY, quantity, price, totalAmount, fee,
-			BigDecimal.ZERO, null, currency, exchangeRate);
+									   Integer quantity, BigDecimal price, BigDecimal totalAmount,
+									   BigDecimal fee, Currency currency, BigDecimal exchangeRate) {
+		return new Trade(orderId, virtualAccountId, stockId, OrderSide.BUY, quantity, price, totalAmount,
+			fee, BigDecimal.ZERO, null, currency, exchangeRate);
+	}
+
+	public static Trade createSellTrade(Long orderId, Long virtualAccountId, Long stockId,
+										Integer quantity, BigDecimal price, BigDecimal totalAmount,
+										BigDecimal fee, BigDecimal tax, BigDecimal realizedProfit,
+										Currency currency, BigDecimal exchangeRate) {
+		return new Trade(orderId, virtualAccountId, stockId, OrderSide.SELL, quantity, price, totalAmount,
+			fee, tax, realizedProfit, currency, exchangeRate);
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/trade/service/TradeService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/service/TradeService.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.trading.trade.service;
+
+import java.math.BigDecimal;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.solv.wefin.domain.trading.portfolio.entity.Currency;
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+import com.solv.wefin.domain.trading.trade.repository.TradeRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TradeService {
+
+	private final TradeRepository tradeRepository;
+
+	@Transactional
+	public Trade createBuyTrade(Long orderId, Long virtualAccountId, Long stockId,
+								Integer quantity, BigDecimal price, BigDecimal totalAmount,
+								BigDecimal fee, Currency currency, BigDecimal exchangeRate) {
+		return tradeRepository.save(Trade.createBuyTrade(orderId, virtualAccountId, stockId, quantity,
+			price, totalAmount, fee, currency, exchangeRate));
+	}
+
+	@Transactional
+	public Trade createSellTrade(Long orderId, Long virtualAccountId, Long stockId,
+								 Integer quantity, BigDecimal price, BigDecimal totalAmount,
+								 BigDecimal fee, BigDecimal tax, BigDecimal realizedProfit,
+								 Currency currency, BigDecimal exchangeRate) {
+		return tradeRepository.save(Trade.createSellTrade(orderId, virtualAccountId, stockId, quantity,
+			price, totalAmount, fee, tax, realizedProfit, currency, exchangeRate));
+	}
+}

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -101,7 +101,7 @@ class OrderServiceTest {
 		Portfolio mockPortfolio = mock(Portfolio.class);
 		given(mockPortfolio.getAvgPrice()).willReturn(new BigDecimal("170000"));
 		given(mockPortfolio.getQuantity()).willReturn(20);
-		given(portfolioService.getPortfolio(1L, 1L))
+		given(portfolioService.getPortfolioForUpdate(1L, 1L))
 			.willReturn(mockPortfolio);
 
 		given(orderRepository.save(any()))
@@ -126,7 +126,7 @@ class OrderServiceTest {
 		given(mockStock.getStockCode()).willReturn("005930");
 		given(marketPriceProvider.getCurrentPrice("005930"))
 			.willReturn(new BigDecimal("178000"));
-		given(portfolioService.getPortfolio(1L, 1L))
+		given(portfolioService.getPortfolioForUpdate(1L, 1L))
 			.willThrow(new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD));
 
 		// when & then
@@ -145,7 +145,7 @@ class OrderServiceTest {
 
 		Portfolio mockPortfolio = mock(Portfolio.class);
 		given(mockPortfolio.getQuantity()).willReturn(20);
-		given(portfolioService.getPortfolio(1L, 1L))
+		given(portfolioService.getPortfolioForUpdate(1L, 1L))
 			.willReturn(mockPortfolio);
 
 		// when & then

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -1,7 +1,7 @@
 package com.solv.wefin.domain.trading.order.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -15,9 +15,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
 import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.portfolio.entity.Portfolio;
 import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
-import com.solv.wefin.domain.trading.trade.repository.TradeRepository;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.trade.service.TradeService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 
@@ -27,13 +30,15 @@ class OrderServiceTest {
 	@Mock
 	private OrderRepository orderRepository;
 	@Mock
-	private TradeRepository tradeRepository;
-	@Mock
-	private MarketPriceProvider marketPriceProvider;
+	private TradeService tradeService;
 	@Mock
 	private VirtualAccountService virtualAccountService;
 	@Mock
 	private PortfolioService portfolioService;
+	@Mock
+	private MarketPriceProvider marketPriceProvider;
+	@Mock
+	private StockInfoProvider stockInfoProvider;
 
 	@InjectMocks
 	private OrderService orderService;
@@ -41,41 +46,110 @@ class OrderServiceTest {
 	@Test
 	void 매수_성공() {
 		// given
-		when(marketPriceProvider.getCurrentPrice("005930"))
-			.thenReturn(new BigDecimal("170000"));
-		when(virtualAccountService.deductBalance(eq(1L), any()))
-			.thenReturn(new VirtualAccount(UUID.randomUUID()));
-		when(orderRepository.save(any()))
-			.thenAnswer(invocation -> invocation.getArgument(0));
-		when(tradeRepository.save(any()))
-			.thenAnswer(invocation -> invocation.getArgument(0));
+		Stock mockStock = mock(Stock.class);
+
+		given(stockInfoProvider.getStock(1L)).willReturn(mockStock);
+		given(mockStock.getStockCode()).willReturn("005930");
+		given(marketPriceProvider.getCurrentPrice("005930"))
+			.willReturn(new BigDecimal("170000"));
+		given(virtualAccountService.deductBalance(eq(1L), any()))
+			.willReturn(new VirtualAccount(UUID.randomUUID()));
+		given(orderRepository.save(any()))
+			.willAnswer(invocation -> invocation.getArgument(0));
 
 		// when
-		orderService.buyMarket(1L, 1L, "005930", 20);
+		orderService.buyMarket(1L, 1L, 20);
 
 		// then
 		verify(orderRepository).save(any());
-		verify(tradeRepository).save(any());
+		verify(tradeService).createBuyTrade(any(), eq(1L), eq(1L), eq(20), any(), any(), any(), any(), any());
 		verify(portfolioService).addHolding(eq(1L), eq(1L), eq(20), any(), any());
 	}
 
 	@Test
 	void 수량_0_이하() {
 		// when & then
-		assertThatThrownBy(() -> orderService.buyMarket(1L, 1L, "005930", 0))
+		assertThatThrownBy(() -> orderService.buyMarket(1L, 1L, 0))
 			.isInstanceOf(BusinessException.class);
 	}
 
 	@Test
 	void 예수금_부족() {
 		// given
-		when(marketPriceProvider.getCurrentPrice("005930"))
-			.thenReturn(new BigDecimal("178000"));
-		when(virtualAccountService.deductBalance(any(), any()))
-			.thenThrow(new BusinessException(ErrorCode.ORDER_INSUFFICIENT_BALANCE));
+		Stock mockStock = mock(Stock.class);
+		given(stockInfoProvider.getStock(1L)).willReturn(mockStock);
+		given(mockStock.getStockCode()).willReturn("005930");
+		given(marketPriceProvider.getCurrentPrice("005930"))
+			.willReturn(new BigDecimal("178000"));
+		given(virtualAccountService.deductBalance(any(), any()))
+			.willThrow(new BusinessException(ErrorCode.ORDER_INSUFFICIENT_BALANCE));
 
 		// when & then
-		assertThatThrownBy(() -> orderService.buyMarket(1L, 1L, "005930", 20))
+		assertThatThrownBy(() -> orderService.buyMarket(1L, 1L, 20))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	void 매도_성공() {
+		// given
+		Stock mockStock = mock(Stock.class);
+		given(stockInfoProvider.getStock(1L)).willReturn(mockStock);
+		given(mockStock.getStockCode()).willReturn("005930");
+		given(marketPriceProvider.getCurrentPrice("005930"))
+			.willReturn(new BigDecimal("178000"));
+
+		Portfolio mockPortfolio = mock(Portfolio.class);
+		given(mockPortfolio.getAvgPrice()).willReturn(new BigDecimal("170000"));
+		given(mockPortfolio.getQuantity()).willReturn(20);
+		given(portfolioService.getPortfolio(1L, 1L))
+			.willReturn(mockPortfolio);
+
+		given(orderRepository.save(any()))
+			.willAnswer(invocation -> invocation.getArgument(0));
+
+		// when
+		orderService.sellMarket(1L, 1L, 10);
+
+		// then
+		verify(tradeService).createSellTrade(any(), eq(1L), eq(1L), eq(10),
+			any(), any(), any(), any(), any(), any(), any());
+		verify(portfolioService).deductQuantity(eq(1L), eq(1L), eq(10));
+		verify(virtualAccountService).depositBalance(eq(1L), any());
+		verify(virtualAccountService).addRealizedProfit(eq(1L), any());
+	}
+
+	@Test
+	void 매도_미보유_종목() {
+		// given
+		Stock mockStock = mock(Stock.class);
+		given(stockInfoProvider.getStock(1L)).willReturn(mockStock);
+		given(mockStock.getStockCode()).willReturn("005930");
+		given(marketPriceProvider.getCurrentPrice("005930"))
+			.willReturn(new BigDecimal("178000"));
+		given(portfolioService.getPortfolio(1L, 1L))
+			.willThrow(new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD));
+
+		// when & then
+		assertThatThrownBy(() -> orderService.sellMarket(1L, 1L, 10))
+			.isInstanceOf(BusinessException.class);
+	}
+
+	@Test
+	void 매도_보유수량_부족() {
+		// given
+		Stock mockStock = mock(Stock.class);
+		given(stockInfoProvider.getStock(1L)).willReturn(mockStock);
+		given(mockStock.getStockCode()).willReturn("005630");
+		given(marketPriceProvider.getCurrentPrice("005630"))
+			.willReturn(new BigDecimal("178000"));
+
+		Portfolio mockPortfolio = mock(Portfolio.class);
+		given(mockPortfolio.getQuantity()).willReturn(20);
+		given(portfolioService.getPortfolio(1L, 1L))
+			.willReturn(mockPortfolio);
+
+		// when & then
+		assertThatThrownBy(() -> orderService.sellMarket(1L, 1L, 30))
 			.isInstanceOf(BusinessException.class);
 	}
 }


### PR DESCRIPTION
  ## 📌 PR 설명
  시장가 매도 주문의 전체 흐름을 구현했습니다.
  보유수량 확인 → 즉시 체결 → 실현손익 계산 → 예수금 입금.
  StockInfoProvider 연동으로 buyMarket도 리팩토링했습니다.
  <br>

  ## ✅ 완료한 기능 명세

  - [x] OrderService.sellMarket() 구현 (시장가 매도 전체 흐름)
  - [x] Trade.createSellTrade() 정적 팩토리 메서드
  - [x] TradeService 생성 (도메인 경계 분리 — OrderService에서 TradeRepository 직접 접근 제거)
  - [x] PortfolioService.getPortfolio() 추가 (매도 시 보유종목 조회용)
  - [x] 매도 세금 계산 (totalAmount × 0.18%, 절사) + TAX_RATE 상수 추출
  - [x] 실현손익 계산 ((매도가 - 평균단가) × 수량)
  - [x] 현재가 null/0 검증 추가 (buyMarket, sellMarket)
  - [x] 보유수량 사전 검증 추가 (포트폴리오 차감 전 미리 체크)
  - [x] StockInfoProvider 연동 — buyMarket에서 stockCode 파라미터 제거
  - [x] 테스트 BDDMockito(given/willReturn) 리팩토링
  - [x] 단위 테스트 (매수 성공 / 수량 0 이하 / 예수금 부족 / 매도 성공 / 미보유 종목 / 보유수량 부족)

  <br>

  ## 💭 고민과 해결과정
  - TradeService를 별도로 만든 이유: 컨벤션상 다른 도메인의 Repository를 직접 접근하면 안 되기 때문에 OrderService → TradeRepository 직접 접근을 OrderService → TradeService → TradeRepository로 변경
  - 보유수량 검증을 sellMarket()에서 미리 하는 이유: deductQuantity()에서도 체크하지만, 그 전에 Order/Trade 생성이 이미 진행된 후라 비효율적. 사전 검증으로 불필요한 DB 작업 방지
  - currentPrice 검증 추가: MarketPriceProvider가 null/0을 반환할 경우 잘못된 금액으로 체결되는 문제 방어
  - BDDMockito로 테스트 리팩토링: given-when-then 패턴과 이름이 일치해서 가독성 향상

  <br>

  ### 🔗 관련 이슈
  Closes #96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주식 시장가 매도 주문 기능 추가
  * 매도 시 세금 및 실현 손익 계산 적용

* **개선 사항**
  * 매수 호출 간소화(종목 식별자 기반)
  * 보유 포트폴리오 조회/잠금 흐름 및 보유량 검증 강화
  * 거래 기록 생성이 전용 서비스로 위임되어 처리 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->