### PR TITLE
[WEF-526] 뉴스 클러스터링 인프라 구축 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -18,7 +18,6 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
 
     /**
      * 임베딩 대상 기사를 조회한다.
-     * PENDING/FAILED 상태이거나, PROCESSING 상태에서 staleBefore 이전에 시도된 기사를 포함한다.
      */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.crawlStatus = :crawlStatus " +
@@ -50,5 +49,18 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
             @Param("processingStatus") NewsArticle.TaggingStatus processingStatus,
             @Param("maxRetryCount") int maxRetryCount,
             @Param("staleBefore") OffsetDateTime staleBefore,
+            Pageable pageable);
+
+    /**
+     * 클러스터링 대상 기사를 조회한다.
+     */
+    @Query("SELECT a FROM NewsArticle a " +
+            "WHERE a.embeddingStatus = :embeddingStatus " +
+            "AND a.id NOT IN (SELECT nca.newsArticleId FROM NewsClusterArticle nca) " +
+            "AND a.createdAt > :since " +
+            "ORDER BY a.collectedAt DESC")
+    List<NewsArticle> findClusteringTargets(
+            @Param("embeddingStatus") NewsArticle.EmbeddingStatus embeddingStatus,
+            @Param("since") OffsetDateTime since,
             Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -56,7 +56,7 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
      */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.embeddingStatus = :embeddingStatus " +
-            "AND a.id NOT IN (SELECT nca.newsArticleId FROM NewsClusterArticle nca) " +
+            "AND NOT EXISTS (SELECT 1 FROM NewsClusterArticle nca WHERE nca.newsArticleId = a.id) " +
             "AND a.createdAt > :since " +
             "ORDER BY a.collectedAt DESC")
     List<NewsArticle> findClusteringTargets(

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -83,7 +83,7 @@ public class NewsCluster extends BaseEntity {
                         Long representativeArticleId, String thumbnailUrl,
                         OffsetDateTime publishedAt) {
         this.clusterType = clusterType;
-        this.centroidVector = centroidVector;
+        this.centroidVector = centroidVector != null ? centroidVector.clone() : null;
         this.representativeArticleId = representativeArticleId;
         this.thumbnailUrl = thumbnailUrl;
         this.publishedAt = publishedAt;

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -1,0 +1,205 @@
+package com.solv.wefin.domain.news.cluster.entity;
+
+import com.solv.wefin.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 뉴스 클러스터 (유사 기사 그룹)
+ */
+@Entity
+@Table(name = "news_cluster")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsCluster extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_cluster_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "cluster_type", nullable = false, length = 30)
+    private ClusterType clusterType;
+
+    @Column(name = "category", length = 50)
+    private String category;
+
+    @Column(name = "topic", length = 100)
+    private String topic;
+
+    @Column(name = "topic_label", length = 100)
+    private String topicLabel;
+
+    @Column(name = "representative_article_id")
+    private Long representativeArticleId;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(name = "thumbnail_url", columnDefinition = "TEXT")
+    private String thumbnailUrl;
+
+    @Column(name = "published_at")
+    private OffsetDateTime publishedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 30)
+    private ClusterStatus status = ClusterStatus.ACTIVE;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "summary_status", nullable = false, length = 30)
+    private SummaryStatus summaryStatus = SummaryStatus.PENDING;
+
+    // 클러스터의 중심점, 소속 기사들의 임베딩 벡터를 평균 낸 값
+    @Column(name = "centroid_vector", columnDefinition = "vector(1536)")
+    private float[] centroidVector;
+
+    @Column(name = "article_count", nullable = false)
+    private int articleCount = 0;
+
+    public enum ClusterStatus {
+        ACTIVE, INACTIVE
+    }
+
+    public enum ClusterType {
+        STOCK, SECTOR, TOPIC, GENERAL
+    }
+
+    public enum SummaryStatus {
+        PENDING, GENERATED, STALE, FAILED
+    }
+
+    @Builder
+    private NewsCluster(ClusterType clusterType, float[] centroidVector,
+                        Long representativeArticleId, String thumbnailUrl,
+                        OffsetDateTime publishedAt) {
+        this.clusterType = clusterType;
+        this.centroidVector = centroidVector;
+        this.representativeArticleId = representativeArticleId;
+        this.thumbnailUrl = thumbnailUrl;
+        this.publishedAt = publishedAt;
+        this.status = ClusterStatus.ACTIVE;
+        this.summaryStatus = SummaryStatus.PENDING;
+        this.articleCount = 1;
+    }
+
+    /**
+     * 새 단독 클러스터를 생성한다.
+     *
+     * @param articleVector 첫 기사의 대표 벡터
+     * @param representativeArticleId 대표 기사 ID (최신 기사)
+     * @param thumbnailUrl 대표 기사의 썸네일
+     * @param publishedAt 대표 기사의 발행 시각
+     */
+    public static NewsCluster createSingle(float[] articleVector, Long representativeArticleId,
+                                           String thumbnailUrl, OffsetDateTime publishedAt) {
+        validateVector(articleVector);
+        if (representativeArticleId == null) {
+            throw new IllegalArgumentException("representativeArticleId는 null일 수 없습니다");
+        }
+
+        return NewsCluster.builder()
+                .clusterType(ClusterType.GENERAL)
+                .centroidVector(articleVector)
+                .representativeArticleId(representativeArticleId)
+                .thumbnailUrl(thumbnailUrl)
+                .publishedAt(publishedAt)
+                .build();
+    }
+
+    /**
+     * 클러스터에 기사를 추가하고 centroid를 점진적으로 업데이트한다.
+     *
+     * 새 centroid = (기존 centroid * 기존 기사 수 + 새 기사 벡터) / (기존 기사 수 + 1)
+     *
+     * @param articleVector 추가되는 기사의 대표 벡터
+     * @param articleId 추가되는 기사 ID
+     * @param thumbnailUrl 기사의 썸네일 (대표 기사 갱신 시 사용)
+     * @param articlePublishedAt 기사의 발행 시각
+     */
+    public void addArticle(float[] articleVector, Long articleId,
+                           String thumbnailUrl, OffsetDateTime articlePublishedAt) {
+        validateVector(articleVector);
+        if (articleId == null) {
+            throw new IllegalArgumentException("articleId는 null일 수 없습니다");
+        }
+
+        updateCentroid(articleVector);
+        this.articleCount++;
+
+        // 대표 기사 갱신: 최신 기사가 대표
+        if (articlePublishedAt != null && (this.publishedAt == null || articlePublishedAt.isAfter(this.publishedAt))) {
+            this.representativeArticleId = articleId;
+            this.publishedAt = articlePublishedAt;
+            if (thumbnailUrl != null && !thumbnailUrl.isBlank()) {
+                this.thumbnailUrl = thumbnailUrl;
+            }
+        }
+
+        // AI 요약 재생성 필요
+        if (this.summaryStatus == SummaryStatus.GENERATED) {
+            this.summaryStatus = SummaryStatus.STALE;
+        }
+    }
+
+    /**
+     * centroid를 점진적으로 재계산한다.
+     */
+    private static void validateVector(float[] vector) {
+        if (vector == null || vector.length == 0) {
+            throw new IllegalArgumentException("벡터가 null이거나 비어있습니다");
+        }
+    }
+
+    private void updateCentroid(float[] newVector) {
+        if (this.centroidVector == null) {
+            this.centroidVector = newVector.clone();
+            return;
+        }
+
+        if (this.centroidVector.length != newVector.length) {
+            throw new IllegalStateException(
+                    "벡터 차원 불일치: centroid=" + this.centroidVector.length + ", new=" + newVector.length);
+        }
+
+        float[] updated = new float[this.centroidVector.length];
+        for (int i = 0; i < updated.length; i++) {
+            updated[i] = (this.centroidVector[i] * this.articleCount + newVector[i]) / (this.articleCount + 1);
+        }
+        this.centroidVector = updated;
+    }
+
+    /**
+     * 24시간 경과 시 비활성화한다.
+     * 피드에서 제외되지만 데이터는 보존된다.
+     */
+    public void deactivate() {
+        this.status = ClusterStatus.INACTIVE;
+    }
+
+    /**
+     * AI 요약 생성 완료를 기록한다.
+     */
+    public void markSummaryGenerated(String title, String summary) {
+        this.title = title;
+        this.summary = summary;
+        this.summaryStatus = SummaryStatus.GENERATED;
+    }
+
+    /**
+     * AI 요약 생성 실패를 기록한다.
+     * 다음 요약 배치에서 재시도 대상이 된다.
+     */
+    public void markSummaryFailed() {
+        this.summaryStatus = SummaryStatus.FAILED;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsClusterArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsClusterArticle.java
@@ -1,0 +1,87 @@
+package com.solv.wefin.domain.news.cluster.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 뉴스 클러스터 - 기사 매핑
+ *
+ * 하나의 기사가 하나의 클러스터에 속하는 관계를 관리한다.
+ * 대표 기사 여부는 NewsCluster.representativeArticleId로 단일 관리한다.
+ *
+ * BaseEntity를 상속하지 않는 이유: 매핑 테이블은 생성/삭제만 수행하고
+ * 수정이 없어서 updatedAt이 불필요. createdAt만 JPA Auditing으로 관리한다.
+ */
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "news_cluster_article",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_news_cluster_article_cluster_article",
+                columnNames = {"news_cluster_id", "news_article_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsClusterArticle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "news_cluster_article_id")
+    private Long id;
+
+    @Column(name = "news_cluster_id", nullable = false)
+    private Long newsClusterId;
+
+    @Column(name = "news_article_id", nullable = false)
+    private Long newsArticleId;
+
+    /**
+     * V1 레거시 컬럼. 대표 기사 판단은 NewsCluster.representativeArticleId를 사용한다.
+     * DB NOT NULL 제약이 있어 기본값 false로 유지.
+     */
+    @Column(name = "is_representative", nullable = false)
+    private boolean isRepresentative = false;
+
+    @Column(name = "article_order", nullable = false)
+    private int articleOrder;
+
+    @Column(name = "suspicious", nullable = false)
+    private boolean suspicious;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private NewsClusterArticle(Long newsClusterId, Long newsArticleId,
+                               int articleOrder, boolean suspicious) {
+        this.newsClusterId = newsClusterId;
+        this.newsArticleId = newsArticleId;
+        this.isRepresentative = false;
+        this.articleOrder = articleOrder;
+        this.suspicious = suspicious;
+    }
+
+    /**
+     * 클러스터에 기사 매핑을 생성한다.
+     *
+     * @param clusterId 클러스터 ID
+     * @param articleId 기사 ID
+     * @param order 정렬 순서
+     * @param suspicious 품질 의심 여부 (soft scoring 60~80점)
+     */
+    public static NewsClusterArticle create(Long clusterId, Long articleId,
+                                            int order, boolean suspicious) {
+        return NewsClusterArticle.builder()
+                .newsClusterId(clusterId)
+                .newsArticleId(articleId)
+                .articleOrder(order)
+                .suspicious(suspicious)
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsClusterArticle.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsClusterArticle.java
@@ -77,6 +77,13 @@ public class NewsClusterArticle {
      */
     public static NewsClusterArticle create(Long clusterId, Long articleId,
                                             int order, boolean suspicious) {
+        if (clusterId == null) {
+            throw new IllegalArgumentException("clusterId는 null일 수 없습니다");
+        }
+        if (articleId == null) {
+            throw new IllegalArgumentException("articleId는 null일 수 없습니다");
+        }
+
         return NewsClusterArticle.builder()
                 .newsClusterId(clusterId)
                 .newsArticleId(articleId)

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterArticleRepository.java
@@ -1,0 +1,31 @@
+package com.solv.wefin.domain.news.cluster.repository;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NewsClusterArticleRepository extends JpaRepository<NewsClusterArticle, Long> {
+
+    /**
+     * 특정 클러스터의 소속 기사 매핑을 조회한다.
+     */
+    List<NewsClusterArticle> findByNewsClusterId(Long newsClusterId);
+
+    /**
+     * 특정 클러스터의 소속 기사 수를 조회한다.
+     */
+    int countByNewsClusterId(Long newsClusterId);
+
+    /**
+     * 특정 기사가 클러스터에 이미 배정되었는지 확인한다.
+     */
+    boolean existsByNewsArticleId(Long newsArticleId);
+
+    /**
+     * 특정 클러스터에서 특정 기사 매핑 1건을 삭제한다. 이상치 제거 시 사용.
+     *
+     * @return 삭제된 건수 (정상이면 1, 매핑이 없었으면 0)
+     */
+    long deleteByNewsClusterIdAndNewsArticleId(Long newsClusterId, Long newsArticleId);
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -1,0 +1,24 @@
+package com.solv.wefin.domain.news.cluster.repository;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> {
+
+    /**
+     * 특정 상태의 클러스터를 조회한다.
+     * 새 기사 매칭 시 ACTIVE 클러스터 목록 조회에 사용.
+     *
+     * <p>MVP에서는 ACTIVE 전체를 메모리로 가져와 유사도 비교하는 단순 구조.
+     * 클러스터 수가 증가하면 후보군 축소가 필요하다:</p>
+     * <ul>
+     *     <li>최근 24시간 생성 클러스터만 조회</li>
+     *     <li>category/topic 기준 pre-filter</li>
+     *     <li>pgvector 기반 nearest neighbor 후보 조회</li>
+     * </ul>
+     */
+    List<NewsCluster> findByStatus(ClusterStatus status);
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ArticleVectorService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ArticleVectorService.java
@@ -42,11 +42,22 @@ public class ArticleVectorService {
      * 청크 임베딩들의 단순 평균 벡터를 계산한다.
      */
     private float[] averageVectors(List<ArticleEmbedding> embeddings) {
-        int dimension = embeddings.get(0).getEmbedding().length;
+        float[] firstVector = embeddings.get(0).getEmbedding();
+        if (firstVector == null || firstVector.length == 0) {
+            throw new IllegalArgumentException("첫 번째 청크의 임베딩이 null이거나 비어있습니다");
+        }
+
+        int dimension = firstVector.length;
         float[] sum = new float[dimension];
 
-        for (ArticleEmbedding embedding : embeddings) {
-            float[] vector = embedding.getEmbedding();
+        for (int idx = 0; idx < embeddings.size(); idx++) {
+            float[] vector = embeddings.get(idx).getEmbedding();
+            if (vector == null || vector.length != dimension) {
+                throw new IllegalArgumentException(
+                        "청크 임베딩 차원 불일치 - index: " + idx
+                                + ", expected: " + dimension
+                                + ", actual: " + (vector == null ? "null" : vector.length));
+            }
             for (int i = 0; i < dimension; i++) {
                 sum[i] += vector[i];
             }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ArticleVectorService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ArticleVectorService.java
@@ -1,0 +1,63 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
+import com.solv.wefin.domain.news.embedding.repository.ArticleEmbeddingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 기사별 대표 벡터를 계산하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class ArticleVectorService {
+
+    private final ArticleEmbeddingRepository articleEmbeddingRepository;
+
+    @Value("${openai.embedding.model:text-embedding-3-small}")
+    private String embeddingModel;
+
+    /**
+     * 기사의 대표 벡터를 계산한다.
+     * 해당 기사의 모든 청크 임베딩을 조회하여 평균 벡터를 반환한다.
+     *
+     * @param newsArticleId 기사 ID
+     * @return 대표 벡터 (1536차원), 임베딩이 없으면 null
+     */
+    public float[] calculateRepresentativeVector(Long newsArticleId) {
+        List<ArticleEmbedding> embeddings = articleEmbeddingRepository
+                .findByNewsArticleIdAndEmbeddingModel(newsArticleId, embeddingModel);
+
+        if (embeddings.isEmpty()) {
+            return null;
+        }
+
+        return averageVectors(embeddings);
+    }
+
+    /**
+     * 청크 임베딩들의 단순 평균 벡터를 계산한다.
+     */
+    private float[] averageVectors(List<ArticleEmbedding> embeddings) {
+        int dimension = embeddings.get(0).getEmbedding().length;
+        float[] sum = new float[dimension];
+
+        for (ArticleEmbedding embedding : embeddings) {
+            float[] vector = embedding.getEmbedding();
+            for (int i = 0; i < dimension; i++) {
+                sum[i] += vector[i];
+            }
+        }
+
+        float count = embeddings.size();
+        float[] average = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            average[i] = sum[i] / count;
+        }
+
+        return average;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ArticleVectorService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ArticleVectorService.java
@@ -28,6 +28,10 @@ public class ArticleVectorService {
      * @return 대표 벡터 (1536차원), 임베딩이 없으면 null
      */
     public float[] calculateRepresentativeVector(Long newsArticleId) {
+        if (newsArticleId == null) {
+            throw new IllegalArgumentException("newsArticleId는 null일 수 없습니다");
+        }
+
         List<ArticleEmbedding> embeddings = articleEmbeddingRepository
                 .findByNewsArticleIdAndEmbeddingModel(newsArticleId, embeddingModel);
 

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -69,6 +69,11 @@ public enum ErrorCode {
     TAGGING_ARTICLE_NOT_FOUND(500, "태깅 대상 기사를 찾을 수 없습니다."),
     TAGGING_ALREADY_RUNNING(409, "태깅 생성이 이미 실행 중입니다."),
 
+    // Clustering
+    CLUSTERING_ALREADY_RUNNING(409, "클러스터링이 이미 실행 중입니다."),
+    CLUSTERING_ARTICLE_NOT_FOUND(500, "클러스터링 대상 기사를 찾을 수 없습니다."),
+    CLUSTERING_NO_EMBEDDING(500, "기사의 임베딩이 존재하지 않습니다."),
+
     // GameRoom
     ROOM_NOT_FOUND(404,"게임장을 찾을 수 없습니다."),
     ROOM_ALREADY_EXISTS(409, "이미 진행 중이거나 대기 중인 게임방이 있습니다."),

--- a/src/main/resources/db/migration/V16__add_clustering_columns_to_news_cluster.sql
+++ b/src/main/resources/db/migration/V16__add_clustering_columns_to_news_cluster.sql
@@ -39,3 +39,6 @@ CREATE INDEX IF NOT EXISTS idx_news_cluster_status ON news_cluster (status);
 
 -- 인덱스: summary_status 기반 요약 대상 조회용
 CREATE INDEX IF NOT EXISTS idx_news_cluster_summary_status ON news_cluster (summary_status);
+
+-- 인덱스: 클러스터 미배정 기사 조회 + existsByNewsArticleId 용
+CREATE INDEX IF NOT EXISTS idx_news_cluster_article_news_article_id ON news_cluster_article (news_article_id);

--- a/src/main/resources/db/migration/V16__add_clustering_columns_to_news_cluster.sql
+++ b/src/main/resources/db/migration/V16__add_clustering_columns_to_news_cluster.sql
@@ -1,0 +1,41 @@
+-- news_cluster에 클러스터링 파이프라인용 컬럼 추가
+
+-- 클러스터 상태 (ACTIVE: 피드 노출, INACTIVE: 24시간 경과 비활성화)
+ALTER TABLE news_cluster
+    ADD COLUMN IF NOT EXISTS status VARCHAR(30) NOT NULL DEFAULT 'ACTIVE';
+
+-- AI 요약 상태 (PENDING: 미생성, GENERATED: 생성 완료, STALE: 재생성 필요)
+ALTER TABLE news_cluster
+    ADD COLUMN IF NOT EXISTS summary_status VARCHAR(30) NOT NULL DEFAULT 'PENDING';
+
+-- 클러스터 centroid 벡터 (매칭 기준, 대표 기사와 분리)
+ALTER TABLE news_cluster
+    ADD COLUMN IF NOT EXISTS centroid_vector vector(1536);
+
+-- 클러스터 내 기사 수
+ALTER TABLE news_cluster
+    ADD COLUMN IF NOT EXISTS article_count INT NOT NULL DEFAULT 0;
+
+-- title NOT NULL 제약 완화 (AI 요약 생성 전에는 null)
+ALTER TABLE news_cluster
+    ALTER COLUMN title DROP NOT NULL;
+
+-- TIMESTAMP → TIMESTAMPTZ 통일
+ALTER TABLE news_cluster
+    ALTER COLUMN published_at TYPE TIMESTAMPTZ,
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ,
+    ALTER COLUMN updated_at TYPE TIMESTAMPTZ;
+
+-- news_cluster_article에 suspicious 플래그 추가 (soft scoring 결과 점수가 60~80인 기사)
+ALTER TABLE news_cluster_article
+    ADD COLUMN IF NOT EXISTS suspicious BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- news_cluster_article TIMESTAMP → TIMESTAMPTZ
+ALTER TABLE news_cluster_article
+    ALTER COLUMN created_at TYPE TIMESTAMPTZ;
+
+-- 인덱스: ACTIVE 클러스터 조회용
+CREATE INDEX IF NOT EXISTS idx_news_cluster_status ON news_cluster (status);
+
+-- 인덱스: summary_status 기반 요약 대상 조회용
+CREATE INDEX IF NOT EXISTS idx_news_cluster_summary_status ON news_cluster (summary_status);


### PR DESCRIPTION
## 📌 PR 설명
뉴스 클러스터링 파이프라인의 기반 인프라를 구축합니다.
- news_cluster/news_cluster_article 테이블에 클러스터링 파이프라인용 컬럼 추가 (status, summary_status, centroid_vector 등)
- NewsCluster Entity (centroid 점진적 업데이트, 대표 기사 갱신, 비활성화)
- 기사별 대표 벡터 계산 서비스 (청크 임베딩 평균)

### 흐름
**1단계. 대상 기사 선정**
 `NewsArticleRepository.findClusteringTargets()`로 해당 기사를 DB에서 조회합니다.
- 임베딩 완료
- 아직 클러스터에 속하지 않음
- 최근 24시간 이내 기사

**2단계. 기사 대표 벡터 생성**
`ArticleVectorService.calculateRepresentativeVector()`가 `ArticleEmbeddingRepository`에서 해당 기사의 청크 임베딩들을 조회합니다. 청크가 여러 개면 평균을 내서 기사 1건당 벡터 1개를 만듭니다.

**3단계. 클러스터 매칭 (유사도 비교)** 
`NewsClusterRepository.findByStatus(ACTIVE)`로 현재 활성 클러스터들을 가져와서, 각 클러스터의 `NewsCluster.centroidVector`와 기사 대표 벡터의 유사도를 비교합니다.

**4-A단계. 유사한 클러스터가 있으면 → 추가**
유사도가 0.80 이상인 클러스터가 있으면 `NewsCluster.addArticle()`을 호출하여
- `centroid`를 다시 계산합니다 (기존 평균에 새 벡터 반영)
- `articleCount`를 1 늘립니다
- 새 기사가 더 최신이면 `representativeArticleId`를 교체합니다 (썸네일/시간 갱신)
- `summaryStatus`가 `GENERATED`였으면 `STALE`로 바꿉니다 (다음 요약 배치에서 재생성)

그리고 `NewsClusterArticle.create()`로 기사-클러스터 매핑을 저장합니다.

**4-B단계. 유사한 클러스터가 없으면 → 신규 클러스터 생성**
모든 기존 클러스터와 유사도가 0.80 미만이면, `NewsCluster.createSingle()`로 해당 기사로 새 클러스터를 만듭니다. 이 기사의 벡터가 곧 `centroid`가 되고, `articleCount`는 1, `clusterType`은 `GENERAL`, `status`는 `ACTIVE`, `summaryStatus`는 `PENDING`으로 생성됩니다.

이 과정을 1단계에서 조회된 대상 기사마다 반복합니다.


<br>

## ✅ 변경 파일
1. `V16__add_clustering_columns_to_news_cluster.sql` — 기존 테이블에 컬럼 추가 + TIMESTAMPTZ 통일 + 인덱스
2. `NewsCluster.java` — Entity (ClusterStatus, ClusterType, SummaryStatus enum + centroid 업데이트 + 대표 기사 갱신)
3. `NewsClusterArticle.java` — 기사-클러스터 매핑 Entity (suspicious 플래그)
4. `NewsClusterRepository.java` — ACTIVE 클러스터 조회
5. `NewsClusterArticleRepository.java` — 소속 기사 조회/존재 확인
6. `ArticleVectorService.java` — 청크 임베딩 평균 → 기사 대표 벡터 계산
7. `NewsArticleRepository.java` — findClusteringTargets() 쿼리 추가
8. `ErrorCode.java` — CLUSTERING 에러코드 3건 추가

<br>

## 💭 고민과 해결과정
### 1. centroid와 대표 기사 분리

초기에는 최신 기사의 벡터를 새 기사 매칭 기준으로도 활용하려 했습니다. 그러나 최신 기사는 화면 표시용 대표 기사로는 적절하지만, 클러스터 전체의 의미를 가장 잘 대변하는 벡터라고 보기는 어려워 특정 시점에 유입된 기사 성격에 따라 매칭 기준이 흔들릴 수 있어, 표시용 대표 기사와 매칭 기준을 분리했습니다.

| 용도 | 기준 | 저장 |
|---|---|---|
| 썸네일/시간 표시 | 최신 기사 | `representative_article_id` |
| 새 기사 매칭 | centroid (소속 기사 임베딩 평균) | `centroid_vector` |

centroid는 기사 추가 시 점진적으로 재계산됩니다: `새 centroid = (기존 centroid * 기존 기사 수 + 새 기사 벡터) / (기존 기사 수 + 1)`

### 2. 기사 대표 벡터

기사는 여러 청크로 분할되어 각각 임베딩이 생성되므로 클러스터링을 위해 기사 단위 벡터 1개가 필요합니다. MVP에서는 전체 청크 임베딩의 단순 평균을 사용합니다.

본문이 긴 기사는 핵심 문장이 희석될 수 있으나, 뉴스 역피라미드 구조 특성상 앞부분 청크의 비중이 자연스럽게 높기 때문에 품질에 큰 영향이 없을 것이라고 판단하였습니다. 향후 리팩토링(제목 가중합, 핵심 N청크 평균 등)을 고려하여 별도 메서드로 분리했습니다.

### 3. ClusterType을 enum으로 관리하는 이유
MVP에서는 임베딩 유사도 단일 기준으로 클러스터링하므로 모든 클러스터가 `GENERAL`로 생성됩니다. 향후 태그 비율 기반 클러스터 유형 자동 분류 또는 인덱스 기반 조회 최적화 시 이 필드를 활용하도록 하였습니다.

<br>

### 🔗 관련 이슈
#112

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 뉴스 기사 자동 클러스터링 도입 — 클러스터 생성·병합·대표 기사 관리 및 요약 상태 추적
  * 클러스터에 기사 추가/대표 벡터 갱신 및 요약 생성/실패 표기 기능
  * 기사 임베딩을 평균내어 대표 벡터 계산하는 서비스 추가
* **데이터베이스**
  * 클러스터·매핑 테이블에 상태·요약상태·벡터·기사수·의심 플래그 컬럼 및 인덱스 추가
* **오류 코드**
  * 클러스터링 관련 신규 오류 코드 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->