### PR TITLE
[WEF-138] 게임 시작 api 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/room/dto/StartRoomInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/dto/StartRoomInfo.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.game.room.dto;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+
+public record StartRoomInfo(GameRoom room, GameTurn firstTurn) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -215,6 +215,7 @@ public class GameRoomService {
     @Transactional
     public StartRoomInfo startRoom(UUID roomId, UUID userId) {
 
+        //검증 로직 Fail-Fast 패턴 적용
         // 1. 방 조회 + 비관적 락 (중복 시작 방지)
         GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -159,6 +159,11 @@ public class GameRoomService {
         GameParticipant member = GameParticipant.createMember(gameRoom, userId);
         gameParticipantRepository.save(member);
 
+        // 게임 진행 중 신규 참가자 시드머니 지급
+        if (gameRoom.getStatus() == RoomStatus.IN_PROGRESS) {
+            member.assignSeed(gameRoom.getSeed());
+        }
+
         return member;
     }
 

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -5,13 +5,15 @@ import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
 import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
 import com.solv.wefin.domain.game.room.dto.RoomListInfo;
+import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
-import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,7 @@ public class GameRoomService {
 
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
+    private final GameTurnRepository gameTurnRepository;
 
     //게임방 생성
     @Transactional //트랜잭션으로 방생성과 방장유저 지정 동시에 이루어짐
@@ -49,16 +52,16 @@ public class GameRoomService {
             throw new BusinessException(ErrorCode.ROOM_HOST_ALREADY_EXISTS);
         }
 
-            // 방장 횟수 제한 1일 1회
+        // 방장 횟수 제한 1일 1회
         OffsetDateTime todayStart = LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime();
         OffsetDateTime todayEnd = todayStart.plusDays(1);
 
-        if(gameRoomRepository.existsByUserIdAndStartedAtBetween(userId, todayStart, todayEnd)) {
+        if (gameRoomRepository.existsByUserIdAndStartedAtBetween(userId, todayStart, todayEnd)) {
             throw new BusinessException(ErrorCode.ROOM_HOST_DAILY_LIMIT);
         }
 
         //endDate 계산
-        LocalDate rangeStart = LocalDate.of(2020,1,1);
+        LocalDate rangeStart = LocalDate.of(2020, 1, 1);
         LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(command.periodMonths());
         long daysBetween = ChronoUnit.DAYS.between(rangeStart, rangeEnd);
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
@@ -77,6 +80,7 @@ public class GameRoomService {
 
         return gameRoom;
     }
+
     // 게임방 목록 조회
     public List<RoomListInfo> getRooms(Long groupId, UUID userId) {
         //그룹 활성화된 방
@@ -102,7 +106,7 @@ public class GameRoomService {
     public RoomDetailInfo getRoomDetail(UUID roomId) {
 
         // 방 조회
-        GameRoom gameRoom= gameRoomRepository.findById(roomId).orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+        GameRoom gameRoom = gameRoomRepository.findById(roomId).orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
         //참가자 상세
         List<GameParticipant> participants = gameParticipantRepository.findByGameRoomOrderByJoinedAtAsc(gameRoom);
@@ -112,8 +116,8 @@ public class GameRoomService {
     }
 
     /**
-     게임 입장
-     비관적 락으로 동시 입장 동시성 제어
+     * 게임 입장
+     * 비관적 락으로 동시 입장 동시성 제어
      *
      */
     @Transactional
@@ -133,7 +137,7 @@ public class GameRoomService {
         if (existing.isPresent()) {
             GameParticipant participant = existing.get();
 
-            if(participant.getStatus() == ParticipantStatus.ACTIVE){
+            if (participant.getStatus() == ParticipantStatus.ACTIVE) {
                 throw new BusinessException(ErrorCode.ROOM_ALREADY_JOINED);
             }
             int currentPlayers = gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
@@ -159,23 +163,23 @@ public class GameRoomService {
     }
 
     /**
-     게임방 퇴장
-     동시 퇴장 시 방장 위임 충돌 미리 방지 - 비관적 락
+     * 게임방 퇴장
+     * 동시 퇴장 시 방장 위임 충돌 미리 방지 - 비관적 락
      */
     @Transactional
     public void leaveRoom(UUID roomId, UUID userId) {
 
         //게임방 조회
         GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
-                .orElseThrow(()->new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
         //finished면 error 처리
         if (gameRoom.getStatus() == RoomStatus.FINISHED) {
             throw new BusinessException(ErrorCode.ROOM_FINISHED);
         }
         //참가자 조회
         GameParticipant participant = gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
-                .filter(p->p.getStatus() == ParticipantStatus.ACTIVE)
-                .orElseThrow(()->new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
 
         // 방장 여부 기록
         Boolean wasLeader = participant.getIsLeader();
@@ -200,12 +204,55 @@ public class GameRoomService {
             newLeader.assignLeader();
         }
 
+    }
 
+    //게임 시작
+    @Transactional
+    public StartRoomInfo startRoom(UUID roomId, UUID userId) {
 
+        // 1. 방 조회 + 비관적 락 (중복 시작 방지)
+        GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
+        // 2. WAITING 상태에서만 시작 가능
+        if (gameRoom.getStatus() != RoomStatus.WAITING) {
+            throw new BusinessException(ErrorCode.ROOM_NOT_WAITING);
+        }
+
+        // 3. 요청자가 방장인지 확인
+        GameParticipant host = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        if (!host.getIsLeader()) {
+            throw new BusinessException(ErrorCode.ROOM_NOT_HOST);
+        }
+
+        // 4. ACTIVE 참가자 2명 이상인지 확인
+        List<GameParticipant> activeParticipants = gameParticipantRepository
+                .findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+
+        if (activeParticipants.size() < 2) {
+            throw new BusinessException(ErrorCode.ROOM_MIN_PLAYERS);
+        }
+
+        // 5. 참가자 전원에게 시드머니 지급
+        Long seedMoney = gameRoom.getSeed();
+        for (GameParticipant participant : activeParticipants) {
+            participant.assignSeed(seedMoney);
+        }
+
+        // 6. 첫 턴 생성
+        GameTurn firstTurn = GameTurn.createFirst(gameRoom);
+        gameTurnRepository.save(firstTurn);
+
+        // 7. 방 상태 변경 (WAITING → IN_PROGRESS, startedAt 기록)
+        gameRoom.start();
+
+        return new StartRoomInfo(gameRoom, firstTurn);
     }
 }
-
 
 /** creatRooom
 

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
@@ -20,11 +20,11 @@ import static com.solv.wefin.domain.game.turn.entity.TurnStatus.*;
 public class GameTurn {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "room_id", nullable = false )
+    @Column(name = "turn_id")
     private UUID turnId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @Column(name = "room_id", nullable = false)
+    @JoinColumn(name = "room_id", nullable = false)
     private GameRoom gameRoom;
 
     //ai 브리핑 테이블 생선 전이라 fk 처리 안 했습니다
@@ -38,7 +38,7 @@ public class GameTurn {
     private LocalDate turnDate;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "turn_status", nullable = false)
+    @Column(name = "status", nullable = false)
     private TurnStatus status;
 
     @Builder

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
@@ -28,7 +28,7 @@ public class GameTurn {
     private GameRoom gameRoom;
 
     //ai 브리핑 테이블 생선 전이라 fk 처리 안 했습니다
-    @Column(name = "briefing_id", nullable = false)
+    @Column(name = "briefing_id")
     private UUID briefingId;
 
     @Column(name= "turn_number", nullable = false)

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
@@ -27,7 +27,7 @@ public class GameTurn {
     @JoinColumn(name = "room_id", nullable = false)
     private GameRoom gameRoom;
 
-    //ai 브리핑 테이블 생선 전이라 fk 처리 안 했습니다
+    //ai 브리핑 테이블 생성 전이라 fk 처리 안 했습니다
     @Column(name = "briefing_id")
     private UUID briefingId;
 

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
@@ -1,0 +1,65 @@
+package com.solv.wefin.domain.game.turn.entity;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static com.solv.wefin.domain.game.turn.entity.TurnStatus.*;
+
+@Entity
+@Table(name = "game_turn",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "turn_number"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameTurn {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "room_id", nullable = false )
+    private UUID turnId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @Column(name = "room_id", nullable = false)
+    private GameRoom gameRoom;
+
+    //ai 브리핑 테이블 생선 전이라 fk 처리 안 했습니다
+    @Column(name = "briefing_id", nullable = false)
+    private UUID briefingId;
+
+    @Column(name= "turn_Number", nullable = false)
+    private Integer turnNumber;
+
+    @Column(name = "turn_date", nullable = false)
+    private LocalDate turnDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "turn_status", nullable = false)
+    private TurnStatus status;
+
+    @Builder
+    private GameTurn(GameRoom gameRoom, Integer turnNumber, LocalDate turnDate ) {
+        this.gameRoom = gameRoom;
+        this.turnNumber = turnNumber;
+        this.turnDate = turnDate;
+        this.status = ACTIVE;
+        //@GeneratedValue(strategy = GenerationType.UUID)로 turnId 자동 생성
+    }
+
+    public static GameTurn createFirst(GameRoom gameRoom){
+        return GameTurn.builder()
+                .gameRoom(gameRoom)
+                .turnNumber(1)
+                .turnDate(gameRoom.getStartDate())
+                .build();
+    }
+
+    public void complete() {
+        this.status = COMPLETED;
+    }
+
+}

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
@@ -31,7 +31,7 @@ public class GameTurn {
     @Column(name = "briefing_id", nullable = false)
     private UUID briefingId;
 
-    @Column(name= "turn_Number", nullable = false)
+    @Column(name= "turn_number", nullable = false)
     private Integer turnNumber;
 
     @Column(name = "turn_date", nullable = false)

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/TurnStatus.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/TurnStatus.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.game.turn.entity;
+
+public enum TurnStatus {
+    ACTIVE, //현재 턴
+    COMPLETED // 지난 턴
+}

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.game.turn.repository;
+
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
+
+
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -62,7 +62,12 @@ public enum ErrorCode {
     ROOM_ALREADY_JOINED(409, "이미 참가 중인 방입니다."),
     ROOM_FULL(400, "인원 초과"),
     ROOM_FINISHED(400, "종료된 방입니다."),
-    ROOM_NOT_PARTICIPANT(404, "참가자가 아닙니다.");
+    ROOM_NOT_PARTICIPANT(404, "참가자가 아닙니다."),
+    ROOM_NOT_HOST(403,"방장만 게임을 시작할 수 있습니다."),
+    ROOM_MIN_PLAYERS(400, "2명 이상의 참가자가 필요합니다."),
+    ROOM_NOT_WAITING(400, "대기 상태가 아닙니다");
+
+    // GaemTurn
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -67,7 +67,7 @@ public enum ErrorCode {
     ROOM_MIN_PLAYERS(400, "2명 이상의 참가자가 필요합니다."),
     ROOM_NOT_WAITING(400, "대기 상태가 아닙니다");
 
-    // GaemTurn
+    // GameTurn
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -30,16 +30,16 @@ public class GameRoomController {
     private final GameRoomService gameRoomService;
 
     //로그인 구현 전 묵데이터
-    private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    //private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEMP_GROUP_ID = 1L;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateRoomResponse>> createRoom(
-            @Valid @RequestBody CreateRoomRequest request) {
+            @RequestHeader("X-User-Id") UUID userId, @Valid @RequestBody CreateRoomRequest request) {
 
         CreateRoomCommand command = new CreateRoomCommand(
                 request.getSeedMoney(), request.getPeriodMonths(), request.getMoveDays());
-        GameRoom gameRoom = gameRoomService.createRoom(TEMP_USER_ID, TEMP_GROUP_ID, command);
+        GameRoom gameRoom = gameRoomService.createRoom(userId, TEMP_GROUP_ID, command);
         CreateRoomResponse response = CreateRoomResponse.from(gameRoom);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, response));
@@ -49,12 +49,10 @@ public class GameRoomController {
     /**
      게임방 목록 조회
      get /api/rooms
-     get /api/rooms?status=WAITING or in_progress or finished
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms() {
-
-        List<RoomListInfo> rooms = gameRoomService.getRooms(TEMP_GROUP_ID, TEMP_USER_ID);
+    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms(@RequestHeader("X-User-Id") UUID userId) {
+        List<RoomListInfo> rooms = gameRoomService.getRooms(TEMP_GROUP_ID, userId);
         List<RoomListResponse> response = rooms.stream().map(
                 r -> RoomListResponse.from(r.room(), r.playerCount())).collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -75,9 +73,9 @@ public class GameRoomController {
 
     // 게임방 입장
     @PostMapping("/{roomId}/join")
-    public ResponseEntity<ApiResponse<JoinRoomResponse>> joinRoom(@PathVariable UUID roomId) {
+    public ResponseEntity<ApiResponse<JoinRoomResponse>> joinRoom(@PathVariable UUID roomId, @RequestHeader("X-User-Id") UUID userId) {
 
-        GameParticipant participant = gameRoomService.joinRoom(roomId, TEMP_USER_ID);
+        GameParticipant participant = gameRoomService.joinRoom(roomId, userId);
         JoinRoomResponse response = JoinRoomResponse.from(participant);
 
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -85,9 +83,9 @@ public class GameRoomController {
 
     //게임방 퇴장
     @DeleteMapping("/{roomId}/leave")
-    public ResponseEntity<ApiResponse<LeaveRoomResponse>> leaveRoom(@PathVariable UUID roomId) {
+    public ResponseEntity<ApiResponse<LeaveRoomResponse>> leaveRoom(@PathVariable UUID roomId, @RequestHeader("X-User-Id") UUID userId) {
 
-        gameRoomService.leaveRoom(roomId, TEMP_USER_ID);
+        gameRoomService.leaveRoom(roomId, userId);
         LeaveRoomResponse response = LeaveRoomResponse.success();
 
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -96,9 +94,9 @@ public class GameRoomController {
     //게임 시작
     @PostMapping("/{roomId}/start")
     public ResponseEntity<ApiResponse<StartRoomResponse>> startRoom(
-            @PathVariable UUID roomId) {
+            @PathVariable UUID roomId, @RequestHeader("X-User-Id") UUID userId) {
 
-        StartRoomInfo info = gameRoomService.startRoom(roomId, TEMP_USER_ID);
+        StartRoomInfo info = gameRoomService.startRoom(roomId, userId);
 
         TurnDetailDto turnDto = TurnDetailDto.from(info.firstTurn());
         StartRoomResponse response = StartRoomResponse.from(info.room().getRoomId(),

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
 import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
 import com.solv.wefin.domain.game.room.dto.RoomListInfo;
+import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.global.common.ApiResponse;
@@ -88,6 +89,21 @@ public class GameRoomController {
 
         gameRoomService.leaveRoom(roomId, TEMP_USER_ID);
         LeaveRoomResponse response = LeaveRoomResponse.success();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    //게임 시작
+    @PostMapping("/{roomId}/start")
+    public ResponseEntity<ApiResponse<StartRoomResponse>> startRoom(
+            @PathVariable UUID roomId) {
+
+        StartRoomInfo info = gameRoomService.startRoom(roomId, TEMP_USER_ID);
+
+        TurnDetailDto turnDto = TurnDetailDto.from(info.firstTurn());
+        StartRoomResponse response = StartRoomResponse.from(info.room().getRoomId(),
+                info.room().getStatus(), turnDto
+        );
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
 @RestController
@@ -99,9 +98,7 @@ public class GameRoomController {
         StartRoomInfo info = gameRoomService.startRoom(roomId, userId);
 
         TurnDetailDto turnDto = TurnDetailDto.from(info.firstTurn());
-        StartRoomResponse response = StartRoomResponse.from(info.room().getRoomId(),
-                info.room().getStatus(), turnDto
-        );
+        StartRoomResponse response = StartRoomResponse.from(info);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/StartRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/StartRoomResponse.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.web.game.room.dto.response;
 
+import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -14,7 +15,11 @@ public class StartRoomResponse {
     private RoomStatus status;
     private TurnDetailDto currentTurn;
 
-    public static StartRoomResponse from(UUID roomId, RoomStatus status, TurnDetailDto currentTurn) {
-        return new StartRoomResponse(roomId, status, currentTurn);
+    public static StartRoomResponse from(StartRoomInfo info) {
+        return new StartRoomResponse(
+                info.room().getRoomId(),
+                info.room().getStatus(),
+                TurnDetailDto.from(info.firstTurn())
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/StartRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/StartRoomResponse.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class StartRoomResponse {
+
+    private UUID roomId;
+    private RoomStatus status;
+    private TurnDetailDto currentTurn;
+
+    public static StartRoomResponse from(UUID roomId, RoomStatus status, TurnDetailDto currentTurn) {
+        return new StartRoomResponse(roomId, status, currentTurn);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/TurnDetailDto.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/TurnDetailDto.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class TurnDetailDto {
+
+    private UUID turnId;
+    private Integer turnNumber;
+    private LocalDate turnDate;
+
+    public static TurnDetailDto from(GameTurn gameTurn) {
+        return new TurnDetailDto(
+                gameTurn.getTurnId(),
+                gameTurn.getTurnNumber(),
+                gameTurn.getTurnDate()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/TurnDetailDto.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/TurnDetailDto.java
@@ -1,19 +1,13 @@
 package com.solv.wefin.web.game.room.dto.response;
 
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+
 
 import java.time.LocalDate;
 import java.util.UUID;
 
-@Getter
-@AllArgsConstructor
-public class TurnDetailDto {
 
-    private UUID turnId;
-    private Integer turnNumber;
-    private LocalDate turnDate;
+public record TurnDetailDto(UUID turnId, Integer turnNumber, LocalDate turnDate) {
 
     public static TurnDetailDto from(GameTurn gameTurn) {
         return new TurnDetailDto(

--- a/src/main/resources/db/migration/V13__alter_turn_column.sql
+++ b/src/main/resources/db/migration/V13__alter_turn_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE game_turn ALTER COLUMN briefing_id DROP NOT NULL;

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -1,14 +1,16 @@
 package com.solv.wefin.domain.game.room.service;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
-import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
 import com.solv.wefin.domain.game.room.dto.RoomListInfo;
+import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
@@ -46,6 +48,9 @@ class GameRoomServiceTest {
 
     @Mock
     private GameParticipantRepository gameParticipantRepository;
+
+    @Mock
+    private GameTurnRepository gameTurnRepository;
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
@@ -531,6 +536,147 @@ class GameRoomServiceTest {
                     BusinessException be = (BusinessException) ex;
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
                 });
+    }
+// === API 6: 게임 시작 테스트 ===
+
+    @Test
+    @DisplayName("게임 시작 성공 — 시드머니 지급, 첫 턴 생성, 상태 IN_PROGRESS")
+    void startRoom_success() {
+        // Given — WAITING 방, 방장 + 일반 참가자 1명 (2명)
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameParticipant member = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(leader));
+        given(gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(List.of(leader, member));
+
+        // When
+        StartRoomInfo result = gameRoomService.startRoom(roomId, TEST_USER_ID);
+
+        // Then — 방 상태 변경
+        assertThat(result.room().getStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
+        assertThat(result.room().getStartedAt()).isNotNull();
+
+        // Then — 첫 턴 생성
+        assertThat(result.firstTurn().getTurnNumber()).isEqualTo(1);
+        assertThat(result.firstTurn().getTurnDate()).isEqualTo(gameRoom.getStartDate());
+        verify(gameTurnRepository).save(any(GameTurn.class));
+
+        // Then — 시드머니 지급
+        assertThat(leader.getSeed()).isEqualTo(10000000L);
+        assertThat(member.getSeed()).isEqualTo(10000000L);
+    }
+
+    @Test
+    @DisplayName("게임 시작 실패 — 존재하지 않는 방")
+    void startRoom_notFound() {
+        // Given
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findByIdForUpdate(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.startRoom(fakeRoomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+    }
+
+    @Test
+    @DisplayName("게임 시작 실패 — WAITING이 아닌 방 (이미 진행 중)")
+    void startRoom_notWaiting() {
+        // Given — IN_PROGRESS 방
+        GameRoom gameRoom = createGameRoom();
+        gameRoom.start();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.startRoom(roomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_WAITING);
+                });
+    }
+
+    @Test
+    @DisplayName("게임 시작 실패 — 참가자가 아닌 경우")
+    void startRoom_notParticipant() {
+        // Given — 참가 이력 없는 유저가 시작 요청
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.startRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+    }
+
+    @Test
+    @DisplayName("게임 시작 실패 — 방장이 아닌 참가자가 시작 요청")
+    void startRoom_notHost() {
+        // Given — 일반 참가자가 시작 요청
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant member = GameParticipant.createMember(gameRoom, OTHER_USER_ID);
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, OTHER_USER_ID))
+                .willReturn(Optional.of(member));
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.startRoom(roomId, OTHER_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_HOST);
+                });
+    }
+
+    @Test
+    @DisplayName("게임 시작 실패 — 참가자 2명 미만")
+    void startRoom_minPlayers() {
+        // Given — 방장 1명만 있는 방
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findByIdForUpdate(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(leader));
+        given(gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
+                .willReturn(List.of(leader)); // 1명만
+
+        // When & Then
+        assertThatThrownBy(() -> gameRoomService.startRoom(roomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_MIN_PLAYERS);
+                });
+
+        // 시작 안 됐으니 턴 생성도 안 됨
+        verify(gameTurnRepository, never()).save(any());
     }
 
     // === 헬퍼 메서드 ===


### PR DESCRIPTION
## 📌 PR 설명
<br>
게임 시작 api 입니다

## ✅ 완료한 기능 명세

- [x] 턴 시작 데이터 계층 
- [x] 게임 시작 로직
- [x] 중복 시작 방지 
- [x] 게임 시작 전 검증 절차
- [x] reJoin 로직 수정
- [x] 에러 코드 작성
- [x] 게임 시작 컨트롤러
- [x] 테스트 코드 작성
<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
검증 절차를  방 조회 -> 상태 체크(필드 비교) -> 참가자 조회 -> 방장 체크(필드 비교) -> 인원 체크 순으로 Fail-Fast 패턴을 도입 해봤습니다. 
게임이 진행 중에 처음 입장한 유저에게도 시드머니를 지급할 수 있게 수정했습니다

<br>

### 🔗 관련 이슈
Closes #65 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **새로운 기능**
  * 방 호스트가 게임을 시작하는 API 추가 및 시작 시 현재 턴 정보(턴 ID·번호·일자)를 반환
  * 게임 시작 시 모든 활성 참가자에게 초기 자금 자동 할당; 진행 중 방에 합류해도 즉시 지급
  * 클라이언트에서 사용자 ID(X-User-Id) 헤더 전달 필요

* **테스트**
  * 게임 시작 성공 및 권한·인원·방 상태별 실패 시나리오 단위 테스트 추가

* **잡업(Chores)**
  * 게임 턴 관련 DB 마이그레이션으로 브리핑 참조 컬럼을 nullable 허용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->