### PR TITLE
[WEF-528] 클러스터 단위 AI 요약 생성 파이프라인 구축

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -206,11 +206,11 @@ public class NewsCluster extends BaseEntity {
     /**
      * 이상치 제거 후 클러스터 집계 상태를 재계산한다.
      *
-     * @param newArticleCount 남은 기사 수
+     * @param newArticleCount 남은 기사 수 (0일 수 있음)
      * @param newCentroid 재계산된 centroid (남은 기사 없으면 null)
-     * @param newRepresentativeArticleId 새 대표 기사 ID (null이면 변경 안 함)
-     * @param newPublishedAt 새 대표 기사 발행 시각
-     * @param newThumbnailUrl 새 대표 기사 썸네일
+     * @param newRepresentativeArticleId 새 대표 기사 ID (남은 기사 없으면 null — 초기화)
+     * @param newPublishedAt 새 대표 기사 발행 시각 (남은 기사 없으면 null)
+     * @param newThumbnailUrl 새 대표 기사 썸네일 (없거나 blank면 null로 초기화)
      */
     public void recalculateAfterOutlierRemoval(int newArticleCount, float[] newCentroid,
                                                 Long newRepresentativeArticleId,
@@ -218,13 +218,9 @@ public class NewsCluster extends BaseEntity {
                                                 String newThumbnailUrl) {
         this.articleCount = newArticleCount;
         this.centroidVector = newCentroid != null ? newCentroid.clone() : null;
-
-        if (newRepresentativeArticleId != null) {
-            this.representativeArticleId = newRepresentativeArticleId;
-            this.publishedAt = newPublishedAt;
-            if (newThumbnailUrl != null && !newThumbnailUrl.isBlank()) {
-                this.thumbnailUrl = newThumbnailUrl;
-            }
-        }
+        this.representativeArticleId = newRepresentativeArticleId;
+        this.publishedAt = newPublishedAt;
+        this.thumbnailUrl = (newThumbnailUrl != null && !newThumbnailUrl.isBlank())
+                ? newThumbnailUrl : null;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -202,4 +202,29 @@ public class NewsCluster extends BaseEntity {
     public void markSummaryFailed() {
         this.summaryStatus = SummaryStatus.FAILED;
     }
+
+    /**
+     * 이상치 제거 후 클러스터 집계 상태를 재계산한다.
+     *
+     * @param newArticleCount 남은 기사 수
+     * @param newCentroid 재계산된 centroid (남은 기사 없으면 null)
+     * @param newRepresentativeArticleId 새 대표 기사 ID (null이면 변경 안 함)
+     * @param newPublishedAt 새 대표 기사 발행 시각
+     * @param newThumbnailUrl 새 대표 기사 썸네일
+     */
+    public void recalculateAfterOutlierRemoval(int newArticleCount, float[] newCentroid,
+                                                Long newRepresentativeArticleId,
+                                                OffsetDateTime newPublishedAt,
+                                                String newThumbnailUrl) {
+        this.articleCount = newArticleCount;
+        this.centroidVector = newCentroid != null ? newCentroid.clone() : null;
+
+        if (newRepresentativeArticleId != null) {
+            this.representativeArticleId = newRepresentativeArticleId;
+            this.publishedAt = newPublishedAt;
+            if (newThumbnailUrl != null && !newThumbnailUrl.isBlank()) {
+                this.thumbnailUrl = newThumbnailUrl;
+            }
+        }
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -18,4 +18,10 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
      * 특정 상태이면서, 마지막 갱신 시각이 기준 시각 이전인 클러스터를 조회한다.
      */
     List<NewsCluster> findByStatusAndUpdatedAtBefore(ClusterStatus status, OffsetDateTime before);
+
+    /**
+     * ACTIVE 클러스터 중 요약 생성이 필요한 클러스터를 조회한다.
+     * INACTIVE 클러스터는 피드에서 제외되었으므로 요약 대상에서 제외.
+     */
+    List<NewsCluster> findByStatusAndSummaryStatusIn(ClusterStatus status, List<NewsCluster.SummaryStatus> statuses);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.news.cluster.repository;
 
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.OffsetDateTime;
@@ -21,7 +22,8 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
 
     /**
      * ACTIVE 클러스터 중 요약 생성이 필요한 클러스터를 조회한다.
-     * INACTIVE 클러스터는 피드에서 제외되었으므로 요약 대상에서 제외.
      */
-    List<NewsCluster> findByStatusAndSummaryStatusIn(ClusterStatus status, List<NewsCluster.SummaryStatus> statuses);
+    List<NewsCluster> findByStatusAndSummaryStatusIn(ClusterStatus status,
+                                                     List<NewsCluster.SummaryStatus> statuses,
+                                                     Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMatchingService.java
@@ -131,7 +131,7 @@ public class ClusterMatchingService {
      *
      * @return -1.0 ~ 1.0 사이의 유사도 값
      */
-    double cosineSimilarity(float[] a, float[] b) {
+    public double cosineSimilarity(float[] a, float[] b) {
         if (a == null || b == null || a.length != b.length) {
             return 0.0;
         }

--- a/src/main/java/com/solv/wefin/domain/news/config/OpenAiConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/OpenAiConfig.java
@@ -23,4 +23,12 @@ public class OpenAiConfig {
         factory.setReadTimeout(60000);
         return new RestTemplate(factory);
     }
+
+    @Bean
+    public RestTemplate summaryRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(10000);
+        factory.setReadTimeout(90000);
+        return new RestTemplate(factory);
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/news/config/dto/OpenAiChatApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/dto/OpenAiChatApiResponse.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.domain.news.config.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * OpenAI Chat Completions API 공통 응답 DTO
+ */
+@Getter
+public class OpenAiChatApiResponse {
+    private List<Choice> choices; //  생성된 응답 후보 목록 (현재는 하나의 응답만 사용)
+
+    @Getter
+    public static class Choice {
+        private Message message; // 하나의 응답 단위
+    }
+
+    @Getter
+    public static class Message {
+        private String content; // 실제 생성된 텍스트
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/batch/SummaryScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/batch/SummaryScheduler.java
@@ -1,0 +1,59 @@
+package com.solv.wefin.domain.news.summary.batch;
+
+import com.solv.wefin.domain.news.summary.service.SummaryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * AI 요약 생성 배치 스케줄러
+ *
+ * 30분 간격으로 ACTIVE 클러스터 중 요약 생성이 필요한(PENDING/STALE/FAILED) 클러스터의 요약을 생성한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SummaryScheduler {
+
+    private final SummaryService summaryService;
+    private final AtomicBoolean running = new AtomicBoolean(false); // 중복 실행 방지
+
+    @Scheduled(cron = "${summary.collect.cron:0 */30 * * * *}")
+    public void generateSummaries() {
+        try {
+            execute();
+        } catch (Exception e) {
+            log.error("요약 생성 배치 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 요약 생성을 실행한다.
+     *
+     * @return 이미 실행 중이면 false, 정상 실행되면 true
+     */
+    public boolean execute() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("요약 생성이 이미 실행 중입니다. 스킵합니다.");
+            return false;
+        }
+
+        log.info("=== 요약 생성 배치 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            summaryService.generatePendingSummaries();
+            return true;
+        } catch (Exception e) {
+            log.error("요약 생성 실행 실패: {}", e.getMessage(), e);
+            throw e;
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 요약 생성 배치 종료 ({}ms) ===", elapsed);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiClientException.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiClientException.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.news.summary.client;
+
+import org.springframework.http.HttpStatusCode;
+
+/**
+ * OpenAI Chat API 호출 자체의 실패(HTTP 오류, 네트워크 장애)를 나타내는 예외
+ * 호출자가 재시도 가능한 transient 오류인지 exception 타입만으로 판단할 수 있게 한다.
+ */
+public class OpenAiClientException extends RuntimeException {
+
+    private final HttpStatusCode statusCode;
+
+    public OpenAiClientException(String message, HttpStatusCode statusCode, Throwable cause) {
+        super(message, cause);
+        this.statusCode = statusCode;
+    }
+
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.List;
@@ -104,7 +106,19 @@ public class OpenAiSummaryClient {
         );
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
-        OpenAiChatApiResponse response = restTemplate.postForObject(OPENAI_CHAT_URL, request, OpenAiChatApiResponse.class);
+
+        OpenAiChatApiResponse response;
+        try {
+            response = restTemplate.postForObject(OPENAI_CHAT_URL, request, OpenAiChatApiResponse.class);
+        } catch (HttpStatusCodeException e) {
+            throw new OpenAiClientException(
+                    "OpenAI Summary API HTTP 오류: " + e.getStatusCode(),
+                    e.getStatusCode(), e);
+        } catch (RestClientException e) {
+            throw new OpenAiClientException(
+                    "OpenAI Summary API 호출 실패: " + e.getMessage(),
+                    null, e);
+        }
 
         if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
             throw new IllegalStateException("OpenAI Summary API 응답이 비어있습니다");

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -1,0 +1,144 @@
+package com.solv.wefin.domain.news.summary.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.news.config.dto.OpenAiChatApiResponse;
+import com.solv.wefin.domain.news.summary.dto.SummaryResult;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * OpenAI Chat Completions API를 호출하여 클러스터 요약을 생성한다.
+ *
+ * 한 클러스터에 묶인 여러 기사를 종합하여 하나의 title + summary 브리핑을 만든다.
+ * 프롬프트에서 팩트, 분석, 전망, 영향 등을 다각도에서 정리하도록 유도한다.
+ */
+@Component
+public class OpenAiSummaryClient {
+    private static final String OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
+
+    private static final int MAX_ARTICLE_LENGTH = 2000;
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 금융 뉴스 전문 에디터입니다.
+            여러 관련 기사를 종합하여 하나의 브리핑을 작성하세요.
+            
+            작성 규칙:
+            1. title: 핵심 이슈를 한 줄로 요약 (50자 이내, 한글)
+            2. summary: 여러 기사를 종합한 브리핑 (200~400자, 한글)
+               - 가능하면 다음 구조를 포함:
+                 · 팩트: 무슨 일이 일어났는가
+                 · 분석/원인: 왜 일어났는가
+                 · 전망: 앞으로 어떻게 될 것인가
+                 · 영향/파급: 투자자에게 어떤 의미인가
+               - 모든 항목이 없어도 괜찮음. 기사에 있는 내용만 작성
+               - 개별 기사를 나열하지 말고 하나의 스토리로 엮을 것
+            
+            반드시 아래 JSON 형식으로만 응답하세요:
+            {
+              "title": "엔비디아 급락, 반도체주 동반 하락",
+              "summary": "미국 증시에서 엔비디아 주가가 10% 넘게 급락하며..."
+            }
+            """;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String apiKey;
+    private final String model;
+
+    public OpenAiSummaryClient(@Qualifier("summaryRestTemplate") RestTemplate restTemplate,
+                               ObjectMapper objectMapper,
+                               @Value("${openai.api-key}") String apiKey,
+                               @Value("${openai.summary.model}") String model) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+        this.apiKey = apiKey;
+        this.model = model;
+    }
+
+    /**
+     * 클러스터 소속 기사들을 종합하여 title + summary를 생성한다.
+     *
+     * @param articles 기사 목록 ("제목: ...\n본문: ...")
+     * @return 생성된 title + summary
+     */
+    public SummaryResult generateSummary(List<String> articles) {
+        // 기사 목록을 하나의 user 메시지로 직렬화
+        // 기사 경계를 "--- 기사 N ---"으로 구분
+        String userMessage = buildUserMessage(articles);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        /**
+         *  response_format=json_object:
+         *  → 모델이 반드시 유효한 JSON만 반환하도록 강제
+         *
+         *  messages 구성:
+         *  → system: 역할/작성 규칙 정의
+         *  → user: 기사 원문 전달
+         */
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "response_format", Map.of("type", "json_object"),
+                "messages", List.of(
+                        Map.of("role", "system", "content", SYSTEM_PROMPT),
+                        Map.of("role", "user", "content", userMessage)
+                )
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+        OpenAiChatApiResponse response = restTemplate.postForObject(OPENAI_CHAT_URL, request, OpenAiChatApiResponse.class);
+
+        if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
+            throw new IllegalStateException("OpenAI Summary API 응답이 비어있습니다");
+        }
+
+        OpenAiChatApiResponse.Message message = response.getChoices().get(0).getMessage();
+        if (message == null || message.getContent() == null) {
+            throw new IllegalStateException("OpenAI Summary API 응답 메시지가 비어있습니다");
+        }
+
+        // JSON 문자열인 content를 SummaryResult로 변환
+        return parseSummaryResult(message.getContent());
+    }
+
+    /**
+     * 기사 목록을 OpenAI user 메시지 한 건으로 직렬화한다.
+     */
+    private String buildUserMessage(List<String> articles) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("아래 ").append(articles.size()).append("건의 관련 기사를 종합하여 브리핑을 작성하세요.\n\n");
+
+        for (int i = 0; i < articles.size(); i++) {
+            String article = articles.get(i);
+            String truncated = article.length() > MAX_ARTICLE_LENGTH
+                    ? article.substring(0, MAX_ARTICLE_LENGTH) : article;
+            sb.append("--- 기사 ").append(i + 1).append(" ---\n");
+            sb.append(truncated).append("\n\n");
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * LLM이 반환한 JSON 문자열(content)을 SummaryResult DTO로 역직렬화한다.
+     */
+    private SummaryResult parseSummaryResult(String json) {
+        try {
+            return objectMapper.readValue(json, SummaryResult.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("요약 결과 JSON 파싱 실패: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -74,6 +74,12 @@ public class OpenAiSummaryClient {
      * @return 생성된 title + summary
      */
     public SummaryResult generateSummary(List<String> articles) {
+        // 입력 사전 검증 — 호출자는 다건(>=2) 기사 리스트를 넘긴다는 전제.
+        // 빈 리스트/null로 호출되면 의미 있는 요약을 만들 수 없으므로 즉시 실패 처리한다.
+        if (articles == null || articles.isEmpty()) {
+            throw new IllegalArgumentException("articles는 null이거나 비어있을 수 없습니다");
+        }
+
         // 기사 목록을 하나의 user 메시지로 직렬화
         // 기사 경계를 "--- 기사 N ---"으로 구분
         String userMessage = buildUserMessage(articles);
@@ -106,7 +112,12 @@ public class OpenAiSummaryClient {
             throw new IllegalStateException("OpenAI Summary API 응답이 비어있습니다");
         }
 
-        OpenAiChatApiResponse.Message message = response.getChoices().get(0).getMessage();
+        OpenAiChatApiResponse.Choice firstChoice = response.getChoices().get(0);
+        if (firstChoice == null) {
+            throw new IllegalStateException("OpenAI Summary API 첫 번째 choice가 비어있습니다");
+        }
+
+        OpenAiChatApiResponse.Message message = firstChoice.getMessage();
         if (message == null || message.getContent() == null) {
             throw new IllegalStateException("OpenAI Summary API 응답 메시지가 비어있습니다");
         }
@@ -127,7 +138,9 @@ public class OpenAiSummaryClient {
         sb.append("아래 ").append(limit).append("건의 관련 기사를 종합하여 브리핑을 작성하세요.\n\n");
 
         for (int i = 0; i < limit; i++) {
-            String article = articles.get(i);
+            // null 원소는 빈 문자열로 취급하여 NPE를 방지한다
+            // (호출자가 null을 넣을 일은 없지만 방어적 처리).
+            String article = articles.get(i) != null ? articles.get(i) : "";
             String truncated = article.length() > MAX_ARTICLE_LENGTH
                     ? article.substring(0, MAX_ARTICLE_LENGTH) : article;
             sb.append("--- 기사 ").append(i + 1).append(" ---\n");

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -74,8 +74,6 @@ public class OpenAiSummaryClient {
      * @return 생성된 title + summary
      */
     public SummaryResult generateSummary(List<String> articles) {
-        // 입력 사전 검증 — 호출자는 다건(>=2) 기사 리스트를 넘긴다는 전제.
-        // 빈 리스트/null로 호출되면 의미 있는 요약을 만들 수 없으므로 즉시 실패 처리한다.
         if (articles == null || articles.isEmpty()) {
             throw new IllegalArgumentException("articles는 null이거나 비어있을 수 없습니다");
         }
@@ -138,8 +136,6 @@ public class OpenAiSummaryClient {
         sb.append("아래 ").append(limit).append("건의 관련 기사를 종합하여 브리핑을 작성하세요.\n\n");
 
         for (int i = 0; i < limit; i++) {
-            // null 원소는 빈 문자열로 취급하여 NPE를 방지한다
-            // (호출자가 null을 넣을 일은 없지만 방어적 처리).
             String article = articles.get(i) != null ? articles.get(i) : "";
             String truncated = article.length() > MAX_ARTICLE_LENGTH
                     ? article.substring(0, MAX_ARTICLE_LENGTH) : article;

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -27,6 +27,9 @@ public class OpenAiSummaryClient {
 
     private static final int MAX_ARTICLE_LENGTH = 2000;
 
+    // 클러스터당 프롬프트에 포함할 최대 기사 수
+    private static final int MAX_ARTICLES_PER_CLUSTER = 10;
+
     private static final String SYSTEM_PROMPT = """
             당신은 금융 뉴스 전문 에디터입니다.
             여러 관련 기사를 종합하여 하나의 브리핑을 작성하세요.
@@ -114,12 +117,16 @@ public class OpenAiSummaryClient {
 
     /**
      * 기사 목록을 OpenAI user 메시지 한 건으로 직렬화한다.
+     *
+     * 기사당 {@link #MAX_ARTICLE_LENGTH}자 + 클러스터당 최대 {@link #MAX_ARTICLES_PER_CLUSTER}건의
+     * 이중 상한을 적용하여 프롬프트 크기가 컨텍스트 한도를 넘지 않도록 보장한다.
      */
     private String buildUserMessage(List<String> articles) {
+        int limit = Math.min(articles.size(), MAX_ARTICLES_PER_CLUSTER);
         StringBuilder sb = new StringBuilder();
-        sb.append("아래 ").append(articles.size()).append("건의 관련 기사를 종합하여 브리핑을 작성하세요.\n\n");
+        sb.append("아래 ").append(limit).append("건의 관련 기사를 종합하여 브리핑을 작성하세요.\n\n");
 
-        for (int i = 0; i < articles.size(); i++) {
+        for (int i = 0; i < limit; i++) {
             String article = articles.get(i);
             String truncated = article.length() > MAX_ARTICLE_LENGTH
                     ? article.substring(0, MAX_ARTICLE_LENGTH) : article;

--- a/src/main/java/com/solv/wefin/domain/news/summary/dto/SummaryResult.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/dto/SummaryResult.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * OpenAI 요약 생성 응답 DTOㄴ
+ * OpenAI 요약 생성 응답 DTO
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/solv/wefin/domain/news/summary/dto/SummaryResult.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/dto/SummaryResult.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.news.summary.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * OpenAI 요약 생성 응답 DTOㄴ
+ */
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SummaryResult {
+
+    private String title;   // 클러스터 대표 제목 (50자 이내)
+    private String summary; // 종합 요약 (팩트/분석/전망/영향, 200~400자)
+
+    public boolean isEmpty() {
+        return (title == null || title.isBlank()) || (summary == null || summary.isBlank());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -173,8 +173,6 @@ public class OutlierDetectionService {
                 .toList();
 
         // 남은 기사 없으면 집계를 초기화하고 클러스터를 INACTIVE로 내려 재조회 대상에서 제외한다.
-        // (INACTIVE로 두지 않으면 SummaryService가 FAILED 상태의 빈 클러스터를 매 배치마다
-        // 계속 집어와서 무의미한 재처리가 반복된다.)
         if (remainingArticleIds.isEmpty()) {
             cluster.recalculateAfterOutlierRemoval(0, null, null, null, null);
             cluster.deactivate();

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -364,12 +364,14 @@ public class OutlierDetectionService {
             return;
         }
 
-        // 태그별 개수 집계
-        Map<String, Long> tagCounts = categoryTags.stream()
-                .collect(Collectors.groupingBy(NewsArticleTag::getTagCode, Collectors.counting()));
+        // 태그별 distinct 기사 집계
+        Map<String, Set<Long>> tagToArticles = categoryTags.stream()
+                .collect(Collectors.groupingBy(
+                        NewsArticleTag::getTagCode,
+                        Collectors.mapping(NewsArticleTag::getNewsArticleId, Collectors.toSet())));
 
         // 최대 비중 계산
-        long maxCount = tagCounts.values().stream().mapToLong(Long::longValue).max().orElse(0);
+        int maxCount = tagToArticles.values().stream().mapToInt(Set::size).max().orElse(0);
         double dominance = (double) maxCount / mappings.size();
 
         // 기준보다 낮으면 경고

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -172,9 +172,12 @@ public class OutlierDetectionService {
                 .filter(id -> !outlierArticleIds.contains(id))
                 .toList();
 
-        // 남은 기사 없으면 클러스터 초기화 (요약 단계에서 FAILED 처리)
+        // 남은 기사 없으면 집계를 초기화하고 클러스터를 INACTIVE로 내려 재조회 대상에서 제외한다.
+        // (INACTIVE로 두지 않으면 SummaryService가 FAILED 상태의 빈 클러스터를 매 배치마다
+        // 계속 집어와서 무의미한 재처리가 반복된다.)
         if (remainingArticleIds.isEmpty()) {
             cluster.recalculateAfterOutlierRemoval(0, null, null, null, null);
+            cluster.deactivate();
             return;
         }
 
@@ -186,19 +189,22 @@ public class OutlierDetectionService {
 
         float[] newCentroid = remainingVectors.isEmpty() ? null : averageVectors(remainingVectors);
 
-        // 3. 대표 기사 재선정 (가장 최신 기사)
-        var latestArticle = newsArticleRepository.findAllById(remainingArticleIds).stream()
+        // 3. 대표 기사 재선정. 기본은 최신 기사(publishedAt 최댓값).
+        //    모든 기사의 publishedAt이 null이면 대표 메타데이터가 사라지는 걸 막기 위해
+        //    남은 기사 중 임의의 한 건을 fallback으로 사용한다.
+        List<NewsArticle> remainingArticles = newsArticleRepository.findAllById(remainingArticleIds);
+        NewsArticle representative = remainingArticles.stream()
                 .filter(a -> a.getPublishedAt() != null)
                 .max((a, b) -> a.getPublishedAt().compareTo(b.getPublishedAt()))
-                .orElse(null);
+                .orElseGet(() -> remainingArticles.stream().findAny().orElse(null));
 
         // 4. 클러스터 상태 업데이트
         cluster.recalculateAfterOutlierRemoval(
                 remainingArticleIds.size(),
                 newCentroid,
-                latestArticle != null ? latestArticle.getId() : null,
-                latestArticle != null ? latestArticle.getPublishedAt() : null,
-                latestArticle != null ? latestArticle.getThumbnailUrl() : null
+                representative != null ? representative.getId() : null,
+                representative != null ? representative.getPublishedAt() : null,
+                representative != null ? representative.getThumbnailUrl() : null
         );
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -1,0 +1,284 @@
+package com.solv.wefin.domain.news.summary.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.service.ArticleVectorService;
+import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 요약 직전 이상치 제거 서비스
+ *
+ * centroid 유사도 하위 + 태그 불일치 기사를 클러스터 매핑에서 제거하고,
+ * 클러스터 집계 상태(articleCount, centroid)를 재계산한다.
+ * 제거된 기사는 다음 클러스터링 배치에서 미배정 기사로 자동 수거된다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutlierDetectionService {
+
+    // centroid와의 cosine similarity 기준
+    // → 0.7 미만이면 해당 클러스터와 의미적으로 어긋난 기사로 판단 (이상치 후보)
+    private static final double OUTLIER_SIMILARITY_THRESHOLD = 0.70;
+
+    // 클러스터 내 특정 카테고리 태그의 최대 비중 기준
+    // → 0.6 미만이면 주제가 분산된 클러스터로 판단 (경고 로그용, 제거 기준 아님)
+    private static final double CATEGORY_DOMINANCE_THRESHOLD = 0.60;
+
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleTagRepository articleTagRepository;
+    private final NewsArticleRepository newsArticleRepository;
+    private final ArticleVectorService articleVectorService;
+    private final ClusterMatchingService clusterMatchingService;
+
+    /**
+     * 클러스터에서 이상치 기사를 제거하고 집계 상태를 갱신한다.
+     * 제거된 기사는 다음 클러스터링 배치에서 미배정 기사로 재수거된다.
+     *
+     * @param cluster 대상 클러스터
+     * @return 제거된 기사 수
+     */
+    @Transactional
+    public int removeOutliers(NewsCluster cluster) {
+        // 1. 클러스터에 속한 기사-매핑 조회
+        List<NewsClusterArticle> mappings = clusterArticleRepository.findByNewsClusterId(cluster.getId());
+
+        // 기사 1개 이하 → 이상치 판단 의미 없음
+        if (mappings.size() <= 1) {
+            return 0;
+        }
+
+        // 2. centroid(클러스터 중심 벡터) 조회
+        float[] centroid = cluster.getCentroidVector();
+
+        // centroid 없으면 유사도 계산 불가 → 종료
+        if (centroid == null) {
+            return 0;
+        }
+
+        // 3. 클러스터 태그 분산 체크 (경고 로그용, 제거 로직과는 별개)
+        checkCategoryDominance(cluster.getId(), mappings);
+
+        // 4. 유사도 + 태그 기준으로 이상치 기사 탐색
+        List<NewsClusterArticle> outliers = findOutliers(mappings, centroid);
+
+
+        // 이상치 없으면 종료
+        if (outliers.isEmpty()) {
+            return 0;
+        }
+
+        // 5. 이상치 기사 ID 수집 (이후 집계 재계산에서 사용)
+        Set<Long> outlierArticleIds = outliers.stream()
+                .map(NewsClusterArticle::getNewsArticleId)
+                .collect(Collectors.toSet());
+
+        // 6. 클러스터-기사 매핑 삭제 (클러스터에서 제거)
+        for (NewsClusterArticle outlier : outliers) {
+            clusterArticleRepository.deleteByNewsClusterIdAndNewsArticleId(
+                    cluster.getId(), outlier.getNewsArticleId());
+            log.info("이상치 제거 — articleId: {}, clusterId: {}", outlier.getNewsArticleId(), cluster.getId());
+        }
+
+        // 7. 남은 기사 기준으로 클러스터 상태 재계산
+        recalculateClusterState(cluster, mappings, outlierArticleIds);
+
+        // 8. 처리 결과 로그
+        log.info("이상치 제거 완료 — clusterId: {}, 제거: {}건, 남은 기사: {}건",
+                cluster.getId(), outliers.size(), mappings.size() - outliers.size());
+
+        // 9. 제거된 기사 수 반환
+        return outliers.size();
+    }
+
+    /**
+     * 이상치 제거 후 남은 기사로 클러스터 집계 상태를 재계산한다.
+     * articleCount, centroid, 대표 기사(최신)를 갱신한다.
+     */
+    private void recalculateClusterState(NewsCluster cluster,
+                                         List<NewsClusterArticle> allMappings,
+                                         Set<Long> outlierArticleIds) {
+        // 1. 이상치 제거 후 남은 기사 ID 추출
+        List<Long> remainingArticleIds = allMappings.stream()
+                .map(NewsClusterArticle::getNewsArticleId)
+                .filter(id -> !outlierArticleIds.contains(id))
+                .toList();
+
+        // 남은 기사 없으면 클러스터 초기화 (요약 단계에서 FAILED 처리)
+        if (remainingArticleIds.isEmpty()) {
+            cluster.recalculateAfterOutlierRemoval(0, null, null, null, null);
+            return;
+        }
+
+        // 2. centroid 재계산 (남은 기사 벡터 평균)
+        List<float[]> remainingVectors = remainingArticleIds.stream()
+                .map(articleVectorService::calculateRepresentativeVector)
+                .filter(v -> v != null)
+                .toList();
+
+        float[] newCentroid = remainingVectors.isEmpty() ? null : averageVectors(remainingVectors);
+
+        // 3. 대표 기사 재선정 (가장 최신 기사)
+        var latestArticle = newsArticleRepository.findAllById(remainingArticleIds).stream()
+                .filter(a -> a.getPublishedAt() != null)
+                .max((a, b) -> a.getPublishedAt().compareTo(b.getPublishedAt()))
+                .orElse(null);
+
+        // 4. 클러스터 상태 업데이트
+        cluster.recalculateAfterOutlierRemoval(
+                remainingArticleIds.size(),
+                newCentroid,
+                latestArticle != null ? latestArticle.getId() : null,
+                latestArticle != null ? latestArticle.getPublishedAt() : null,
+                latestArticle != null ? latestArticle.getThumbnailUrl() : null
+        );
+    }
+
+    /**
+     * 여러 벡터의 평균을 계산 (centroid 생성)
+     */
+    private float[] averageVectors(List<float[]> vectors) {
+        int dimension = vectors.get(0).length;
+        float[] sum = new float[dimension];
+
+        for (float[] vector : vectors) {
+            for (int i = 0; i < dimension; i++) {
+                sum[i] += vector[i];
+            }
+        }
+
+        float count = vectors.size();
+        float[] average = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            average[i] = sum[i] / count;
+        }
+        return average;
+    }
+
+    /**
+     * 이상치 기사 탐색
+     * centroid와 유사도가 낮고 태그가 클러스터와 불일치하면 → outlier로 판단
+     */
+    private List<NewsClusterArticle> findOutliers(List<NewsClusterArticle> mappings, float[] centroid) {
+        // 클러스터 전체 기사 ID
+        List<Long> articleIds = mappings.stream().map(NewsClusterArticle::getNewsArticleId).toList();
+
+        // 모든 기사 태그 조회 (한 번에 조회해서 성능 최적화)
+        List<NewsArticleTag> allTags = articleTagRepository.findByNewsArticleIdIn(articleIds);
+
+        // 클러스터 태그를 타입별(STOCK, SECTOR, TOPIC)로 그룹핑
+        Map<TagType, List<String>> clusterTagsByType = allTags.stream()
+                .collect(Collectors.groupingBy(
+                        NewsArticleTag::getTagType,
+                        Collectors.mapping(NewsArticleTag::getTagCode, Collectors.toList())));
+
+        List<NewsClusterArticle> outliers = new ArrayList<>();
+
+        for (NewsClusterArticle mapping : mappings) {
+            // 기사 벡터 계산
+            float[] vector = articleVectorService.calculateRepresentativeVector(mapping.getNewsArticleId());
+            if (vector == null) {
+                continue;
+            }
+
+            // centroid와 유사도 계산
+            double similarity = clusterMatchingService.cosineSimilarity(vector, centroid);
+
+            // 1차 필터: 유사도 낮음
+            if (similarity < OUTLIER_SIMILARITY_THRESHOLD) {
+                // 해당 기사 태그 추출
+                List<NewsArticleTag> articleTags = allTags.stream()
+                        .filter(t -> t.getNewsArticleId().equals(mapping.getNewsArticleId()))
+                        .toList();
+
+                // 2차 필터: 태그 불일치
+                if (isTagMismatch(articleTags, clusterTagsByType)) {
+                    outliers.add(mapping);
+                }
+            }
+        }
+
+        return outliers;
+    }
+
+    /**
+     * 기사 태그가 클러스터와 맞지 않는지 판단
+     *
+     * STOCK, SECTOR, TOPIC 중 하나도 겹치지 않으면 → mismatch
+     */
+    private boolean isTagMismatch(List<NewsArticleTag> articleTags,
+                                  Map<TagType, List<String>> clusterTagsByType) {
+        if (articleTags.isEmpty()) {
+            return false;
+        }
+
+        // 클러스터 태그 목록
+        List<String> clusterStocks = clusterTagsByType.getOrDefault(TagType.STOCK, List.of());
+        List<String> clusterSectors = clusterTagsByType.getOrDefault(TagType.SECTOR, List.of());
+        List<String> clusterTopics = clusterTagsByType.getOrDefault(TagType.TOPIC, List.of());
+
+        // 각각 교집합 체크
+        boolean stockOverlap = articleTags.stream()
+                .filter(t -> t.getTagType() == TagType.STOCK)
+                .anyMatch(t -> clusterStocks.contains(t.getTagCode()));
+
+        boolean sectorOverlap = articleTags.stream()
+                .filter(t -> t.getTagType() == TagType.SECTOR)
+                .anyMatch(t -> clusterSectors.contains(t.getTagCode()));
+
+        boolean topicOverlap = articleTags.stream()
+                .filter(t -> t.getTagType() == TagType.TOPIC)
+                .anyMatch(t -> clusterTopics.contains(t.getTagCode()));
+
+        return !stockOverlap && !sectorOverlap && !topicOverlap;
+    }
+
+    /**
+     * 클러스터 태그 분산 체크 (모니터링용)
+     *
+     * 특정 카테고리가 충분히 지배적이지 않으면 경고 로그 출력
+     */
+    private void checkCategoryDominance(Long clusterId, List<NewsClusterArticle> mappings) {
+        List<Long> articleIds = mappings.stream().map(NewsClusterArticle::getNewsArticleId).toList();
+        List<NewsArticleTag> tags = articleTagRepository.findByNewsArticleIdIn(articleIds);
+
+        // SECTOR, TOPIC만 대상으로 분석
+        // → 클러스터는 산업/주제 단위로 묶이므로 상위 개념(SECTOR, TOPIC)만 사용
+        List<NewsArticleTag> categoryTags = tags.stream()
+                .filter(t -> t.getTagType() == TagType.SECTOR || t.getTagType() == TagType.TOPIC)
+                .toList();
+
+        if (categoryTags.isEmpty()) {
+            return;
+        }
+
+        // 태그별 개수 집계
+        Map<String, Long> tagCounts = categoryTags.stream()
+                .collect(Collectors.groupingBy(NewsArticleTag::getTagCode, Collectors.counting()));
+
+        // 최대 비중 계산
+        long maxCount = tagCounts.values().stream().mapToLong(Long::longValue).max().orElse(0);
+        double dominance = (double) maxCount / categoryTags.size();
+
+        // 기준보다 낮으면 경고
+        if (dominance < CATEGORY_DOMINANCE_THRESHOLD) {
+            log.warn("클러스터 category 분산 경고 — clusterId: {}, 최대 비중: {}%",
+                    clusterId, String.format("%.1f", dominance * 100));
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -4,17 +4,24 @@ import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
 import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
 import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.service.ArticleVectorService;
 import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -25,7 +32,6 @@ import java.util.stream.Collectors;
  *
  * centroid 유사도 하위 + 태그 불일치 기사를 클러스터 매핑에서 제거하고,
  * 클러스터 집계 상태(articleCount, centroid)를 재계산한다.
- * 제거된 기사는 다음 클러스터링 배치에서 미배정 기사로 자동 수거된다.
  */
 @Slf4j
 @Service
@@ -41,6 +47,7 @@ public class OutlierDetectionService {
     private static final double CATEGORY_DOMINANCE_THRESHOLD = 0.60;
 
     private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsClusterRepository newsClusterRepository;
     private final NewsArticleTagRepository articleTagRepository;
     private final NewsArticleRepository newsArticleRepository;
     private final ArticleVectorService articleVectorService;
@@ -48,15 +55,26 @@ public class OutlierDetectionService {
 
     /**
      * 클러스터에서 이상치 기사를 제거하고 집계 상태를 갱신한다.
-     * 제거된 기사는 다음 클러스터링 배치에서 미배정 기사로 재수거된다.
      *
-     * @param cluster 대상 클러스터
+     * <p>제거된 기사는 같은 트랜잭션 안에서 즉시 단독 클러스터로 승격되어
+     * orphan 상태가 되지 않도록 한다.</p>
+     *
+     * <p>호출자(SummaryService)는 @Transactional 없이 클러스터 엔티티를 전달하므로
+     * 파라미터는 detached 상태다. 이 메서드에서 id로 re-fetch하여 현재 트랜잭션의
+     * 영속 컨텍스트에서 관리되는 엔티티를 얻은 뒤 dirty checking으로 집계 변경을 커밋한다.</p>
+     *
+     * @param cluster 대상 클러스터 (id 참조 용도, detached 허용)
      * @return 제거된 기사 수
      */
     @Transactional
     public int removeOutliers(NewsCluster cluster) {
+        // 0. 현재 트랜잭션의 영속 컨텍스트에서 관리되는 엔티티로 re-fetch.
+        //    이렇게 해야 recalculateAfterOutlierRemoval의 필드 변경이 dirty checking으로 커밋된다.
+        NewsCluster managedCluster = newsClusterRepository.findById(cluster.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.SUMMARY_CLUSTER_NOT_FOUND));
+
         // 1. 클러스터에 속한 기사-매핑 조회
-        List<NewsClusterArticle> mappings = clusterArticleRepository.findByNewsClusterId(cluster.getId());
+        List<NewsClusterArticle> mappings = clusterArticleRepository.findByNewsClusterId(managedCluster.getId());
 
         // 기사 1개 이하 → 이상치 판단 의미 없음
         if (mappings.size() <= 1) {
@@ -64,7 +82,7 @@ public class OutlierDetectionService {
         }
 
         // 2. centroid(클러스터 중심 벡터) 조회
-        float[] centroid = cluster.getCentroidVector();
+        float[] centroid = managedCluster.getCentroidVector();
 
         // centroid 없으면 유사도 계산 불가 → 종료
         if (centroid == null) {
@@ -72,7 +90,7 @@ public class OutlierDetectionService {
         }
 
         // 3. 클러스터 태그 분산 체크 (경고 로그용, 제거 로직과는 별개)
-        checkCategoryDominance(cluster.getId(), mappings);
+        checkCategoryDominance(managedCluster.getId(), mappings);
 
         // 4. 유사도 + 태그 기준으로 이상치 기사 탐색
         List<NewsClusterArticle> outliers = findOutliers(mappings, centroid);
@@ -88,22 +106,57 @@ public class OutlierDetectionService {
                 .map(NewsClusterArticle::getNewsArticleId)
                 .collect(Collectors.toSet());
 
-        // 6. 클러스터-기사 매핑 삭제 (클러스터에서 제거)
+        // 6. 기존 매핑 삭제 + 즉시 단독 클러스터로 승격 (같은 트랜잭션 안에서)
         for (NewsClusterArticle outlier : outliers) {
-            clusterArticleRepository.deleteByNewsClusterIdAndNewsArticleId(
-                    cluster.getId(), outlier.getNewsArticleId());
-            log.info("이상치 제거 — articleId: {}, clusterId: {}", outlier.getNewsArticleId(), cluster.getId());
+            Long articleId = outlier.getNewsArticleId();
+            clusterArticleRepository.deleteByNewsClusterIdAndNewsArticleId(managedCluster.getId(), articleId);
+            promoteToSingletonCluster(articleId, managedCluster.getId());
         }
 
-        // 7. 남은 기사 기준으로 클러스터 상태 재계산
-        recalculateClusterState(cluster, mappings, outlierArticleIds);
+        // 7. 남은 기사 기준으로 클러스터 상태 재계산 (managed 엔티티에 dirty checking 적용)
+        recalculateClusterState(managedCluster, mappings, outlierArticleIds);
 
         // 8. 처리 결과 로그
         log.info("이상치 제거 완료 — clusterId: {}, 제거: {}건, 남은 기사: {}건",
-                cluster.getId(), outliers.size(), mappings.size() - outliers.size());
+                managedCluster.getId(), outliers.size(), mappings.size() - outliers.size());
 
         // 9. 제거된 기사 수 반환
         return outliers.size();
+    }
+
+    /**
+     * 이상치 기사를 새 단독 클러스터로 승격시킨다.
+     *
+     * <p>클러스터에서 빠진 기사가 다음 클러스터링 배치(최근 24시간 이내 기사만 대상)에서
+     * 수거되지 않을 위험이 있으므로, 이 시점에서 바로 자기 자신으로 구성된 단독 클러스터를
+     * 만들어 피드 노출과 요약 재시도가 가능한 상태로 만든다. 새 클러스터는 PENDING 상태로
+     * 시작되어 다음 요약 배치에서 자연스럽게 단독 클러스터 경로(AI 미호출, 원본 사용)로 처리된다.</p>
+     *
+     * <p>벡터 또는 기사 레코드 조회에 실패하면 승격을 스킵하고 경고 로그만 남긴다.
+     * 승격 실패가 이상치 제거 전체를 롤백시킬 만한 치명도는 아니기 때문.</p>
+     */
+    private void promoteToSingletonCluster(Long articleId, Long fromClusterId) {
+        float[] vector = articleVectorService.calculateRepresentativeVector(articleId);
+        if (vector == null) {
+            log.warn("이상치 기사의 벡터 없음 — 단독 클러스터 승격 스킵, articleId: {}, fromClusterId: {}",
+                    articleId, fromClusterId);
+            return;
+        }
+
+        NewsArticle article = newsArticleRepository.findById(articleId).orElse(null);
+        if (article == null) {
+            log.warn("이상치 기사 조회 실패 — 단독 클러스터 승격 스킵, articleId: {}, fromClusterId: {}",
+                    articleId, fromClusterId);
+            return;
+        }
+
+        NewsCluster singleton = NewsCluster.createSingle(
+                vector, articleId, article.getThumbnailUrl(), article.getPublishedAt());
+        NewsCluster saved = newsClusterRepository.save(singleton);
+        clusterArticleRepository.save(NewsClusterArticle.create(saved.getId(), articleId, 0, false));
+
+        log.info("이상치 제거 → 단독 클러스터 승격 — articleId: {}, fromClusterId: {}, newClusterId: {}",
+                articleId, fromClusterId, saved.getId());
     }
 
     /**
@@ -173,6 +226,10 @@ public class OutlierDetectionService {
     /**
      * 이상치 기사 탐색
      * centroid와 유사도가 낮고 태그가 클러스터와 불일치하면 → outlier로 판단
+     *
+     * <p>태그 일치 여부를 판정할 때는 후보 기사 자신의 태그는 제외한 "다른 기사들의 태그"와
+     * 비교해야 한다. 후보 자신의 태그를 포함시키면 자기 자신과는 항상 일치하게 되어
+     * 이상치 판정이 무력화된다.</p>
      */
     private List<NewsClusterArticle> findOutliers(List<NewsClusterArticle> mappings, float[] centroid) {
         // 클러스터 전체 기사 ID
@@ -181,17 +238,17 @@ public class OutlierDetectionService {
         // 모든 기사 태그 조회 (한 번에 조회해서 성능 최적화)
         List<NewsArticleTag> allTags = articleTagRepository.findByNewsArticleIdIn(articleIds);
 
-        // 클러스터 태그를 타입별(STOCK, SECTOR, TOPIC)로 그룹핑
-        Map<TagType, List<String>> clusterTagsByType = allTags.stream()
-                .collect(Collectors.groupingBy(
-                        NewsArticleTag::getTagType,
-                        Collectors.mapping(NewsArticleTag::getTagCode, Collectors.toList())));
+        // articleId → (TagType → Set<tagCode>) 사전 인덱싱
+        // 후보 기사를 제외한 "나머지 기사들의 태그 집합"을 O(1)에 구하기 위해 사용한다.
+        Map<Long, Map<TagType, Set<String>>> tagsByArticle = groupTagsByArticle(allTags);
 
         List<NewsClusterArticle> outliers = new ArrayList<>();
 
         for (NewsClusterArticle mapping : mappings) {
+            Long candidateId = mapping.getNewsArticleId();
+
             // 기사 벡터 계산
-            float[] vector = articleVectorService.calculateRepresentativeVector(mapping.getNewsArticleId());
+            float[] vector = articleVectorService.calculateRepresentativeVector(candidateId);
             if (vector == null) {
                 continue;
             }
@@ -201,13 +258,14 @@ public class OutlierDetectionService {
 
             // 1차 필터: 유사도 낮음
             if (similarity < OUTLIER_SIMILARITY_THRESHOLD) {
-                // 해당 기사 태그 추출
-                List<NewsArticleTag> articleTags = allTags.stream()
-                        .filter(t -> t.getNewsArticleId().equals(mapping.getNewsArticleId()))
-                        .toList();
+                // 후보 기사의 태그
+                Map<TagType, Set<String>> candidateTags = tagsByArticle.getOrDefault(candidateId, Map.of());
+
+                // 후보를 제외한 나머지 기사들의 태그 집합 (타입별 union)
+                Map<TagType, Set<String>> otherTagsByType = unionTagsExcluding(tagsByArticle, candidateId);
 
                 // 2차 필터: 태그 불일치
-                if (isTagMismatch(articleTags, clusterTagsByType)) {
+                if (isTagMismatch(candidateTags, otherTagsByType)) {
                     outliers.add(mapping);
                 }
             }
@@ -217,35 +275,70 @@ public class OutlierDetectionService {
     }
 
     /**
+     * 태그 리스트를 articleId → (TagType → Set<tagCode>) 형태로 그룹핑한다.
+     */
+    private Map<Long, Map<TagType, Set<String>>> groupTagsByArticle(List<NewsArticleTag> allTags) {
+        Map<Long, Map<TagType, Set<String>>> result = new HashMap<>();
+        for (NewsArticleTag tag : allTags) {
+            result
+                    .computeIfAbsent(tag.getNewsArticleId(), k -> new HashMap<>())
+                    .computeIfAbsent(tag.getTagType(), k -> new HashSet<>())
+                    .add(tag.getTagCode());
+        }
+        return result;
+    }
+
+    /**
+     * 특정 articleId를 제외한 나머지 기사들의 태그를 TagType별 Set으로 합친다.
+     */
+    private Map<TagType, Set<String>> unionTagsExcluding(
+            Map<Long, Map<TagType, Set<String>>> tagsByArticle, Long excludeArticleId) {
+        Map<TagType, Set<String>> merged = new HashMap<>();
+        for (Map.Entry<Long, Map<TagType, Set<String>>> entry : tagsByArticle.entrySet()) {
+            if (entry.getKey().equals(excludeArticleId)) {
+                continue;
+            }
+            for (Map.Entry<TagType, Set<String>> typeEntry : entry.getValue().entrySet()) {
+                merged.computeIfAbsent(typeEntry.getKey(), k -> new HashSet<>()).addAll(typeEntry.getValue());
+            }
+        }
+        return merged;
+    }
+
+    /**
      * 기사 태그가 클러스터와 맞지 않는지 판단
      *
-     * STOCK, SECTOR, TOPIC 중 하나도 겹치지 않으면 → mismatch
+     * <p>STOCK, SECTOR, TOPIC 중 하나도 겹치지 않으면 mismatch로 간주한다.
+     * clusterTagsByType은 후보 기사 자신의 태그가 제외된 "나머지 기사들의 태그 집합"이어야 한다.</p>
      */
-    private boolean isTagMismatch(List<NewsArticleTag> articleTags,
-                                  Map<TagType, List<String>> clusterTagsByType) {
-        if (articleTags.isEmpty()) {
+    private boolean isTagMismatch(Map<TagType, Set<String>> candidateTagsByType,
+                                  Map<TagType, Set<String>> clusterTagsByType) {
+        if (candidateTagsByType.isEmpty()) {
             return false;
         }
 
-        // 클러스터 태그 목록
-        List<String> clusterStocks = clusterTagsByType.getOrDefault(TagType.STOCK, List.of());
-        List<String> clusterSectors = clusterTagsByType.getOrDefault(TagType.SECTOR, List.of());
-        List<String> clusterTopics = clusterTagsByType.getOrDefault(TagType.TOPIC, List.of());
+        return !hasOverlap(TagType.STOCK, candidateTagsByType, clusterTagsByType)
+                && !hasOverlap(TagType.SECTOR, candidateTagsByType, clusterTagsByType)
+                && !hasOverlap(TagType.TOPIC, candidateTagsByType, clusterTagsByType);
+    }
 
-        // 각각 교집합 체크
-        boolean stockOverlap = articleTags.stream()
-                .filter(t -> t.getTagType() == TagType.STOCK)
-                .anyMatch(t -> clusterStocks.contains(t.getTagCode()));
-
-        boolean sectorOverlap = articleTags.stream()
-                .filter(t -> t.getTagType() == TagType.SECTOR)
-                .anyMatch(t -> clusterSectors.contains(t.getTagCode()));
-
-        boolean topicOverlap = articleTags.stream()
-                .filter(t -> t.getTagType() == TagType.TOPIC)
-                .anyMatch(t -> clusterTopics.contains(t.getTagCode()));
-
-        return !stockOverlap && !sectorOverlap && !topicOverlap;
+    /**
+     * 특정 TagType에 대해 후보 태그와 클러스터 태그 사이에 교집합이 있는지 검사한다.
+     */
+    private boolean hasOverlap(TagType type,
+                               Map<TagType, Set<String>> candidateTagsByType,
+                               Map<TagType, Set<String>> clusterTagsByType) {
+        Set<String> candidate = candidateTagsByType.getOrDefault(type, Collections.emptySet());
+        Set<String> cluster = clusterTagsByType.getOrDefault(type, Collections.emptySet());
+        if (candidate.isEmpty() || cluster.isEmpty()) {
+            return false;
+        }
+        for (String code : candidate) {
+            if (cluster.contains(code)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -370,7 +370,7 @@ public class OutlierDetectionService {
 
         // 최대 비중 계산
         long maxCount = tagCounts.values().stream().mapToLong(Long::longValue).max().orElse(0);
-        double dominance = (double) maxCount / categoryTags.size();
+        double dominance = (double) maxCount / mappings.size();
 
         // 기준보다 낮으면 경고
         if (dominance < CATEGORY_DOMINANCE_THRESHOLD) {

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryPersistenceService.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.domain.news.summary.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AI 요약 결과를 DB에 반영하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class SummaryPersistenceService {
+
+    private final NewsClusterRepository newsClusterRepository;
+
+    /**
+     * AI 요약 생성 성공을 반영한다.
+     */
+    @Transactional
+    public void markGenerated(Long clusterId, String title, String summary) {
+        NewsCluster cluster = newsClusterRepository.findById(clusterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SUMMARY_CLUSTER_NOT_FOUND));
+        cluster.markSummaryGenerated(title, summary);
+    }
+
+    /**
+     * AI 요약 생성 실패를 반영한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(Long clusterId) {
+        NewsCluster cluster = newsClusterRepository.findById(clusterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SUMMARY_CLUSTER_NOT_FOUND));
+        cluster.markSummaryFailed();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -11,6 +11,8 @@ import com.solv.wefin.domain.news.summary.client.OpenAiSummaryClient;
 import com.solv.wefin.domain.news.summary.dto.SummaryResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -43,14 +45,11 @@ public class SummaryService {
      * 요약 생성이 필요한 클러스터를 조회하여 AI 요약을 생성한다.
      */
     public void generatePendingSummaries() {
-        // 대상 조회: ACTIVE 상태 + 요약이 필요한 상태(PENDING/STALE/FAILED)
-        List<NewsCluster> allTargets = newsClusterRepository.findByStatusAndSummaryStatusIn(
+        // 대상 조회: ACTIVE 상태 + 요약이 필요한 상태(PENDING/STALE/FAILED).
+        List<NewsCluster> targets = newsClusterRepository.findByStatusAndSummaryStatusIn(
                 ClusterStatus.ACTIVE,
-                List.of(SummaryStatus.PENDING, SummaryStatus.STALE, SummaryStatus.FAILED));
-
-        // 배치 크기 제한
-        List<NewsCluster> targets = allTargets.size() > BATCH_SIZE
-                ? allTargets.subList(0, BATCH_SIZE) : allTargets;
+                List.of(SummaryStatus.PENDING, SummaryStatus.STALE, SummaryStatus.FAILED),
+                PageRequest.of(0, BATCH_SIZE, Sort.by(Sort.Direction.ASC, "id")));
 
         log.info("요약 생성 대상 클러스터 수: {}", targets.size());
 

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -1,0 +1,167 @@
+package com.solv.wefin.domain.news.summary.service;
+
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.summary.client.OpenAiSummaryClient;
+import com.solv.wefin.domain.news.summary.dto.SummaryResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * AI 요약 생성 전체 흐름을 관리하는 서비스
+ *
+ * 한 클러스터에 대한 요약 파이프라인:
+ * 이상치 제거 → 소속 기사 조회 → (단독/다건 분기) → AI 호출 → 저장
+ *
+ * 처리 대상 선정 기준:
+ * ACTIVE 클러스터 + summaryStatus ∈ {PENDING, STALE, FAILED}.
+ * STALE은 기사가 새로 추가되어 요약 재생성이 필요한 상태, FAILED는 재시도 대상이다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SummaryService {
+
+    private static final int BATCH_SIZE = 50;
+
+    private final NewsClusterRepository newsClusterRepository;
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleRepository newsArticleRepository;
+    private final OpenAiSummaryClient openAiSummaryClient;
+    private final OutlierDetectionService outlierDetectionService;
+    private final SummaryPersistenceService persistenceService;
+
+    /**
+     * 요약 생성이 필요한 클러스터를 조회하여 AI 요약을 생성한다.
+     */
+    public void generatePendingSummaries() {
+        // 대상 조회: ACTIVE 상태 + 요약이 필요한 상태(PENDING/STALE/FAILED)
+        List<NewsCluster> allTargets = newsClusterRepository.findByStatusAndSummaryStatusIn(
+                ClusterStatus.ACTIVE,
+                List.of(SummaryStatus.PENDING, SummaryStatus.STALE, SummaryStatus.FAILED));
+
+        // 배치 크기 제한
+        List<NewsCluster> targets = allTargets.size() > BATCH_SIZE
+                ? allTargets.subList(0, BATCH_SIZE) : allTargets;
+
+        log.info("요약 생성 대상 클러스터 수: {}", targets.size());
+
+        if (targets.isEmpty()) {
+            return;
+        }
+
+        int successCount = 0;
+        int failCount = 0;
+        int outlierCount = 0;
+
+        for (NewsCluster cluster : targets) {
+            try {
+                // 1) 이상치 제거 — 다건 클러스터만 대상
+                if (cluster.getArticleCount() > 1) {
+                    int removed = outlierDetectionService.removeOutliers(cluster);
+                    outlierCount += removed;
+                }
+
+                // 2) 소속 기사 조회
+                List<String> articleTexts = getArticleTexts(cluster.getId());
+
+                if (articleTexts.isEmpty()) {
+                    log.warn("요약 생성 실패 — 소속 기사 없음, clusterId: {}", cluster.getId());
+                    persistenceService.markFailed(cluster.getId());
+                    failCount++;
+                    continue;
+                }
+
+                // 3) 단독 클러스터 최적화 — AI 호출 없이 기사 제목/요약을 그대로 사용.
+                if (articleTexts.size() == 1) {
+                    if (handleSingleArticleCluster(cluster)) {
+                        successCount++;
+                    } else {
+                        log.warn("단독 클러스터 요약 실패 — 기사 조회 불가, clusterId: {}", cluster.getId());
+                        persistenceService.markFailed(cluster.getId());
+                        failCount++;
+                    }
+                    continue;
+                }
+
+                // 4) AI 요약 생성 (다건 종합)
+                SummaryResult result = openAiSummaryClient.generateSummary(articleTexts);
+
+                if (result.isEmpty()) {
+                    throw new IllegalStateException("AI 요약 결과가 비어있습니다");
+                }
+
+                // 5) 저장 — GENERATED 상태로 마킹하며 title/summary를 커밋
+                persistenceService.markGenerated(cluster.getId(), result.getTitle(), result.getSummary());
+                successCount++;
+
+            } catch (Exception e) {
+                log.warn("요약 생성 실패 — clusterId: {}, error: {}", cluster.getId(), e.getMessage());
+                try {
+                    persistenceService.markFailed(cluster.getId());
+                } catch (Exception ex) {
+                    log.error("요약 실패 마킹도 실패 — clusterId: {}", cluster.getId());
+                }
+                failCount++;
+            }
+        }
+
+        log.info("요약 생성 완료 — 성공: {}, 실패: {}, 이상치 제거: {}건", successCount, failCount, outlierCount);
+    }
+
+    /**
+     * 단독 클러스터(기사 1건)는 AI 호출 없이 기사 제목/요약을 그대로 사용한다.
+     *
+     * @return true면 성공, false면 기사를 찾지 못해 실패
+     */
+    private boolean handleSingleArticleCluster(NewsCluster cluster) {
+        // 매핑 재조회 (이상치 제거 후의 실제 상태를 반영)
+        List<NewsClusterArticle> mappings = clusterArticleRepository.findByNewsClusterId(cluster.getId());
+        // 단독 클러스터인데 매핑이 사라진 경우 (동시성/데이터 이상)
+        if (mappings.isEmpty()) {
+            return false;
+        }
+
+        Long articleId = mappings.get(0).getNewsArticleId();
+        var articleOpt = newsArticleRepository.findById(articleId);
+        // 매핑은 있는데 기사가 없는 경우 (기사 삭제 후 매핑 미정리)
+        if (articleOpt.isEmpty()) {
+            return false;
+        }
+
+        var article = articleOpt.get();
+        String title = article.getTitle();
+
+        // summary가 null일 수 있으므로 title을 fallback
+        String summary = article.getSummary() != null ? article.getSummary() : article.getTitle();
+        persistenceService.markGenerated(cluster.getId(), title, summary);
+        return true;
+    }
+
+    /**
+     * 클러스터에 속한 기사들을 "제목 + 본문" 문자열 형태로 변환한다.
+     */
+    private List<String> getArticleTexts(Long clusterId) {
+        // 1. 클러스터-기사 매핑 조회 (현재 소속된 기사만)
+        List<NewsClusterArticle> mappings = clusterArticleRepository.findByNewsClusterId(clusterId);
+
+        // 2. 기사 ID 추출
+        List<Long> articleIds = mappings.stream()
+                .map(NewsClusterArticle::getNewsArticleId)
+                .toList();
+
+        // 3. 기사 일괄 조회 + "제목 + 본문" 형태로 변환
+        return newsArticleRepository.findAllById(articleIds).stream()
+                .map(article -> "제목: " + article.getTitle() + "\n본문: " +
+                        (article.getContent() != null ? article.getContent() : ""))
+                .toList();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
@@ -2,8 +2,8 @@ package com.solv.wefin.domain.news.tagging.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.news.config.dto.OpenAiChatApiResponse;
 import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -92,13 +92,13 @@ public class OpenAiTaggingClient {
         );
 
         HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
-        ChatResponse response = restTemplate.postForObject(OPENAI_CHAT_URL, request, ChatResponse.class);
+        OpenAiChatApiResponse response = restTemplate.postForObject(OPENAI_CHAT_URL, request, OpenAiChatApiResponse.class);
 
         if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
             throw new IllegalStateException("OpenAI Tagging API 응답이 비어있습니다");
         }
 
-        Message message = response.getChoices().get(0).getMessage();
+        OpenAiChatApiResponse.Message message = response.getChoices().get(0).getMessage();
         if (message == null || message.getContent() == null) {
             throw new IllegalStateException("OpenAI Tagging API 응답 메시지가 비어있습니다");
         }
@@ -122,18 +122,4 @@ public class OpenAiTaggingClient {
                 : content.substring(0, MAX_CONTENT_LENGTH);
     }
 
-    @Getter
-    private static class ChatResponse {
-        private List<Choice> choices;
-    }
-
-    @Getter
-    private static class Choice {
-        private Message message;
-    }
-
-    @Getter
-    private static class Message {
-        private String content;
-    }
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -74,6 +74,10 @@ public enum ErrorCode {
     CLUSTERING_ARTICLE_NOT_FOUND(500, "클러스터링 대상 기사를 찾을 수 없습니다."),
     CLUSTERING_NO_EMBEDDING(500, "기사의 임베딩이 존재하지 않습니다."),
 
+    // Summary
+    SUMMARY_ALREADY_RUNNING(409, "요약 생성이 이미 실행 중입니다."),
+    SUMMARY_CLUSTER_NOT_FOUND(500, "요약 대상 클러스터를 찾을 수 없습니다."),
+
     // GameRoom
     ROOM_NOT_FOUND(404,"게임장을 찾을 수 없습니다."),
     ROOM_ALREADY_EXISTS(409, "이미 진행 중이거나 대기 중인 게임방이 있습니다."),

--- a/src/main/java/com/solv/wefin/web/news/SummaryAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/SummaryAdminController.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.news;
+
+import com.solv.wefin.domain.news.summary.batch.SummaryScheduler;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/api/admin/news/summary")
+@RequiredArgsConstructor
+public class SummaryAdminController {
+
+    private final SummaryScheduler summaryScheduler;
+
+    /**
+     * AI 요약 생성을 수동으로 트리거한다.
+     */
+    @PostMapping("/trigger")
+    public ApiResponse<String> triggerSummary() {
+        boolean executed = summaryScheduler.execute();
+        if (!executed) {
+            throw new BusinessException(ErrorCode.SUMMARY_ALREADY_RUNNING);
+        }
+        return ApiResponse.success("요약 생성 배치 실행 완료");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -54,6 +54,10 @@ clustering:
   collect:
     cron: "0 */30 * * * *"
 
+summary:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,6 +55,10 @@ clustering:
   collect:
     cron: ${CLUSTERING_COLLECT_CRON:-}
 
+summary:
+  collect:
+    cron: ${SUMMARY_COLLECT_CRON:-}
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -51,6 +51,10 @@ clustering:
   collect:
     cron: "0 */30 * * * *"
 
+summary:
+  collect:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ openai:
     version: v1
   tagging:
     model: gpt-4o-mini
+  summary:
+    model: gpt-4o-mini
 
 embedding:
   collect:
@@ -34,6 +36,10 @@ clustering:
   score:
     reject-cutoff: 70
     suspicious-cutoff: 80
+  collect:
+    cron: "0 */30 * * * *"
+
+summary:
   collect:
     cron: "0 */30 * * * *"
 

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
@@ -1,0 +1,290 @@
+package com.solv.wefin.domain.news.summary.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.summary.client.OpenAiSummaryClient;
+import com.solv.wefin.domain.news.summary.dto.SummaryResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SummaryServiceTest {
+
+    @InjectMocks
+    private SummaryService summaryService;
+
+    @Mock
+    private NewsClusterRepository newsClusterRepository;
+
+    @Mock
+    private NewsClusterArticleRepository clusterArticleRepository;
+
+    @Mock
+    private NewsArticleRepository newsArticleRepository;
+
+    @Mock
+    private OpenAiSummaryClient openAiSummaryClient;
+
+    @Mock
+    private OutlierDetectionService outlierDetectionService;
+
+    @Mock
+    private SummaryPersistenceService persistenceService;
+
+    private NewsCluster createCluster(Long id, int articleCount, SummaryStatus status) {
+        float[] vector = {1.0f, 0.0f, 0.0f};
+        NewsCluster cluster = NewsCluster.createSingle(vector, 1L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", id);
+        ReflectionTestUtils.setField(cluster, "articleCount", articleCount);
+        ReflectionTestUtils.setField(cluster, "summaryStatus", status);
+        return cluster;
+    }
+
+    private NewsArticle createArticle(Long id) {
+        NewsArticle article = NewsArticle.builder()
+                .rawNewsArticleId(1L)
+                .publisherName("테스트")
+                .title("테스트 기사 " + id)
+                .content("테스트 본문 " + id)
+                .originalUrl("https://example.com/" + id)
+                .build();
+        ReflectionTestUtils.setField(article, "id", id);
+        return article;
+    }
+
+    @Test
+    @DisplayName("다건 클러스터 — AI 요약 생성 성공")
+    void generatePendingSummaries_multiArticle_success() {
+        // given
+        NewsCluster cluster = createCluster(10L, 3, SummaryStatus.PENDING);
+        NewsArticle article1 = createArticle(1L);
+        NewsArticle article2 = createArticle(2L);
+        NewsArticle article3 = createArticle(3L);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(outlierDetectionService.removeOutliers(cluster))
+                .willReturn(0);
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(10L, 1L, 1, false),
+                        NewsClusterArticle.create(10L, 2L, 2, false),
+                        NewsClusterArticle.create(10L, 3L, 3, false)));
+        given(newsArticleRepository.findAllById(List.of(1L, 2L, 3L)))
+                .willReturn(List.of(article1, article2, article3));
+
+        SummaryResult result = new SummaryResult();
+        ReflectionTestUtils.setField(result, "title", "테스트 제목");
+        ReflectionTestUtils.setField(result, "summary", "테스트 요약");
+        given(openAiSummaryClient.generateSummary(any()))
+                .willReturn(result);
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(openAiSummaryClient).generateSummary(any());
+        verify(persistenceService).markGenerated(10L, "테스트 제목", "테스트 요약");
+        verify(persistenceService, never()).markFailed(any());
+    }
+
+    @Test
+    @DisplayName("단독 클러스터 — AI 호출 없이 기사 제목/요약 사용")
+    void generatePendingSummaries_singleArticle_noApiCall() {
+        // given
+        NewsCluster cluster = createCluster(10L, 1, SummaryStatus.PENDING);
+        NewsArticle article = createArticle(1L);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(NewsClusterArticle.create(10L, 1L, 1, false)));
+        given(newsArticleRepository.findAllById(List.of(1L)))
+                .willReturn(List.of(article));
+        given(newsArticleRepository.findById(1L))
+                .willReturn(Optional.of(article));
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(openAiSummaryClient, never()).generateSummary(any());
+        verify(persistenceService).markGenerated(eq(10L), eq("테스트 기사 1"), any());
+    }
+
+    @Test
+    @DisplayName("AI 요약 실패 시 FAILED 마킹")
+    void generatePendingSummaries_apiFailure_markFailed() {
+        // given
+        NewsCluster cluster = createCluster(10L, 2, SummaryStatus.PENDING);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(outlierDetectionService.removeOutliers(cluster))
+                .willReturn(0);
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(10L, 1L, 1, false),
+                        NewsClusterArticle.create(10L, 2L, 2, false)));
+        given(newsArticleRepository.findAllById(any()))
+                .willReturn(List.of(createArticle(1L), createArticle(2L)));
+        given(openAiSummaryClient.generateSummary(any()))
+                .willThrow(new RuntimeException("API 오류"));
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(persistenceService).markFailed(10L);
+        verify(persistenceService, never()).markGenerated(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("대상 클러스터가 없으면 아무것도 실행하지 않음")
+    void generatePendingSummaries_noTargets() {
+        // given
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of());
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(openAiSummaryClient, never()).generateSummary(any());
+        verify(persistenceService, never()).markGenerated(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("STALE 클러스터도 요약 대상에 포함")
+    void generatePendingSummaries_staleCluster() {
+        // given
+        NewsCluster cluster = createCluster(10L, 2, SummaryStatus.STALE);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(outlierDetectionService.removeOutliers(cluster))
+                .willReturn(0);
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(10L, 1L, 1, false),
+                        NewsClusterArticle.create(10L, 2L, 2, false)));
+        given(newsArticleRepository.findAllById(any()))
+                .willReturn(List.of(createArticle(1L), createArticle(2L)));
+
+        SummaryResult result = new SummaryResult();
+        ReflectionTestUtils.setField(result, "title", "갱신된 제목");
+        ReflectionTestUtils.setField(result, "summary", "갱신된 요약");
+        given(openAiSummaryClient.generateSummary(any()))
+                .willReturn(result);
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(persistenceService).markGenerated(10L, "갱신된 제목", "갱신된 요약");
+    }
+
+    @Test
+    @DisplayName("이상치 제거 후 요약 생성")
+    void generatePendingSummaries_withOutlierRemoval() {
+        // given
+        NewsCluster cluster = createCluster(10L, 5, SummaryStatus.PENDING);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(outlierDetectionService.removeOutliers(cluster))
+                .willReturn(2); // 2건 제거
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(10L, 1L, 1, false),
+                        NewsClusterArticle.create(10L, 2L, 2, false),
+                        NewsClusterArticle.create(10L, 3L, 3, false)));
+        given(newsArticleRepository.findAllById(any()))
+                .willReturn(List.of(createArticle(1L), createArticle(2L), createArticle(3L)));
+
+        SummaryResult result = new SummaryResult();
+        ReflectionTestUtils.setField(result, "title", "정제된 제목");
+        ReflectionTestUtils.setField(result, "summary", "정제된 요약");
+        given(openAiSummaryClient.generateSummary(any()))
+                .willReturn(result);
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(outlierDetectionService).removeOutliers(cluster);
+        verify(persistenceService).markGenerated(10L, "정제된 제목", "정제된 요약");
+    }
+
+    @Test
+    @DisplayName("이상치 제거 후 기사 0건이면 FAILED 마킹")
+    void generatePendingSummaries_emptyAfterOutlierRemoval_markFailed() {
+        // given
+        NewsCluster cluster = createCluster(10L, 3, SummaryStatus.PENDING);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(outlierDetectionService.removeOutliers(cluster))
+                .willReturn(3);
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of());
+        given(newsArticleRepository.findAllById(List.of()))
+                .willReturn(List.of());
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(persistenceService).markFailed(10L);
+        verify(openAiSummaryClient, never()).generateSummary(any());
+    }
+
+    @Test
+    @DisplayName("AI 응답에 title만 있고 summary가 없으면 실패 처리")
+    void generatePendingSummaries_partialResult_markFailed() {
+        // given
+        NewsCluster cluster = createCluster(10L, 2, SummaryStatus.PENDING);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+                .willReturn(List.of(cluster));
+        given(outlierDetectionService.removeOutliers(cluster))
+                .willReturn(0);
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(10L, 1L, 1, false),
+                        NewsClusterArticle.create(10L, 2L, 2, false)));
+        given(newsArticleRepository.findAllById(any()))
+                .willReturn(List.of(createArticle(1L), createArticle(2L)));
+
+        SummaryResult result = new SummaryResult();
+        ReflectionTestUtils.setField(result, "title", "제목만 있음");
+
+        given(openAiSummaryClient.generateSummary(any()))
+                .willReturn(result);
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
+        verify(persistenceService).markFailed(10L);
+        verify(persistenceService, never()).markGenerated(any(), any(), any());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
@@ -79,7 +79,7 @@ class SummaryServiceTest {
         NewsArticle article2 = createArticle(2L);
         NewsArticle article3 = createArticle(3L);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(outlierDetectionService.removeOutliers(cluster))
                 .willReturn(0);
@@ -113,7 +113,7 @@ class SummaryServiceTest {
         NewsCluster cluster = createCluster(10L, 1, SummaryStatus.PENDING);
         NewsArticle article = createArticle(1L);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(clusterArticleRepository.findByNewsClusterId(10L))
                 .willReturn(List.of(NewsClusterArticle.create(10L, 1L, 1, false)));
@@ -136,7 +136,7 @@ class SummaryServiceTest {
         // given
         NewsCluster cluster = createCluster(10L, 2, SummaryStatus.PENDING);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(outlierDetectionService.removeOutliers(cluster))
                 .willReturn(0);
@@ -161,7 +161,7 @@ class SummaryServiceTest {
     @DisplayName("대상 클러스터가 없으면 아무것도 실행하지 않음")
     void generatePendingSummaries_noTargets() {
         // given
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of());
 
         // when
@@ -178,7 +178,7 @@ class SummaryServiceTest {
         // given
         NewsCluster cluster = createCluster(10L, 2, SummaryStatus.STALE);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(outlierDetectionService.removeOutliers(cluster))
                 .willReturn(0);
@@ -208,7 +208,7 @@ class SummaryServiceTest {
         // given
         NewsCluster cluster = createCluster(10L, 5, SummaryStatus.PENDING);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(outlierDetectionService.removeOutliers(cluster))
                 .willReturn(2); // 2건 제거
@@ -240,7 +240,7 @@ class SummaryServiceTest {
         // given
         NewsCluster cluster = createCluster(10L, 3, SummaryStatus.PENDING);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(outlierDetectionService.removeOutliers(cluster))
                 .willReturn(3);
@@ -263,7 +263,7 @@ class SummaryServiceTest {
         // given
         NewsCluster cluster = createCluster(10L, 2, SummaryStatus.PENDING);
 
-        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any()))
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
                 .willReturn(List.of(cluster));
         given(outlierDetectionService.removeOutliers(cluster))
                 .willReturn(0);

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -40,6 +40,8 @@ openai:
     version: v1
   tagging:
     model: gpt-4o-mini
+  summary:
+    model: gpt-4o-mini
 
 embedding:
   collect:
@@ -58,5 +60,9 @@ clustering:
   score:
     reject-cutoff: 70
     suspicious-cutoff: 80
+  collect:
+    cron: "-"
+
+summary:
   collect:
     cron: "-"


### PR DESCRIPTION
## 📌 PR 설명
사용자가 관심 종목·섹터·주제의 여러 기사를 하나의 뉴스 카드 형태로 편리하게 소비할 수 있도록, 동일한 이슈의 기사들을 묶어 AI가 대표 제목과 요약을 자동 생성하는 기능을 제공해야 했습니다.

이번 PR에서는 이 기능을 위한 '클러스터 단위 AI 요약 생성 배치 파이프라인'을 작업했습니다. 클러스터링이 완료된 뉴스 데이터를 기반으로 OpenAI Chat API를 호출해 서비스에 노출될 title과 summary를 생성하고 DB에 저장하는 역할을 합니다.

세부적인 동작 방식은 다음과 같습니다. 우선 ACTIVE 상태의 클러스터 중 요약이 필요한 상태(PENDING, STALE, FAILED)만 선별합니다. 이후 요약 생성 직전에 Centroid 유사도와 태그 교집합을 기준으로 이상치 기사를 제거해 클러스터의 품질을 한 번 더 보정합니다. 요약 생성 시, 단일 기사 클러스터는 AI 호출 없이 원문을 그대로 활용하여 비용을 절감했습니다. 반면 여러 기사로 구성된 클러스터는 팩트·분석·전망·영향을 균형 있게 정리하도록 프롬프트를 설계해 금융 브리핑에 적합한 결과물을 만들도록 유도했습니다.

배치는 30분 주기로 자동 실행됩니다. 이때 클러스터별로 트랜잭션을 독립 시작하여 일부 처리 실패가 전체 파이프라인에 영향을 주지 않도록 했으며(실패 마킹 경로는 REQUIRES_NEW로 격리), FAILED 건에 대해서는 자동으로 재시도되도록 처리해 운영 안정성도 함께 고려했습니다.

주요 구현 포인트:

- ACTIVE 클러스터 중 요약 생성이 필요한(PENDING/STALE/FAILED) 클러스터를 대상으로 처리
- 요약 직전 이상치 제거 (centroid 유사도 하위 + 태그 불일치) + 클러스터 집계 재계산
- 단독 클러스터(1건)는 AI 호출 없이 기사 제목/요약 사용
- 프롬프트에서 팩트/분석/전망/영향 다각도 정리를 유도
- STALE 클러스터도 재생성 대상에 포함
- 30분 주기 배치 + 어드민 수동 트리거 + 클러스터 단위 실패 격리
<img width="5960" height="5610" alt="Alice Bob Message Flow-2026-04-05-130005" src="https://github.com/user-attachments/assets/a96979ce-2aff-4b41-a5af-3a36c691227c" />


<br>

## ✅ 변경 파일

1. `OpenAiChatApiResponse.java` — OpenAI Chat API 공통 응답 DTO (태깅/요약 공유)
2. `SummaryResult.java` — 요약 응답 DTO (title + summary, isEmpty는 OR 조건)
3. `OpenAiSummaryClient.java` — OpenAI Chat API 호출 + 프롬프트 (summaryRestTemplate + openai.summary.model)
4. `OutlierDetectionService.java` — 이상치 full 검증 (매핑 삭제 + 집계 재계산, 제거된 기사는 다음 배치에서 수거)
5. `SummaryPersistenceService.java` — 트랜잭션 분리 (GENERATED/FAILED 마킹)
6. `SummaryService.java` — 전체 흐름 오케스트레이션 (ACTIVE만 대상, BATCH_SIZE 50건 제한, 빈 클러스터 FAILED 마킹)
7. `SummaryScheduler.java` — 30분 배치 (AtomicBoolean + catch-log-rethrow)
8. `SummaryAdminController.java` — 수동 트리거 (@Profile local, dev)
9. `NewsCluster.java` — recalculateAfterOutlierRemoval() 도메인 메서드 추가 (modified)
10. `NewsClusterRepository.java` — findByStatusAndSummaryStatusIn 추가 (modified)
11. `OpenAiConfig.java` — summaryRestTemplate 추가 (modified)
12. `OpenAiTaggingClient.java` — inner ChatResponse → 공통 OpenAiChatResponse로 교체 (modified)
13. `ErrorCode.java` — SUMMARY_ALREADY_RUNNING, SUMMARY_CLUSTER_NOT_FOUND 추가 (modified)
14. `application.yml` — openai.summary.model + summary.collect.cron (modified)
15. `application-local.yml` — cron 비활성화 (modified)
16. `application-dev.yml` — cron 30분 (modified)
17. `application-prod.yml` — cron 30분 (modified)
18. `application-test.yml` — 테스트 설정 (modified)
19. `SummaryServiceTest.java` — 단위 테스트 8건

<br>


## 💭 고민과 해결과정
### OutlierDetection 책임 과다
현재 이상치 탐지 + 매핑 삭제 + 집계 재계산이 한 클래스에 있습니다. 향후 책임을 분리하여 집계 재계산 로직을 별도 서비스로 추출하고자 합니다.

<br>

## 🧭 실측 결과 및 후속 과제

### AI 요약 품질 — 다건 클러스터 기준 양호

실제로 DB(`news_cluster.title`, `news_cluster.summary`)에 저장된 결과를 확인한 결과, 다건 클러스터(article_count ≥ 2)의 AI 요약은 설계 의도대로 동작합니다.

- 예시 클러스터 20: "기아와 현대차, 안정적인 실적 속 성장 모멘텀 기대" — 팩트/분석/전망/영향 구조 정상
- 예시 클러스터 15: "한국인 해외 유학생 수, 팬데믹 이전 절반으로 감소" — 매끄러운 종합 요약 생성
- 예시 클러스터 36: "조인성 SNS" -  클러스터링/요약은 정상 작동했으나 애초에 금융 무관 콘텐츠로 필터링됐어야 함


<img width="400"  alt="image" src="https://github.com/user-attachments/assets/89b5fcc9-4eaf-4591-aef5-db586d2deeaa" />

<br>

### 발견된 상위 단계 이슈

다음은 실제 결과를 검증하면서 확인된 이슈들입니다. 요약 파이프라인 자체는 정상적으로 동작하지만, 입력 데이터의 품질이 요약 결과에 직접적인 영향을 주는 구조라 선행 단계의 완성도를 개선해야겠다고 판단하였습니다.

**① 비금융 뉴스 유입** (서비스 범위 확정: 금융 전용)
* 조인성 SNS, 정치 기사 등 금융과 무관한 콘텐츠가 피드에 포함됨
* 수집/태깅 단계에서 관련성 필터링이 부족한 상태
* 결정사항: 서비스 범위를 "금융 전용"으로 확정하고, UI 카테고리도 금융 중심 구조로 재정의 필요
* 해결 방향: 수집 단계에서 카테고리 화이트리스트 적용 + AI 태깅에 "금융 관련성" 판정 추가 (`IRRELEVANT` 태그 부여 → 요약 대상 제외)

**② 중복 클러스터**
* 동일한 주제(예: "유학생 감소")가 서로 다른 클러스터(15, 28)로 분리됨
* 클러스터 매칭 임계값 또는 centroid 이동 정책의 영향으로 추정
* 해결 방향: 유사 클러스터를 후처리로 합치는 병합 배치 도입 필요

**③ 잘못된 클러스터링**
* 서로 무관한 주제(비트코인 해킹 + 유학생 감소)가 하나의 클러스터로 묶이는 문제 발생
* 이상치 제거 단계에서 `TOPIC` 교집합이 존재해 필터링되지 않은 것으로 보임
* 해결 방향: 이상치 기준을 태그 교집합 중심에서 유사도 기반 또는 STOCK 태그 우선 방식으로 조정 필요


### UI 요구사항 비교
목표로 하는 뉴스 상세 화면은 소제목 + 단락 N개 + 단락별 출처 매칭 구조이지만, 현재는 단일 `summary` 문자열만 생성하고 있는 상태입니다. 또한 홈 피드에서 요구하는 "요새 ~가 뜨고 있어요" 형태의 인사이트 카드(종목/섹터별 트렌드 + 투자 힌트)는 클러스터 단위 요약과는 역할이 다른 상위 집계 레이어에서 처리되어야 합니다. 본 PR은 섹션형 요약과 인사이트 카드의 공통 인프라(1단계)입니다. 클러스터 단위 title/lead summary 생성 + 배치/트랜잭션/실패 격리 + OpenAI 호출 레이어 공통화가 목표이며, 섹션형 요약과 인사이트 카드는 이 인프라 위에서 별도 PR로 구현할 예정입니다.

<img width="200"  alt="image" src="https://github.com/user-attachments/assets/de9ffd60-767a-460c-843a-edb2ce5ce8dd" />


<br>

### 🔗 관련 이슈
Closes #132 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI 기반 뉴스 클러스터 요약 파이프라인 추가(스케줄러, 요약 클라이언트, 요약 서비스, 퍼시스턴스)
  * 이상치 탐지·제거 및 제거 후 클러스터 재집계 기능 추가
  * 관리자용 수동 요약 트리거 API(로컬/개발 환경) 추가
  * 요약용 HTTP 클라이언트 빈 추가

* **Tests**
  * 요약 생성 서비스 단위 테스트 추가(다양한 시나리오 포함)

* **Chores**
  * OpenAI 요약 모델 및 스케줄링 설정 추가
  * 요약 응답 DTO, OpenAI 클라이언트 예외 및 관련 오류 코드 추가
* **API**
  * 클러스터 조회용 페이징 쿼리 및 유틸리티 함수 접근성 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->