### PR TITLE
[WEF-333] 시세 캐싱 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -1,7 +1,7 @@
 package com.solv.wefin.domain.trading.market.client;
 
-import com.solv.wefin.domain.trading.market.dto.HantuOrderbookApiResponse;
-import com.solv.wefin.domain.trading.market.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuOrderbookApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuOrderbookApiResponse.java
@@ -1,4 +1,4 @@
-package com.solv.wefin.domain.trading.market.dto;
+package com.solv.wefin.domain.trading.market.client.dto;
 
 public record HantuOrderbookApiResponse(
         Output1 output1

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuPriceApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuPriceApiResponse.java
@@ -1,4 +1,4 @@
-package com.solv.wefin.domain.trading.market.dto;
+package com.solv.wefin.domain.trading.market.client.dto;
 
 public record HantuPriceApiResponse(
         Output output

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/OrderbookResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/OrderbookResponse.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.trading.market.dto;
 
+import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
+
 import java.util.List;
 
 public record OrderbookResponse(

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/PriceResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/PriceResponse.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.trading.market.dto;
 
+import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+
 public record PriceResponse(
         String stockCode,
         int currentPrice,

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -53,6 +53,7 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
                 }
                 throw new BusinessException(ErrorCode.MARKET_API_FAILED);
             } catch (TimeoutException | InterruptedException e) {
+                Thread.currentThread().interrupt();
                 throw new BusinessException(ErrorCode.MARKET_API_FAILED);
             }
         }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class MarketService implements MarketPriceProvider, ExchangeRateProvider {
 
     private final HantuMarketClient hantuMarketClient;
+    private final StockService stockService;
 
     private final ConcurrentHashMap<String, CompletableFuture<PriceResponse>> ongoingRequests = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, PriceResponse> priceCache = new ConcurrentHashMap<>();
@@ -29,10 +31,14 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private static final long CACHE_TTL_MS = 5000; // 5초
 
     public PriceResponse getPrice(String stockCode) {
+        if (!stockService.existsByCode(stockCode)) {
+            throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
+        }
+
         // 캐시 확인
-        Long cachedTime = priceCacheTimestamp.get(stockCode);
-        if (cachedTime != null && System.currentTimeMillis() - cachedTime < CACHE_TTL_MS) {
-            return priceCache.get(stockCode);
+        PriceResponse cached = getCachedPrice(stockCode);
+        if (cached != null) {
+            return cached;
         }
 
         // thundering herd 방지: 같은 종목에 대해 첫 요청만 API를 호출하고, 나머지는 결과를 공유
@@ -54,11 +60,16 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
 
         // 첫 번째 요청만 처리
         try {
+            cached = getCachedPrice(stockCode);
+            if (cached != null) {
+                newFuture.complete(cached);
+                return cached;
+            }
+
             // 캐시 미스 -> 한투 API 호출 + PriceResponse 생성
             HantuPriceApiResponse.Output output = hantuMarketClient.fetchCurrentPrice(stockCode).output();
             PriceResponse response = PriceResponse.from(stockCode, output);
 
-            // 캐시 저장
             priceCache.put(stockCode, response);
             priceCacheTimestamp.put(stockCode, System.currentTimeMillis());
 
@@ -67,12 +78,25 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             return response;
 
         } catch (Exception e) {
-            newFuture.completeExceptionally(e); // 비즈니스 에러 추출
+            newFuture.completeExceptionally(e);
             throw new BusinessException(ErrorCode.MARKET_API_FAILED);
         }
         finally {
             ongoingRequests.remove(stockCode);
         }
+    }
+
+    /**
+     * 캐시에서 유효한 시세를 조회한다. TTL 만료 시 null 반환.
+     */
+    private PriceResponse getCachedPrice(String stockCode) {
+        Long cachedTime = priceCacheTimestamp.get(stockCode);
+
+        if (cachedTime != null && System.currentTimeMillis() - cachedTime < CACHE_TTL_MS) {
+            return priceCache.get(stockCode);
+        }
+
+        return null;
     }
 
     public OrderbookResponse getOrderbook(String stockCode) {

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -14,9 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
 
 @RequiredArgsConstructor
 @Service
@@ -48,12 +46,13 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         // 이미 누군가 API 호출 중
         if (existing != null) {
             try {
-                return existing.join();
-            } catch (CompletionException e) {
-                // 첫 번째 요청의 API 호출이 실패해서 completeExceptionally(e)로 채워진 경우, join()이 CompletionException을 던짐
+                return existing.get(10, TimeUnit.SECONDS);
+            } catch (ExecutionException e) {
                 if (e.getCause() instanceof BusinessException) {
                     throw (BusinessException) e.getCause();
                 }
+                throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+            } catch (TimeoutException | InterruptedException e) {
                 throw new BusinessException(ErrorCode.MARKET_API_FAILED);
             }
         }
@@ -79,6 +78,10 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
 
         } catch (Exception e) {
             newFuture.completeExceptionally(e);
+            if (e instanceof BusinessException) {
+                throw (BusinessException) e;
+            }
+
             throw new BusinessException(ErrorCode.MARKET_API_FAILED);
         }
         finally {
@@ -94,6 +97,11 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
 
         if (cachedTime != null && System.currentTimeMillis() - cachedTime < CACHE_TTL_MS) {
             return priceCache.get(stockCode);
+        }
+
+        if (cachedTime != null) {
+            priceCache.remove(stockCode);
+            priceCacheTimestamp.remove(stockCode);
         }
 
         return null;

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -2,15 +2,20 @@ package com.solv.wefin.domain.trading.market.service;
 
 import com.solv.wefin.domain.trading.common.ExchangeRateProvider;
 import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
-import com.solv.wefin.domain.trading.market.dto.HantuOrderbookApiResponse;
-import com.solv.wefin.domain.trading.market.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
 
 @RequiredArgsConstructor
 @Service
@@ -18,9 +23,56 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
 
     private final HantuMarketClient hantuMarketClient;
 
+    private final ConcurrentHashMap<String, CompletableFuture<PriceResponse>> ongoingRequests = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, PriceResponse> priceCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> priceCacheTimestamp = new ConcurrentHashMap<>();
+    private static final long CACHE_TTL_MS = 5000; // 5초
+
     public PriceResponse getPrice(String stockCode) {
-        HantuPriceApiResponse.Output output = hantuMarketClient.fetchCurrentPrice(stockCode).output();
-        return PriceResponse.from(stockCode, output);
+        // 캐시 확인
+        Long cachedTime = priceCacheTimestamp.get(stockCode);
+        if (cachedTime != null && System.currentTimeMillis() - cachedTime < CACHE_TTL_MS) {
+            return priceCache.get(stockCode);
+        }
+
+        // thundering herd 방지: 같은 종목에 대해 첫 요청만 API를 호출하고, 나머지는 결과를 공유
+        CompletableFuture<PriceResponse> newFuture = new CompletableFuture<>();
+        CompletableFuture<PriceResponse> existing = ongoingRequests.putIfAbsent(stockCode, newFuture);
+
+        // 이미 누군가 API 호출 중
+        if (existing != null) {
+            try {
+                return existing.join();
+            } catch (CompletionException e) {
+                // 첫 번째 요청의 API 호출이 실패해서 completeExceptionally(e)로 채워진 경우, join()이 CompletionException을 던짐
+                if (e.getCause() instanceof BusinessException) {
+                    throw (BusinessException) e.getCause();
+                }
+                throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+            }
+        }
+
+        // 첫 번째 요청만 처리
+        try {
+            // 캐시 미스 -> 한투 API 호출 + PriceResponse 생성
+            HantuPriceApiResponse.Output output = hantuMarketClient.fetchCurrentPrice(stockCode).output();
+            PriceResponse response = PriceResponse.from(stockCode, output);
+
+            // 캐시 저장
+            priceCache.put(stockCode, response);
+            priceCacheTimestamp.put(stockCode, System.currentTimeMillis());
+
+            newFuture.complete(response);
+
+            return response;
+
+        } catch (Exception e) {
+            newFuture.completeExceptionally(e); // 비즈니스 에러 추출
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+        finally {
+            ongoingRequests.remove(stockCode);
+        }
     }
 
     public OrderbookResponse getOrderbook(String stockCode) {


### PR DESCRIPTION
## 📌 PR 설명
시세 조회 시 캐싱 + thundering herd 방지를 구현했습니다.
ConcurrentHashMap 기반 인메모리 캐시(TTL 5초)와 CompletableFuture를 활용해, 동일 종목에 대한 동시 요청이 한투 API를 중복 호출하지 않도록 합니다.
또한 한투 API 전용 DTO(HantuPriceApiResponse, HantuOrderbookApiResponse)를 client.dto 패키지로 이동하여 계층 간 책임을 명확히 분리했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] MarketService — ConcurrentHashMap 기반 시세 캐싱 (5초 TTL)
- [x] MarketService — CompletableFuture + putIfAbsent로 thundering herd 방지
- [x] 캐시 미스 시 첫 번째 요청만 한투 API 호출, 나머지는 결과 공유
   - 리더 선출 직후 캐시 재확인 (double-check)
   - 만료 캐시 엔트리 제거 
- [x] API 호출 실패 시 CompletionException → BusinessException 변환 처리 (대기 요청 에러 전파)
- [x] 한투 API DTO → client.dto 패키지 이동 (패키지 구조 리팩터링)
- [x] stockCode 유효성 검증 추가 

 
<br>

## 💭 고민과 해결과정
### 패키지 구조 리팩토링
```
domain/trading/market/
├── client/
│   ├── HantuMarketClient.java          ← 한투 API 호출 담당
│   └── dto/
│       ├── HantuOrderbookApiResponse.java  ← 한투 API 응답 DTO (이동)
│       └── HantuPriceApiResponse.java      ← 한투 API 응답 DTO (이동)
├── dto/
│   ├── OrderbookResponse.java          ← 서비스 레이어 응답 DTO
│   └── PriceResponse.java             ← 서비스 레이어 응답 DTO
└── service/
    └── MarketService.java              ← 캐싱 + thundering herd 방지 추가
```
- HantuOrderbookApiResponse, HantuPriceApiResponse — 한투 API 전용 DTO이므로 client.dto로 이동. market/dto에는 서비스 레이어에서 사용하는 PriceResponse, OrderbookResponse만 남김.
- 외부 API 응답 DTO와 내부 서비스 DTO의 책임을 패키지 수준에서 분리.



### Thundering herd 방지 전략
```
요청 A (삼성전자) ──→ 캐시 미스 → putIfAbsent(리더) → 한투 API 호출 → 캐시 저장 → 응답
요청 B (삼성전자) ──→ 캐시 미스 → putIfAbsent(대기) → future.get(timeout) ──────────→ 응답 공유
요청 C (삼성전자) ──→ 캐시 히트 (TTL 내) → 즉시 응답
```
- `ConcurrentHashMap<String, CompletableFuture<PriceResponse>>` — 종목코드 키로 진행 중인 요청을 관리
- `putIfAbsent`로 첫 번째 요청만 리더로 선출, 나머지는 `get(10, TimeUnit.SECONDS)`으로 결과 대기
- 리더의 API 호출 실패 시 `completeExceptionally`로 대기 요청들에게도 예외 전파
- finally 블록에서 `ongoingRequests.remove(stockCode)`로 정리

<br>

### 🔗 관련 이슈
Closes #26 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 내부 시장 연동 타입 및 구조를 정리해 유지보수성을 개선했습니다.
* **New Features**
  * 가격 조회에 5초 TTL 인메모리 캐시를 도입해 동일 요청 응답 속도를 개선했습니다.
  * 동시 요청 병합을 추가해 동일 시점 다중 호출 시 외부 호출을 단일화했습니다.
* **Bug Fixes**
  * 존재하지 않는 종목 조회 시 적절한 비즈니스 오류를 반환하도록 검증을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->