### PR TITLE
[WEF-488] 동시성 테스트

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/account/service/VirtualAccountService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/account/service/VirtualAccountService.java
@@ -100,4 +100,11 @@ public class VirtualAccountService {
 		return accountRepository.findByIdForUpdate(virtualAccountId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND));
 	}
+
+	/**
+	 * 락을 잡고 계좌 조회 (락 순서 보장용)
+	 */
+	public VirtualAccount getAccountWithLock(Long virtualAccountId) {
+		return getAccountForUpdate(virtualAccountId);
+	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -103,6 +103,9 @@ public class OrderService {
 			throw new BusinessException(ErrorCode.MARKET_API_FAILED);
 		}
 
+		// 계좌 락 선점
+		VirtualAccount account = virtualAccountService.getAccountWithLock(virtualAccountId);
+
 		// 4. 보유 종목 확인
 		Portfolio portfolio = portfolioService.getPortfolioForUpdate(virtualAccountId, stockId);
 		if (portfolio.getQuantity() < quantity) {
@@ -138,7 +141,7 @@ public class OrderService {
 		portfolioService.deductQuantity(virtualAccountId, stockId, quantity);
 
 		// 13. 예수금 입금
-		VirtualAccount account = virtualAccountService.depositBalance(virtualAccountId,
+		account = virtualAccountService.depositBalance(virtualAccountId,
 			totalAmount.subtract(fee).subtract(tax));
 
 		// 14. 실현손익 누적

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -127,8 +127,8 @@ public class OrderService {
 
 		// 9. Order 생성 + 저장
 		Order order = orderRepository.save(
-			new Order(virtualAccountId, stockId, OrderType.MARKET, OrderSide.SELL, quantity
-				, null, Currency.KRW, null, fee, tax));
+			new Order(virtualAccountId, stockId, OrderType.MARKET, OrderSide.SELL, quantity,
+				null, Currency.KRW, null, fee, tax));
 
 		// 10. Trade 생성 + 저장
 		tradeService.createSellTrade(order.getOrderId(), virtualAccountId, stockId, quantity, currentPrice,

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -141,11 +141,10 @@ public class OrderService {
 		portfolioService.deductQuantity(virtualAccountId, stockId, quantity);
 
 		// 13. 예수금 입금
-		account = virtualAccountService.depositBalance(virtualAccountId,
-			totalAmount.subtract(fee).subtract(tax));
+		account.deposit(totalAmount.subtract(fee).subtract(tax));
 
 		// 14. 실현손익 누적
-		virtualAccountService.addRealizedProfit(virtualAccountId, realizedAmount);
+		account.addProfit(realizedAmount);
 
 		// 15. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofSell(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,7 +36,7 @@ kis:
 
 stock:
   collect:
-    enabled: true
+    enabled: false
 
 clustering:
   threshold: 0.80

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -104,9 +104,9 @@ class OrderServiceTest {
 			.willReturn(new BigDecimal("178000"));
 
 		VirtualAccount mockAccount = mock(VirtualAccount.class);
-		given(mockAccount.getBalance()).willReturn(new BigDecimal("9000000"));
-		given(virtualAccountService.depositBalance(eq(1L), any()))
+		given(virtualAccountService.getAccountWithLock(1L))
 			.willReturn(mockAccount);
+		given(mockAccount.getBalance()).willReturn(new BigDecimal("9000000"));
 
 		Portfolio mockPortfolio = mock(Portfolio.class);
 		given(mockPortfolio.getAvgPrice()).willReturn(new BigDecimal("170000"));
@@ -124,8 +124,6 @@ class OrderServiceTest {
 		verify(tradeService).createSellTrade(any(), eq(1L), eq(1L), eq(10),
 			any(), any(), any(), any(), any(), any(), any());
 		verify(portfolioService).deductQuantity(eq(1L), eq(1L), eq(10));
-		verify(virtualAccountService).depositBalance(eq(1L), any());
-		verify(virtualAccountService).addRealizedProfit(eq(1L), any());
 		verify(eventPublisher).publishEvent(any(OrderMatchedEvent.class));
 	}
 
@@ -139,6 +137,8 @@ class OrderServiceTest {
 			.willReturn(new BigDecimal("178000"));
 		given(portfolioService.getPortfolioForUpdate(1L, 1L))
 			.willThrow(new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD));
+		given(virtualAccountService.getAccountWithLock(1L))
+			.willReturn(mock(VirtualAccount.class));
 
 		// when & then
 		assertThatThrownBy(() -> orderService.sellMarket(1L, 1L, 10))
@@ -153,6 +153,8 @@ class OrderServiceTest {
 		given(mockStock.getStockCode()).willReturn("005630");
 		given(marketPriceProvider.getCurrentPrice("005630"))
 			.willReturn(new BigDecimal("178000"));
+		given(virtualAccountService.getAccountWithLock(1L))
+			.willReturn(mock(VirtualAccount.class));
 
 		Portfolio mockPortfolio = mock(Portfolio.class);
 		given(mockPortfolio.getQuantity()).willReturn(20);

--- a/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
+++ b/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
@@ -1,0 +1,261 @@
+package com.solv.wefin.integration;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.solv.wefin.common.IntegrationTestBase;
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.HantuTokenManager;
+import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.order.service.OrderService;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@SpringBootTest
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+public class OrderConcurrencyTest extends IntegrationTestBase {
+
+	@Autowired
+	private OrderService orderService;
+	@Autowired
+	private VirtualAccountService accountService;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@MockitoBean
+	private HantuMarketClient hantuMarketClient;
+	@MockitoBean
+	private HantuTokenManager hantuTokenManager;
+
+	private UUID userId;
+	private Long stockId;
+	private Long accountId;
+
+	@BeforeEach
+	void setUp() {
+		HantuPriceApiResponse.Output mockOutput = mock(HantuPriceApiResponse.Output.class);
+		given(mockOutput.stck_prpr()).willReturn("1500000");
+		given(mockOutput.prdy_vrss()).willReturn("0");
+		given(mockOutput.prdy_ctrt()).willReturn("0.0");
+		given(mockOutput.acml_vol()).willReturn("0");
+		given(mockOutput.stck_oprc()).willReturn("186000");
+		given(mockOutput.stck_hgpr()).willReturn("186000");
+		given(mockOutput.stck_lwpr()).willReturn("186000");
+		HantuPriceApiResponse mockResponse = new HantuPriceApiResponse(mockOutput);
+		given(hantuMarketClient.fetchCurrentPrice(anyString())).willReturn(mockResponse);
+
+		userId = UUID.randomUUID();
+
+		jdbcTemplate.execute(
+			"INSERT INTO users (user_id, email, nickname, password, created_at, updated_at) " +
+				"VALUES ('" + userId + "', 'test@test.com', 'tester', 'password', NOW(), NOW())"
+		);
+
+		jdbcTemplate.execute(
+			"INSERT INTO stock (stock_code, stock_name, market, sector) " +
+				"VALUES ('005930', '삼성전자', 'KR', '전자')"
+		);
+		stockId = jdbcTemplate.queryForObject(
+			"SELECT stock_id FROM stock WHERE stock_code = '005930'", Long.class
+		);
+
+		VirtualAccount account = accountService.createAccount(userId);
+		accountId = account.getVirtualAccountId();
+	}
+
+	@AfterEach
+	void cleanUp() {
+		jdbcTemplate.execute("DELETE FROM trade");
+		jdbcTemplate.execute("DELETE FROM orders");
+		jdbcTemplate.execute("DELETE FROM portfolio");
+		jdbcTemplate.execute("DELETE FROM virtual_account");
+		jdbcTemplate.execute("DELETE FROM stock WHERE stock_code = '005930'");
+		jdbcTemplate.execute("DELETE FROM users WHERE email = 'test@test.com'");
+	}
+
+	@Test
+	void 동시_매수_10건_잔고_음수_안됨() throws Exception{
+		// given - setUp()에서 계좌 (1000만원) + 종목 준비
+		int threadCount = 10;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failCount = new AtomicInteger(0);
+
+		// when - 10개 스레드에서 동시에 매수
+		for (int i = 0; i < threadCount; i++) {
+			executor.submit(() -> {
+				try {
+					orderService.buyMarket(accountId, stockId, 1); // 1주 매수
+					successCount.incrementAndGet();
+				} catch (Exception e) {
+					log.error("매수 실패: {}", e.getMessage());
+					failCount.incrementAndGet();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		// 전부 끝날 때까지 대기
+		latch.await();
+		executor.shutdown();
+
+		// then - 검증
+		VirtualAccount result = accountService.getAccountByUserId(userId);
+		assertThat(result.getBalance()).isGreaterThanOrEqualTo(BigDecimal.ZERO);
+		assertThat(successCount.get()).isLessThanOrEqualTo(6);
+
+		log.info("성공: {}, 실패: {}, 잔고: {}", successCount.get(), failCount.get(), result.getBalance());
+	}
+
+	@Test
+	void 동시_매수5건_매도5건_잔고_정합성_유지() throws Exception {
+		// given - 5주 사전 매수
+		for (int i = 0; i < 5; i++) {
+			orderService.buyMarket(accountId, stockId, 1);
+		}
+
+		VirtualAccount before = accountService.getAccountByUserId(userId);
+		BigDecimal startBalance = before.getBalance();
+
+		int startQuantity = 5;
+
+		int totalThread = 10;
+		ExecutorService executor = Executors.newFixedThreadPool(totalThread);
+		CountDownLatch latch = new CountDownLatch(totalThread);
+
+		AtomicInteger buySuccess = new AtomicInteger(0);
+		AtomicInteger sellSuccess = new AtomicInteger(0);
+		AtomicInteger buyFail = new AtomicInteger(0);
+		AtomicInteger sellFail = new AtomicInteger(0);
+
+		// when
+		for (int i = 0; i < 5; i++) {
+			executor.submit(() -> {
+				try {
+					orderService.buyMarket(accountId, stockId, 1);
+					buySuccess.incrementAndGet();
+				} catch (Exception e) {
+					buyFail.incrementAndGet();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		for (int i = 0; i < 5; i++) {
+			executor.submit(() -> {
+				try {
+					orderService.sellMarket(accountId, stockId, 1);
+					sellSuccess.incrementAndGet();
+				} catch (Exception e) {
+					sellFail.incrementAndGet();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executor.shutdown();
+
+		// then
+		// 최종 계좌 조회
+		VirtualAccount result = accountService.getAccountByUserId(userId);
+
+		// 매수/매도 단가 계산
+		BigDecimal price = new BigDecimal("1500000");
+		BigDecimal fee = price.multiply(new BigDecimal("0.00015")).setScale(0, RoundingMode.DOWN);
+		BigDecimal tax = price.multiply(new BigDecimal("0.0018")).setScale(0, RoundingMode.DOWN);
+		BigDecimal buyCost = price.add(fee);
+		BigDecimal sellRevenue = price.subtract(fee).subtract(tax);
+
+		// 기대잔고 계산
+		BigDecimal expectedBalance = startBalance.subtract(buyCost.multiply(BigDecimal.valueOf(buySuccess.get())))
+			.add(sellRevenue.multiply(BigDecimal.valueOf(sellSuccess.get())));
+
+		// 검증
+		assertThat(result.getBalance()).isEqualByComparingTo(expectedBalance);
+		assertThat(result.getBalance()).isGreaterThanOrEqualTo(BigDecimal.ZERO);
+
+		Integer finalQuantity = jdbcTemplate.queryForObject(
+			"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",
+			Integer.class, accountId, stockId
+		);
+		int expectedQuantity = startQuantity + buySuccess.get() - sellSuccess.get();
+		assertThat(finalQuantity).isEqualTo(expectedQuantity);
+
+		log.info("매수 성공: {}, 매수 실패:{}, 매도 성공: {}, 매도 실패:{}, 최종 잔고: {}",
+			buySuccess.get(), buyFail.get(), sellSuccess.get(), sellFail.get(), result.getBalance());
+	}
+
+	@Test
+	void 동시_매도_10건_보유수량_초과_안됨() throws Exception {
+		// given - 5주 사전 매수
+		for (int i = 0; i < 5; i++) {
+			orderService.buyMarket(accountId, stockId, 1);
+		}
+
+		int threadCount = 10;
+		ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+		AtomicInteger successCount = new AtomicInteger(0);
+		AtomicInteger failCount = new AtomicInteger(0);
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executor.submit(() -> {
+				try {
+					orderService.sellMarket(accountId, stockId, 1);
+					successCount.incrementAndGet();
+				} catch (Exception e) {
+					log.info("매도 실패: {}", e.getMessage());
+					failCount.incrementAndGet();
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+		executor.shutdown();
+
+		// then
+		VirtualAccount result = accountService.getAccountByUserId(userId);
+		Integer finalQuantity = 0;
+		try {
+			finalQuantity = jdbcTemplate.queryForObject(
+				"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",
+				Integer.class, accountId, stockId
+
+			);
+		} catch (Exception e) {
+			finalQuantity = 0;
+		}
+
+		assertThat(finalQuantity).isGreaterThanOrEqualTo(0);
+		log.info("성공: {}, 실패: {}, 잔고: {}", successCount, failCount, result.getBalance());
+	}
+}

--- a/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
+++ b/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Propagation;
@@ -206,8 +207,9 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 				"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",
 				Integer.class, accountId, stockId
 			);
-		} catch (Exception e) {
+		} catch (EmptyResultDataAccessException e) {
 			finalQuantity = 0;
+			log.info("포트폴리오 행 없음 - 전량 매도 완료로 판단, 수량 0 처리");
 		}
 
 		int expectedQuantity = startQuantity + buySuccess.get() - sellSuccess.get();
@@ -255,10 +257,10 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 			finalQuantity = jdbcTemplate.queryForObject(
 				"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",
 				Integer.class, accountId, stockId
-
 			);
-		} catch (Exception e) {
+		} catch (EmptyResultDataAccessException e) {
 			finalQuantity = 0;
+			log.info("포트폴리오 행 없음 - 전량 매도 완료로 판단, 수량 0 처리");
 		}
 
 		assertThat(finalQuantity).isGreaterThanOrEqualTo(0);

--- a/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
+++ b/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
@@ -120,7 +121,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 		}
 
 		// 전부 끝날 때까지 대기
-		latch.await();
+		latch.await(10, TimeUnit.SECONDS);
 		executor.shutdown();
 
 		// then - 검증
@@ -179,7 +180,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 			});
 		}
 
-		latch.await();
+		latch.await(10, TimeUnit.SECONDS);
 		executor.shutdown();
 
 		// then
@@ -247,7 +248,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 			});
 		}
 
-		latch.await();
+		latch.await(10, TimeUnit.SECONDS);
 		executor.shutdown();
 
 		// then

--- a/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
+++ b/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
@@ -200,10 +200,16 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 		assertThat(result.getBalance()).isEqualByComparingTo(expectedBalance);
 		assertThat(result.getBalance()).isGreaterThanOrEqualTo(BigDecimal.ZERO);
 
-		Integer finalQuantity = jdbcTemplate.queryForObject(
-			"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",
-			Integer.class, accountId, stockId
-		);
+		Integer finalQuantity;
+		try {
+			finalQuantity = jdbcTemplate.queryForObject(
+				"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",
+				Integer.class, accountId, stockId
+			);
+		} catch (Exception e) {
+			finalQuantity = 0;
+		}
+
 		int expectedQuantity = startQuantity + buySuccess.get() - sellSuccess.get();
 		assertThat(finalQuantity).isEqualTo(expectedQuantity);
 
@@ -244,7 +250,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 
 		// then
 		VirtualAccount result = accountService.getAccountByUserId(userId);
-		Integer finalQuantity = 0;
+		Integer finalQuantity;
 		try {
 			finalQuantity = jdbcTemplate.queryForObject(
 				"SELECT quantity FROM portfolio WHERE virtual_account_id = ? AND stock_id = ?",


### PR DESCRIPTION
## 📌 PR 설명
  동시성 통합 테스트 3건 작성 및 매도 로직 deadlock 수정

  <br>

  ## ✅ 완료한 기능 명세

  - [x] **[WEF-488]** 동시 매수 10건 — 잔고 음수 방지 테스트
  - [x] **[WEF-488]** 동시 매수 5건 + 매도 5건 — 잔고/수량 정합성 테스트
  - [x] **[WEF-488]** 동시 매도 10건 — 보유수량 초과 매도 방지 테스트
  - [x] **[WEF-488]** sellMarket deadlock 수정 (락 순서 통일)

  <br>

  ## 📸 스크린샷
<img width="936" height="283" alt="스크린샷 2026-04-06 오후 12 05 09" src="https://github.com/user-attachments/assets/b25d0dd9-6ab0-466f-abfe-688cce737218" />

  테스트 결과:
  - 동시 매수 10건: 성공 6, 실패 4, 잔고 998,650원 (음수 안 됨)
  - 동시 매수5+매도5: 매수 성공 2, 매도 성공 5, 잔고 6,983,800원 (정합성 유지)
  - 동시 매도 10건: 성공 5, 실패 5, 잔고 9,984,250원 (수량 초과 안 됨)

  <br>

  ## 💭 고민과 해결과정

  ### 테스트 설계
  - 주식 가격을 150만원으로 설정하여 초기 잔고 1000만원 기준 최대 6주만 매수 가능하도록 조정
  - 10개 스레드가 동시에 요청을 보내 잔고/수량 제한을 초과하는 주문이 통과되는지 검증
  - ExecutorService + CountDownLatch로 동시 요청 시뮬레이션, AtomicInteger로 성공/실패 카운트
  - 매도 시 보유수량이 0이 되면 portfolio 행이 삭제되므로, 조회 결과가 없을 때 try-catch로 수량 0 처리

  ### deadlock 원인
  - buyMarket 락 순서: virtual_account → portfolio
  - sellMarket 락 순서: portfolio → virtual_account
  - 매수와 매도가 동시에 같은 계좌에 들어오면 서로 상대방이 잡고 있는 락을 기다리며 순환 대기 발생
  - PostgreSQL이 deadlock을 감지하고 한쪽 트랜잭션을 강제 롤백시킴

  ### 해결 방법
  - sellMarket에서 portfolio 조회 전에 virtual_account 락을 먼저 잡도록 변경
  - VirtualAccountService에 getAccountWithLock() 메서드 추가 (기존 private getAccountForUpdate()를 내부 호출)
  - buyMarket과 sellMarket 모두 account → portfolio 순서로 락을 잡아 deadlock 제거
  - 컨벤션 문서(trading-convention.md)의 락 순서 규칙(VirtualAccount → Portfolio → Order)과도 일치

  ### 변경 파일
  - OrderService.java: sellMarket에 getAccountWithLock() 호출 추가
  - VirtualAccountService.java: getAccountWithLock() public 메서드 추가
  - OrderConcurrencyTest.java: 동시성 통합 테스트 3건 작성

  <br>

  ### 🔗 관련 이슈
  Closes #129

  <br>

[WEF-488]: https://sol-v.atlassian.net/browse/WEF-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-488]: https://sol-v.atlassian.net/browse/WEF-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-488]: https://sol-v.atlassian.net/browse/WEF-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-488]: https://sol-v.atlassian.net/browse/WEF-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 계정 잠금 기반 조회를 공개해 주문 처리 초기에 잠금된 계정 인스턴스를 확보하도록 변경
  * 매도 흐름에서 잠금된 계정 인스턴스에 직접 잔액·실현손익 반영하도록 일괄화해 동시성 안정성 향상

* **Tests**
  * 실제 DB 환경에서 다중 스레드 동시 매수/매도 시나리오를 검증하는 통합 테스트 추가(잔고·보유수량 정합성 및 경계 조건 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->