### PR TITLE
[WEF-304] 이벤트 기반 아키텍처 설계

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
@@ -23,7 +23,7 @@ public record OrderMatchedEvent(
 										  String stockName, Integer quantity,
 										  BigDecimal price, BigDecimal fee, BigDecimal balance) {
 		return new OrderMatchedEvent(OrderType.MARKET, orderNo, stockCode, stockName,
-			OrderSide.BUY, quantity, price, fee, BigDecimal.ZERO, null, balance);
+			OrderSide.BUY, quantity, price, fee, BigDecimal.ZERO, BigDecimal.ZERO, balance);
 	}
 
 	public static OrderMatchedEvent ofSell(UUID orderNo, String stockCode,

--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
@@ -1,0 +1,36 @@
+package com.solv.wefin.domain.trading.matching.event;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+
+public record OrderMatchedEvent(
+	OrderType orderType,
+	UUID orderNo,
+	String stockCode,
+	String stockName,
+	OrderSide side,
+	Integer quantity,
+	BigDecimal price,
+	BigDecimal fee,
+	BigDecimal tax,
+	BigDecimal realizedProfit,
+	BigDecimal balance
+) {
+	public static OrderMatchedEvent ofBuy(UUID orderNo, String stockCode,
+										  String stockName, Integer quantity,
+										  BigDecimal price, BigDecimal fee, BigDecimal balance) {
+		return new OrderMatchedEvent(OrderType.MARKET, orderNo, stockCode, stockName,
+			OrderSide.BUY, quantity, price, fee, BigDecimal.ZERO, null, balance);
+	}
+
+	public static OrderMatchedEvent ofSell(UUID orderNo, String stockCode,
+										   String stockName, Integer quantity,
+										   BigDecimal price, BigDecimal fee, BigDecimal tax,
+										   BigDecimal realizedProfit, BigDecimal balance) {
+		return new OrderMatchedEvent(OrderType.MARKET, orderNo, stockCode, stockName,
+			OrderSide.SELL, quantity, price, fee, tax, realizedProfit, balance);
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListener.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.trading.matching.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class OrderMatchedEventListener {
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleOrderMatchedEvent(OrderMatchedEvent event) {
+		log.info("체결 완료 - orderNo: {}, side: {}, stockCode: {}, quantity: {}, price: {}",
+			event.orderNo(), event.side(), event.stockCode(), event.quantity(), event.price());
+
+		// TODO: WebSocket 체결 알림 (스프린트 5)
+		// TODO: 채팅 알림 - 수익금 +-50만원 이상 매도 시 (스프린트 5)
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -3,12 +3,15 @@ package com.solv.wefin.domain.trading.order.service;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
 import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.matching.event.OrderMatchedEvent;
 import com.solv.wefin.domain.trading.order.entity.Order;
 import com.solv.wefin.domain.trading.order.entity.OrderSide;
 import com.solv.wefin.domain.trading.order.entity.OrderType;
@@ -37,6 +40,7 @@ public class OrderService {
 	private final MarketPriceProvider marketPriceProvider;
 	private final StockInfoProvider stockInfoProvider;
 	private final TradeService tradeService;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional
 	public Order buyMarket(Long virtualAccountId, Long stockId, Integer quantity) {
@@ -49,7 +53,7 @@ public class OrderService {
 		Stock stock = stockInfoProvider.getStock(stockId);
 		BigDecimal currentPrice = marketPriceProvider.getCurrentPrice(stock.getStockCode());
 		if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
-			throw new BusinessException(ErrorCode.ORDER_STOCK_NOT_FOUND);
+			throw new BusinessException(ErrorCode.MARKET_API_FAILED);
 		}
 
 		// 3. 금액 계산
@@ -59,7 +63,7 @@ public class OrderService {
 		BigDecimal fee = totalAmount.multiply(FEE_RATE).setScale(0, RoundingMode.DOWN);
 
 		// 5. 예수금 차감 (totalAmount + fee)
-		virtualAccountService.deductBalance(virtualAccountId, totalAmount.add(fee));
+		VirtualAccount account = virtualAccountService.deductBalance(virtualAccountId, totalAmount.add(fee));
 
 		// 6. Order 생성 + 저장
 		Order order = orderRepository.save(new Order(virtualAccountId, stockId, OrderType.MARKET, OrderSide.BUY, quantity,
@@ -73,7 +77,12 @@ public class OrderService {
 		// 8. 포트폴리오 갱신
 		portfolioService.addHolding(virtualAccountId, stockId, quantity, currentPrice, Currency.KRW);
 
-		// 9. 반환
+		// 9. 이벤트 발행
+		eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
+			order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
+			quantity, currentPrice, fee, account.getBalance()
+		));
+
 		return order;
 	}
 
@@ -90,7 +99,7 @@ public class OrderService {
 		// 3. 현재가 조회
 		BigDecimal currentPrice = marketPriceProvider.getCurrentPrice(stock.getStockCode());
 		if (currentPrice == null || currentPrice.compareTo(BigDecimal.ZERO) <= 0) {
-			throw new BusinessException(ErrorCode.ORDER_STOCK_NOT_FOUND);
+			throw new BusinessException(ErrorCode.MARKET_API_FAILED);
 		}
 
 		// 4. 보유 종목 확인
@@ -128,10 +137,17 @@ public class OrderService {
 		portfolioService.deductQuantity(virtualAccountId, stockId, quantity);
 
 		// 13. 예수금 입금
-		virtualAccountService.depositBalance(virtualAccountId, totalAmount.subtract(fee).subtract(tax));
+		VirtualAccount account = virtualAccountService.depositBalance(virtualAccountId,
+			totalAmount.subtract(fee).subtract(tax));
 
 		// 14. 실현손익 누적
 		virtualAccountService.addRealizedProfit(virtualAccountId, realizedAmount);
+
+		// 15. 이벤트 발행
+		eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
+			order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
+			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance()
+		));
 
 		return order;
 	}

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -11,11 +11,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
 import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.matching.event.OrderMatchedEvent;
 import com.solv.wefin.domain.trading.order.repository.OrderRepository;
 import com.solv.wefin.domain.trading.portfolio.entity.Portfolio;
 import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
@@ -39,6 +41,8 @@ class OrderServiceTest {
 	private MarketPriceProvider marketPriceProvider;
 	@Mock
 	private StockInfoProvider stockInfoProvider;
+	@Mock
+	private ApplicationEventPublisher eventPublisher;
 
 	@InjectMocks
 	private OrderService orderService;
@@ -64,6 +68,7 @@ class OrderServiceTest {
 		verify(orderRepository).save(any());
 		verify(tradeService).createBuyTrade(any(), eq(1L), eq(1L), eq(20), any(), any(), any(), any(), any());
 		verify(portfolioService).addHolding(eq(1L), eq(1L), eq(20), any(), any());
+		verify(eventPublisher).publishEvent(any(OrderMatchedEvent.class));
 	}
 
 	@Test
@@ -98,6 +103,11 @@ class OrderServiceTest {
 		given(marketPriceProvider.getCurrentPrice("005930"))
 			.willReturn(new BigDecimal("178000"));
 
+		VirtualAccount mockAccount = mock(VirtualAccount.class);
+		given(mockAccount.getBalance()).willReturn(new BigDecimal("9000000"));
+		given(virtualAccountService.depositBalance(eq(1L), any()))
+			.willReturn(mockAccount);
+
 		Portfolio mockPortfolio = mock(Portfolio.class);
 		given(mockPortfolio.getAvgPrice()).willReturn(new BigDecimal("170000"));
 		given(mockPortfolio.getQuantity()).willReturn(20);
@@ -116,6 +126,7 @@ class OrderServiceTest {
 		verify(portfolioService).deductQuantity(eq(1L), eq(1L), eq(10));
 		verify(virtualAccountService).depositBalance(eq(1L), any());
 		verify(virtualAccountService).addRealizedProfit(eq(1L), any());
+		verify(eventPublisher).publishEvent(any(OrderMatchedEvent.class));
 	}
 
 	@Test


### PR DESCRIPTION
  ## 📌 PR 설명
  체결 완료 시 OrderMatchedEvent를 발행하여 WebSocket 알림, 채팅 알림을 느슨하게 연결하는 이벤트 기반 아키텍처를 구현했습니다.
  @TransactionalEventListener(AFTER_COMMIT)로 체결 커밋 후에만 이벤트가 처리됩니다.
  <br>

  ## ✅ 완료한 기능 명세

  - [x] OrderMatchedEvent 클래스 정의 (record, ofBuy/ofSell 정적 팩토리 메서드)
  - [x] OrderMatchedEventListener 뼈대 (@TransactionalEventListener AFTER_COMMIT)
  - [x] OrderService buyMarket/sellMarket에 이벤트 발행 추가
  - [x] currentPrice 검증 ErrorCode 변경 (ORDER_STOCK_NOT_FOUND → MARKET_API_FAILED)
  - [x] 단위 테스트 이벤트 발행 verify 추가

  <br>

  ## 💭 고민과 해결과정
  - 이벤트 기반을 선택한 이유: 체결 로직과 알림 로직이 다른 도메인의 관심사라 직접 호출 대신 이벤트로 분리. 알림 실패가 체결을 롤백시키면 안됨
  - AFTER_COMMIT을 사용한 이유: publishEvent()는 즉시 실행이 아니라 예약이고, 트랜잭션 커밋 성공 후에만 리스너가 동작해서 체결 롤백됐는데 알림이 나가는 문제 방지
  - ofBuy/ofSell 정적 팩토리 메서드로 분리: 매수는 tax=ZERO, realizedProfit=null 고정. 매도는 둘 다 필요. 호출하는 쪽이 고정값을 신경 안 써도 됨
  - currentPrice 검증 ErrorCode를 MARKET_API_FAILED로 변경: 가격이 null/0이하는 "종목 없음"이 아니라 "시세 조회 실패"에 해당
  - WebSocket/채팅 알림은 리스너에 TODO로 남기고 스프린트 5에서 구현 예정

  <br>

  ### 🔗 관련 이슈
  Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 체결 이벤트 발행 및 트래킹 추가
  * 트랜잭션 커밋 후 체결 이벤트 수신 및 로깅(실시간 알림 확장 기반 포함)

* **버그 수정**
  * 시장 가격 조회 실패 시 오류 처리 개선(적절한 실패 코드로 변경)

* **테스트**
  * 체결 이벤트 발행 검증 추가 및 관련 목(mock) 설정 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->