### PR TITLE
[WEF-524] 게임방 퇴장 api

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -90,7 +90,17 @@ public class GameParticipant {
         this.status = LEFT;
     }
 
+    //방장 퇴장 시
+    public void resignLeader() {
+        this.isLeader = false;
+    }
+    //방장 위임
+    public void assignLeader() {
+        this.isLeader = true;
+    }
+
     public void rejoin() {
+
         this.status = ACTIVE;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -22,4 +22,7 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
     // 유저 참가 이력 조회 - 재참가 때 사용
     Optional<GameParticipant> findByGameRoomAndUserId(GameRoom gameRoom, UUID userId);
 
+    //방장 위임 - 참가자 중 랜덤 선택
+    List<GameParticipant> findByGameRoomAndStatus(GameRoom gameRoom, ParticipantStatus status);
+
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -77,7 +77,7 @@ public class GameRoomService {
 
         return gameRoom;
     }
-
+    // 게임방 목록 조회
     public List<RoomListInfo> getRooms(Long groupId, UUID userId) {
         //그룹 활성화된 방
         List<RoomStatus> activeStatuses = List.of(RoomStatus.WAITING, RoomStatus.IN_PROGRESS);
@@ -158,7 +158,52 @@ public class GameRoomService {
         return member;
     }
 
+    /**
+     게임방 퇴장
+     동시 퇴장 시 방장 위임 충돌 미리 방지 - 비관적 락
+     */
+    @Transactional
+    public void LeaveRoom(UUID roomId, UUID userId) {
 
+        //게임방 조회
+        GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(()->new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+        //finished면 error 처리
+        if (gameRoom.getStatus() == RoomStatus.FINISHED) {
+            throw new BusinessException(ErrorCode.ROOM_FINISHED);
+        }
+        //참가자 조회
+        GameParticipant participant = gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p->p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(()->new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 방장 여부 기록
+        Boolean wasLeader = participant.getIsLeader();
+        // 방장이면 비활성화
+        if (wasLeader) {
+            participant.resignLeader();
+        }
+
+        participant.leave();
+
+        //남은 ACTIVE 유저 조회
+        List<GameParticipant> remainingActive = gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+        // 아무도 없으면 방 종료다음
+        if (remainingActive.isEmpty()) {
+            gameRoom.finish();
+            return;
+        }
+        // 방장 위임
+        if (wasLeader) {
+            int randomIndex = ThreadLocalRandom.current().nextInt(remainingActive.size());
+            GameParticipant newleader = remainingActive.get(randomIndex);
+            newleader.assignLeader();
+        }
+
+
+
+
+    }
 }
 
 
@@ -197,9 +242,23 @@ gameParticipant.builder()
 
  재참가로 로직 변경
  조회 - 방 상태 체크 - 참가 기록 확인 (기록 있으면 인워 수 체크 후 재참가 로직 )- 인원체크 입장
+
+
+ 방 나가기
+
+ 동시 퇴장 방장 위임 충돌 방지 비관적 락으로 실행
+ 종료된 방인지 확인
+ 종료된 방 아니면
+ 참가자 -> left
+ 방장 -> 방장 위임
+    남은 ACTIVE 찾아서 없으면 게임 종료
+    있으면 랜덤 ACTIVE 유저 방장 위임 isLeader
+
+
+
+
  */
-/**cancel room
- *
- */
+
+
 
 

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -163,7 +163,7 @@ public class GameRoomService {
      동시 퇴장 시 방장 위임 충돌 미리 방지 - 비관적 락
      */
     @Transactional
-    public void LeaveRoom(UUID roomId, UUID userId) {
+    public void leaveRoom(UUID roomId, UUID userId) {
 
         //게임방 조회
         GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
@@ -175,7 +175,7 @@ public class GameRoomService {
         //참가자 조회
         GameParticipant participant = gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
                 .filter(p->p.getStatus() == ParticipantStatus.ACTIVE)
-                .orElseThrow(()->new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+                .orElseThrow(()->new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
 
         // 방장 여부 기록
         Boolean wasLeader = participant.getIsLeader();
@@ -188,7 +188,7 @@ public class GameRoomService {
 
         //남은 ACTIVE 유저 조회
         List<GameParticipant> remainingActive = gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
-        // 아무도 없으면 방 종료다음
+        // 아무도 없으면 방 종료
         if (remainingActive.isEmpty()) {
             gameRoom.finish();
             return;
@@ -196,8 +196,8 @@ public class GameRoomService {
         // 방장 위임
         if (wasLeader) {
             int randomIndex = ThreadLocalRandom.current().nextInt(remainingActive.size());
-            GameParticipant newleader = remainingActive.get(randomIndex);
-            newleader.assignLeader();
+            GameParticipant newLeader = remainingActive.get(randomIndex);
+            newLeader.assignLeader();
         }
 
 

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode {
     ROOM_HOST_DAILY_LIMIT(409, "하루 방 생성 가능 횟수 초과"),
     ROOM_ALREADY_JOINED(409, "이미 참가 중인 방입니다."),
     ROOM_FULL(400, "인원 초과"),
-    ROOM_FINISHED(400, "종료된 방입니다.");
+    ROOM_FINISHED(400, "종료된 방입니다."),
+    ROOM_NOT_PARTICIPANT(403, "참가자가 아닙니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -62,7 +62,7 @@ public enum ErrorCode {
     ROOM_ALREADY_JOINED(409, "이미 참가 중인 방입니다."),
     ROOM_FULL(400, "인원 초과"),
     ROOM_FINISHED(400, "종료된 방입니다."),
-    ROOM_NOT_PARTICIPANT(403, "참가자가 아닙니다.");
+    ROOM_NOT_PARTICIPANT(404, "참가자가 아닙니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.game.room.dto.RoomListInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.room.dto.LeaveRoomResponse;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.*;
 import jakarta.validation.Valid;
@@ -77,6 +78,16 @@ public class GameRoomController {
 
         GameParticipant participant = gameRoomService.joinRoom(roomId, TEMP_USER_ID);
         JoinRoomResponse response = JoinRoomResponse.from(participant);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    //게임방 퇴장
+    @DeleteMapping("/{roomId}/leave")
+    public ResponseEntity<ApiResponse<LeaveRoomResponse>> leaveRoom(@PathVariable UUID roomId) {
+
+        gameRoomService.LeaveRoom(roomId, TEMP_USER_ID);
+        LeaveRoomResponse response = LeaveRoomResponse.success();
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -86,7 +86,7 @@ public class GameRoomController {
     @DeleteMapping("/{roomId}/leave")
     public ResponseEntity<ApiResponse<LeaveRoomResponse>> leaveRoom(@PathVariable UUID roomId) {
 
-        gameRoomService.LeaveRoom(roomId, TEMP_USER_ID);
+        gameRoomService.leaveRoom(roomId, TEMP_USER_ID);
         LeaveRoomResponse response = LeaveRoomResponse.success();
 
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/solv/wefin/web/game/room/dto/LeaveRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/LeaveRoomResponse.java
@@ -1,0 +1,16 @@
+package com.solv.wefin.web.game.room.dto;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LeaveRoomResponse {
+
+    private String message;
+
+    public static LeaveRoomResponse success() {
+        return new LeaveRoomResponse("퇴장 완료");
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -368,6 +368,171 @@ class GameRoomServiceTest {
         verify(gameParticipantRepository, never()).save(any());
     }
 
+    // === API 5: 게임방 퇴장 테스트 ===
+
+    @Test
+    @DisplayName("게임방 퇴장 성공 — 일반 참가자가 퇴장하면 LEFT 상태로 변경")
+    void leaveRoom_success_member() {
+        // Given — WAITING 방, ACTIVE 일반 참가자
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant member = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.of(member));
+        // 퇴장 후 남은 참가자 1명 (방장)
+        GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        given(gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(List.of(leader));
+
+        // When
+        gameRoomService.leaveRoom(roomId, OTHER_USER_ID);
+
+        // Then — 참가자 상태가 LEFT로 변경
+        assertThat(member.getStatus()).isEqualTo(ParticipantStatus.LEFT);
+        // 방장은 변경되지 않음
+        assertThat(leader.getIsLeader()).isTrue();
+        // 방은 종료되지 않음
+        assertThat(gameRoom.getStatus()).isEqualTo(RoomStatus.WAITING);
+    }
+
+    @Test
+    @DisplayName("게임방 퇴장 성공 — 방장이 나가면 남은 참가자에게 방장 위임")
+    void leaveRoom_success_leaderDelegation() {
+        // Given — 방장 + 일반 참가자 1명
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameParticipant member = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(leader));
+        // 퇴장 후 남은 ACTIVE 참가자: member 1명
+        given(gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(List.of(member));
+
+        // When
+        gameRoomService.leaveRoom(roomId, TEST_USER_ID);
+
+        // Then — 기존 방장은 LEFT + 방장 해제
+        assertThat(leader.getStatus()).isEqualTo(ParticipantStatus.LEFT);
+        assertThat(leader.getIsLeader()).isFalse();
+        // 남은 참가자가 새 방장이 됨
+        assertThat(member.getIsLeader()).isTrue();
+        // 방은 종료되지 않음
+        assertThat(gameRoom.getStatus()).isEqualTo(RoomStatus.WAITING);
+    }
+
+    @Test
+    @DisplayName("게임방 퇴장 성공 — 마지막 사람이 나가면 방 종료")
+    void leaveRoom_success_lastPersonFinishesRoom() {
+        // Given — 참가자 1명만 있는 방
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(leader));
+        // 퇴장 후 남은 ACTIVE 참가자 없음
+        given(gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(Collections.emptyList());
+
+        // When
+        gameRoomService.leaveRoom(roomId, TEST_USER_ID);
+
+        // Then — 방이 FINISHED로 변경
+        assertThat(gameRoom.getStatus()).isEqualTo(RoomStatus.FINISHED);
+        assertThat(leader.getStatus()).isEqualTo(ParticipantStatus.LEFT);
+    }
+
+    @Test
+    @DisplayName("게임방 퇴장 실패 — 존재하지 않는 방")
+    void leaveRoom_notFound() {
+        // Given
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findByIdForUpdate(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.leaveRoom(fakeRoomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("게임방 퇴장 실패 — 종료된 방")
+    void leaveRoom_finished() {
+        // Given — FINISHED 방
+        GameRoom gameRoom = createGameRoom();
+        gameRoom.start();
+        gameRoom.finish();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.leaveRoom(roomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_FINISHED);
+                });
+    }
+
+    @Test
+    @DisplayName("게임방 퇴장 실패 — 참가자가 아닌 경우 (이력 없음)")
+    void leaveRoom_notParticipant() {
+        // Given — 참가 이력 자체가 없는 유저
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.leaveRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+    }
+
+    @Test
+    @DisplayName("게임방 퇴장 실패 — 이미 퇴장한 참가자 (LEFT 상태)")
+    void leaveRoom_alreadyLeft() {
+        // Given — LEFT 상태의 참가자가 다시 퇴장 요청
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leftParticipant = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
+        leftParticipant.leave(); // ACTIVE → LEFT
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.of(leftParticipant)); // LEFT 상태로 존재
+
+        // When & Then — filter에서 걸러져서 ROOM_NOT_PARTICIPANT
+        assertThatThrownBy(() -> gameRoomService.leaveRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+    }
+
     // === 헬퍼 메서드 ===
 
     private CreateRoomCommand createCommand() {


### PR DESCRIPTION
## 📌 PR 설명
<br>
게임방 퇴장 api

## ✅ 완료한 기능 명세

- [x] 게임룸 퇴장
- [x] 방장 위임
- [x] 방장 위임 충돌 방지 - 비관적락
- [x] 모두 나가면 게임 종료
- [x] 에러코드
- [x] 퇴장 테스트코드

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
현재 로직은 방장이 게임을 나갈 시 참가중인 랜덤 유저에게 방장을 위임한다
참여자 [a b c]가 있고 a가 방장인 경우
a 퇴장 -> b c 중 랜덤으로 b 선택 과 b 퇴장이 동시에 이루어질 경우 충돌이 생기게 된다
이를 방지하기 위해  트랜잭션과 이전에 만들어 뒀던 findByIdForUpdate () 로 비관적 락을 사용하여 방지 했습니다

동작 과정 (방장 a와 참가자 b의 퇴장 요청이 동시에 들어온 경우)
1. a유저 : findByIdForUpdate(roomId) 락 획득
2. b유저 : findByIdForUpdate(roomId)  대기
3. 유저a : 트랜잭션 커밋 ->  락 해제
4. 유저 b : 락획득
<br>

### 🔗 관련 이슈
Closes #95 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게임방 퇴장 기능 추가
  * 리더 역할 자동 재할당: 리더가 게임방을 떠나면 남은 참가자 중 한 명이 자동으로 새 리더로 선정됨
  * 게임방 자동 완료: 모든 참가자가 떠나면 게임방이 자동으로 완료 상태로 변경됨
  * 참가자 검증 강화: 게임방에 참여하지 않은 사용자의 퇴장 시도 감지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->