### PR TITLE
[WEF-526] 뉴스 클러스터링 배치 및 라이프사이클 관리 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusteringScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusteringScheduler.java
@@ -57,6 +57,9 @@ public class ClusteringScheduler {
             // 2. 미배정 기사 클러스터링
             clusteringService.clusterPendingArticles();
             return true;
+        } catch (Exception e) {
+            log.error("클러스터링 실행 실패: {}", e.getMessage(), e);
+            throw e; // AdminController 경로에서도 로그 보장
         } finally {
             running.set(false); // 배치 종료 시 락 해제
             long elapsed = System.currentTimeMillis() - start;

--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusteringScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusteringScheduler.java
@@ -1,0 +1,66 @@
+package com.solv.wefin.domain.news.cluster.batch;
+
+import com.solv.wefin.domain.news.cluster.service.ClusterLifecycleService;
+import com.solv.wefin.domain.news.cluster.service.ClusteringService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 클러스터링 배치 스케줄러
+ *
+ * 30분 간격으로 미배정 기사를 클러스터링한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClusteringScheduler {
+
+    private final ClusteringService clusteringService;
+    private final ClusterLifecycleService clusterLifecycleService;
+    private final AtomicBoolean running = new AtomicBoolean(false); // 현재 배치 실행 여부 플래그 (중복 실행 방지)
+
+    @Scheduled(cron = "${clustering.collect.cron:0 */30 * * * *}")
+    public void clusterArticles() {
+        try {
+            execute();
+        } catch (Exception e) {
+            log.error("클러스터링 배치 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 클러스터링을 실행한다.
+     *
+     * @return 이미 실행 중이면 false, 정상 실행되면 true
+     * @throws RuntimeException 클러스터링 실행 중 예외 발생 시
+     */
+    public boolean execute() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("클러스터링이 이미 실행 중입니다. 스킵합니다.");
+            return false;
+        }
+
+        log.info("=== 클러스터링 배치 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            // 1. 24시간 지난 클러스터 비활성화 (실패해도 클러스터링은 계속)
+            try {
+                clusterLifecycleService.deactivateExpiredClusters();
+            } catch (Exception e) {
+                log.error("클러스터 비활성화 실패 (클러스터링은 계속 진행): {}", e.getMessage(), e);
+            }
+            // 2. 미배정 기사 클러스터링
+            clusteringService.clusterPendingArticles();
+            return true;
+        } finally {
+            running.set(false); // 배치 종료 시 락 해제
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 클러스터링 배치 종료 ({}ms) ===", elapsed);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -60,7 +60,7 @@ public class NewsCluster extends BaseEntity {
     private SummaryStatus summaryStatus = SummaryStatus.PENDING;
 
     // 클러스터의 중심점, 소속 기사들의 임베딩 벡터를 평균 낸 값
-    @Column(name = "centroid_vector", columnDefinition = "vector(1536)")
+    @Column(name = "centroid_vector", columnDefinition = "float8[]")
     private float[] centroidVector;
 
     @Column(name = "article_count", nullable = false)

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -4,21 +4,18 @@ import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> {
 
     /**
-     * 특정 상태의 클러스터를 조회한다.
-     * 새 기사 매칭 시 ACTIVE 클러스터 목록 조회에 사용.
-     *
-     * <p>MVP에서는 ACTIVE 전체를 메모리로 가져와 유사도 비교하는 단순 구조.
-     * 클러스터 수가 증가하면 후보군 축소가 필요하다:</p>
-     * <ul>
-     *     <li>최근 24시간 생성 클러스터만 조회</li>
-     *     <li>category/topic 기준 pre-filter</li>
-     *     <li>pgvector 기반 nearest neighbor 후보 조회</li>
-     * </ul>
+     * 특정 상태의 클러스터 목록을 조회한다.
      */
     List<NewsCluster> findByStatus(ClusterStatus status);
+
+    /**
+     * 특정 상태이면서, 마지막 갱신 시각이 기준 시각 이전인 클러스터를 조회한다.
+     */
+    List<NewsCluster> findByStatusAndUpdatedAtBefore(ClusterStatus status, OffsetDateTime before);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterLifecycleService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterLifecycleService.java
@@ -1,0 +1,59 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 클러스터 라이프사이클 관리 서비스
+ *
+ * 오래된 클러스터를 자동으로 비활성화한다.
+ *
+ * [비활성화 기준]
+ * - 마지막 갱신(updatedAt) 이후 24시간 동안 변화가 없는 경우
+ *
+ * [동작]
+ * - ACTIVE → INACTIVE 전환 (더 이상 최신 트렌드로 간주하지 않음)
+ *
+ * [데이터 정책]
+ * - INACTIVE 클러스터는 피드에서 제외되지만,
+ *   데이터는 삭제하지 않고 유지한다 (읽음 기록, 사용자 피드백 보존)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClusterLifecycleService {
+
+    private static final int INACTIVE_HOURS = 24; // 비활성화 기준 경과 시간
+
+    private final NewsClusterRepository newsClusterRepository;
+
+    /**
+     * 마지막 갱신 후 24시간이 지난 ACTIVE 클러스터를 비활성화한다.
+     */
+    @Transactional
+    public void deactivateExpiredClusters() {
+        OffsetDateTime cutoff = OffsetDateTime.now().minusHours(INACTIVE_HOURS); // 현재 시각에서 24시간 전
+
+        List<NewsCluster> expired = newsClusterRepository
+                .findByStatusAndUpdatedAtBefore(ClusterStatus.ACTIVE, cutoff); // updatedAt < cutoff인 ACTIVE 클러스터 조회
+
+        if (expired.isEmpty()) {
+            return;
+        }
+
+        // INACTIVE로 상태 변경
+        for (NewsCluster cluster : expired) {
+            cluster.deactivate();
+        }
+
+        log.info("클러스터 비활성화 완료 — {}건 INACTIVE 전환", expired.size());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMatchingService.java
@@ -131,7 +131,7 @@ public class ClusterMatchingService {
      *
      * @return -1.0 ~ 1.0 사이의 유사도 값
      */
-    public double cosineSimilarity(float[] a, float[] b) {
+    double cosineSimilarity(float[] a, float[] b) {
         if (a == null || b == null || a.length != b.length) {
             return 0.0;
         }

--- a/src/main/java/com/solv/wefin/domain/news/embedding/entity/ArticleEmbedding.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/entity/ArticleEmbedding.java
@@ -39,7 +39,7 @@ public class ArticleEmbedding extends BaseEntity {
     @Column(name = "token_count", nullable = false)
     private int tokenCount;
 
-    @Column(name = "embedding", nullable = false, columnDefinition = "vector(1536)")
+    @Column(name = "embedding", nullable = false, columnDefinition = "float8[]")
     private float[] embedding;
 
     @Builder

--- a/src/main/java/com/solv/wefin/web/news/ClusteringAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/ClusteringAdminController.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.news;
+
+import com.solv.wefin.domain.news.cluster.batch.ClusteringScheduler;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/api/admin/news/clustering")
+@RequiredArgsConstructor
+public class ClusteringAdminController {
+
+    private final ClusteringScheduler clusteringScheduler;
+
+    /**
+     * 클러스터링을 수동으로 트리거한다.
+     */
+    @PostMapping("/trigger")
+    public ApiResponse<String> triggerClustering() {
+        boolean executed = clusteringScheduler.execute();
+        if (!executed) {
+            throw new BusinessException(ErrorCode.CLUSTERING_ALREADY_RUNNING);
+        }
+        return ApiResponse.success("클러스터링 배치 실행 완료");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -50,6 +50,10 @@ tagging:
   collect:
     cron: "0 */30 * * * *"
 
+clustering:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -51,6 +51,10 @@ tagging:
   collect:
     cron: ${TAGGING_COLLECT_CRON:-}
 
+clustering:
+  collect:
+    cron: ${CLUSTERING_COLLECT_CRON:-}
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -47,6 +47,10 @@ tagging:
   collect:
     cron: "0 */30 * * * *"
 
+clustering:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,18 @@ tagging:
   collect:
     cron: "0 */30 * * * *"
 
+clustering:
+  threshold: 0.80
+  sample-k: 5
+  penalty:
+    category-mismatch: 15
+    stocks-no-overlap: 20
+  score:
+    reject-cutoff: 70
+    suspicious-cutoff: 80
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/db/migration/V18__change_centroid_vector_to_float_array.sql
+++ b/src/main/resources/db/migration/V18__change_centroid_vector_to_float_array.sql
@@ -1,0 +1,12 @@
+-- vector → float8[] 변경
+-- Hibernate가 vector 타입 읽기/쓰기 시 타입 변환 실패하는 문제 해결
+-- cosine similarity를 Java 코드에서 계산하므로 pgvector 타입이 불필요
+
+-- news_cluster.centroid_vector: vector → float8[]
+ALTER TABLE news_cluster DROP COLUMN IF EXISTS centroid_vector;
+ALTER TABLE news_cluster ADD COLUMN centroid_vector float8[];
+
+-- article_embedding.embedding: vector → float8[] (text 경유 변환)
+ALTER TABLE article_embedding
+    ALTER COLUMN embedding TYPE float8[]
+    USING (string_to_array(trim(both '[]' from embedding::text), ','))::float8[];

--- a/src/test/java/com/solv/wefin/domain/news/cluster/batch/ClusteringSchedulerTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/batch/ClusteringSchedulerTest.java
@@ -1,0 +1,75 @@
+package com.solv.wefin.domain.news.cluster.batch;
+
+import com.solv.wefin.domain.news.cluster.service.ClusterLifecycleService;
+import com.solv.wefin.domain.news.cluster.service.ClusteringService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClusteringSchedulerTest {
+
+    @InjectMocks
+    private ClusteringScheduler clusteringScheduler;
+
+    @Mock
+    private ClusteringService clusteringService;
+
+    @Mock
+    private ClusterLifecycleService clusterLifecycleService;
+
+    @Test
+    @DisplayName("정상 실행 시 비활성화 후 클러스터링을 수행한다")
+    void execute_success() {
+        // when
+        boolean result = clusteringScheduler.execute();
+
+        // then
+        assertThat(result).isTrue();
+        verify(clusterLifecycleService).deactivateExpiredClusters();
+        verify(clusteringService).clusterPendingArticles();
+    }
+
+    @Test
+    @DisplayName("비활성화 실패 시에도 클러스터링은 계속 진행한다")
+    void execute_lifecycleFails_clusteringContinues() {
+        // given
+        doThrow(new RuntimeException("비활성화 실패"))
+                .when(clusterLifecycleService).deactivateExpiredClusters();
+
+        // when
+        boolean result = clusteringScheduler.execute();
+
+        // then
+        assertThat(result).isTrue();
+        verify(clusteringService).clusterPendingArticles();
+    }
+
+    @Test
+    @DisplayName("중복 실행 시 false를 반환한다")
+    void execute_alreadyRunning() throws InterruptedException {
+        // given — 첫 번째 실행을 느리게 만듦
+        doAnswer(invocation -> {
+            Thread.sleep(200);
+            return null;
+        }).when(clusteringService).clusterPendingArticles();
+
+        // when — 동시에 두 번 실행
+        Thread thread1 = new Thread(() -> clusteringScheduler.execute());
+        thread1.start();
+        Thread.sleep(50); // 첫 번째가 시작된 후
+
+        boolean secondResult = clusteringScheduler.execute();
+
+        thread1.join();
+
+        // then
+        assertThat(secondResult).isFalse();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterLifecycleServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterLifecycleServiceTest.java
@@ -1,0 +1,64 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterLifecycleServiceTest {
+
+    @InjectMocks
+    private ClusterLifecycleService clusterLifecycleService;
+
+    @Mock
+    private NewsClusterRepository newsClusterRepository;
+
+    @Test
+    @DisplayName("만료 대상이 있으면 INACTIVE로 전환한다")
+    void deactivateExpiredClusters_success() {
+        // given
+        float[] vector = {1.0f, 0.0f, 0.0f};
+        NewsCluster cluster = NewsCluster.createSingle(vector, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", 1L);
+
+        given(newsClusterRepository.findByStatusAndUpdatedAtBefore(eq(ClusterStatus.ACTIVE), any()))
+                .willReturn(List.of(cluster));
+
+        // when
+        clusterLifecycleService.deactivateExpiredClusters();
+
+        // then
+        assertThat(cluster.getStatus()).isEqualTo(ClusterStatus.INACTIVE);
+    }
+
+    @Test
+    @DisplayName("만료 대상이 없으면 아무것도 하지 않는다")
+    void deactivateExpiredClusters_noExpired() {
+        // given
+        given(newsClusterRepository.findByStatusAndUpdatedAtBefore(eq(ClusterStatus.ACTIVE), any()))
+                .willReturn(List.of());
+
+        // when
+        clusterLifecycleService.deactivateExpiredClusters();
+
+        // then
+        verify(newsClusterRepository, never()).saveAll(any());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterMatchingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterMatchingServiceTest.java
@@ -1,0 +1,120 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterMatchingServiceTest {
+
+    @InjectMocks
+    private ClusterMatchingService clusterMatchingService;
+
+    @Mock
+    private NewsClusterArticleRepository clusterArticleRepository;
+
+    @Mock
+    private ArticleVectorService articleVectorService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(clusterMatchingService, "threshold", 0.80);
+        ReflectionTestUtils.setField(clusterMatchingService, "sampleK", 5);
+    }
+
+    @Test
+    @DisplayName("centroid 유사도가 threshold 이상이면 매칭 성공")
+    void findBestMatch_success() {
+        // given
+        float[] articleVector = {1.0f, 0.0f, 0.0f};
+        float[] centroid = {0.9f, 0.1f, 0.0f};
+
+        NewsCluster cluster = NewsCluster.createSingle(centroid, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", 1L);
+
+        given(clusterArticleRepository.findByNewsClusterIdOrderByCreatedAtDesc(eq(1L), any()))
+                .willReturn(List.of());
+
+        // when
+        Optional<ClusterMatchingService.MatchResult> result =
+                clusterMatchingService.findBestMatch(articleVector, List.of(cluster));
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().cluster()).isEqualTo(cluster);
+        assertThat(result.get().similarity()).isGreaterThanOrEqualTo(0.80);
+    }
+
+    @Test
+    @DisplayName("centroid 유사도가 threshold 미만이면 매칭 실패")
+    void findBestMatch_belowThreshold() {
+        // given
+        float[] articleVector = {1.0f, 0.0f, 0.0f};
+        float[] centroid = {0.0f, 1.0f, 0.0f}; // 직교 → 유사도 0
+
+        NewsCluster cluster = NewsCluster.createSingle(centroid, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", 1L);
+
+        // when
+        Optional<ClusterMatchingService.MatchResult> result =
+                clusterMatchingService.findBestMatch(articleVector, List.of(cluster));
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 클러스터가 없으면 매칭 실패")
+    void findBestMatch_emptyClusters() {
+        // given
+        float[] articleVector = {1.0f, 0.0f, 0.0f};
+
+        // when
+        Optional<ClusterMatchingService.MatchResult> result =
+                clusterMatchingService.findBestMatch(articleVector, List.of());
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 클러스터 중 가장 유사한 클러스터를 반환한다")
+    void findBestMatch_selectsBestCluster() {
+        // given
+        float[] articleVector = {1.0f, 0.0f, 0.0f};
+        float[] centroid1 = {0.85f, 0.15f, 0.0f}; // 유사도 높음
+        float[] centroid2 = {0.95f, 0.05f, 0.0f}; // 유사도 더 높음
+
+        NewsCluster cluster1 = NewsCluster.createSingle(centroid1, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster1, "id", 1L);
+        NewsCluster cluster2 = NewsCluster.createSingle(centroid2, 2L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster2, "id", 2L);
+
+        given(clusterArticleRepository.findByNewsClusterIdOrderByCreatedAtDesc(any(), any()))
+                .willReturn(List.of());
+
+        // when
+        Optional<ClusterMatchingService.MatchResult> result =
+                clusterMatchingService.findBestMatch(articleVector, List.of(cluster1, cluster2));
+
+        // then
+        assertThat(result).isPresent();
+        assertThat(result.get().cluster()).isEqualTo(cluster2);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusteringServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusteringServiceTest.java
@@ -1,0 +1,222 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService.MatchResult;
+import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.ScoreResult;
+import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.Verdict;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClusteringServiceTest {
+
+    @InjectMocks
+    private ClusteringService clusteringService;
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+
+    @Mock
+    private NewsClusterRepository newsClusterRepository;
+
+    @Mock
+    private ArticleVectorService articleVectorService;
+
+    @Mock
+    private ClusterMatchingService clusterMatchingService;
+
+    @Mock
+    private SuspiciousScoringService suspiciousScoringService;
+
+    @Mock
+    private ClusteringPersistenceService persistenceService;
+
+    private NewsArticle createArticle(Long id) {
+        NewsArticle article = NewsArticle.builder()
+                .rawNewsArticleId(1L)
+                .publisherName("테스트")
+                .title("테스트 기사 " + id)
+                .originalUrl("https://example.com/" + id)
+                .build();
+        ReflectionTestUtils.setField(article, "id", id);
+        ReflectionTestUtils.setField(article, "embeddingStatus", NewsArticle.EmbeddingStatus.SUCCESS);
+        return article;
+    }
+
+    @Test
+    @DisplayName("매칭 성공 시 기존 클러스터에 추가한다")
+    void clusterPendingArticles_matched() {
+        // given
+        NewsArticle article = createArticle(1L);
+        float[] vector = {1.0f, 0.0f, 0.0f};
+
+        NewsCluster cluster = NewsCluster.createSingle(vector, 99L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", 10L);
+
+        given(newsArticleRepository.findClusteringTargets(any(), any(), any()))
+                .willReturn(List.of(article));
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE))
+                .willReturn(new ArrayList<>(List.of(cluster)));
+        given(articleVectorService.calculateRepresentativeVector(1L))
+                .willReturn(vector);
+        given(clusterMatchingService.findBestMatch(any(), any()))
+                .willReturn(Optional.of(new MatchResult(cluster, 0.95)));
+        given(suspiciousScoringService.score(1L, 10L))
+                .willReturn(new ScoreResult(100, Verdict.NORMAL));
+
+        // when
+        clusteringService.clusterPendingArticles();
+
+        // then
+        verify(clusterMatchingService).clearCache();
+        verify(persistenceService).addToCluster(eq(cluster), eq(article), eq(vector), eq(false));
+        verify(persistenceService, never()).createSingleCluster(any(), any());
+    }
+
+    @Test
+    @DisplayName("매칭 실패 시 새 단독 클러스터를 생성한다")
+    void clusterPendingArticles_created() {
+        // given
+        NewsArticle article = createArticle(1L);
+        float[] vector = {1.0f, 0.0f, 0.0f};
+
+        NewsCluster newCluster = NewsCluster.createSingle(vector, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(newCluster, "id", 20L);
+
+        given(newsArticleRepository.findClusteringTargets(any(), any(), any()))
+                .willReturn(List.of(article));
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE))
+                .willReturn(new ArrayList<>());
+        given(articleVectorService.calculateRepresentativeVector(1L))
+                .willReturn(vector);
+        given(clusterMatchingService.findBestMatch(any(), any()))
+                .willReturn(Optional.empty());
+        given(persistenceService.createSingleCluster(article, vector))
+                .willReturn(newCluster);
+
+        // when
+        clusteringService.clusterPendingArticles();
+
+        // then
+        verify(persistenceService).createSingleCluster(article, vector);
+        verify(persistenceService, never()).addToCluster(any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("태그 scoring REJECT 시 새 단독 클러스터를 생성한다")
+    void clusterPendingArticles_rejectedByScoring() {
+        // given
+        NewsArticle article = createArticle(1L);
+        float[] vector = {1.0f, 0.0f, 0.0f};
+
+        NewsCluster cluster = NewsCluster.createSingle(vector, 99L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", 10L);
+
+        NewsCluster newCluster = NewsCluster.createSingle(vector, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(newCluster, "id", 20L);
+
+        given(newsArticleRepository.findClusteringTargets(any(), any(), any()))
+                .willReturn(List.of(article));
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE))
+                .willReturn(new ArrayList<>(List.of(cluster)));
+        given(articleVectorService.calculateRepresentativeVector(1L))
+                .willReturn(vector);
+        given(clusterMatchingService.findBestMatch(any(), any()))
+                .willReturn(Optional.of(new MatchResult(cluster, 0.85)));
+        given(suspiciousScoringService.score(1L, 10L))
+                .willReturn(new ScoreResult(60, Verdict.REJECT));
+        given(persistenceService.createSingleCluster(article, vector))
+                .willReturn(newCluster);
+
+        // when
+        clusteringService.clusterPendingArticles();
+
+        // then
+        verify(persistenceService).createSingleCluster(article, vector);
+        verify(persistenceService, never()).addToCluster(any(), any(), any(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("태그 scoring SUSPICIOUS 시 suspicious 플래그와 함께 추가한다")
+    void clusterPendingArticles_suspicious() {
+        // given
+        NewsArticle article = createArticle(1L);
+        float[] vector = {1.0f, 0.0f, 0.0f};
+
+        NewsCluster cluster = NewsCluster.createSingle(vector, 99L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", 10L);
+
+        given(newsArticleRepository.findClusteringTargets(any(), any(), any()))
+                .willReturn(List.of(article));
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE))
+                .willReturn(new ArrayList<>(List.of(cluster)));
+        given(articleVectorService.calculateRepresentativeVector(1L))
+                .willReturn(vector);
+        given(clusterMatchingService.findBestMatch(any(), any()))
+                .willReturn(Optional.of(new MatchResult(cluster, 0.85)));
+        given(suspiciousScoringService.score(1L, 10L))
+                .willReturn(new ScoreResult(75, Verdict.SUSPICIOUS));
+
+        // when
+        clusteringService.clusterPendingArticles();
+
+        // then
+        verify(persistenceService).addToCluster(eq(cluster), eq(article), eq(vector), eq(true));
+    }
+
+    @Test
+    @DisplayName("벡터가 없는 기사는 SKIPPED 처리한다")
+    void clusterPendingArticles_skippedNoVector() {
+        // given
+        NewsArticle article = createArticle(1L);
+
+        given(newsArticleRepository.findClusteringTargets(any(), any(), any()))
+                .willReturn(List.of(article));
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE))
+                .willReturn(new ArrayList<>());
+        given(articleVectorService.calculateRepresentativeVector(1L))
+                .willReturn(null);
+
+        // when
+        clusteringService.clusterPendingArticles();
+
+        // then
+        verify(persistenceService, never()).addToCluster(any(), any(), any(), anyBoolean());
+        verify(persistenceService, never()).createSingleCluster(any(), any());
+    }
+
+    @Test
+    @DisplayName("대상 기사가 없으면 아무것도 실행하지 않는다")
+    void clusterPendingArticles_noTargets() {
+        // given
+        given(newsArticleRepository.findClusteringTargets(any(), any(), any()))
+                .willReturn(List.of());
+
+        // when
+        clusteringService.clusterPendingArticles();
+
+        // then
+        verify(newsClusterRepository, never()).findByStatus(any());
+        verify(persistenceService, never()).addToCluster(any(), any(), any(), anyBoolean());
+        verify(persistenceService, never()).createSingleCluster(any(), any());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -48,3 +48,15 @@ embedding:
 tagging:
   collect:
     cron: "-"
+
+clustering:
+  threshold: 0.80
+  sample-k: 5
+  penalty:
+    category-mismatch: 15
+    stocks-no-overlap: 20
+  score:
+    reject-cutoff: 70
+    suspicious-cutoff: 80
+  collect:
+    cron: "-"


### PR DESCRIPTION
## 📌 PR 설명
클러스터링 파이프라인 내에서 오래된 클러스터가 자동으로 피드에서 제외되도록 시스템을 구성했습니다.
30분 주기로 새 기사를 기존 클러스터에 매칭하고, 24시간 동안 추가 기사가 없는 클러스터는 비활성화하여 오늘 금융 동향 서비스에 맞는 라이프사이클을 구현했습니다. 또한 배치 실행 과정에서 발생한 Hibernate–pgvector 타입 호환 문제를 분석하고, 불필요한 vector 타입 대신 PostgreSQL 네이티브 배열인 float8[]로 전환하여 해결했습니다.

- 30분 간격 배치 스케줄러 (AtomicBoolean 중복 실행 방지)
- 24시간 INACTIVE 전환 (updatedAt 기준 — 새 기사가 안 들어온 클러스터만 비활성화)
- 수동 트리거 Admin API (@Profile local, dev)
- 클러스터링 전체 설정 yml 추가 (threshold, sample-k, penalty, cron)
- vector → float8[] 타입 변경 (Hibernate가 pgvector vector 타입 읽기/쓰기 실패 → PostgreSQL 네이티브 배열로 전환하여 해결)

<br>

## ✅ 변경 파일

1. `ClusterLifecycleService.java` — 24시간 INACTIVE 전환 (updatedAt 기준)
2. `ClusteringScheduler.java` — 30분 배치 (비활성화 → 클러스터링, 장애 격리)
3. `ClusteringAdminController.java` — 수동 트리거
4. `NewsClusterRepository.java` — findByStatusAndUpdatedAtBefore 추가 (modified)
5. `V18__change_centroid_vector_to_float_array.sql` — vector → float8[] 마이그레이션
6. `NewsCluster.java` — centroidVector columnDefinition float8[] (modified)
7. `ArticleEmbedding.java` — embedding columnDefinition float8[] (modified)
8. `application.yml` — clustering 설정 전체 (modified)
9. `application-local.yml` — cron 비활성화 (modified)
10. `application-dev.yml` — cron 30분 설정 (modified)
11. `application-prod.yml` — cron 30분 설정 (modified)
12. `application-test.yml` — 테스트 설정 (modified)
13. `ClusterLifecycleServiceTest.java` — 비활성화 테스트 2건
14. `ClusteringSchedulerTest.java` — 스케줄러 테스트 3건
15. `ClusterMatchingServiceTest.java` — 매칭 테스트 4건
16. `ClusteringServiceTest.java` — 전체 흐름 테스트 6건

<br>

## 📸 스크린샷
<img width="1114" height="535" alt="image" src="https://github.com/user-attachments/assets/fc780e2e-6138-4de2-83c9-da845268d16b" />


<br>

## 💭 고민과 해결과정

### 1. 비활성화 기준 — createdAt이 아닌 updatedAt
처음에는 `createdAt` 기준으로 24시간이 지나면 클러스터를 비활성화하려고 했습니다. 하지만 클러스터는 생성된 이후에도 계속 새로운 기사가 추가될 수 있기 때문에, `createdAt` 기준은 적절하지 않다고 판단했습니다. 
예를 들어, 24시간 전에 생성됐지만 5분 전에 새 기사가 들어온 클러스터도 비활성화되는 문제가 발생합니다. 그래서 마지막으로 갱신된 시각인 `updatedAt`을 기준으로 변경했습니다. `updatedAt`은 `@LastModifiedDate`로 관리되어 기사 추가 시 자동으로 갱신되기 때문에, 결과적으로 24시간 동안 새 기사가 들어오지 않은 클러스터만 비활성화할 수 있게 되었습니다.

### 2. 비활성화 실패 시 클러스터링 계속 진행
스케줄러에서는 클러스터 비활성화, 미배정 기사 클러스터링을 순서대로 실행합니다.
이때 비활성화는 보조적인 관리 작업이라고 판단하여, 비활성화 과정에서 오류가 발생하더라도 전체 클러스터링 작업이 중단되지 않도록 처리했습니다.이를 위해 try-catch로 예외를 분리하여, 비활성화 실패와 클러스터링 로직을 분리했습니다.

### 3. AtomicBoolean 한계
현재는 단일 인스턴스 운영 기준으로 `AtomicBoolean`을 적용했습니다. 다중 인스턴스 확장 시 ShedLock/DB Lock 기반으로 전환 예정이며, 기존 파이프라인(수집/크롤링/임베딩/태깅)과 함께 일괄 전환할 계획입니다.

### 4. dirty checking으로 saveAll 제거
`ClusterLifecycleService.deactivateExpiredClusters()`에서 `@Transactional` 내 영속 상태 엔티티의 상태 변경은 JPA dirty checking으로 자동 반영됩니다. 명시적 `saveAll()` 호출을 제거하여 불필요한 중복 저장을 방지했습니다.

### 5. vector → float8[] 타입 변경 (트러블슈팅)
클러스터링 배치를 실행하는 과정에서 모든 기사에 대해 `PSQLException: No results were returned by the query` 에러가 발생했습니다. 원인을 확인해보니, Hibernate가 PostgreSQL의 `vector` 타입을 Java의 `float[]`로 변환하는 과정에서 타입 매핑에 실패하고 있었습니다. 처음에는 이를 해결하기 위해 pgvector-java 라이브러리를 적용해봤지만, 오히려 기존에 정상 동작하던 `ArticleEmbedding` 조회까지 깨지는 문제가 발생했습니다. 그래서 구조를 다시 살펴보니 현재 시스템에서는 cosine similarity를 DB가 아닌 Java 코드에서 직접 계산하고 있어서 굳이 pgvector의 `vector` 타입을 사용할 필요가 없다는 걸 확인했습니다. 이후 컬럼 타입을 PostgreSQL의 네이티브 배열 타입인 `float8[]`로 변경했고, Hibernate의 기본 타입 매핑을 활용해 별도 설정 없이 문제를 해결했습니다.

<br>

### 🔗 관련 이슈
Closes #112

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 뉴스 자동 클러스터링 기능 추가: 30분마다 자동으로 실행
  * 관리자용 수동 클러스터링 트리거 엔드포인트 추가
  * 24시간 미사용 클러스터 자동 비활성화 기능 추가

* **Chores**
  * 클러스터링 관련 설정 추가
  * 벡터 저장소 형식 데이터베이스 마이그레이션

<!-- end of auto-generated comment: release notes by coderabbit.ai -->