### PR TITLE
[WEF-76] 로그인 인증 처리

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/dto/LoginInfo.java
+++ b/src/main/java/com/solv/wefin/domain/auth/dto/LoginInfo.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.auth.dto;
+
+import java.util.UUID;
+
+public record LoginInfo(
+        UUID userId,
+        String nickname,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,48 @@
+package com.solv.wefin.domain.auth.entity;
+
+import com.solv.wefin.global.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "refresh_token")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "token", nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Column(name = "expires_at", nullable = false)
+    private OffsetDateTime expiresAt;
+
+    @Column(name = "revoked", nullable = false)
+    private boolean revoked;
+
+    @Builder
+    public RefreshToken(UUID userId, String token, OffsetDateTime expiresAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.revoked = false;
+    }
+
+    public void update(String token, OffsetDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.revoked = false;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/auth/entity/User.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/User.java
@@ -30,10 +30,15 @@ public class User extends BaseEntity {
     @Column(name = "password", nullable = false, length = 255)
     private String password;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private UserStatus status;
+
     @Builder
     public User(String email, String nickname, String password) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
+        this.status = UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/entity/UserStatus.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/UserStatus.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.auth.entity;
+
+public enum UserStatus {
+    ACTIVE,
+    LOCKED,
+    WITHDRAWN
+}

--- a/src/main/java/com/solv/wefin/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/solv/wefin/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.auth.repository;
+
+import com.solv.wefin.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, UUID> {
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -1,10 +1,15 @@
 package com.solv.wefin.domain.auth.service;
 
+import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
+import com.solv.wefin.domain.auth.entity.RefreshToken;
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.entity.UserStatus;
+import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +19,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.Locale;
 
 @Service
@@ -27,6 +33,8 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final GroupService groupService;
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public SignupInfo signup(SignupCommand command) {
@@ -34,26 +42,21 @@ public class AuthService {
         String nickname = command.nickname();
         String password = command.password();
 
-        // null 처리
         if (email == null || nickname == null || password == null) {
             throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
         }
 
-        // 입력값 정규화
         email = email.trim().toLowerCase(Locale.ROOT);
         nickname = nickname.trim();
 
-        // 빈 값 처리
         if (email.isBlank() || nickname.isBlank() || password.isBlank()) {
             throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
         }
 
-        // 비밀번호 앞뒤 공백 비허용
         if (!password.equals(password.trim())) {
             throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
         }
 
-        // 중복 처리
         if (userRepository.existsByEmail(email)) {
             throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
         }
@@ -82,7 +85,62 @@ public class AuthService {
         }
     }
 
-    // unique 제약 위반 예외를 도메인 에러 코드로 변환
+    @Transactional
+    public LoginInfo login(String email, String password) {
+        if (email == null || password == null) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        email = email.trim().toLowerCase(Locale.ROOT);
+
+        if (email.isBlank() || password.isBlank()) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        if (!password.equals(password.trim())) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_LOGIN_FAILED));
+
+        if (user.getStatus() == UserStatus.LOCKED) {
+            throw new BusinessException(ErrorCode.ACCOUNT_LOCKED);
+        }
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(ErrorCode.AUTH_LOGIN_FAILED);
+        }
+
+        String accessToken = jwtProvider.generateAccessToken(user.getUserId());
+        String refreshTokenValue = jwtProvider.generateRefreshToken(user.getUserId());
+        OffsetDateTime refreshTokenExpiresAt = jwtProvider.getExpiration(refreshTokenValue);
+
+        RefreshToken refreshToken = refreshTokenRepository.findById(user.getUserId())
+                .map(saved -> {
+                    saved.update(refreshTokenValue, refreshTokenExpiresAt);
+                    return saved;
+                })
+                .orElseGet(() -> RefreshToken.builder()
+                        .userId(user.getUserId())
+                        .token(refreshTokenValue)
+                        .expiresAt(refreshTokenExpiresAt)
+                        .build());
+
+        refreshTokenRepository.save(refreshToken);
+
+        return new LoginInfo(
+                user.getUserId(),
+                user.getNickname(),
+                accessToken,
+                refreshTokenValue
+        );
+    }
+
     private BusinessException mapConstraintViolation(DataIntegrityViolationException e) {
         Throwable cause = e;
 

--- a/src/main/java/com/solv/wefin/global/config/security/JwtProvider.java
+++ b/src/main/java/com/solv/wefin/global/config/security/JwtProvider.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 @Component
 public class JwtProvider {
 
-    @Value("${JWT_SECRET}")
+    @Value("${jwt.secret}")
     private String secretKey;
 
     private SecretKey key;

--- a/src/main/java/com/solv/wefin/global/config/security/JwtProvider.java
+++ b/src/main/java/com/solv/wefin/global/config/security/JwtProvider.java
@@ -1,0 +1,90 @@
+package com.solv.wefin.global.config.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.UUID;
+
+@Component
+public class JwtProvider {
+
+    @Value("${JWT_SECRET}")
+    private String secretKey;
+
+    private SecretKey key;
+
+    private static final long ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 30L; // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_SECONDS = 60 * 60 * 24 * 14L; // 14일
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateAccessToken(UUID userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + ACCESS_TOKEN_EXPIRE_SECONDS * 1000);
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .claim("type", "access")
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(UUID userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_SECONDS * 1000);
+
+        return Jwts.builder()
+                .setSubject(userId.toString())
+                .claim("type", "refresh")
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public UUID getUserId(String token) {
+        Claims claims = parseClaims(token);
+        return UUID.fromString(claims.getSubject());
+    }
+
+    public String getTokenType(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get("type", String.class);
+    }
+
+    public OffsetDateTime getExpiration(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getExpiration().toInstant().atOffset(java.time.ZoneOffset.UTC);
+    }
+
+    public boolean isValid(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -30,6 +30,10 @@ public enum ErrorCode {
     AUTH_NICKNAME_DUPLICATED(409, "이미 사용 중인 닉네임입니다."),
     AUTH_VALIDATION_FAILED(400, "잘못된 입력입니다."),
 
+    // Auth - LOGIN
+    AUTH_LOGIN_FAILED(401, "이메일 또는 비밀번호가 올바르지 않습니다."),
+    ACCOUNT_LOCKED(423, "계정이 잠금 상태입니다."),
+
     // Order - BUY
     ORDER_INSUFFICIENT_BALANCE(400, "예수금이 부족합니다."),
     ORDER_INVALID_QUANTITY(400, "주문 수량은 1 이상이어야 합니다."),

--- a/src/main/java/com/solv/wefin/web/auth/AuthController.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthController.java
@@ -44,8 +44,8 @@ public class AuthController {
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
         LoginInfo result = authService.login(
-                request.getEmail(),
-                request.getPassword()
+                request.email(),
+                request.password()
         );
 
         LoginResponse response = LoginResponse.builder()

--- a/src/main/java/com/solv/wefin/web/auth/AuthController.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthController.java
@@ -1,9 +1,12 @@
 package com.solv.wefin.web.auth;
 
+import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.service.AuthService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.auth.dto.LoginRequest;
+import com.solv.wefin.web.auth.dto.LoginResponse;
 import com.solv.wefin.web.auth.dto.SignupRequest;
 import com.solv.wefin.web.auth.dto.SignupResponse;
 import jakarta.validation.Valid;
@@ -32,6 +35,23 @@ public class AuthController {
         SignupResponse response = SignupResponse.builder()
                 .userId(result.userId())
                 .email(result.email())
+                .nickname(result.nickname())
+                .build();
+
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+        LoginInfo result = authService.login(
+                request.getEmail(),
+                request.getPassword()
+        );
+
+        LoginResponse response = LoginResponse.builder()
+                .accessToken(result.accessToken())
+                .refreshToken(result.refreshToken())
+                .userId(result.userId())
                 .nickname(result.nickname())
                 .build();
 

--- a/src/main/java/com/solv/wefin/web/auth/dto/LoginRequest.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/LoginRequest.java
@@ -2,17 +2,12 @@ package com.solv.wefin.web.auth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class LoginRequest {
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
 
-    @NotBlank(message = "이메일은 필수입니다.")
-    @Email(message = "올바른 이메일 형식이 아닙니다.")
-    private String email;
-
-    @NotBlank(message = "비밀번호는 필수입니다.")
-    private String password;
-}
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        String password
+) {}

--- a/src/main/java/com/solv/wefin/web/auth/dto/LoginRequest.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.web.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    private String password;
+}

--- a/src/main/java/com/solv/wefin/web/auth/dto/LoginResponse.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.auth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+public class LoginResponse {
+    private String accessToken;
+    private String refreshToken;
+    private UUID userId;
+    private String nickname;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ websocket:
     - http://localhost:5173
 
 jwt:
-  secret: ${JWT_SECRET:test-secret-key-test-secret-key-test-secret-key}
+  secret: ${JWT_SECRET:wefin-test-jwt-secret-key-1234567890}
 
 hantu:
   api:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,9 @@ websocket:
   allowed-origins:
     - http://localhost:5173
 
+jwt:
+  secret: ${JWT_SECRET:test-secret-key-test-secret-key-test-secret-key}
+
 hantu:
   api:
     baseUrl: https://openapivts.koreainvestment.com:29443

--- a/src/main/resources/db/migration/V14__add_auth_status_and_refresh_token.sql
+++ b/src/main/resources/db/migration/V14__add_auth_status_and_refresh_token.sql
@@ -1,0 +1,29 @@
+ALTER TABLE "users"
+    ADD COLUMN "status" VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE "users"
+    ADD CONSTRAINT "chk_users_status"
+        CHECK ("status" IN ('ACTIVE', 'LOCKED', 'WITHDRAWN'));
+
+CREATE TABLE "refresh_token" (
+                                 "user_id" UUID NOT NULL,
+                                 "token" VARCHAR(500) NOT NULL,
+                                 "expires_at" TIMESTAMPTZ NOT NULL,
+                                 "revoked" BOOLEAN NOT NULL DEFAULT FALSE,
+                                 "created_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                                 "updated_at" TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+ALTER TABLE "refresh_token"
+    ADD CONSTRAINT "PK_REFRESH_TOKEN" PRIMARY KEY ("user_id");
+
+ALTER TABLE "refresh_token"
+    ADD CONSTRAINT "FK_user_TO_refresh_token_1"
+        FOREIGN KEY ("user_id")
+            REFERENCES "users" ("user_id");
+
+ALTER TABLE "refresh_token"
+    ADD CONSTRAINT "uk_refresh_token_token" UNIQUE ("token");
+
+CREATE INDEX "idx_refresh_token_token"
+    ON "refresh_token" ("token");

--- a/src/main/resources/db/migration/V15__remove_duplicate_index_refresh_token.sql
+++ b/src/main/resources/db/migration/V15__remove_duplicate_index_refresh_token.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_refresh_token_token;

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -1,10 +1,15 @@
 package com.solv.wefin.domain.auth.service;
 
+import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
+import com.solv.wefin.domain.auth.entity.RefreshToken;
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.entity.UserStatus;
+import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.hibernate.exception.ConstraintViolationException;
@@ -21,6 +26,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +49,12 @@ class AuthServiceTest {
     @Mock
     private GroupService groupService;
 
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
     @InjectMocks
     private AuthService authService;
 
@@ -52,7 +65,6 @@ class AuthServiceTest {
         @Test
         @DisplayName("회원가입에 성공한다")
         void signup_success() {
-            // given
             String rawEmail = "  TEST@Example.com  ";
             String rawNickname = "  testuser  ";
             String rawPassword = "pass1234";
@@ -73,12 +85,10 @@ class AuthServiceTest {
 
             when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
-            // when
             SignupInfo response = authService.signup(
                     new SignupCommand(rawEmail, rawNickname, rawPassword)
             );
 
-            // then
             ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
             verify(userRepository).save(captor.capture());
             verify(groupService).createDefaultGroup(savedUser);
@@ -98,10 +108,8 @@ class AuthServiceTest {
         @Test
         @DisplayName("이메일이 중복되면 예외가 발생한다")
         void signup_fail_when_email_duplicated() {
-            // given
             when(userRepository.existsByEmail("test@example.com")).thenReturn(true);
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> authService.signup(
@@ -109,7 +117,6 @@ class AuthServiceTest {
                     )
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_EMAIL_DUPLICATED);
             verify(userRepository, never()).existsByNickname(anyString());
             verify(userRepository, never()).save(any(User.class));
@@ -119,11 +126,9 @@ class AuthServiceTest {
         @Test
         @DisplayName("닉네임이 중복되면 예외가 발생한다")
         void signup_fail_when_nickname_duplicated() {
-            // given
             when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
             when(userRepository.existsByNickname("nickname")).thenReturn(true);
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> authService.signup(
@@ -131,7 +136,6 @@ class AuthServiceTest {
                     )
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_NICKNAME_DUPLICATED);
             verify(userRepository, never()).save(any(User.class));
             verify(groupService, never()).createDefaultGroup(any(User.class));
@@ -166,7 +170,6 @@ class AuthServiceTest {
         @Test
         @DisplayName("DB 이메일 unique 제약 위반 시 이메일 중복 예외로 변환한다")
         void signup_fail_when_email_constraint_violated() {
-            // given
             when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
             when(userRepository.existsByNickname("nickname")).thenReturn(false);
             when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
@@ -177,7 +180,6 @@ class AuthServiceTest {
             when(userRepository.save(any(User.class)))
                     .thenThrow(new DataIntegrityViolationException("db error", cause));
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> authService.signup(
@@ -185,7 +187,6 @@ class AuthServiceTest {
                     )
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_EMAIL_DUPLICATED);
             verify(groupService, never()).createDefaultGroup(any(User.class));
         }
@@ -193,7 +194,6 @@ class AuthServiceTest {
         @Test
         @DisplayName("DB 닉네임 unique 제약 위반 시 닉네임 중복 예외로 변환한다")
         void signup_fail_when_nickname_constraint_violated() {
-            // given
             when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
             when(userRepository.existsByNickname("nickname")).thenReturn(false);
             when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
@@ -204,7 +204,6 @@ class AuthServiceTest {
             when(userRepository.save(any(User.class)))
                     .thenThrow(new DataIntegrityViolationException("db error", cause));
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> authService.signup(
@@ -212,9 +211,141 @@ class AuthServiceTest {
                     )
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_NICKNAME_DUPLICATED);
             verify(groupService, never()).createDefaultGroup(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("login")
+    class LoginTest {
+
+        @Test
+        @DisplayName("로그인에 성공하면 access token, refresh token을 발급하고 저장한다")
+        void login_success() {
+            UUID userId = UUID.randomUUID();
+            OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+            ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
+
+            when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pass1234", "encoded-password")).thenReturn(true);
+            when(jwtProvider.generateAccessToken(userId)).thenReturn("access-token");
+            when(jwtProvider.generateRefreshToken(userId)).thenReturn("refresh-token");
+            when(jwtProvider.getExpiration("refresh-token")).thenReturn(expiresAt);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.empty());
+
+            LoginInfo result = authService.login("test@example.com", "pass1234");
+
+            ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+            verify(refreshTokenRepository).save(captor.capture());
+
+            RefreshToken savedToken = captor.getValue();
+
+            assertAll(
+                    () -> assertThat(result.userId()).isEqualTo(userId),
+                    () -> assertThat(result.nickname()).isEqualTo("testuser"),
+                    () -> assertThat(result.accessToken()).isEqualTo("access-token"),
+                    () -> assertThat(result.refreshToken()).isEqualTo("refresh-token"),
+                    () -> assertThat(savedToken.getUserId()).isEqualTo(userId),
+                    () -> assertThat(savedToken.getToken()).isEqualTo("refresh-token"),
+                    () -> assertThat(savedToken.getExpiresAt()).isEqualTo(expiresAt),
+                    () -> assertThat(savedToken.isRevoked()).isFalse()
+            );
+        }
+
+        @Test
+        @DisplayName("이메일이 존재하지 않으면 로그인 실패 예외가 발생한다")
+        void login_fail_when_user_not_found() {
+            when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.login("test@example.com", "pass12324")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+            verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 로그인 실패 예외가 발생한다")
+        void login_fail_when_password_not_matched() {
+            UUID userId = UUID.randomUUID();
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+            ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
+
+            when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("wrong-pass", "encoded-password")).thenReturn(false);
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.login("test@example.com", "wrong-pass")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_LOGIN_FAILED);
+            verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("계정이 잠금 상태면 ACCOUNT_LOCKED 예외가 발생한다")
+        void login_fail_when_account_locked() {
+            UUID userId = UUID.randomUUID();
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+            ReflectionTestUtils.setField(user, "status", UserStatus.LOCKED);
+
+            when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.login("test@example.com", "pass1234")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ACCOUNT_LOCKED);
+            verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+        }
+
+        @Test
+        @DisplayName("입력값이 null 또는 blank면 validation 예외가 발생한다")
+        void login_fail_when_input_invalid() {
+            BusinessException nullException = assertThrows(
+                    BusinessException.class,
+                    () -> authService.login(null, "pass1234")
+            );
+
+            BusinessException blankException = assertThrows(
+                    BusinessException.class,
+                    () -> authService.login("   ", "pass1234")
+            );
+
+            assertAll(
+                    () -> assertThat(nullException.getErrorCode()).isEqualTo(ErrorCode.AUTH_VALIDATION_FAILED),
+                    () -> assertThat(blankException.getErrorCode()).isEqualTo(ErrorCode.AUTH_VALIDATION_FAILED)
+            );
+
+            verify(userRepository, never()).findByEmail(anyString());
+            verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
         }
     }
 }

--- a/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.web.auth;
 
+import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.service.AuthService;
@@ -161,6 +162,111 @@ class AuthControllerTest {
                     .andExpect(jsonPath("$.status").value(409))
                     .andExpect(jsonPath("$.code").value("AUTH_NICKNAME_DUPLICATED"))
                     .andExpect(jsonPath("$.message").value("이미 사용 중인 닉네임입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/login")
+    class LoginTest {
+
+        private String loginRequest(String email, String password) {
+            return """
+            {
+              "email": "%s",
+              "password": "%s"
+            }
+            """.formatted(email, password);
+        }
+
+        @Test
+        @DisplayName("로그인 성공 시 200과 토큰 응답 데이터를 반환한다")
+        void login_success() throws Exception {
+            UUID userId = UUID.randomUUID();
+
+            LoginInfo result = new LoginInfo(
+                    userId,
+                    "testuser",
+                    "access-token",
+                    "refresh-token"
+            );
+
+            when(authService.login("test@example.com", "pass1234"))
+                    .thenReturn(result);
+
+            String requestBody = loginRequest("test@example.com", "pass1234");
+
+            mockMvc.perform(post("/api/auth/login")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                    .andExpect(jsonPath("$.data.nickname").value("testuser"))
+                    .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                    .andExpect(jsonPath("$.data.refreshToken").value("refresh-token"));
+
+            verify(authService).login("test@example.com", "pass1234");
+        }
+
+        @Test
+        @DisplayName("이메일 형식이 잘못되면 validation 에러를 반환한다")
+        void login_fail_when_email_invalid() throws Exception {
+            String requestBody = """
+                    {
+                      "email": "wrong-email",
+                      "password": "pass1234"
+                    }
+                    """;
+
+            mockMvc.perform(post("/api/auth/login")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.code").value("AUTH_VALIDATION_FAILED"))
+                    .andExpect(jsonPath("$.data.email").value("올바른 이메일 형식이 아닙니다."));
+        }
+
+        @Test
+        @DisplayName("이메일 또는 비밀번호가 틀리면 401 에러를 반환한다")
+        void login_fail_when_login_failed() throws Exception {
+            when(authService.login("test@example.com", "wrongpass"))
+                    .thenThrow(new BusinessException(ErrorCode.AUTH_LOGIN_FAILED));
+
+            String requestBody = loginRequest("test@example.com", "wrongpass");
+
+            mockMvc.perform(post("/api/auth/login")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401))
+                    .andExpect(jsonPath("$.code").value("AUTH_LOGIN_FAILED"))
+                    .andExpect(jsonPath("$.message").value("이메일 또는 비밀번호가 올바르지 않습니다."));
+        }
+
+        @Test
+        @DisplayName("잠긴 계정이면 423 에러를 반환한다")
+        void login_fail_when_account_locked() throws Exception {
+            when(authService.login("test@example.com", "pass1234"))
+                    .thenThrow(new BusinessException(ErrorCode.ACCOUNT_LOCKED));
+
+            String requestBody = loginRequest("test@example.com", "pass1234");
+
+            mockMvc.perform(post("/api/auth/login")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isLocked())
+                    .andExpect(jsonPath("$.status").value(423))
+                    .andExpect(jsonPath("$.code").value("ACCOUNT_LOCKED"))
+                    .andExpect(jsonPath("$.message").value("계정이 잠금 상태입니다."));
         }
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,7 +16,7 @@ ai:
     url: http://localhost:8000
 
 jwt:
-  secret: test-secret-key
+  secret: ${JWT_SECRET:wefin-test-jwt-secret-key-1234567890}
 
 news:
   naver:


### PR DESCRIPTION
## 📌 PR 설명
JWT 기반 로그인 기능을 구현하고, 인증을 위한 DB 스키마를 추가.
이메일/비밀번호 인증 후 access token과 refresh token을 발급하며 refresh token은 DB에 저장되도록 구성
<br>

## ✅ 완료한 기능 명세

- [x] 로그인 요청 DTO 및 응답 DTO 구현
- [x] 사용자 조회 로직 구현
- [x] 비밀번호 비교 검증 구현 (PasswordEncoder)
- [x] JWT access/refresh token 발급 로직 구현
- [x] 로그인 API 구현
- [x] 인증 실패 예외 처리 구현
- [x] 로그인 시 refresh token 갱신 로직 구현
- [x] JWT Provider 구현 및 토큰 파싱/검증 로직 추가
- [x] AuthService / AuthController 테스트 코드 작성


- [x] users.status 컬럼 추가 및 CHECK 제약 조건 적용
- [x] refresh_token 테이블 생성
- [x] refresh_token.token UNIQUE 제약 추가
- [x] refresh_token.token 인덱스 추가


- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- refresh token을 사용자 기준으로 1개만 유지하도록 설계하여 토큰 관리 복잡도를 줄임
- 사용자 상태를 enum으로 관리하고 DB에도 반영하여 향후 계정 잠금/탈퇴 확장성을 고려
- 보안을 위해 로그인 시마다 refresh token을 재사용하지 않고 새로운 토큰으로 갱신하는 방식으로 결정함
<br>

### 🔗 관련 이슈
Closes #117 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로그인 API 추가: 이메일/비밀번호 인증 후 액세스/리프레시 토큰 발급 및 사용자 메타데이터 반환
  * 리프레시 토큰 영구 저장·갱신 및 계정 상태(ACTIVE/LOCKED/WITHDRAWN) 기반 로그인 제어
  * JWT 발급/검증 추가(액세스 30분, 리프레시 14일), 요청/응답 DTO 도입

* **Tests**
  * 로그인 성공/실패 경로 및 컨트롤러 검증 테스트 추가

* **Chores**
  * DB 마이그레이션 및 jwt.secret 설정 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->