### PR TITLE
[WEF-350] 웹소켓 중계 서버 및 구독 관리 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -30,7 +30,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
 
     private final WebSocketClient hantuWsClient;
     private final HantuWebSocketKeyManager hantuWebSocketKeyManager;
-    private WebSocketSession session;
+    private volatile WebSocketSession session;
     private final ObjectMapper objectMapper;
     private final SimpMessagingTemplate messagingTemplate;
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -1,0 +1,61 @@
+package com.solv.wefin.domain.trading.market.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+/**
+ * 한투 WebSocket 연결/재연결 클라이언트
+ */
+@RequiredArgsConstructor
+@Slf4j
+@Component
+public class HantuWebSocketClient extends TextWebSocketHandler {
+
+    @Value("${hantu.ws.url}")
+    private String wsUrl;
+
+    private final WebSocketClient hantuWsClient;
+    private final HantuWsKeyManager hantuWsKeyManager;
+    private WebSocketSession session;
+
+    // 한투 WS에 연결
+    @EventListener(ApplicationReadyEvent.class)
+    public void connect() {
+        hantuWsClient.execute(this, wsUrl);
+    }
+
+    // 연결 성공 시
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        this.session = session;
+        log.info("한투 웹소켓 연결에 성공했습니다.");
+    }
+
+    // 메시지 수신 시
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) {
+
+    }
+
+    // 연결 끊겼을 때 → 재연결
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        log.warn("한투 웹소켓 연결 끊김. 재연결 시도...");
+        try {
+            Thread.sleep(5000);
+            connect();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("한투 웹소켓 재연결 중 인터럽트 발생");
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -1,16 +1,22 @@
 package com.solv.wefin.domain.trading.market.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.WebSocketClient;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.math.BigDecimal;
+import java.util.Map;
 
 /**
  * 한투 WebSocket 연결/재연결 클라이언트
@@ -26,6 +32,8 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private final WebSocketClient hantuWsClient;
     private final HantuWebSocketKeyManager hantuWebSocketKeyManager;
     private WebSocketSession session;
+    private final ObjectMapper objectMapper;
+    private final SimpMessagingTemplate messagingTemplate;
 
     // 한투 WS에 연결
     @EventListener(ApplicationReadyEvent.class)
@@ -57,5 +65,19 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
             Thread.currentThread().interrupt();
             log.error("한투 웹소켓 재연결 중 인터럽트 발생");
         }
+    }
+
+    // 종목 구독 요청
+    public void sendSubscribe(String stockCode) {
+        // WEF-356에서 구현
+    }
+
+    // 종목 구독 해제 요청
+    public void sendUnsubscribe(String stockCode) {
+        // WEF-356에서 구현
+    }
+
+    private void sendMessage(String stockCode, String trType) {
+        // WEF-356에서 구현
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -16,6 +16,9 @@ import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.math.BigDecimal;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 한투 WebSocket 연결/재연결 클라이언트
@@ -29,6 +32,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private String wsUrl;
 
     private final WebSocketClient hantuWsClient;
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
     private final HantuWebSocketKeyManager hantuWebSocketKeyManager;
     private volatile WebSocketSession session;
     private final ObjectMapper objectMapper;
@@ -57,13 +61,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         log.warn("한투 웹소켓 연결 끊김. 재연결 시도...");
-        try {
-            Thread.sleep(5000);
-            connect();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("한투 웹소켓 재연결 중 인터럽트 발생");
-        }
+        scheduler.schedule(this::connect, 5, TimeUnit.SECONDS);
     }
 
     // 종목 구독 요청

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -1,7 +1,6 @@
 package com.solv.wefin.domain.trading.market.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -41,7 +41,13 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     // 한투 WS에 연결
     @EventListener(ApplicationReadyEvent.class)
     public void connect() {
-        hantuWsClient.execute(this, wsUrl);
+        try {
+            hantuWsClient.execute(this, wsUrl);
+        } catch (Exception e) {
+            log.error("한투 웹소켓 초기 연결 실패. 5초 후 재시도...", e);
+            scheduler.schedule(this::connect, 5, TimeUnit.SECONDS);
+
+        }
     }
 
     // 연결 성공 시

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -24,7 +24,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private String wsUrl;
 
     private final WebSocketClient hantuWsClient;
-    private final HantuWsKeyManager hantuWsKeyManager;
+    private final HantuWebSocketKeyManager hantuWebSocketKeyManager;
     private WebSocketSession session;
 
     // 한투 WS에 연결

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketKeyManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketKeyManager.java
@@ -22,7 +22,7 @@ public class HantuWebSocketKeyManager {
     private final RestClient hantuRestClient;
     private String approvalKey;
 
-    public String getApprovalKey() {
+    public synchronized String getApprovalKey() {
         if (approvalKey == null) {
             fetchApprovalKey();
         }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketKeyManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketKeyManager.java
@@ -33,12 +33,16 @@ public class HantuWebSocketKeyManager {
     private void fetchApprovalKey() {
         for (int tries = 1; tries <= 3; tries++) {
             try {
-                Map response = hantuRestClient.post()
+                @SuppressWarnings("unchecked")
+                Map<String, Object> response = hantuRestClient.post()
                         .uri("/oauth2/Approval")
                         .body(Map.of("grant_type", "client_credentials",
                                 "appkey", appKey, "secretkey", appSecret))
                         .retrieve()
                         .body(Map.class);
+                if (response == null || response.get("approval_key") == null) {
+                    throw new RuntimeException("한투 웹소켓 접속키 응답이 비어있습니다.");
+                }
                 this.approvalKey = (String) response.get("approval_key");
 
                 return;

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketKeyManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketKeyManager.java
@@ -11,7 +11,7 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class HantuWsKeyManager {
+public class HantuWebSocketKeyManager {
 
     @Value("${hantu.api.appkey}")
     private String appKey;

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWsKeyManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWsKeyManager.java
@@ -1,0 +1,56 @@
+package com.solv.wefin.domain.trading.market.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class HantuWsKeyManager {
+
+    @Value("${hantu.api.appkey}")
+    private String appKey;
+
+    @Value("${hantu.api.appsecret}")
+    private String appSecret;
+
+    private final RestClient hantuRestClient;
+    private String approvalKey;
+
+    public String getApprovalKey() {
+        if (approvalKey == null) {
+            fetchApprovalKey();
+        }
+
+        return approvalKey;
+    }
+
+    private void fetchApprovalKey() {
+        for (int tries = 1; tries <= 3; tries++) {
+            try {
+                Map response = hantuRestClient.post()
+                        .uri("/oauth2/Approval")
+                        .body(Map.of("grant_type", "client_credentials",
+                                "appkey", appKey, "secretkey", appSecret))
+                        .retrieve()
+                        .body(Map.class);
+                this.approvalKey = (String) response.get("approval_key");
+
+                return;
+            } catch (Exception e) {
+                log.error("한투 웹소켓 접속키 발급 실패 ({}/3)", tries, e);
+                if (tries == 3) throw e;
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/config/HantuWebSocketConfig.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/config/HantuWebSocketConfig.java
@@ -7,7 +7,7 @@ import org.springframework.web.socket.client.WebSocketClient;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 
 @Configuration
-public class HantuWsConfig {
+public class HantuWebSocketConfig {
 
     @Value("${hantu.ws.url}")
     private String baseUrl;

--- a/src/main/java/com/solv/wefin/domain/trading/market/config/HantuWsConfig.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/config/HantuWsConfig.java
@@ -1,0 +1,19 @@
+package com.solv.wefin.domain.trading.market.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+
+@Configuration
+public class HantuWsConfig {
+
+    @Value("${hantu.ws.url}")
+    private String baseUrl;
+
+    @Bean
+    public WebSocketClient hantuWsClient() {
+        return new StandardWebSocketClient();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuWebSocketClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@RequiredArgsConstructor
+@Service
+public class SubscriptionManager {
+
+    private final HantuWebSocketClient hantuWebSocketClient;
+    private final ConcurrentHashMap<String, AtomicInteger> subscriptions = new ConcurrentHashMap<>();
+
+    public void subscribe(String stockCode) {
+
+        AtomicInteger count = subscriptions.computeIfAbsent
+                (stockCode, k -> new AtomicInteger(0));
+
+        if (count.incrementAndGet() == 1) {
+            hantuWebSocketClient.sendSubscribe(stockCode);
+        }
+    }
+
+    public void unsubscribe(String stockCode) {
+        AtomicInteger count = subscriptions.get(stockCode);
+
+        if (count == null) {
+            return;
+        }
+
+        if (count.decrementAndGet() == 0) {
+            hantuWebSocketClient.sendUnsubscribe(stockCode);
+            subscriptions.remove(stockCode);
+        }
+
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/market/MarketWebSocketController.java
+++ b/src/main/java/com/solv/wefin/web/trading/market/MarketWebSocketController.java
@@ -1,0 +1,28 @@
+package com.solv.wefin.web.trading.market;
+
+import com.solv.wefin.domain.trading.market.service.SubscriptionManager;
+import com.solv.wefin.web.trading.market.dto.request.StockSubscribeRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class MarketWebSocketController {
+
+    private final SubscriptionManager subscriptionManager;
+
+    @MessageMapping("/stocks/subscribe")
+    public void subscribe(StockSubscribeRequest request) {
+        log.info("종목 구독 요청: {}", request.stockCode());
+        subscriptionManager.subscribe(request.stockCode());
+    }
+
+    @MessageMapping("/stocks/unsubscribe")
+    public void unsubscribe(StockSubscribeRequest request) {
+        log.info("종목 구독 해제 요청: {}", request.stockCode());
+        subscriptionManager.unsubscribe(request.stockCode());
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/market/dto/request/StockSubscribeRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/market/dto/request/StockSubscribeRequest.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.web.trading.market.dto.request;
+
+public record StockSubscribeRequest (
+        String stockCode
+){
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,6 @@ hantu:
     baseUrl: https://openapivts.koreainvestment.com:29443
     appkey: ${HANTU_APPKEY:}
     appsecret: ${HANTU_APPSECRET:}
+
+  ws:
+    url: ws://ops.koreainvestment.com:31000


### PR DESCRIPTION
## 📌 PR 설명
한투 WebSocket 연결/재연결, 종목 구독 관리(레퍼런스 카운팅), 클라이언트 WebSocket 엔드포인트를 구현했습니다.
<br>

## ✅ 완료한 기능 명세

- [x] HantuWebSocketConfig — WebSocket 클라이언트 빈 등록
- [x] HantuWebSocketKeyManager — WebSocket 접속키(approval_key) 발급/관리
- [x] HantuWebSocketClient — 한투 WS 연결/재연결 (ApplicationReadyEvent)
- [x] SubscriptionManager — 레퍼런스 카운팅 기반 종목 구독 관리
- [x] MarketWebSocketController — STOMP 기반 구독/해제 메시지 처리
- [x] StockSubscribeRequest DTO
- [x] 스레드 안전성 적용 (volatile session, synchronized getApprovalKey)
- [x] 비동기 재연결 (ScheduledExecutorService) 

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
### 한투 WebSocket 접속키 vs REST 토큰

  REST API는 access_token(24시간 유효, 6시간 갱신)을 사용하고, WebSocket은 approval_key(세션 연결 시 1회 사용)를 사용한다. 역할이 다르므로 HantuTokenManager와 별도로 HantuWebSocketKeyManager를 분리했다.

### 레퍼런스 카운팅 구독 관리

한투 WS는 세션당 41종목 제한이 있어, 같은 종목을 여러 유저가 구독해도 한투 WS에는 1회만 구독한다. ConcurrentHashMap<String, AtomicInteger>로 종목별 구독자 수를 관리하며, 
count가 1이 될 때 한투 구독, 0이 될 때 한투 해제를 수행한다.

```
실시간 데이터 파싱과 클라이언트 push는 WEF-356에서 구현 예정
```

<br>

### 🔗 관련 이슈
Closes #70 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 실시간 주식 시장 데이터 구독 및 해제 기능 추가
  * WebSocket 기반 시장 데이터 연결 및 자동 재연결 지원
  * 주식 코드별 구독 관리로 중복 구독 방지 및 참조 카운트 처리
  * WebSocket 구독 제어용 메시지 엔드포인트(구독/구독해제) 추가
  * 승인 키를 안전하게 조회·캐시하여 WebSocket 접근에 사용

* **Configuration**
  * WebSocket 서버 URL 설정 항목(hantu.ws.url) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->