### PR TITLE
[WEF-534] Jacoco 테스트 커버리지 도입

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -34,6 +34,13 @@ jobs:
           name: test-report
           path: build/reports/tests/test/
 
+      - name: Upload jacoco report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: build/reports/jacoco/test/html/
+
   build:
     runs-on: ubuntu-latest
     needs: test

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 	id 'org.springframework.boot' version '3.5.11'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -12,6 +13,10 @@ java {
 	toolchain {
 		languageVersion = JavaLanguageVersion.of(17)
 	}
+}
+
+jacoco {
+	toolVersion = "0.8.14"
 }
 
 configurations {
@@ -57,6 +62,71 @@ dependencies {
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
+def JACOCO_EXCLUDES = [
+        '**/*Application*',
+		'**/*Config*',
+		'**/config/**',
+		'**/global/error/**',
+		'**/global/common/**',
+		'**/*Dto*',
+		'**/*Request*',
+		'**/*Response*',
+		'**/*Command*',
+		'**/*Info*',
+		'**/*Exception*',
+		'**/*Error*',
+		'**/entity/**',
+		'**/dto/**',
+		'**/Q*',
+		'**/generated/**'
+]
+
 tasks.named('test') {
 	useJUnitPlatform()
+	finalizedBy tasks.jacocoTestReport
+}
+
+tasks.jacocoTestReport {
+	dependsOn tasks.test
+
+	executionData fileTree(dir: "$buildDir", includes: [
+			"jacoco/*.exec", "jacoco/*.ec",
+			"outputs/unit_test_code_coverage/*/*.ec"
+	])
+
+	classDirectories.setFrom(
+			files(sourceSets.main.output).asFileTree.matching {
+				exclude JACOCO_EXCLUDES
+			}
+	)
+
+	reports {
+		html.required.set(true)
+		xml.required.set(true)
+	}
+}
+
+tasks.jacocoTestCoverageVerification {
+	dependsOn tasks.jacocoTestReport
+
+	classDirectories.setFrom(
+			files(sourceSets.main.output).asFileTree.matching {
+				exclude JACOCO_EXCLUDES
+			}
+	)
+
+	violationRules {
+		rule {
+			element = 'BUNDLE'
+			limit {
+				counter = 'INSTRUCTION'
+				value = 'COVEREDRATIO'
+				minimum = 0.0
+			}
+		}
+	}
+}
+
+tasks.named('check') {
+	dependsOn tasks.jacocoTestCoverageVerification
 }


### PR DESCRIPTION
 PR 본문:
  ## 📌 PR 설명
  Jacoco를 도입하여 테스트 커버리지를 측정하고 CI에서 리포트를 확인할 수 있게 한다.

  <br>

  ## ✅ 완료한 기능 명세

  - [x] **[WEF-148]** build.gradle Jacoco 플러그인 설정 (0.8.14)
  - [x] **[WEF-148]** 커버리지 제외 대상 설정 (DTO, Entity, Config, QueryDSL 등)
  - [x] **[WEF-148]** backend-ci.yml Jacoco 리포트 업로드 step 추가

  <br>

  ## 📸 스크린샷
<img width="777" height="571" alt="스크린샷 2026-04-06 오후 4 24 35" src="https://github.com/user-attachments/assets/9832994e-9490-404a-91f6-cba93d6c5c52" />

  trading 도메인 커버리지 결과:
  - trading.order.service — 95%
  - trading.matching.event — 63%
  - trading.portfolio.service — 46%
  - trading.account.service — 39%
  - trading.common — 100%

  <br>

  ## 💭 고민과 해결과정

  ### 왜 도입했는가
  - 테스트 코드가 쌓이고 있지만 실제로 어디를 커버하는지 수치로 확인할 방법이 없었음
  - 커버리지 리포트를 통해 테스트 사각지대를 객관적으로 파악하기 위해 도입

  ### 품질 게이트는 비활성
  - 도입 초기이므로 커버리지 미달 시 빌드 실패(머지 차단)는 적용하지 않음
  - minimum = 0.00으로 설정하여 검증 태스크는 존재하지만 비활성 상태
  - 현재 커버리지를 먼저 파악하고 팀 합의 후 기준을 정할 예정

  ### 제외 대상 선정
  - 비즈니스 로직이 아닌 클래스는 제외 (DTO, Entity, Config, Exception, QueryDSL Q클래스 등)
  - 우리 프로젝트의 domain/web 계층 분리에 맞춰 Command, Info 패턴도 제외

  ### 향후 계획
  1. 팀 합의로 최소 커버리지 기준 설정
  2. 품질 게이트 활성화
  3. SonarCloud 연동 검토

  <br>

  ### 🔗 관련 이슈
  Closes #148

[WEF-148]: https://sol-v.atlassian.net/browse/WEF-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-148]: https://sol-v.atlassian.net/browse/WEF-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-148]: https://sol-v.atlassian.net/browse/WEF-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 코드 커버리지 보고 기능이 빌드 파이프라인에 통합되었습니다. 이제 자동으로 커버리지 리포트가 생성되고 아티팩트로 저장됩니다.
  * 빌드 검증 프로세스에 커버리지 확인 단계가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->