### PR TITLE
[WER-527] 게임방, 게임 시작 웹소켓 적용

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/room/event/GameRoomEvent.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/event/GameRoomEvent.java
@@ -1,8 +1,5 @@
 package com.solv.wefin.domain.game.room.event;
 
-import jdk.jfr.Event;
-import jdk.jfr.EventType;
-
 import java.util.UUID;
 
 public record GameRoomEvent(UUID roomId, EventType type) {

--- a/src/main/java/com/solv/wefin/domain/game/room/event/GameRoomEvent.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/event/GameRoomEvent.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.game.room.event;
+
+import jdk.jfr.Event;
+import jdk.jfr.EventType;
+
+import java.util.UUID;
+
+public record GameRoomEvent(UUID roomId, EventType type) {
+    public enum EventType {
+        PARTICIPANT_JOINED,
+        PARTICIPANT_LEFT,
+        GAME_STARTED
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -9,6 +9,7 @@ import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.event.GameRoomEvent;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
@@ -16,6 +17,7 @@ import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.response.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +40,8 @@ public class GameRoomService {
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
 
     //게임방 생성
     @Transactional //트랜잭션으로 방생성과 방장유저 지정 동시에 이루어짐
@@ -145,6 +149,7 @@ public class GameRoomService {
                 throw new BusinessException(ErrorCode.ROOM_FULL);
             }
             participant.rejoin();
+            eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
             return participant;
         }
 
@@ -164,6 +169,7 @@ public class GameRoomService {
             member.assignSeed(gameRoom.getSeed());
         }
 
+        eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
         return member;
     }
 
@@ -208,6 +214,7 @@ public class GameRoomService {
             GameParticipant newLeader = remainingActive.get(randomIndex);
             newLeader.assignLeader();
         }
+        eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_LEFT));
 
     }
 
@@ -256,6 +263,7 @@ public class GameRoomService {
         // 7. 방 상태 변경 (WAITING → IN_PROGRESS, startedAt 기록)
         gameRoom.start();
 
+        eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.GAME_STARTED));
         return new StartRoomInfo(gameRoom, firstTurn);
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/WebSocketEventListener.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketEventListener.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.socket.messaging.SessionConnectEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
+import java.security.Principal;
+
 @Slf4j
 @Component
 public class WebSocketEventListener {
@@ -16,9 +18,12 @@ public class WebSocketEventListener {
     public void handleWebSocketConnectListener(SessionConnectEvent event) {
         StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
         Object user = accessor.getUser();
-
+        // 분기 처리 추가
+        // jwt 반영 전 Authentication 없으면 principal로
         if (user instanceof Authentication auth) {
             log.info("WebSocket connected user={}", auth.getName());
+        } else if (user instanceof Principal p) {
+            log.info("WebSocket connected user={}", p.getName());
         } else {
             log.info("WebSocket connected");
         }
@@ -31,6 +36,8 @@ public class WebSocketEventListener {
 
         if (user instanceof Authentication auth) {
             log.info("WebSocket disconnected user={}", auth.getName());
+        } else if (user instanceof Principal p) {
+            log.info("WebSocket disconnected user={}", p.getName());
         } else {
             log.info("WebSocket disconnected");
         }

--- a/src/main/java/com/solv/wefin/web/game/room/listener/GameRoomEventListener.java
+++ b/src/main/java/com/solv/wefin/web/game/room/listener/GameRoomEventListener.java
@@ -1,0 +1,28 @@
+package com.solv.wefin.web.game.room.listener;
+
+import com.solv.wefin.domain.game.room.event.GameRoomEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameRoomEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    //트랜잭션 커밋 후에만  브로드캐스트
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handle(GameRoomEvent event) {
+        //구독은 /topic/  or  /queue/
+        String destination = "/topic/room/" + event.roomId();
+        log.info("Broadcasting {} to {}", event.type(), destination);
+        messagingTemplate.convertAndSend(destination, event.type());
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -54,3 +54,4 @@ tagging:
 websocket:
   allowed-origins:
     - http://localhost:5173
+    - http://localhost:5174

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,7 @@ tagging:
 websocket:
   allowed-origins:
     - http://localhost:5173
+    - http://localhost:5174
 
 hantu:
   api:

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.game.room.dto.RoomListInfo;
 import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.event.GameRoomEvent;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
@@ -259,6 +260,7 @@ class GameRoomServiceTest {
         // Then
         assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
         verify(gameParticipantRepository).save(any(GameParticipant.class));
+        verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
     }
 
     @Test
@@ -284,6 +286,7 @@ class GameRoomServiceTest {
         assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.WAITING);
         assertThat(result.getStatus()).isEqualTo(ParticipantStatus.ACTIVE); // LEFT → ACTIVE
         verify(gameParticipantRepository, never()).save(any()); // 더티 체킹이니까 save 안 부름
+        verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
     }
 
     @Test
@@ -405,6 +408,7 @@ class GameRoomServiceTest {
         assertThat(leader.getIsLeader()).isTrue();
         // 방은 종료되지 않음
         assertThat(gameRoom.getStatus()).isEqualTo(RoomStatus.WAITING);
+        verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_LEFT));
     }
 
     @Test
@@ -434,6 +438,7 @@ class GameRoomServiceTest {
         assertThat(member.getIsLeader()).isTrue();
         // 방은 종료되지 않음
         assertThat(gameRoom.getStatus()).isEqualTo(RoomStatus.WAITING);
+        verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_LEFT));
     }
 
     @Test
@@ -574,6 +579,7 @@ class GameRoomServiceTest {
         // Then — 시드머니 지급
         assertThat(leader.getSeed()).isEqualTo(10000000L);
         assertThat(member.getSeed()).isEqualTo(10000000L);
+        verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.GAME_STARTED));
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -14,6 +14,7 @@ import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
+import org.springframework.context.ApplicationEventPublisher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +52,9 @@ class GameRoomServiceTest {
 
     @Mock
     private GameTurnRepository gameTurnRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;


### PR DESCRIPTION
## 📌 PR 설명
<br> 구현된 기존 게임방 관련 기능에 ws 연결하여 실시간성을 추가했습니다.

## ✅ 완료한 기능 명세

- [x]  참가/퇴장 시 참여자 목록 실시간 갱신        
- [x] 게임 시작 시 전체 참가자 동시 페이지 이동  
- [x]  Domain Event 패턴 (GameRoomEvent -> @TransactionalEventListener -> STOMP broadcast)  

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #65 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 게임 룸에서 참가자 입장, 퇴장, 게임 시작 이벤트를 실시간으로 브로드캐스트합니다.

* **개선사항**
  * 웹소켓 연결 처리 강화로 사용자 정보 로깅이 더욱 안정적으로 작동합니다.
  * 새로운 클라이언트 출처(localhost:5174)에 대한 웹소켓 지원 추가.

* **테스트**
  * 게임 룸 생명주기 이벤트에 대한 테스트 커버리지 확대.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->