### PR TITLE
[WEF-77] 로그인 상태 유지 및 인증 만료

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -152,6 +152,13 @@ public class AuthService {
 
         UUID userId = jwtProvider.getUserId(refreshToken);
 
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
         RefreshToken savedToken = refreshTokenRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
 
@@ -161,7 +168,7 @@ public class AuthService {
         }
 
         // 만료 체크
-        if (savedToken.getExpiresAt().isBefore(OffsetDateTime.now())) {
+        if (!savedToken.getExpiresAt().isAfter(OffsetDateTime.now())) {
             throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
         }
 

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.Locale;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -139,6 +140,33 @@ public class AuthService {
                 accessToken,
                 refreshTokenValue
         );
+    }
+
+    @Transactional
+    public String refresh(String refreshToken) {
+
+        // 토큰 유효성 검증
+        if (!jwtProvider.isValid(refreshToken) || !"refresh".equals(jwtProvider.getTokenType(refreshToken))) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        UUID userId = jwtProvider.getUserId(refreshToken);
+
+        RefreshToken savedToken = refreshTokenRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+
+        // 토큰 일치 여부 확인
+        if (!savedToken.getToken().equals(refreshToken) || savedToken.isRevoked()) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        // 만료 체크
+        if (savedToken.getExpiresAt().isBefore(OffsetDateTime.now())) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        // 새 access token 발급
+        return jwtProvider.generateAccessToken(userId);
     }
 
     private BusinessException mapConstraintViolation(DataIntegrityViolationException e) {

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -1,24 +1,44 @@
 package com.solv.wefin.global.config;
 
+import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
+import com.solv.wefin.global.config.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(csrf -> csrf.disable())
+                .cors(Customizer.withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll()
-                );
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 

--- a/src/main/java/com/solv/wefin/global/config/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/solv/wefin/global/config/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,43 @@
+package com.solv.wefin.global.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.ErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        String authExceptionAttr = (String) request.getAttribute("authException");
+
+        ErrorCode errorCode = ErrorCode.AUTH_UNAUTHORIZED;
+
+        if ("INVALID_TOKEN".equals(authExceptionAttr)) {
+            errorCode = ErrorCode.AUTH_INVALID_TOKEN;
+        }
+
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Object> body = ApiResponse.error(errorCode);
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/solv/wefin/global/config/security/JwtAuthenticationFilter.java
@@ -37,7 +37,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String token = authorizationHeader.substring(BEARER_PREFIX.length());
 
-        if (!jwtProvider.isValid(token) || !jwtProvider.isAccessToken(token)) {
+        boolean validAccessToken;
+        try {
+            validAccessToken = jwtProvider.isValid(token) && jwtProvider.isAccessToken(token);
+        } catch (RuntimeException e) {
+            validAccessToken = false;
+        }
+
+        if (!validAccessToken) {
             request.setAttribute("authException", "INVALID_TOKEN");
             filterChain.doFilter(request, response);
             return;

--- a/src/main/java/com/solv/wefin/global/config/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/solv/wefin/global/config/security/JwtAuthenticationFilter.java
@@ -1,0 +1,58 @@
+package com.solv.wefin.global.config.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = authorizationHeader.substring(BEARER_PREFIX.length());
+
+        if (!jwtProvider.isValid(token) || !jwtProvider.isAccessToken(token)) {
+            request.setAttribute("authException", "INVALID_TOKEN");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        UUID userId = jwtProvider.getUserId(token);
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        AuthorityUtils.NO_AUTHORITIES
+                );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/security/JwtProvider.java
+++ b/src/main/java/com/solv/wefin/global/config/security/JwtProvider.java
@@ -80,6 +80,10 @@ public class JwtProvider {
         }
     }
 
+    public boolean isAccessToken(String token) {
+        return "access".equals(getTokenType(token));
+    }
+
     private Claims parseClaims(String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(key)

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
     // Auth - LOGIN
     AUTH_LOGIN_FAILED(401, "이메일 또는 비밀번호가 올바르지 않습니다."),
     ACCOUNT_LOCKED(423, "계정이 잠금 상태입니다."),
+    AUTH_INVALID_TOKEN(401, "유효하지 않은 인증 토큰입니다."),
+    AUTH_UNAUTHORIZED(401, "인증이 필요합니다."),
 
     // Order - BUY
     ORDER_INSUFFICIENT_BALANCE(400, "예수금이 부족합니다."),

--- a/src/main/java/com/solv/wefin/web/auth/AuthController.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthController.java
@@ -5,10 +5,7 @@ import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.service.AuthService;
 import com.solv.wefin.global.common.ApiResponse;
-import com.solv.wefin.web.auth.dto.LoginRequest;
-import com.solv.wefin.web.auth.dto.LoginResponse;
-import com.solv.wefin.web.auth.dto.SignupRequest;
-import com.solv.wefin.web.auth.dto.SignupResponse;
+import com.solv.wefin.web.auth.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -54,6 +51,17 @@ public class AuthController {
                 .userId(result.userId())
                 .nickname(result.nickname())
                 .build();
+
+        return ApiResponse.success(response);
+    }
+
+    @PostMapping("/refresh")
+    public ApiResponse<RefreshTokenResponse> refresh(
+            @RequestBody @Valid RefreshTokenRequest request
+    ) {
+        String newAccessToken = authService.refresh(request.refreshToken());
+
+        RefreshTokenResponse response = new RefreshTokenResponse(newAccessToken);
 
         return ApiResponse.success(response);
     }

--- a/src/main/java/com/solv/wefin/web/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.web.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+
+        @NotBlank(message = "리프레시 토큰은 필수입니다.")
+        String refreshToken
+
+) {
+}

--- a/src/main/java/com/solv/wefin/web/auth/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/RefreshTokenResponse.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.web.auth.dto;
+
+public record RefreshTokenResponse(
+        String accessToken
+) {
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -353,6 +353,13 @@ class AuthServiceTest {
     @DisplayName("refresh")
     class RefreshTest {
 
+        private User activeUser(UUID userId) {
+            User user = User.builder().build();
+            ReflectionTestUtils.setField(user, "userId", userId);
+            ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
+            return user;
+        }
+
         @Test
         @DisplayName("유효한 refresh token이면 새 access token을 발급한다")
         void refresh_success() {
@@ -368,6 +375,7 @@ class AuthServiceTest {
             when(jwtProvider.isValid("refresh-token")).thenReturn(true);
             when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
             when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(activeUser(userId)));
             when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
             when(jwtProvider.generateAccessToken(userId)).thenReturn("new-access-token");
 
@@ -388,6 +396,7 @@ class AuthServiceTest {
             );
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(userRepository, never()).findById(any(UUID.class));
             verify(refreshTokenRepository, never()).findById(any(UUID.class));
             verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
         }
@@ -404,6 +413,7 @@ class AuthServiceTest {
             );
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(userRepository, never()).findById(any(UUID.class));
             verify(refreshTokenRepository, never()).findById(any(UUID.class));
             verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
         }
@@ -416,6 +426,7 @@ class AuthServiceTest {
             when(jwtProvider.isValid("refresh-token")).thenReturn(true);
             when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
             when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(activeUser(userId)));
             when(refreshTokenRepository.findById(userId)).thenReturn(Optional.empty());
 
             BusinessException exception = assertThrows(
@@ -442,6 +453,7 @@ class AuthServiceTest {
             when(jwtProvider.isValid("refresh-token")).thenReturn(true);
             when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
             when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(activeUser(userId)));
             when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
 
             BusinessException exception = assertThrows(
@@ -469,6 +481,7 @@ class AuthServiceTest {
             when(jwtProvider.isValid("refresh-token")).thenReturn(true);
             when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
             when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(activeUser(userId)));
             when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
 
             BusinessException exception = assertThrows(
@@ -495,6 +508,7 @@ class AuthServiceTest {
             when(jwtProvider.isValid("refresh-token")).thenReturn(true);
             when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
             when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(activeUser(userId)));
             when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
 
             BusinessException exception = assertThrows(

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -348,4 +348,162 @@ class AuthServiceTest {
             verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
         }
     }
+
+    @Nested
+    @DisplayName("refresh")
+    class RefreshTest {
+
+        @Test
+        @DisplayName("유효한 refresh token이면 새 access token을 발급한다")
+        void refresh_success() {
+            UUID userId = UUID.randomUUID();
+            OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
+
+            RefreshToken savedToken = RefreshToken.builder()
+                    .userId(userId)
+                    .token("refresh-token")
+                    .expiresAt(expiresAt)
+                    .build();
+
+            when(jwtProvider.isValid("refresh-token")).thenReturn(true);
+            when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
+            when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
+            when(jwtProvider.generateAccessToken(userId)).thenReturn("new-access-token");
+
+            String result = authService.refresh("refresh-token");
+
+            assertThat(result).isEqualTo("new-access-token");
+            verify(jwtProvider).generateAccessToken(userId);
+        }
+
+        @Test
+        @DisplayName("토큰이 유효하지 않으면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        void refresh_fail_when_token_invalid() {
+            when(jwtProvider.isValid("invalid-token")).thenReturn(false);
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.refresh("invalid-token")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(refreshTokenRepository, never()).findById(any(UUID.class));
+            verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("refresh 타입 토큰이 아니면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        void refresh_fail_when_token_type_is_not_refresh() {
+            when(jwtProvider.isValid("access-token")).thenReturn(true);
+            when(jwtProvider.getTokenType("access-token")).thenReturn("access");
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.refresh("access-token")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(refreshTokenRepository, never()).findById(any(UUID.class));
+            verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("DB에 저장된 refresh token이 없으면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        void refresh_fail_when_saved_token_not_found() {
+            UUID userId = UUID.randomUUID();
+
+            when(jwtProvider.isValid("refresh-token")).thenReturn(true);
+            when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
+            when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.empty());
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.refresh("refresh-token")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("DB에 저장된 토큰 값과 다르면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        void refresh_fail_when_token_not_matched() {
+            UUID userId = UUID.randomUUID();
+            OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
+
+            RefreshToken savedToken = RefreshToken.builder()
+                    .userId(userId)
+                    .token("different-token")
+                    .expiresAt(expiresAt)
+                    .build();
+
+            when(jwtProvider.isValid("refresh-token")).thenReturn(true);
+            when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
+            when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.refresh("refresh-token")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("revoked 된 토큰이면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        void refresh_fail_when_token_revoked() {
+            UUID userId = UUID.randomUUID();
+            OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
+
+            RefreshToken savedToken = RefreshToken.builder()
+                    .userId(userId)
+                    .token("refresh-token")
+                    .expiresAt(expiresAt)
+                    .build();
+            ReflectionTestUtils.setField(savedToken, "revoked", true);
+
+            when(jwtProvider.isValid("refresh-token")).thenReturn(true);
+            when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
+            when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.refresh("refresh-token")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
+        }
+
+        @Test
+        @DisplayName("만료된 refresh token이면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        void refresh_fail_when_token_expired() {
+            UUID userId = UUID.randomUUID();
+            OffsetDateTime expiresAt = OffsetDateTime.now().minusMinutes(1);
+
+            RefreshToken savedToken = RefreshToken.builder()
+                    .userId(userId)
+                    .token("refresh-token")
+                    .expiresAt(expiresAt)
+                    .build();
+
+            when(jwtProvider.isValid("refresh-token")).thenReturn(true);
+            when(jwtProvider.getTokenType("refresh-token")).thenReturn("refresh");
+            when(jwtProvider.getUserId("refresh-token")).thenReturn(userId);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.of(savedToken));
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.refresh("refresh-token")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_INVALID_TOKEN);
+            verify(jwtProvider, never()).generateAccessToken(any(UUID.class));
+        }
+    }
 }

--- a/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.service.AuthService;
+import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -35,6 +36,9 @@ class AuthControllerTest {
 
     @MockBean
     private AuthService authService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
 
     @Nested
     @DisplayName("POST /api/auth/signup")
@@ -267,6 +271,78 @@ class AuthControllerTest {
                     .andExpect(jsonPath("$.status").value(423))
                     .andExpect(jsonPath("$.code").value("ACCOUNT_LOCKED"))
                     .andExpect(jsonPath("$.message").value("계정이 잠금 상태입니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/auth/refresh")
+    class RefreshTest {
+
+        private String refreshRequest(String refreshToken) {
+            return """
+        {
+          "refreshToken": "%s"
+        }
+        """.formatted(refreshToken);
+        }
+
+        @Test
+        @DisplayName("토큰 재발급 성공 시 200과 새 access token을 반환한다")
+        void refresh_success() throws Exception {
+            when(authService.refresh("refresh-token"))
+                    .thenReturn("new-access-token");
+
+            String requestBody = refreshRequest("refresh-token");
+
+            mockMvc.perform(post("/api/auth/refresh")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.accessToken").value("new-access-token"));
+
+            verify(authService).refresh("refresh-token");
+        }
+
+        @Test
+        @DisplayName("refreshToken이 비어 있으면 validation 에러를 반환한다")
+        void refresh_fail_when_refresh_token_blank() throws Exception {
+            String requestBody = """
+                {
+                  "refreshToken": ""
+                }
+                """;
+
+            mockMvc.perform(post("/api/auth/refresh")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.code").value("AUTH_VALIDATION_FAILED"))
+                    .andExpect(jsonPath("$.data.refreshToken").value("리프레시 토큰은 필수입니다."));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 refresh token이면 401 에러를 반환한다")
+        void refresh_fail_when_token_invalid() throws Exception {
+            when(authService.refresh("invalid-refresh-token"))
+                    .thenThrow(new BusinessException(ErrorCode.AUTH_INVALID_TOKEN));
+
+            String requestBody = refreshRequest("invalid-refresh-token");
+
+            mockMvc.perform(post("/api/auth/refresh")
+                            .with(csrf())
+                            .with(user("test"))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status").value(401))
+                    .andExpect(jsonPath("$.code").value("AUTH_INVALID_TOKEN"))
+                    .andExpect(jsonPath("$.message").value("유효하지 않은 인증 토큰입니다."));
         }
     }
 }

--- a/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.service.AuthService;
+import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -39,6 +40,9 @@ class AuthControllerTest {
 
     @MockBean
     private JwtProvider jwtProvider;
+
+    @MockBean
+    private JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Nested
     @DisplayName("POST /api/auth/signup")

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -2,12 +2,14 @@ package com.solv.wefin.web.group;
 
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.global.config.security.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
@@ -25,6 +27,9 @@ class GroupControllerTest {
 
     @MockBean
     private GroupService groupService;
+
+    @MockBean
+    private JwtProvider jwtProvider;
 
     @Test
     @WithMockUser

--- a/src/test/java/com/solv/wefin/web/trading/account/AccountControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/account/AccountControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.math.BigDecimal;
 
+import com.solv.wefin.global.config.security.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,6 +25,9 @@ class AccountControllerTest {
 
 	@MockitoBean
 	private VirtualAccountService accountService;
+
+	@MockitoBean
+	private JwtProvider jwtProvider;
 
 	@Test
 	@WithMockUser

--- a/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
+import com.solv.wefin.global.config.security.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,8 @@ class OrderControllerTest {
 	private OrderService orderService;
 	@MockitoBean
 	private VirtualAccountService accountService;
+	@MockitoBean
+	private JwtProvider jwtProvider;
 
 	private VirtualAccount mockAccount;
 

--- a/src/test/java/com/solv/wefin/web/trading/portfolio/PortfolioControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/portfolio/PortfolioControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.solv.wefin.global.config.security.JwtProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -30,6 +31,8 @@ class PortfolioControllerTest {
 	private PortfolioService portfolioService;
 	@MockitoBean
 	private VirtualAccountService accountService;
+	@MockitoBean
+	private JwtProvider jwtProvider;
 
 	@Test
 	@WithMockUser


### PR DESCRIPTION
## 📌 PR 설명
JWT 기반 인증 시스템에서 Refresh Token을 활용한 Access Token 재발급 API를 추가.
재발급 로직에 대한 서비스/컨트롤러 테스트를 함께 구현하여 안정성을 확보하고자 함.
<br>

## ✅ 완료한 기능 명세

- [x] Refresh Token 기반 Access Token 재발급 기능 구현
- [x] /api/auth/refresh API 추가
- [x] Refresh Token 유효성 검증 로직 구현
- [x] 토큰 서명 및 타입 검증
- [x] DB 저장 토큰과 일치 여부 확인
- [x] revoked 여부 확인
- [x] 만료 시간 검증
- [x] 인증 실패 시 ErrorCode 기반 응답 처리
- [x] refresh 로직 테스트 추가

- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
- 단순 토큰 검증이 아닌 DB에 저장된 토큰과의 일치 여부 및 상태(revoked, 만료 여부)를 함께 검증하도록 설계
- JWT 필터에서 access token만 허용하도록 분리하여 refresh token이 인증에 사용되지 않도록 함
<br>

### 🔗 관련 이슈
Closes #118 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 리프레시 토큰으로 액세스 토큰을 재발급하는 API(POST /api/auth/refresh) 추가 및 관련 요청/응답 DTO 도입.
  * 요청별 JWT 인증 필터와 인증 실패 응답 처리기 도입.

* **보안/동작 변경**
  * 허용 경로를 화이트리스트로 제한하고 기타 요청은 인증 필요로 변경.
  * 토큰 유형·만료·폐기 여부 검증 강화, 무상태 세션 및 기본 CORS 활성화.

* **테스트**
  * 리프레시 흐름과 인증 오류·검증 케이스에 대한 단위 및 컨트롤러 테스트 추가/확장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->