### PR TITLE
[WEF-525] 뉴스 기사 AI 태깅 파이프라인 구축

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/article/entity/NewsArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/entity/NewsArticle.java
@@ -88,6 +88,19 @@ public class NewsArticle extends BaseEntity {
     @Column(name = "embedding_error_message")
     private String embeddingErrorMessage;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "tagging_status", nullable = false, length = 30)
+    private TaggingStatus taggingStatus = TaggingStatus.PENDING;
+
+    @Column(name = "tagging_retry_count", nullable = false)
+    private int taggingRetryCount = 0;
+
+    @Column(name = "tagging_attempted_at")
+    private OffsetDateTime taggingAttemptedAt;
+
+    @Column(name = "tagging_error_message")
+    private String taggingErrorMessage;
+
     @Builder
     private NewsArticle(Long rawNewsArticleId, String publisherName, String title,
                         String summary, String content, String originalUrl,
@@ -115,6 +128,10 @@ public class NewsArticle extends BaseEntity {
     }
 
     public enum EmbeddingStatus {
+        PENDING, PROCESSING, SUCCESS, FAILED
+    }
+
+    public enum TaggingStatus {
         PENDING, PROCESSING, SUCCESS, FAILED
     }
 
@@ -192,6 +209,50 @@ public class NewsArticle extends BaseEntity {
         this.embeddingStatus = EmbeddingStatus.FAILED;
         this.embeddingAttemptedAt = OffsetDateTime.now();
         this.embeddingErrorMessage = errorMessage;
+    }
+
+    /**
+     * 태깅 처리 시작을 기록한다.
+     * 상태를 PROCESSING으로 변경하고 이전 에러 메시지를 초기화한다.
+     */
+    public void markTaggingProcessing() {
+        this.taggingStatus = TaggingStatus.PROCESSING;
+        this.taggingAttemptedAt = OffsetDateTime.now();
+        this.taggingErrorMessage = null;
+    }
+
+    /**
+     * 태깅 성공을 기록한다.
+     * 상태를 SUCCESS로 변경하고 에러 메시지를 초기화한다.
+     */
+    public void markTaggingSuccess() {
+        this.taggingStatus = TaggingStatus.SUCCESS;
+        this.taggingAttemptedAt = OffsetDateTime.now();
+        this.taggingErrorMessage = null;
+    }
+
+    /**
+     * AI 요약을 저장한다. 태깅 시 함께 생성된 한 줄 요약을 반영한다.
+     *
+     * @param summary 한 줄 요약 (50자 이내)
+     */
+    public void updateSummary(String summary) {
+        if (summary != null && !summary.isBlank()) {
+            this.summary = summary;
+        }
+    }
+
+    /**
+     * 태깅 실패를 기록한다.
+     * retryCount를 증가시키고 상태를 FAILED로 변경한다.
+     *
+     * @param errorMessage 실패 원인 메시지
+     */
+    public void markTaggingFailed(String errorMessage) {
+        this.taggingRetryCount++;
+        this.taggingStatus = TaggingStatus.FAILED;
+        this.taggingAttemptedAt = OffsetDateTime.now();
+        this.taggingErrorMessage = errorMessage;
     }
 
     public static NewsArticle of(RawNewsArticle rawArticle, CollectedNewsApiResponse dto,

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -33,4 +33,22 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
             @Param("maxRetryCount") int maxRetryCount,
             @Param("staleBefore") OffsetDateTime staleBefore,
             Pageable pageable);
+
+    /**
+     * 태깅 대상 기사를 조회한다.
+     * PENDING/FAILED 상태이거나, PROCESSING 상태에서 staleBefore 이전에 시도된 기사를 포함한다.
+     */
+    @Query("SELECT a FROM NewsArticle a " +
+            "WHERE a.crawlStatus = :crawlStatus " +
+            "AND a.taggingRetryCount < :maxRetryCount " +
+            "AND (a.taggingStatus IN :taggingStatuses " +
+            "     OR (a.taggingStatus = :processingStatus AND a.taggingAttemptedAt < :staleBefore)) " +
+            "ORDER BY a.collectedAt DESC")
+    List<NewsArticle> findTaggingTargets(
+            @Param("crawlStatus") NewsArticle.CrawlStatus crawlStatus,
+            @Param("taggingStatuses") List<NewsArticle.TaggingStatus> taggingStatuses,
+            @Param("processingStatus") NewsArticle.TaggingStatus processingStatus,
+            @Param("maxRetryCount") int maxRetryCount,
+            @Param("staleBefore") OffsetDateTime staleBefore,
+            Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/tagging/batch/TaggingScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/batch/TaggingScheduler.java
@@ -1,0 +1,53 @@
+package com.solv.wefin.domain.news.tagging.batch;
+
+import com.solv.wefin.domain.news.tagging.service.TaggingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 태깅 생성 스케줄러
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TaggingScheduler {
+
+    private final TaggingService taggingService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Scheduled(cron = "${tagging.collect.cron:0 */30 * * * *}")
+    public void generateTags() {
+        execute();
+    }
+
+    /**
+     * 태깅 생성을 실행한다
+     *
+     * @return 실행 여부 (이미 실행 중이면 false)
+     */
+    public boolean execute() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("태깅 생성이 이미 실행 중입니다. 스킵합니다.");
+            return false;
+        }
+
+        log.info("=== 태깅 생성 배치 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            taggingService.tagPendingArticles();
+            return true;
+        } catch (Exception e) {
+            log.error("태깅 생성 실패: {}", e.getMessage(), e);
+            return false;
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 태깅 생성 배치 종료 ({}ms) ===", elapsed);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/batch/TaggingScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/batch/TaggingScheduler.java
@@ -21,13 +21,23 @@ public class TaggingScheduler {
 
     @Scheduled(cron = "${tagging.collect.cron:0 */30 * * * *}")
     public void generateTags() {
-        execute();
+        try {
+            execute();
+        } catch (Exception e) {
+            log.error("태깅 생성 배치 실패: {}", e.getMessage(), e);
+        }
     }
 
     /**
      * 태깅 생성을 실행한다
      *
      * @return 실행 여부 (이미 실행 중이면 false)
+     */
+    /**
+     * 태깅 생성을 실행한다.
+     *
+     * @return 이미 실행 중이면 false, 정상 실행되면 true
+     * @throws RuntimeException 태깅 실행 중 예외 발생 시
      */
     public boolean execute() {
         if (!running.compareAndSet(false, true)) {
@@ -41,9 +51,6 @@ public class TaggingScheduler {
         try {
             taggingService.tagPendingArticles();
             return true;
-        } catch (Exception e) {
-            log.error("태깅 생성 실패: {}", e.getMessage(), e);
-            return false;
         } finally {
             running.set(false);
             long elapsed = System.currentTimeMillis() - start;

--- a/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
@@ -1,0 +1,139 @@
+package com.solv.wefin.domain.news.tagging.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI Chat Completions API를 호출하여 기사에서 태그를 추출한다.
+ */
+@Slf4j
+@Component
+public class OpenAiTaggingClient {
+
+    private static final String OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
+    private static final int MAX_CONTENT_LENGTH = 3000;
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 금융 뉴스 기사를 분석하여 태그를 추출하고 한 줄 요약을 작성하는 전문가입니다.
+            기사를 읽고 다음을 추출하세요.
+
+            1. stocks: 기사에서 언급된 개별 종목 (코드와 한글 이름)
+            2. sectors: 기사와 관련된 산업/섹터 (영문 코드와 한글 이름)
+            3. topics: 기사의 주제/테마 (영문 코드와 한글 이름)
+            4. summary: 기사 핵심 내용을 한 문장(50자 이내)으로 요약
+
+            규칙:
+            - 각 카테고리는 최대 5개까지
+            - 확실한 것만 포함 (추측 금지)
+            - 종목 코드는 한국 종목이면 6자리 숫자, 미국 종목이면 티커 심볼
+            - sector 코드는 대문자 영문 (예: SEMICONDUCTOR, FINANCE, ENERGY)
+            - topic 코드는 대문자 영문 (예: EARNINGS, AI, REGULATION, IPO)
+            - summary는 한글로 작성, 50자 이내
+
+            반드시 아래 JSON 형식으로만 응답하세요:
+            {
+              "stocks": [{"code": "005930", "name": "삼성전자"}],
+              "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
+              "topics": [{"code": "EARNINGS", "name": "실적"}],
+              "summary": "삼성전자가 2분기 반도체 실적 호조를 발표했다."
+            }
+            """;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String model;
+
+    public OpenAiTaggingClient(@Qualifier("taggingRestTemplate") RestTemplate restTemplate,
+                               ObjectMapper objectMapper,
+                               @Value("${openai.api-key}") String apiKey,
+                               @Value("${openai.tagging.model}") String model) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.model = model;
+    }
+
+    /**
+     * 기사 제목과 본문을 분석하여 태그를 추출한다.
+     *
+     * @param title   기사 제목
+     * @param content 기사 본문
+     * @return 추출된 태그 결과
+     */
+    public TaggingResult analyzeTags(String title, String content) {
+        String truncatedContent = truncateContent(content);
+        String userMessage = "제목: " + title + "\n\n본문: " + truncatedContent;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "response_format", Map.of("type", "json_object"),
+                "messages", List.of(
+                        Map.of("role", "system", "content", SYSTEM_PROMPT),
+                        Map.of("role", "user", "content", userMessage)
+                )
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+        ChatResponse response = restTemplate.postForObject(OPENAI_CHAT_URL, request, ChatResponse.class);
+
+        if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
+            throw new IllegalStateException("OpenAI Tagging API 응답이 비어있습니다");
+        }
+
+        Message message = response.getChoices().get(0).getMessage();
+        if (message == null || message.getContent() == null) {
+            throw new IllegalStateException("OpenAI Tagging API 응답 메시지가 비어있습니다");
+        }
+        return parseTaggingResult(message.getContent());
+    }
+
+    private TaggingResult parseTaggingResult(String json) {
+        try {
+            return objectMapper.readValue(json, TaggingResult.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("태깅 결과 JSON 파싱 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private String truncateContent(String content) {
+        if (content == null) {
+            return "";
+        }
+        return content.length() <= MAX_CONTENT_LENGTH
+                ? content
+                : content.substring(0, MAX_CONTENT_LENGTH);
+    }
+
+    @Getter
+    private static class ChatResponse {
+        private List<Choice> choices;
+    }
+
+    @Getter
+    private static class Choice {
+        private Message message;
+    }
+
+    @Getter
+    private static class Message {
+        private String content;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/dto/TaggingResult.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/dto/TaggingResult.java
@@ -1,0 +1,38 @@
+package com.solv.wefin.domain.news.tagging.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * OpenAI 태깅 API의 구조화된 응답 결과를 담는 DTO
+ */
+@Getter
+public class TaggingResult {
+
+    private List<TagItem> stocks;
+    private List<TagItem> sectors;
+    private List<TagItem> topics;
+    private String summary;
+
+    public TaggingResult() {
+        this.stocks = List.of();
+        this.sectors = List.of();
+        this.topics = List.of();
+    }
+
+    /**
+     * 전체 태그가 비어있는지 확인한다.
+     */
+    public boolean isEmpty() {
+        return (stocks == null || stocks.isEmpty())
+                && (sectors == null || sectors.isEmpty())
+                && (topics == null || topics.isEmpty());
+    }
+
+    @Getter
+    public static class TagItem {
+        private String code;
+        private String name;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingPersistenceService.java
@@ -1,0 +1,69 @@
+package com.solv.wefin.domain.news.tagging.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 태깅 결과를 DB에 반영하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class TaggingPersistenceService {
+
+    private final NewsArticleTagRepository newsArticleTagRepository;
+    private final NewsArticleRepository newsArticleRepository;
+
+    /**
+     * 태깅 대상 기사들의 상태를 PROCESSING으로 일괄 전환한다.
+     */
+    @Transactional
+    public void markProcessing(List<NewsArticle> articles) {
+        for (NewsArticle article : articles) {
+            article.markTaggingProcessing();
+        }
+        newsArticleRepository.saveAll(articles);
+    }
+
+    /**
+     * 여러 기사의 태그를 한 트랜잭션으로 저장하고 상태를 SUCCESS로 변경한다.
+     * 재태깅 대응을 위해 기존 태그를 삭제한 뒤 새로 저장한다.
+     */
+    @Transactional
+    public void saveTagsBatch(List<NewsArticleTag> tags, List<NewsArticle> articles) {
+        for (NewsArticle article : articles) {
+            newsArticleTagRepository.deleteByNewsArticleId(article.getId());
+        }
+        newsArticleTagRepository.saveAll(tags);
+        for (NewsArticle article : articles) {
+            article.markTaggingSuccess();
+        }
+        newsArticleRepository.saveAll(articles);
+    }
+
+    /**
+     * 태깅 실패를 기록한다. 개별 트랜잭션으로 격리하여 다른 건에 영향을 주지 않는다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long articleId, String errorMessage) {
+        NewsArticle article = newsArticleRepository.findById(articleId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TAGGING_ARTICLE_NOT_FOUND));
+        article.markTaggingFailed(truncate(errorMessage, 500));
+    }
+
+    private String truncate(String text, int maxLength) {
+        if (text == null) {
+            return "Unknown error";
+        }
+        return text.length() <= maxLength ? text : text.substring(0, maxLength);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
@@ -1,0 +1,166 @@
+package com.solv.wefin.domain.news.tagging.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.article.entity.NewsArticle.TaggingStatus;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.tagging.client.OpenAiTaggingClient;
+import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 태깅 생성 전체 흐름을 관리하는 서비스.
+ * 외부 API 호출은 트랜잭션 밖에서 수행하고,
+ * DB 저장은 TaggingPersistenceService에서 트랜잭션으로 처리한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TaggingService {
+
+    private static final int BATCH_SIZE = 500;
+    private static final int PROCESS_CHUNK_SIZE = 20;
+    private static final int MAX_RETRY = 3;
+    private static final int STALE_PROCESSING_MINUTES = 30;
+
+    private final NewsArticleRepository newsArticleRepository;
+    private final OpenAiTaggingClient openAiTaggingClient;
+    private final TaggingPersistenceService persistenceService;
+
+    /**
+     * 크롤링 완료 + 태깅 미완료 기사를 조회하여 태그를 생성한다.
+     */
+    public void tagPendingArticles() {
+        List<NewsArticle> targets = findTaggingTargets();
+        log.info("태깅 대상 기사 수: {}", targets.size());
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        persistenceService.markProcessing(targets);
+
+        int successCount = 0;
+        int failCount = 0;
+
+        for (int i = 0; i < targets.size(); i += PROCESS_CHUNK_SIZE) {
+            List<NewsArticle> chunk = targets.subList(i, Math.min(i + PROCESS_CHUNK_SIZE, targets.size()));
+            int[] result = processChunk(chunk);
+            successCount += result[0];
+            failCount += result[1];
+        }
+
+        log.info("태깅 완료 - 성공: {}, 실패: {}", successCount, failCount);
+    }
+
+    private List<NewsArticle> findTaggingTargets() {
+        OffsetDateTime staleBefore = OffsetDateTime.now().minusMinutes(STALE_PROCESSING_MINUTES);
+        return newsArticleRepository.findTaggingTargets(
+                CrawlStatus.SUCCESS,
+                List.of(TaggingStatus.PENDING, TaggingStatus.FAILED),
+                TaggingStatus.PROCESSING,
+                MAX_RETRY,
+                staleBefore,
+                PageRequest.of(0, BATCH_SIZE));
+    }
+
+    private int[] processChunk(List<NewsArticle> articles) {
+        List<NewsArticleTag> allTags = new ArrayList<>();
+        List<NewsArticle> successArticles = new ArrayList<>();
+        int failCount = 0;
+
+        for (NewsArticle article : articles) {
+            try {
+                List<NewsArticleTag> tags = generateTagsForArticle(article);
+                allTags.addAll(tags);
+                successArticles.add(article);
+            } catch (Exception e) {
+                log.warn("태깅 실패 - articleId: {}, error: {}", article.getId(), e.getMessage());
+                persistenceService.markFailed(article.getId(), e.getMessage());
+                failCount++;
+            }
+        }
+
+        if (!allTags.isEmpty()) {
+            try {
+                persistenceService.saveTagsBatch(allTags, successArticles);
+            } catch (Exception e) {
+                log.error("태깅 배치 저장 실패, 개별 fallback 시도: {}", e.getMessage());
+                failCount += handleBatchSaveFailure(successArticles, e.getMessage());
+                return new int[]{0, failCount};
+            }
+        }
+
+        return new int[]{successArticles.size(), failCount};
+    }
+
+    private List<NewsArticleTag> generateTagsForArticle(NewsArticle article) {
+        TaggingResult result = openAiTaggingClient.analyzeTags(article.getTitle(), article.getContent());
+
+        if (result.isEmpty()) {
+            throw new IllegalStateException("태깅 결과가 비어있습니다");
+        }
+
+        article.updateSummary(result.getSummary());
+
+        List<NewsArticleTag> tags = new ArrayList<>();
+
+        if (result.getStocks() != null) {
+            for (TaggingResult.TagItem item : result.getStocks()) {
+                tags.add(NewsArticleTag.builder()
+                        .newsArticleId(article.getId())
+                        .tagType(TagType.STOCK)
+                        .tagCode(item.getCode())
+                        .tagName(item.getName())
+                        .build());
+            }
+        }
+
+        if (result.getSectors() != null) {
+            for (TaggingResult.TagItem item : result.getSectors()) {
+                tags.add(NewsArticleTag.builder()
+                        .newsArticleId(article.getId())
+                        .tagType(TagType.SECTOR)
+                        .tagCode(item.getCode())
+                        .tagName(item.getName())
+                        .build());
+            }
+        }
+
+        if (result.getTopics() != null) {
+            for (TaggingResult.TagItem item : result.getTopics()) {
+                tags.add(NewsArticleTag.builder()
+                        .newsArticleId(article.getId())
+                        .tagType(TagType.TOPIC)
+                        .tagCode(item.getCode())
+                        .tagName(item.getName())
+                        .build());
+            }
+        }
+
+        return tags;
+    }
+
+    private int handleBatchSaveFailure(List<NewsArticle> articles, String errorMessage) {
+        int failCount = 0;
+        for (NewsArticle article : articles) {
+            try {
+                persistenceService.markFailed(article.getId(), "배치 저장 실패: " + errorMessage);
+                failCount++;
+            } catch (Exception e) {
+                log.error("개별 실패 마킹도 실패 - articleId: {}, error: {}", article.getId(), e.getMessage());
+                failCount++;
+            }
+        }
+        return failCount;
+    }
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
 
     // Tagging
     TAGGING_ARTICLE_NOT_FOUND(500, "태깅 대상 기사를 찾을 수 없습니다."),
+    TAGGING_ALREADY_RUNNING(409, "태깅 생성이 이미 실행 중입니다."),
 
     // GameRoom
     ROOM_NOT_FOUND(404,"게임장을 찾을 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/news/TaggingAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/TaggingAdminController.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.web.news;
+
+import com.solv.wefin.domain.news.tagging.batch.TaggingScheduler;
+import com.solv.wefin.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/api/admin/news/tagging")
+@RequiredArgsConstructor
+public class TaggingAdminController {
+
+    private final TaggingScheduler taggingScheduler;
+
+    /**
+     * 태깅 생성을 수동으로 트리거한다.
+     */
+    @PostMapping("/generate")
+    public ApiResponse<String> generateNow() {
+        boolean executed = taggingScheduler.execute();
+        if (executed) {
+            return ApiResponse.success("태깅 생성 완료");
+        }
+        return ApiResponse.success("태깅 생성이 이미 실행 중입니다. 스킵합니다.");
+    }
+}

--- a/src/main/java/com/solv/wefin/web/news/TaggingAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/TaggingAdminController.java
@@ -2,6 +2,8 @@ package com.solv.wefin.web.news;
 
 import com.solv.wefin.domain.news.tagging.batch.TaggingScheduler;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,13 +20,14 @@ public class TaggingAdminController {
 
     /**
      * 태깅 생성을 수동으로 트리거한다.
+     * 이미 실행 중이면 409, 실행 중 예외 발생 시 500으로 GlobalExceptionHandler에서 처리된다.
      */
     @PostMapping("/generate")
     public ApiResponse<String> generateNow() {
         boolean executed = taggingScheduler.execute();
-        if (executed) {
-            return ApiResponse.success("태깅 생성 완료");
+        if (!executed) {
+            throw new BusinessException(ErrorCode.TAGGING_ALREADY_RUNNING);
         }
-        return ApiResponse.success("태깅 생성이 이미 실행 중입니다. 스킵합니다.");
+        return ApiResponse.success("태깅 생성 완료");
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -46,6 +46,10 @@ embedding:
   collect:
     cron: "0 */30 * * * *"
 
+tagging:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -34,18 +34,22 @@ news:
     display: ${NAVER_NEWS_DISPLAY:100}
     base-url: ${NAVER_NEWS_BASE_URL:https://openapi.naver.com/v1/search/news.json}
   collect:
-    cron: "0 0 */2 * * *"
+    cron: ${NEWS_COLLECT_CRON:-}
 
 market:
   bok:
     api-key: ${BOK_API_KEY:}
     base-url: ${BOK_BASE_URL:https://ecos.bok.or.kr/api}
   collect:
-    cron: "0 */5 * * * *"
+    cron: ${MARKET_COLLECT_CRON:-}
 
 embedding:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${EMBEDDING_COLLECT_CRON:-}
+
+tagging:
+  collect:
+    cron: ${TAGGING_COLLECT_CRON:-}
 
 websocket:
   allowed-origins:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -43,6 +43,10 @@ embedding:
   collect:
     cron: "0 */30 * * * *"
 
+tagging:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,8 +14,14 @@ openai:
   embedding:
     model: text-embedding-3-small
     version: v1
+  tagging:
+    model: gpt-4o-mini
 
 embedding:
+  collect:
+    cron: "0 */30 * * * *"
+
+tagging:
   collect:
     cron: "0 */30 * * * *"
 

--- a/src/main/resources/db/migration/V12__add_tagging_status_to_news_article.sql
+++ b/src/main/resources/db/migration/V12__add_tagging_status_to_news_article.sql
@@ -1,0 +1,6 @@
+-- news_article에 태깅 처리 상태 추적 컬럼 추가
+ALTER TABLE news_article
+    ADD COLUMN IF NOT EXISTS tagging_status        VARCHAR(30) NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN IF NOT EXISTS tagging_retry_count   INT         NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS tagging_attempted_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS tagging_error_message TEXT;

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingMarkFailedIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingMarkFailedIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.solv.wefin.domain.news.tagging.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.entity.NewsArticle.TaggingStatus;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * markFailed()는 REQUIRES_NEW 전파를 사용하므로
+ * 테스트 트랜잭션과 분리하여 검증한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class TaggingMarkFailedIntegrationTest {
+
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>(
+                    DockerImageName.parse("pgvector/pgvector:pg16")
+                            .asCompatibleSubstituteFor("postgres"))
+                    .withDatabaseName("wefin_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    static {
+        postgres.start();
+    }
+
+    @Autowired
+    private TaggingPersistenceService persistenceService;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Autowired
+    private NewsArticleTagRepository newsArticleTagRepository;
+
+    @AfterEach
+    void cleanup() {
+        newsArticleTagRepository.deleteAllInBatch();
+        newsArticleRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("서비스의 markFailed 호출 시 상태가 FAILED로 변경되고 에러 메시지가 저장된다")
+    void markFailed_updatesStatusThroughService() {
+        // given
+        NewsArticle article = createAndSaveProcessingArticle();
+
+        // when
+        persistenceService.markFailed(article.getId(), "API 호출 실패");
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getTaggingStatus()).isEqualTo(TaggingStatus.FAILED);
+        assertThat(updated.getTaggingErrorMessage()).isEqualTo("API 호출 실패");
+        assertThat(updated.getTaggingRetryCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("서비스의 markFailed 호출 시 500자를 초과하는 에러 메시지가 잘린다")
+    void markFailed_truncatesLongErrorMessage() {
+        // given
+        NewsArticle article = createAndSaveProcessingArticle();
+        String longMessage = "E".repeat(600);
+
+        // when
+        persistenceService.markFailed(article.getId(), longMessage);
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getTaggingStatus()).isEqualTo(TaggingStatus.FAILED);
+        assertThat(updated.getTaggingErrorMessage()).hasSize(500);
+    }
+
+    private NewsArticle createAndSaveProcessingArticle() {
+        NewsArticle article = NewsArticle.builder()
+                .rawNewsArticleId(null)
+                .publisherName("test")
+                .title("테스트 기사")
+                .content("테스트 본문")
+                .originalUrl("https://example.com/test-" + System.nanoTime())
+                .dedupKey("key-" + System.nanoTime())
+                .build();
+        article = newsArticleRepository.saveAndFlush(article);
+        article.markTaggingProcessing();
+        return newsArticleRepository.saveAndFlush(article);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingPersistenceServiceIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingPersistenceServiceIntegrationTest.java
@@ -97,25 +97,6 @@ class TaggingPersistenceServiceIntegrationTest extends IntegrationTestBase {
         assertThat(saved.get(0).getTagCode()).isEqualTo("NEW_TOPIC");
     }
 
-    @Test
-    @DisplayName("markTaggingFailed 호출 시 상태가 FAILED로 변경되고 에러 메시지가 저장된다")
-    void markTaggingFailed_updatesStatus() {
-        // given
-        NewsArticle article = createAndSaveArticle();
-        article.markTaggingProcessing();
-        newsArticleRepository.flush();
-
-        // when
-        article.markTaggingFailed("API 호출 실패");
-        newsArticleRepository.flush();
-
-        // then
-        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
-        assertThat(updated.getTaggingStatus()).isEqualTo(TaggingStatus.FAILED);
-        assertThat(updated.getTaggingErrorMessage()).isEqualTo("API 호출 실패");
-        assertThat(updated.getTaggingRetryCount()).isEqualTo(1);
-    }
-
     private NewsArticle createAndSaveArticle() {
         NewsArticle article = NewsArticle.builder()
                 .rawNewsArticleId(null)

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingPersistenceServiceIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingPersistenceServiceIntegrationTest.java
@@ -1,0 +1,130 @@
+package com.solv.wefin.domain.news.tagging.service;
+
+import com.solv.wefin.common.IntegrationTestBase;
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.entity.NewsArticle.TaggingStatus;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaggingPersistenceServiceIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private TaggingPersistenceService persistenceService;
+
+    @Autowired
+    private NewsArticleTagRepository newsArticleTagRepository;
+
+    @Autowired
+    private NewsArticleRepository newsArticleRepository;
+
+    @Test
+    @DisplayName("태그 배치 저장 시 태그가 저장되고 기사 상태가 SUCCESS로 변경된다")
+    void saveTagsBatch_success() {
+        // given
+        NewsArticle article = createAndSaveArticle();
+        article.markTaggingProcessing();
+        newsArticleRepository.flush();
+
+        List<NewsArticleTag> tags = List.of(
+                NewsArticleTag.builder()
+                        .newsArticleId(article.getId())
+                        .tagType(TagType.STOCK)
+                        .tagCode("005930")
+                        .tagName("삼성전자")
+                        .build(),
+                NewsArticleTag.builder()
+                        .newsArticleId(article.getId())
+                        .tagType(TagType.SECTOR)
+                        .tagCode("SEMICONDUCTOR")
+                        .tagName("반도체")
+                        .build()
+        );
+
+        // when
+        persistenceService.saveTagsBatch(tags, List.of(article));
+
+        // then
+        List<NewsArticleTag> saved = newsArticleTagRepository.findByNewsArticleId(article.getId());
+        assertThat(saved).hasSize(2);
+
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getTaggingStatus()).isEqualTo(TaggingStatus.SUCCESS);
+    }
+
+    @Test
+    @DisplayName("재태깅 시 기존 태그가 삭제되고 새 태그로 교체된다")
+    void saveTagsBatch_retagging() {
+        // given
+        NewsArticle article = createAndSaveArticle();
+
+        // 기존 태그 저장
+        newsArticleTagRepository.save(NewsArticleTag.builder()
+                .newsArticleId(article.getId())
+                .tagType(TagType.TOPIC)
+                .tagCode("OLD_TOPIC")
+                .tagName("이전 주제")
+                .build());
+        newsArticleTagRepository.flush();
+
+        article.markTaggingProcessing();
+        newsArticleRepository.flush();
+
+        // 새 태그
+        List<NewsArticleTag> newTags = List.of(
+                NewsArticleTag.builder()
+                        .newsArticleId(article.getId())
+                        .tagType(TagType.TOPIC)
+                        .tagCode("NEW_TOPIC")
+                        .tagName("새 주제")
+                        .build()
+        );
+
+        // when
+        persistenceService.saveTagsBatch(newTags, List.of(article));
+
+        // then
+        List<NewsArticleTag> saved = newsArticleTagRepository.findByNewsArticleId(article.getId());
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getTagCode()).isEqualTo("NEW_TOPIC");
+    }
+
+    @Test
+    @DisplayName("markTaggingFailed 호출 시 상태가 FAILED로 변경되고 에러 메시지가 저장된다")
+    void markTaggingFailed_updatesStatus() {
+        // given
+        NewsArticle article = createAndSaveArticle();
+        article.markTaggingProcessing();
+        newsArticleRepository.flush();
+
+        // when
+        article.markTaggingFailed("API 호출 실패");
+        newsArticleRepository.flush();
+
+        // then
+        NewsArticle updated = newsArticleRepository.findById(article.getId()).orElseThrow();
+        assertThat(updated.getTaggingStatus()).isEqualTo(TaggingStatus.FAILED);
+        assertThat(updated.getTaggingErrorMessage()).isEqualTo("API 호출 실패");
+        assertThat(updated.getTaggingRetryCount()).isEqualTo(1);
+    }
+
+    private NewsArticle createAndSaveArticle() {
+        NewsArticle article = NewsArticle.builder()
+                .rawNewsArticleId(null)
+                .publisherName("test")
+                .title("테스트 기사")
+                .content("테스트 본문")
+                .originalUrl("https://example.com/test-" + System.nanoTime())
+                .dedupKey("key-" + System.nanoTime())
+                .build();
+        return newsArticleRepository.save(article);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
@@ -1,0 +1,187 @@
+package com.solv.wefin.domain.news.tagging.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.entity.NewsArticle.CrawlStatus;
+import com.solv.wefin.domain.news.article.entity.NewsArticle.TaggingStatus;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.tagging.client.OpenAiTaggingClient;
+import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TaggingServiceTest {
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+    @Mock
+    private OpenAiTaggingClient openAiTaggingClient;
+    @Mock
+    private TaggingPersistenceService persistenceService;
+    @Captor
+    private ArgumentCaptor<List<NewsArticleTag>> tagsCaptor;
+    @Captor
+    private ArgumentCaptor<List<NewsArticle>> articlesCaptor;
+
+    private TaggingService taggingService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setUp() {
+        taggingService = new TaggingService(newsArticleRepository, openAiTaggingClient, persistenceService);
+    }
+
+    @Test
+    @DisplayName("대상 기사 3건이 있으면 태깅 → 저장을 수행한다")
+    void tagPendingArticles_success() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(3);
+        stubFindTargets(articles);
+
+        TaggingResult result = createTaggingResult();
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then
+        verify(persistenceService).markProcessing(articles);
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), articlesCaptor.capture());
+        assertThat(tagsCaptor.getValue()).isNotEmpty();
+        assertThat(articlesCaptor.getValue()).hasSize(3);
+        verify(persistenceService, never()).markFailed(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("대상 기사가 없으면 아무 작업도 하지 않는다")
+    void tagPendingArticles_noTargets() {
+        // given
+        stubFindTargets(List.of());
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then
+        verifyNoInteractions(openAiTaggingClient);
+        verify(persistenceService, never()).markProcessing(anyList());
+    }
+
+    @Test
+    @DisplayName("OpenAI API 실패 시 해당 기사만 FAILED로 마킹하고 나머지는 진행한다")
+    void tagPendingArticles_partialFailure() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(3);
+        stubFindTargets(articles);
+
+        TaggingResult result = createTaggingResult();
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString()))
+                .willReturn(result)
+                .willThrow(new RuntimeException("API 오류"))
+                .willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then
+        verify(persistenceService).markFailed(eq(2L), contains("API 오류"));
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), articlesCaptor.capture());
+        assertThat(articlesCaptor.getValue()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("태깅 결과가 비어있으면 해당 기사를 FAILED로 마킹한다")
+    void tagPendingArticles_emptyResult() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        TaggingResult emptyResult = new TaggingResult();
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(emptyResult);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then
+        verify(persistenceService).markFailed(eq(1L), contains("태깅 결과가 비어있습니다"));
+        verify(openAiTaggingClient).analyzeTags(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("태깅 결과에서 STOCK/SECTOR/TOPIC 태그가 모두 생성된다")
+    void tagPendingArticles_allTagTypes() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        TaggingResult result = createTaggingResult();
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        List<NewsArticleTag> tags = tagsCaptor.getValue();
+        assertThat(tags).extracting(NewsArticleTag::getTagType)
+                .containsExactlyInAnyOrder(
+                        NewsArticleTag.TagType.STOCK,
+                        NewsArticleTag.TagType.SECTOR,
+                        NewsArticleTag.TagType.TOPIC);
+    }
+
+    private void stubFindTargets(List<NewsArticle> articles) {
+        given(newsArticleRepository.findTaggingTargets(
+                eq(CrawlStatus.SUCCESS),
+                eq(List.of(TaggingStatus.PENDING, TaggingStatus.FAILED)),
+                eq(TaggingStatus.PROCESSING),
+                eq(3), any(), any()))
+                .willReturn(articles);
+    }
+
+    private List<NewsArticle> createArticles(int count) {
+        List<NewsArticle> articles = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            NewsArticle article = NewsArticle.builder()
+                    .rawNewsArticleId(null)
+                    .publisherName("test")
+                    .title("테스트 기사 " + i)
+                    .content("본문 내용 " + i)
+                    .originalUrl("https://example.com/" + i)
+                    .dedupKey("key" + i)
+                    .build();
+            ReflectionTestUtils.setField(article, "id", (long) (i + 1));
+            ReflectionTestUtils.setField(article, "crawlStatus", CrawlStatus.SUCCESS);
+            ReflectionTestUtils.setField(article, "taggingStatus", TaggingStatus.PENDING);
+            articles.add(article);
+        }
+        return articles;
+    }
+
+    private TaggingResult createTaggingResult() throws Exception {
+        String json = """
+                {
+                  "stocks": [{"code": "005930", "name": "삼성전자"}],
+                  "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        return objectMapper.readValue(json, TaggingResult.class);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -38,7 +38,13 @@ openai:
   embedding:
     model: text-embedding-3-small
     version: v1
+  tagging:
+    model: gpt-4o-mini
 
 embedding:
+  collect:
+    cron: "-"
+
+tagging:
   collect:
     cron: "-"


### PR DESCRIPTION
## 📌 PR 설명

크롤링 완료(SUCCESS) 기사를 대상으로 OpenAI Chat API(gpt-4o-mini)로 분석하여 STOCK/SECTOR/TOPIC 태그를 자동 부여하는 배치 파이프라인입니다.

- 기사 제목 + 본문을 OpenAI에 보내 구조화된 태그 추출 (JSON mode)

### 참고
local 프로필에서는 배치 스케줄러가 기본 비활성화되도록 설정을 변경하였습니다. 배치 실행이 필요한 경우, IntelliJ Run Configuration > Environment variables에 아래 환경변수를 추가해주세요!
```
NEWS_COLLECT_CRON=0 0 */2 * * *
MARKET_COLLECT_CRON=0 */5 * * * *
EMBEDDING_COLLECT_CRON=0 */30 * * * *
TAGGING_COLLECT_CRON=0 */30 * * * 
```

### 뉴스기사 AI 태깅 파이프라인

```mermaid
 sequenceDiagram
      participant Scheduler as TaggingScheduler
      participant Service as TaggingService
      participant Persist as TaggingPersistenceService
      participant Repo as NewsArticleRepository
      participant TagRepo as NewsArticleTagRepository
      participant Client as OpenAiTaggingClient
      participant OpenAI as OpenAI API

      Note over Scheduler: @Scheduled (30분 간격)
      Scheduler->>Service: tagPendingArticles()

      Service->>Repo: findTaggingTargets()<br/>(PENDING/FAILED, retry < 3, stale PROCESSING)
      Repo-->>Service: List<NewsArticle> (max 500건)

      alt 대상 없음
          Service-->>Scheduler: return (종료)
      end

      Service->>Persist: markProcessing(targets)
      Persist->>Repo: saveAll() [PENDING → PROCESSING]

      loop 20건 단위 chunk
          loop 기사별 처리 (try-catch)
              Service->>Client: analyzeTags(title, content)
              Client->>OpenAI: POST /v1/chat/completions<br/>(gpt-4o-mini, JSON mode)
              OpenAI-->>Client: JSON 응답

              alt 파싱 성공
                  Client-->>Service: TaggingResult (stocks, sectors, topics, summary)
                  Service->>Service: article.updateSummary()
                  Service->>Service: TaggingResult → List<NewsArticleTag> 변환
              else 파싱 실패 / 빈 결과
                  Service->>Persist: markFailed(articleId, errorMessage)
                  Persist->>Repo: findById() → markTaggingFailed() [REQUIRES_NEW]
              end
          end

          alt 청크 내 성공 건 있음
              Service->>Persist: saveTagsBatch(tags, successArticles)
              Persist->>TagRepo: deleteByNewsArticleId() (재태깅 대응)
              Persist->>TagRepo: saveAll(newTags)
              Persist->>Repo: saveAll() [PROCESSING → SUCCESS]
          end

          alt 배치 저장 실패
              loop 개별 fallback
                  Service->>Persist: markFailed(articleId, errorMessage)
                  Persist->>Repo: findById() → markTaggingFailed() [REQUIRES_NEW]
              end
          end
      end

      Service-->>Scheduler: 완료 (성공: N, 실패: M)

```


<br>

## ✅  변경 파일
1. `V12__add_tagging_status_to_news_article.sql` — tagging 상태 컬럼 추가
2. `NewsArticle.java` — TaggingStatus enum + 상태 변경 메서드 추가
3. `NewsArticleRepository.java` — findTaggingTargets() 쿼리 추가
4. `TaggingResult.java` — OpenAI 응답 파싱 DTO
5. `OpenAiTaggingClient.java` — Chat Completions API 호출 + 프롬프트 + JSON 파싱
6. `TaggingPersistenceService.java` — DB 저장 + 상태 관리
7. `TaggingService.java` — 전체 흐름 오케스트레이션
8. `TaggingScheduler.java` — 30분 배치 스케줄러
9. `TaggingAdminController.java` — 수동 트리거 API
10. `application*.yml` — openai.tagging.model + tagging.collect.cron 설정
11. `TaggingServiceTest.java` — 단위 테스트
12. `TaggingPersistenceServiceIntegrationTest.java` — 통합 테스트

<br>

## 📸 스크린샷
### 태깅 결과
<img width="960" height="430" alt="image" src="https://github.com/user-attachments/assets/29cb0000-cb8d-4e95-8a50-9d45485d452f" />

### 뉴스 요약 결과
<img width="878" height="237" alt="image" src="https://github.com/user-attachments/assets/5ee117f3-0db8-41c1-894a-6feceea6437a" />

<br>

## 💭 고민과 해결과정

### 1. 태깅 상태 관리 — NewsArticle에 컬럼 추가한 이유

임베딩과 동일하게 `news_article`에 `tagging_status`, `tagging_retry_count`, `tagging_attempted_at`, `tagging_error_message` 컬럼을 추가했습니다.

별도 테이블(`TaggingJob`)로 분리하는 방안도 검토했지만, 현재 단계에서는 NewsArticle에 두는 것이 더 적합하다고 판단했습니다. 조회 시 JOIN 없이 단일 쿼리로 파이프라인 상태를 확인할 수 있고, 운영 시 기사 한 건의 전체 상태를 한 눈에 볼 수 있습니다.

### 2. OpenAI 모델 선택: gpt-4o-mini

태깅은 기사를 읽고 카테고리/종목/주제를 추출하는 분류 작업입니다. gpt-4o-mini는 비용 대비 성능이 좋고(기사 1건당 약 $0.0004) 구조화된 출력(JSON mode)을 지원하므로 선택하게 되었습니다.

### 3. 프롬프트 설계

기사 제목과 본문(최대 3000자)을 넣고 JSON 형태로 태그를 추출합니다:

```json
{
  "stocks": [{"code": "005930", "name": "삼성전자"}],
  "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
  "topics": [{"code": "EARNINGS", "name": "실적"}]
}
```

- `response_format: json_object`로 JSON 형식 강제
- 각 카테고리 최대 5개, 확실한 것만 포함한다는 규칙으로 노이즈 방지
- 파싱 실패 시 해당 기사만 FAILED 마킹

### 3. 본문 3000자 절단 — 토큰이 아닌 문자 기준인 이유

gpt-4o-mini의 컨텍스트 윈도우는 128K 토큰 수준이므로, 3,000자(약 1,500토큰) 기준에서는 입력 한도를 초과할 가능성이 사실상 없습니다. 그래도 3,000자로 제한한 이유는 뉴스 기사 특유의 ‘역피라미드 구조’를 고려했기 때문입니다. 핵심 정보가 기사 초반부에 집중되는 특성상, 약 3,000자 범위 내에서도 태깅에 필요한 정보는 충분히 확보할 수 있다고 판단했습니다. 또한 별도의 토큰 계산 로직을 도입하기보다 문자열 기준으로 단순 절단하는 방식이 구현 복잡도와 리소스 측면에서 더 효율적이라고 판단했습니다.

### 5. 재태깅 전략 — delete + insert

재태깅은 배치가 돌 때 tagging_status가 FAILED인 기사를 다시 수거하면서 발생합니다. 

#### Failed로 마킹되는 경우
  1. OpenAI API 호출 실패 — 네트워크 에러, 타임아웃, 응답 파싱 실패
  2. 태깅 결과가 비어있음 — OpenAI가 응답은 했지만 stocks/sectors/topics가 모두 비어있는 경우
  3. 배치 저장 실패 — DB 저장 중 예외 발생

재태깅 시 기존 데이터와의 Diff 기반 업데이트 방식은 적용하지 않았습니다. LLM의 특성상 멱등성(같은 작업을 여러 번 수행해도 결과가 동일한 성질)이 어느 정도 유지되더라도, 응답이 매번 미세하게 달라질 수 있어 비교 자체의 신뢰도가 낮다고 판단했습니다.

대신 기존 태그를 모두 삭제한 후 새로 저장하는(Delete + Insert) 방식을 선택했습니다. 기사당 태그 수가 많지 않아(약 15개 내외) DB 부하가 크지 않으며, 전체 작업이 @Transactional 범위 내에서 수행되기 때문에 중간 오류 발생 시에도 일관성을 보장할 수 있습니다.


<br>

### 🔗 관련 이슈
Closes #98

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 뉴스 기사의 자동 태깅 기능 추가: 종목, 섹터, 토픽 자동 분류
  * AI 기반 자동 뉴스 요약 생성
  * 태깅 상태 추적 및 재시도 메커니즘으로 안정적인 처리
  * 정기적인 스케줄된 자동 태깅 실행
  * 관리자 수동 태깅 트리거 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->