### PR TITLE
[WEF-525] OpenAI 설정 통합 및 타임스탬프 타입 수정

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/article/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/entity/NewsArticle.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "news_article")
@@ -66,7 +67,7 @@ public class NewsArticle extends BaseEntity {
     private CrawlStatus crawlStatus = CrawlStatus.PENDING;
 
     @Column(name = "crawl_attempted_at")
-    private LocalDateTime crawlAttemptedAt;
+    private OffsetDateTime crawlAttemptedAt;
 
     @Column(name = "crawl_retry_count", nullable = false)
     private int crawlRetryCount = 0;
@@ -82,7 +83,7 @@ public class NewsArticle extends BaseEntity {
     private int embeddingRetryCount = 0;
 
     @Column(name = "embedding_attempted_at")
-    private LocalDateTime embeddingAttemptedAt;
+    private OffsetDateTime embeddingAttemptedAt;
 
     @Column(name = "embedding_error_message")
     private String embeddingErrorMessage;
@@ -133,7 +134,7 @@ public class NewsArticle extends BaseEntity {
             this.thumbnailUrl = thumbnailUrl;
         }
         this.crawlStatus = CrawlStatus.SUCCESS;
-        this.crawlAttemptedAt = LocalDateTime.now();
+        this.crawlAttemptedAt = OffsetDateTime.now();
         this.crawlErrorMessage = null;
     }
 
@@ -146,7 +147,7 @@ public class NewsArticle extends BaseEntity {
     public void markCrawlFailed(String errorMessage) {
         this.crawlRetryCount++;
         this.crawlStatus = CrawlStatus.FAILED;
-        this.crawlAttemptedAt = LocalDateTime.now();
+        this.crawlAttemptedAt = OffsetDateTime.now();
         this.crawlErrorMessage = errorMessage;
     }
 
@@ -156,7 +157,7 @@ public class NewsArticle extends BaseEntity {
      */
     public void markCrawlSkipped() {
         this.crawlStatus = CrawlStatus.SKIPPED;
-        this.crawlAttemptedAt = LocalDateTime.now();
+        this.crawlAttemptedAt = OffsetDateTime.now();
         this.crawlErrorMessage = null;
     }
 
@@ -166,7 +167,7 @@ public class NewsArticle extends BaseEntity {
      */
     public void markEmbeddingProcessing() {
         this.embeddingStatus = EmbeddingStatus.PROCESSING;
-        this.embeddingAttemptedAt = LocalDateTime.now();
+        this.embeddingAttemptedAt = OffsetDateTime.now();
         this.embeddingErrorMessage = null;
     }
 
@@ -176,7 +177,7 @@ public class NewsArticle extends BaseEntity {
      */
     public void markEmbeddingSuccess() {
         this.embeddingStatus = EmbeddingStatus.SUCCESS;
-        this.embeddingAttemptedAt = LocalDateTime.now();
+        this.embeddingAttemptedAt = OffsetDateTime.now();
         this.embeddingErrorMessage = null;
     }
 
@@ -189,7 +190,7 @@ public class NewsArticle extends BaseEntity {
     public void markEmbeddingFailed(String errorMessage) {
         this.embeddingRetryCount++;
         this.embeddingStatus = EmbeddingStatus.FAILED;
-        this.embeddingAttemptedAt = LocalDateTime.now();
+        this.embeddingAttemptedAt = OffsetDateTime.now();
         this.embeddingErrorMessage = errorMessage;
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> {
@@ -18,18 +18,19 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
 
     /**
      * 임베딩 대상 기사를 조회한다.
-     * PENDING/FAILED 상태이거나, PROCESSING 상태에서 staleBefore 이전에 시도된 기사(크래시로 방치된 건)를 포함한다.
+     * PENDING/FAILED 상태이거나, PROCESSING 상태에서 staleBefore 이전에 시도된 기사를 포함한다.
      */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.crawlStatus = :crawlStatus " +
             "AND a.embeddingRetryCount < :maxRetryCount " +
             "AND (a.embeddingStatus IN :embeddingStatuses " +
-            "     OR (a.embeddingStatus = 'PROCESSING' AND a.embeddingAttemptedAt < :staleBefore)) " +
+            "     OR (a.embeddingStatus = :processingStatus AND a.embeddingAttemptedAt < :staleBefore)) " +
             "ORDER BY a.collectedAt DESC")
     List<NewsArticle> findEmbeddingTargets(
             @Param("crawlStatus") NewsArticle.CrawlStatus crawlStatus,
             @Param("embeddingStatuses") List<NewsArticle.EmbeddingStatus> embeddingStatuses,
+            @Param("processingStatus") NewsArticle.EmbeddingStatus processingStatus,
             @Param("maxRetryCount") int maxRetryCount,
-            @Param("staleBefore") LocalDateTime staleBefore,
+            @Param("staleBefore") OffsetDateTime staleBefore,
             Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
@@ -8,4 +8,9 @@ import java.util.List;
 public interface NewsArticleTagRepository extends JpaRepository<NewsArticleTag, Long> {
 
     List<NewsArticleTag> findByNewsArticleId(Long newsArticleId);
+
+    /**
+     * 특정 기사의 태그를 전부 삭제한다. 재태깅 시 기존 태그 정리에 사용한다.
+     */
+    void deleteByNewsArticleId(Long newsArticleId);
 }

--- a/src/main/java/com/solv/wefin/domain/news/config/OpenAiConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/OpenAiConfig.java
@@ -6,13 +6,21 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-public class EmbeddingConfig {
+public class OpenAiConfig {
 
     @Bean
     public RestTemplate embeddingRestTemplate() {
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
         factory.setConnectTimeout(10000);
         factory.setReadTimeout(30000);
+        return new RestTemplate(factory);
+    }
+
+    @Bean
+    public RestTemplate taggingRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000);
+        factory.setReadTimeout(60000);
         return new RestTemplate(factory);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -76,10 +76,11 @@ public class EmbeddingService {
     }
 
     private List<NewsArticle> findEmbeddingTargets() {
-        LocalDateTime staleBefore = LocalDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
+        OffsetDateTime staleBefore = OffsetDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
         return newsArticleRepository.findEmbeddingTargets(
                 CrawlStatus.SUCCESS,
                 List.of(EmbeddingStatus.PENDING, EmbeddingStatus.FAILED),
+                EmbeddingStatus.PROCESSING,
                 MAX_RETRY,
                 staleBefore,
                 PageRequest.of(0, BATCH_SIZE));

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -54,6 +54,9 @@ public enum ErrorCode {
     // Embedding
     EMBEDDING_ARTICLE_NOT_FOUND(500, "임베딩 대상 기사를 찾을 수 없습니다."),
 
+    // Tagging
+    TAGGING_ARTICLE_NOT_FOUND(500, "태깅 대상 기사를 찾을 수 없습니다."),
+
     // GameRoom
     ROOM_NOT_FOUND(404,"게임장을 찾을 수 없습니다."),
     ROOM_ALREADY_EXISTS(409, "이미 진행 중이거나 대기 중인 게임방이 있습니다."),

--- a/src/main/resources/db/migration/V11__fix_crawl_attempted_at_timestamptz.sql
+++ b/src/main/resources/db/migration/V11__fix_crawl_attempted_at_timestamptz.sql
@@ -1,0 +1,3 @@
+-- crawl_attempted_at 타입을 TIMESTAMP → TIMESTAMPTZ로 변경 (OffsetDateTime 통일)
+ALTER TABLE news_article
+    ALTER COLUMN crawl_attempted_at TYPE TIMESTAMPTZ;

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
@@ -166,6 +166,7 @@ class EmbeddingServiceTest {
         given(newsArticleRepository.findEmbeddingTargets(
                         eq(CrawlStatus.SUCCESS),
                         eq(List.of(EmbeddingStatus.PENDING, EmbeddingStatus.FAILED)),
+                        eq(EmbeddingStatus.PROCESSING),
                         eq(3), any(), any()))
                 .willReturn(articles);
     }


### PR DESCRIPTION
## 📌 PR 설명
AI 태깅 파이프라인 도입 PR의 변경 범위가 커지는 것을 방지하기 위해, 사전 리팩토링 및 작은 수정 사항들을 분리하여 먼저 올렸습니다! 이후 기능 구현 PR에서는 핵심 로직에 집중할 수 있도록 구성했습니다.

- EmbeddingConfig → OpenAiConfig 통합 (임베딩 + 태깅 RestTemplate 관리)
- `crawl_attempted_at`, `embedding_attempted_at` 타입을 LocalDateTime → OffsetDateTime으로 통일
- JPQL enum 하드코딩 제거
<br>

## ✅ 변경 파일
- [x] `V11__fix_crawl_attempted_at_timestamptz.sql` — crawl_attempted_at TIMESTAMPTZ 변환
- [x] `NewsArticle.java` — OffsetDateTime 통일
- [x] `NewsArticleRepository.java` — OffsetDateTime + JPQL enum 파라미터화
- [x] `EmbeddingConfig.java` → `OpenAiConfig.java` — 이름 변경 + taggingRestTemplate 추가
- [x] `EmbeddingService.java` — OffsetDateTime + processingStatus 파라미터 반영
- [x] `EmbeddingServiceTest.java` — 테스트 반영
- [x] `NewsArticleTagRepository.java` — deleteByNewsArticleId() 추가
- [x] `ErrorCode.java` — TAGGING_ARTICLE_NOT_FOUND 추가 (다음 PR로 분리해야 하는데 같이 올라갔습니다..!)


<br>


### 🔗 관련 이슈
close #98

<br>
