### PR TITLE
[WEF-74] 그룹 사용자 구조 관리

### DIFF
--- a/src/main/java/com/solv/wefin/domain/group/dto/GroupMemberInfo.java
+++ b/src/main/java/com/solv/wefin/domain/group/dto/GroupMemberInfo.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.domain.group.dto;
+
+import com.solv.wefin.domain.group.entity.GroupMember;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class GroupMemberInfo {
+    private UUID userId;
+    private String nickname;
+    private String role;
+
+    public static GroupMemberInfo from(GroupMember groupMember) {
+        return GroupMemberInfo.builder()
+                .userId(groupMember.getUser().getUserId())
+                .nickname(groupMember.getUser().getNickname())
+                .role(groupMember.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
@@ -4,7 +4,21 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
     boolean existsByUserAndGroup(User user, Group group);
+
+    @Query("""
+            select gm
+            from GroupMember gm
+            join fetch gm.user
+            where gm.group = :group
+              and gm.status = :status
+            """)
+    List<GroupMember> findByGroupAndStatusWithUser(@Param("group") Group group,
+                                                   @Param("status") GroupMember.GroupMemberStatus status);
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -5,9 +5,12 @@ import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,5 +34,17 @@ public class GroupService {
                 .build();
 
         groupMemberRepository.save(groupMember);
+    }
+
+    public List<GroupMemberInfo> getActiveMembers(Long groupId) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("그룹이 존재하지 않습니다."));
+
+        return groupMemberRepository.findByGroupAndStatusWithUser(
+                        group,
+                        GroupMember.GroupMemberStatus.ACTIVE
+                ).stream()
+                .map(GroupMemberInfo::from)
+                .toList();
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -6,6 +6,8 @@ import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +40,7 @@ public class GroupService {
 
     public List<GroupMemberInfo> getActiveMembers(Long groupId) {
         Group group = groupRepository.findById(groupId)
-                .orElseThrow(() -> new IllegalArgumentException("그룹이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
 
         return groupMemberRepository.findByGroupAndStatusWithUser(
                         group,

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -10,6 +10,10 @@ public enum ErrorCode {
     // User
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
 
+    // Group
+    GROUP_NOT_FOUND(404, "그룹을 찾을 수 없습니다."),
+    GROUP_MEMBER_FORBIDDEN(403, "해당 그룹의 멤버만 조회할 수 있습니다."),
+
     // Chat
     CHAT_MESSAGE_EMPTY(400, "메시지 내용은 비어 있을 수 없습니다."),
     CHAT_MESSAGE_TOO_LONG(400, "메시지는 1000자를 초과할 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/group/GroupController.java
+++ b/src/main/java/com/solv/wefin/web/group/GroupController.java
@@ -1,0 +1,26 @@
+package com.solv.wefin.web.group;
+
+import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.web.group.dto.GroupMemberResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/groups")
+public class GroupController {
+
+    private final GroupService groupService;
+
+    @GetMapping("/{groupId}/members")
+    public List<GroupMemberResponse> getGroupMembers(@PathVariable Long groupId) {
+        return groupService.getActiveMembers(groupId).stream()
+                .map(GroupMemberResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/solv/wefin/web/group/GroupController.java
+++ b/src/main/java/com/solv/wefin/web/group/GroupController.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.web.group;
 
 import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.group.dto.GroupMemberResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,9 +19,11 @@ public class GroupController {
     private final GroupService groupService;
 
     @GetMapping("/{groupId}/members")
-    public List<GroupMemberResponse> getGroupMembers(@PathVariable Long groupId) {
-        return groupService.getActiveMembers(groupId).stream()
+    public ApiResponse<List<GroupMemberResponse>> getMembers(@PathVariable Long groupId) {
+        List<GroupMemberResponse> responses = groupService.getActiveMembers(groupId).stream()
                 .map(GroupMemberResponse::from)
                 .toList();
+
+        return ApiResponse.success(responses);
     }
 }

--- a/src/main/java/com/solv/wefin/web/group/dto/GroupMemberResponse.java
+++ b/src/main/java/com/solv/wefin/web/group/dto/GroupMemberResponse.java
@@ -1,23 +1,19 @@
 package com.solv.wefin.web.group.dto;
 
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
-import lombok.Builder;
-import lombok.Getter;
 
 import java.util.UUID;
 
-@Getter
-@Builder
-public class GroupMemberResponse {
-    private UUID userId;
-    private String nickname;
-    private String role;
-
+public record GroupMemberResponse(
+        UUID userId,
+        String nickname,
+        String role
+) {
     public static GroupMemberResponse from(GroupMemberInfo info) {
-        return GroupMemberResponse.builder()
-                .userId(info.getUserId())
-                .nickname(info.getNickname())
-                .role(info.getRole())
-                .build();
+        return new GroupMemberResponse(
+                info.getUserId(),
+                info.getNickname(),
+                info.getRole()
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/web/group/dto/GroupMemberResponse.java
+++ b/src/main/java/com/solv/wefin/web/group/dto/GroupMemberResponse.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.web.group.dto;
+
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class GroupMemberResponse {
+    private UUID userId;
+    private String nickname;
+    private String role;
+
+    public static GroupMemberResponse from(GroupMemberInfo info) {
+        return GroupMemberResponse.builder()
+                .userId(info.getUserId())
+                .nickname(info.getNickname())
+                .role(info.getRole())
+                .build();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -6,6 +6,8 @@ import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,7 +41,7 @@ class GroupServiceTest {
 
     @Nested
     @DisplayName("getActiveMembers")
-    class GetActiveMembers {
+    class GetActiveMembersTest {
 
         @Test
         @DisplayName("그룹이 존재하면 ACTIVE 멤버 목록을 반환한다")
@@ -84,15 +87,15 @@ class GroupServiceTest {
             List<GroupMemberInfo> result = groupService.getActiveMembers(1L);
 
             // then
-            assertThat(result).hasSize(2);
-
-            assertThat(result.get(0).getUserId()).isEqualTo(leaderUser.getUserId());
-            assertThat(result.get(0).getNickname()).isEqualTo("리더");
-            assertThat(result.get(0).getRole()).isEqualTo("LEADER");
-
-            assertThat(result.get(1).getUserId()).isEqualTo(memberUser.getUserId());
-            assertThat(result.get(1).getNickname()).isEqualTo("멤버");
-            assertThat(result.get(1).getRole()).isEqualTo("MEMBER");
+            assertAll(
+                    () -> assertThat(result).hasSize(2),
+                    () -> assertThat(result.get(0).getUserId()).isEqualTo(leaderUser.getUserId()),
+                    () -> assertThat(result.get(0).getNickname()).isEqualTo("리더"),
+                    () -> assertThat(result.get(0).getRole()).isEqualTo("LEADER"),
+                    () -> assertThat(result.get(1).getUserId()).isEqualTo(memberUser.getUserId()),
+                    () -> assertThat(result.get(1).getNickname()).isEqualTo("멤버"),
+                    () -> assertThat(result.get(1).getRole()).isEqualTo("MEMBER")
+            );
 
             verify(groupRepository).findById(1L);
             verify(groupMemberRepository).findByGroupAndStatusWithUser(
@@ -103,16 +106,18 @@ class GroupServiceTest {
 
         @Test
         @DisplayName("그룹이 없으면 예외가 발생한다")
-        void getActiveMembers_fail_whenGroupNotFound() {
+        void getActiveMembers_fail_when_group_not_found() {
             // given
             when(groupRepository.findById(999L)).thenReturn(Optional.empty());
 
-            // when & then
-            assertThatThrownBy(() -> groupService.getActiveMembers(999L))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("그룹이 존재하지 않습니다.");
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.getActiveMembers(999L)
+            );
 
-            verify(groupRepository).findById(999L);
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_NOT_FOUND);
             verify(groupMemberRepository, never()).findByGroupAndStatusWithUser(any(), any());
         }
     }

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -1,0 +1,166 @@
+package com.solv.wefin.domain.group.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.domain.group.repository.GroupRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GroupServiceTest {
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
+
+    @InjectMocks
+    private GroupService groupService;
+
+    @Nested
+    @DisplayName("getActiveMembers")
+    class GetActiveMembers {
+
+        @Test
+        @DisplayName("그룹이 존재하면 ACTIVE 멤버 목록을 반환한다")
+        void getActiveMembers_success() throws Exception {
+            // given
+            Group group = createGroup(1L, "테스트 그룹");
+
+            User leaderUser = createUser(
+                    UUID.randomUUID(),
+                    "leader@test.com",
+                    "리더",
+                    "encoded-password"
+            );
+            User memberUser = createUser(
+                    UUID.randomUUID(),
+                    "member@test.com",
+                    "멤버",
+                    "encoded-password"
+            );
+
+            GroupMember leader = createGroupMember(
+                    1L,
+                    leaderUser,
+                    group,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+            GroupMember member = createGroupMember(
+                    2L,
+                    memberUser,
+                    group,
+                    GroupMember.GroupMemberRole.MEMBER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+            when(groupMemberRepository.findByGroupAndStatusWithUser(
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(List.of(leader, member));
+
+            // when
+            List<GroupMemberInfo> result = groupService.getActiveMembers(1L);
+
+            // then
+            assertThat(result).hasSize(2);
+
+            assertThat(result.get(0).getUserId()).isEqualTo(leaderUser.getUserId());
+            assertThat(result.get(0).getNickname()).isEqualTo("리더");
+            assertThat(result.get(0).getRole()).isEqualTo("LEADER");
+
+            assertThat(result.get(1).getUserId()).isEqualTo(memberUser.getUserId());
+            assertThat(result.get(1).getNickname()).isEqualTo("멤버");
+            assertThat(result.get(1).getRole()).isEqualTo("MEMBER");
+
+            verify(groupRepository).findById(1L);
+            verify(groupMemberRepository).findByGroupAndStatusWithUser(
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+        }
+
+        @Test
+        @DisplayName("그룹이 없으면 예외가 발생한다")
+        void getActiveMembers_fail_whenGroupNotFound() {
+            // given
+            when(groupRepository.findById(999L)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> groupService.getActiveMembers(999L))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("그룹이 존재하지 않습니다.");
+
+            verify(groupRepository).findById(999L);
+            verify(groupMemberRepository, never()).findByGroupAndStatusWithUser(any(), any());
+        }
+    }
+
+    private Group createGroup(Long id, String name) throws Exception {
+        Constructor<Group> constructor = Group.class.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+        Group group = constructor.newInstance(name);
+
+        Field idField = Group.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(group, id);
+
+        return group;
+    }
+
+    private User createUser(UUID userId, String email, String nickname, String password) throws Exception {
+        Constructor<User> constructor = User.class.getDeclaredConstructor(String.class, String.class, String.class);
+        constructor.setAccessible(true);
+        User user = constructor.newInstance(email, nickname, password);
+
+        Field userIdField = User.class.getDeclaredField("userId");
+        userIdField.setAccessible(true);
+        userIdField.set(user, userId);
+
+        return user;
+    }
+
+    private GroupMember createGroupMember(
+            Long id,
+            User user,
+            Group group,
+            GroupMember.GroupMemberRole role,
+            GroupMember.GroupMemberStatus status
+    ) throws Exception {
+        Constructor<GroupMember> constructor = GroupMember.class.getDeclaredConstructor(
+                User.class,
+                Group.class,
+                GroupMember.GroupMemberRole.class,
+                GroupMember.GroupMemberStatus.class
+        );
+        constructor.setAccessible(true);
+        GroupMember groupMember = constructor.newInstance(user, group, role, status);
+
+        Field idField = GroupMember.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(groupMember, id);
+
+        return groupMember;
+    }
+}

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -1,0 +1,62 @@
+package com.solv.wefin.web.group;
+
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import com.solv.wefin.domain.group.service.GroupService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(GroupController.class)
+class GroupControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private GroupService groupService;
+
+    @Test
+    @WithMockUser
+    @DisplayName("그룹 멤버 목록 조회에 성공한다")
+    void getGroupMembers_success() throws Exception {
+        // given
+        UUID leaderId = UUID.randomUUID();
+        UUID memberId = UUID.randomUUID();
+
+        given(groupService.getActiveMembers(1L))
+                .willReturn(List.of(
+                        GroupMemberInfo.builder()
+                                .userId(leaderId)
+                                .nickname("리더")
+                                .role("LEADER")
+                                .build(),
+                        GroupMemberInfo.builder()
+                                .userId(memberId)
+                                .nickname("멤버")
+                                .role("MEMBER")
+                                .build()
+                ));
+
+        // when & then
+        mockMvc.perform(get("/api/groups/{groupId}/members", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].userId").value(leaderId.toString()))
+                .andExpect(jsonPath("$[0].nickname").value("리더"))
+                .andExpect(jsonPath("$[0].role").value("LEADER"))
+                .andExpect(jsonPath("$[1].userId").value(memberId.toString()))
+                .andExpect(jsonPath("$[1].nickname").value("멤버"))
+                .andExpect(jsonPath("$[1].role").value("MEMBER"));
+    }
+}

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -51,12 +51,13 @@ class GroupControllerTest {
         // when & then
         mockMvc.perform(get("/api/groups/{groupId}/members", 1L))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].userId").value(leaderId.toString()))
-                .andExpect(jsonPath("$[0].nickname").value("리더"))
-                .andExpect(jsonPath("$[0].role").value("LEADER"))
-                .andExpect(jsonPath("$[1].userId").value(memberId.toString()))
-                .andExpect(jsonPath("$[1].nickname").value("멤버"))
-                .andExpect(jsonPath("$[1].role").value("MEMBER"));
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].userId").value(leaderId.toString()))
+                .andExpect(jsonPath("$.data[0].nickname").value("리더"))
+                .andExpect(jsonPath("$.data[0].role").value("LEADER"))
+                .andExpect(jsonPath("$.data[1].userId").value(memberId.toString()))
+                .andExpect(jsonPath("$.data[1].nickname").value("멤버"))
+                .andExpect(jsonPath("$.data[1].role").value("MEMBER"));
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
그룹 멤버 조회 API를 구현.
Service, Repository, DTO, Controller 계층을 분리하여 설계하였고 N+1 문제를 방지하기 위해 join fetch를 적용
<br>


## ✅ 완료한 기능 명세

- [x] 그룹 멤버 조회 API 구현
- [x] 그룹 내 ACTIVE 상태 멤버 목록 조회 기능 구현
- [x] 그룹 존재 여부 검증 로직 추가
- [x] Service 테스트 코드 작성 (정상/예외 케이스 검증)
- [x] Controller 테스트 코드 작성 (API 응답 및 JSON 검증)

- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
N+1 문제 해결

- GroupMember → User 관계가 LAZY라서 조회 시 N+1 발생 가능
- join fetch 쿼리(findByGroupAndStatusWithUser)를 통해 한 번의 쿼리로 해결
<br>

### 🔗 관련 이슈
Closes #114 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 그룹 활성 멤버 조회 API 추가: GET /api/groups/{groupId}/members — 사용자 ID, 닉네임, 역할 반환
  * 응답 포맷에 멤버 목록 형태 도입
  * 그룹 관련 오류 코드 추가: GROUP_NOT_FOUND(404), GROUP_MEMBER_FORBIDDEN(403)

* **테스트**
  * 서비스 및 컨트롤러에 대한 단위 및 웹 계층 테스트 추가 (멤버 조회 성공/실패 시나리오 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->