### PR TITLE
[WEF-356/357] 국내 실시간 체결가/호가 WebSocket 수신

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -22,6 +22,8 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -44,6 +46,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private final ObjectMapper objectMapper;
     private final SimpMessagingTemplate messagingTemplate;
     private final MarketService marketService;
+    private final Set<String> subscribedStocks = ConcurrentHashMap.newKeySet();
 
     // 한투 WS에 연결
     @EventListener(ApplicationReadyEvent.class)
@@ -62,6 +65,13 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     public void afterConnectionEstablished(WebSocketSession session) {
         this.session = session;
         log.info("한투 웹소켓 연결에 성공했습니다.");
+
+        // sendSubscribe() 호출x (subscribedStocks.add() 중복 실행 방지)
+        subscribedStocks.forEach(stockCode -> {
+            sendMessage("H0STCNT0", stockCode, "1");
+            sendMessage("H0STASP0", stockCode, "1");
+            log.info("종목 재구독: {}", stockCode);
+        });
     }
 
     // 메시지 수신 시
@@ -98,11 +108,13 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
 
     // 종목 구독 요청
     public void sendSubscribe(String trId, String stockCode) {
+        subscribedStocks.add(stockCode);
         sendMessage(trId, stockCode, "1");
     }
 
     // 종목 구독 해제 요청
     public void sendUnsubscribe(String trId, String stockCode) {
+        subscribedStocks.remove(stockCode);
         sendMessage(trId, stockCode, "2");
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.trading.market.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,7 +61,37 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     // 메시지 수신 시
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) {
+        String payload = message.getPayload();
 
+        // JSON 응답 (구독 확인) → 로그만
+        if (payload.startsWith("{")) {
+            log.info("한투 WS 응답: {}", payload);
+            return;
+        }
+
+        // 실시간 데이터: 0|H0STCNT0|004|데이터
+        String[] parts = payload.split("\\|");
+        if (parts.length < 4) return;
+
+        String[] fields = parts[3].split("\\^");
+        int fieldCount = 46;
+        int recordCount = Integer.parseInt(parts[2]);
+
+        for (int i = 0; i < recordCount; i++) {
+            int offset = i * fieldCount;
+
+            TradeResponse response = new TradeResponse(
+                    fields[offset],                           // stockCode
+                    new BigDecimal(fields[offset + 2]),       // currentPrice
+                    new BigDecimal(fields[offset + 4]),       // changePrice
+                    new BigDecimal(fields[offset + 5]),       // changeRate
+                    Long.parseLong(fields[offset + 12]),      // tradeVolume
+                    Long.parseLong(fields[offset + 13]),      // totalVolume
+                    fields[offset + 1]                        // tradeTime
+            );
+
+            messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
+        }
     }
 
     // 연결 끊겼을 때 → 재연결
@@ -71,16 +102,35 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     }
 
     // 종목 구독 요청
-    public void sendSubscribe(String stockCode) {
-        // WEF-356에서 구현
+    public void sendSubscribe(String trId, String stockCode) {
+        sendMessage(trId, stockCode, "1");
     }
 
     // 종목 구독 해제 요청
-    public void sendUnsubscribe(String stockCode) {
-        // WEF-356에서 구현
+    public void sendUnsubscribe(String trId, String stockCode) {
+        sendMessage(trId, stockCode, "2");
     }
 
-    private void sendMessage(String stockCode, String trType) {
-        // WEF-356에서 구현
+    private void sendMessage(String trId, String stockCode, String trType) {
+        try {
+            Map<String, Object> message = Map.of(
+                    "header", Map.of(
+                            "approval_key", hantuWebSocketKeyManager.getApprovalKey(),
+                            "custtype", "P",
+                            "tr_type", trType,
+                            "content-type", "utf-8"
+                    ),
+                    "body", Map.of(
+                            "input", Map.of(
+                                    "tr_id", trId,
+                                    "tr_key", stockCode
+                            )
+                    )
+            );
+
+            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(message)));
+        } catch (Exception e) {
+            log.error("한투 웹소켓 메시지 전송 실패: {}", stockCode, e);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -1,7 +1,10 @@
 package com.solv.wefin.domain.trading.market.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
+import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.dto.TradeResponse;
+import com.solv.wefin.domain.trading.market.service.MarketService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +19,8 @@ import org.springframework.web.socket.client.WebSocketClient;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,6 +43,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private volatile WebSocketSession session;
     private final ObjectMapper objectMapper;
     private final SimpMessagingTemplate messagingTemplate;
+    private final MarketService marketService;
 
     // 한투 WS에 연결
     @EventListener(ApplicationReadyEvent.class)
@@ -69,28 +75,17 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
             return;
         }
 
-        // 실시간 데이터: 0|H0STCNT0|004|데이터
+        // 실시간 데이터: 0|tr_id|004|데이터
         String[] parts = payload.split("\\|");
         if (parts.length < 4) return;
 
-        String[] fields = parts[3].split("\\^");
-        int fieldCount = 46;
-        int recordCount = Integer.parseInt(parts[2]);
+        String trId = parts[1];
+        String data = parts[3];
 
-        for (int i = 0; i < recordCount; i++) {
-            int offset = i * fieldCount;
-
-            TradeResponse response = new TradeResponse(
-                    fields[offset],                           // stockCode
-                    new BigDecimal(fields[offset + 2]),       // currentPrice
-                    new BigDecimal(fields[offset + 4]),       // changePrice
-                    new BigDecimal(fields[offset + 5]),       // changeRate
-                    Long.parseLong(fields[offset + 12]),      // tradeVolume
-                    Long.parseLong(fields[offset + 13]),      // totalVolume
-                    fields[offset + 1]                        // tradeTime
-            );
-
-            messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
+        if ("H0STCNT0".equals(trId)) {
+            parseAndSendTrade(data, Integer.parseInt(parts[2]));
+        } else if ("H0STASP0".equals(trId)) {
+            parseAndSendOrderbook(data);
         }
     }
 
@@ -132,5 +127,64 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
         } catch (Exception e) {
             log.error("한투 웹소켓 메시지 전송 실패: {}", stockCode, e);
         }
+    }
+
+    private void parseAndSendTrade(String data, int recordCount) {
+        String[] fields = data.split("\\^");
+        int fieldCount = 46;
+
+        for (int i = 0; i < recordCount; i++) {
+            int offset = i * fieldCount;
+            TradeResponse response = new TradeResponse(
+                    fields[offset],                           // stockCode
+                    new BigDecimal(fields[offset + 2]),       // currentPrice
+                    new BigDecimal(fields[offset + 4]),       // changePrice
+                    new BigDecimal(fields[offset + 5]),       // changeRate
+                    Long.parseLong(fields[offset + 12]),      // tradeVolume
+                    Long.parseLong(fields[offset + 13]),      // totalVolume
+                    fields[offset + 1]                        // tradeTime
+            );
+            messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
+
+            PriceResponse priceResponse = new PriceResponse(
+                    fields[offset],
+                    Integer.parseInt(fields[offset + 2]),
+                    Integer.parseInt(fields[offset + 4]),
+                    Float.parseFloat(fields[offset + 5]),
+                    Long.parseLong(fields[offset + 13]),
+                    Integer.parseInt(fields[offset + 7]),
+                    Integer.parseInt(fields[offset + 8]),
+                    Integer.parseInt(fields[offset + 9])
+            );
+            marketService.updatePriceCache(fields[offset], priceResponse);
+        }
+    }
+
+    private void parseAndSendOrderbook(String data) {
+        String[] fields = data.split("\\^");
+        String stockCode = fields[0];
+
+        List<OrderbookResponse.OrderbookEntry> asks = new ArrayList<>();
+        List<OrderbookResponse.OrderbookEntry> bids = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+            asks.add(new OrderbookResponse.OrderbookEntry(
+                    Integer.parseInt(fields[3 + i]),      // ASKP1~10
+                    Long.parseLong(fields[23 + i])         // ASKP_RSQN1~10
+            ));
+            bids.add(new OrderbookResponse.OrderbookEntry(
+                    Integer.parseInt(fields[13 + i]),      // BIDP1~10
+                    Long.parseLong(fields[33 + i])         // BIDP_RSQN1~10
+            ));
+        }
+
+        OrderbookResponse response = new OrderbookResponse(
+                asks, bids,
+                Long.parseLong(fields[43]),                // TOTAL_ASKP_RSQN
+                Long.parseLong(fields[44])                 // TOTAL_BIDP_RSQN
+        );
+
+        messagingTemplate.convertAndSend("/topic/stocks/" + stockCode + "/orderbook",
+                response);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.dto.TradeResponse;
+import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -167,7 +168,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
 
             try {
                 TradeResponse response = new TradeResponse(
-                        "TRADE",
+                        WebSocketMessageType.TRADE,
                         fields[offset],                           // stockCode
                         new BigDecimal(fields[offset + 2]),       // currentPrice
                         new BigDecimal(fields[offset + 4]),       // changePrice
@@ -221,7 +222,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
         }
 
         OrderbookResponse response = new OrderbookResponse(
-                "ORDERBOOK",
+                WebSocketMessageType.ORDERBOOK,
                 asks, bids,
                 Long.parseLong(fields[43]),                // TOTAL_ASKP_RSQN
                 Long.parseLong(fields[44])                 // TOTAL_BIDP_RSQN

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -169,7 +169,8 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
                     new BigDecimal(fields[offset + 5]),       // changeRate
                     Long.parseLong(fields[offset + 12]),      // tradeVolume
                     Long.parseLong(fields[offset + 13]),      // totalVolume
-                    fields[offset + 1]                        // tradeTime
+                    fields[offset + 1],                       // tradeTime
+                    fields[offset + 21]                       // tradeSide
             );
             messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -154,6 +154,11 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
         String[] fields = data.split("\\^");
         int fieldCount = 46;
 
+        if (fields.length < recordCount * fieldCount) {
+            log.warn("체결 데이터 필드 수 부족: expected={}, actual={}", recordCount * fieldCount, fields.length);
+            return;
+        }
+
         for (int i = 0; i < recordCount; i++) {
             int offset = i * fieldCount;
             TradeResponse response = new TradeResponse(
@@ -184,6 +189,12 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
 
     private void parseAndSendOrderbook(String data) {
         String[] fields = data.split("\\^");
+
+        if (fields.length < 45) {
+            log.warn("호가 데이터 필드 수 부족: expected=45, actual={}", fields.length);
+            return;
+        }
+
         String stockCode = fields[0];
 
         List<OrderbookResponse.OrderbookEntry> asks = new ArrayList<>();

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -92,10 +92,14 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
         String trId = parts[1];
         String data = parts[3];
 
-        if ("H0STCNT0".equals(trId)) {
-            parseAndSendTrade(data, Integer.parseInt(parts[2]));
-        } else if ("H0STASP0".equals(trId)) {
-            parseAndSendOrderbook(data);
+        try {
+            if ("H0STCNT0".equals(trId)) {
+                parseAndSendTrade(data, Integer.parseInt(parts[2]));
+            } else if ("H0STASP0".equals(trId)) {
+                parseAndSendOrderbook(data);
+            }
+        } catch (Exception e) {
+            log.error("한투 실시간 데이터 파싱 실패 [trId={}, data={}]", trId, data, e);
         }
     }
 
@@ -119,6 +123,11 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     }
 
     private void sendMessage(String trId, String stockCode, String trType) {
+        if (session == null || !session.isOpen()) {
+            log.warn("한투 웹소켓 미연결 상태. 메시지 전송 스킵: {}", stockCode);
+            return;
+        }
+
         try {
             Map<String, Object> message = Map.of(
                     "header", Map.of(
@@ -148,6 +157,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
         for (int i = 0; i < recordCount; i++) {
             int offset = i * fieldCount;
             TradeResponse response = new TradeResponse(
+                    "TRADE",
                     fields[offset],                           // stockCode
                     new BigDecimal(fields[offset + 2]),       // currentPrice
                     new BigDecimal(fields[offset + 4]),       // changePrice
@@ -191,6 +201,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
         }
 
         OrderbookResponse response = new OrderbookResponse(
+                "ORDERBOOK",
                 asks, bids,
                 Long.parseLong(fields[43]),                // TOTAL_ASKP_RSQN
                 Long.parseLong(fields[44])                 // TOTAL_BIDP_RSQN

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -87,7 +87,10 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
 
         // 실시간 데이터: 0|tr_id|004|데이터
         String[] parts = payload.split("\\|");
-        if (parts.length < 4) return;
+        if (parts.length < 4) {
+            log.warn("비정상 payload 수신: {}", payload);
+            return;
+        }
 
         String trId = parts[1];
         String data = parts[3];
@@ -161,30 +164,35 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
 
         for (int i = 0; i < recordCount; i++) {
             int offset = i * fieldCount;
-            TradeResponse response = new TradeResponse(
-                    "TRADE",
-                    fields[offset],                           // stockCode
-                    new BigDecimal(fields[offset + 2]),       // currentPrice
-                    new BigDecimal(fields[offset + 4]),       // changePrice
-                    new BigDecimal(fields[offset + 5]),       // changeRate
-                    Long.parseLong(fields[offset + 12]),      // tradeVolume
-                    Long.parseLong(fields[offset + 13]),      // totalVolume
-                    fields[offset + 1],                       // tradeTime
-                    fields[offset + 21]                       // tradeSide
-            );
-            messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
 
-            PriceResponse priceResponse = new PriceResponse(
-                    fields[offset],
-                    Integer.parseInt(fields[offset + 2]),
-                    Integer.parseInt(fields[offset + 4]),
-                    Float.parseFloat(fields[offset + 5]),
-                    Long.parseLong(fields[offset + 13]),
-                    Integer.parseInt(fields[offset + 7]),
-                    Integer.parseInt(fields[offset + 8]),
-                    Integer.parseInt(fields[offset + 9])
-            );
-            marketService.updatePriceCache(fields[offset], priceResponse);
+            try {
+                TradeResponse response = new TradeResponse(
+                        "TRADE",
+                        fields[offset],                           // stockCode
+                        new BigDecimal(fields[offset + 2]),       // currentPrice
+                        new BigDecimal(fields[offset + 4]),       // changePrice
+                        new BigDecimal(fields[offset + 5]),       // changeRate
+                        Long.parseLong(fields[offset + 12]),      // tradeVolume
+                        Long.parseLong(fields[offset + 13]),      // totalVolume
+                        fields[offset + 1],                       // tradeTime
+                        fields[offset + 21]                       // tradeSide
+                );
+                messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
+
+                PriceResponse priceResponse = new PriceResponse(
+                        fields[offset],
+                        Integer.parseInt(fields[offset + 2]),
+                        Integer.parseInt(fields[offset + 4]),
+                        Float.parseFloat(fields[offset + 5]),
+                        Long.parseLong(fields[offset + 13]),
+                        Integer.parseInt(fields[offset + 7]),
+                        Integer.parseInt(fields[offset + 8]),
+                        Integer.parseInt(fields[offset + 9])
+                );
+                marketService.updatePriceCache(fields[offset], priceResponse);
+            } catch (Exception e) {
+                log.warn("체결 레코드 파싱 스킵: index={}, offset={}", i, offset, e);
+            }
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/OrderbookResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/OrderbookResponse.java
@@ -5,7 +5,7 @@ import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse
 import java.util.List;
 
 public record OrderbookResponse(
-        String type,
+        WebSocketMessageType type,
         List<OrderbookEntry> asks,   // 매도호가 10개
         List<OrderbookEntry> bids,   // 매수호가 10개
         long totalAskQuantity,       // 총 매도 잔량
@@ -49,7 +49,7 @@ public record OrderbookResponse(
         );
 
         return new OrderbookResponse(
-                "ORDERBOOK",
+                WebSocketMessageType.ORDERBOOK,
                 asks,
                 bids,
                 Long.parseLong(output.total_askp_rsqn()),

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/OrderbookResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/OrderbookResponse.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse
 import java.util.List;
 
 public record OrderbookResponse(
+        String type,
         List<OrderbookEntry> asks,   // 매도호가 10개
         List<OrderbookEntry> bids,   // 매수호가 10개
         long totalAskQuantity,       // 총 매도 잔량
@@ -48,6 +49,7 @@ public record OrderbookResponse(
         );
 
         return new OrderbookResponse(
+                "ORDERBOOK",
                 asks,
                 bids,
                 Long.parseLong(output.total_askp_rsqn()),

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
@@ -6,7 +6,7 @@ import java.math.BigDecimal;
  * 실시간 체결가 WebSocket push 응답
  */
 public record TradeResponse(
-        String type,
+        WebSocketMessageType type,
         String stockCode,
         BigDecimal currentPrice,
         BigDecimal changePrice,

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
  * 실시간 체결가 WebSocket push 응답
  */
 public record TradeResponse(
+        String type,
         String stockCode,
         BigDecimal currentPrice,
         BigDecimal changePrice,

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
@@ -13,5 +13,6 @@ public record TradeResponse(
         BigDecimal changeRate,
         long tradeVolume,
         long totalVolume,
-        String tradeTime
+        String tradeTime,
+        String tradeSide        // "1": 매수, "5": 매도
 ) {}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/TradeResponse.java
@@ -1,0 +1,16 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+import java.math.BigDecimal;
+
+/**
+ * 실시간 체결가 WebSocket push 응답
+ */
+public record TradeResponse(
+        String stockCode,
+        BigDecimal currentPrice,
+        BigDecimal changePrice,
+        BigDecimal changeRate,
+        long tradeVolume,
+        long totalVolume,
+        String tradeTime
+) {}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/WebSocketMessageType.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/WebSocketMessageType.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+public enum WebSocketMessageType {
+    TRADE,
+    ORDERBOOK
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -171,4 +171,9 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
         }
     }
+
+    public void updatePriceCache(String stockCode, PriceResponse response) {
+        priceCache.put(stockCode, response);
+        priceCacheTimestamp.put(stockCode, System.currentTimeMillis());
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -13,6 +13,7 @@ import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class MarketService implements MarketPriceProvider, ExchangeRateProvider {
@@ -146,13 +148,16 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         }
 
         HantuCandleApiResponse response = hantuMarketClient.fetchPeriodPrice(stockCode, start, end, periodCode);
+        log.info("캔들 API 응답: {}", response);
 
         if (response == null) {
             return List.of();
         }
 
         // 한투 API 응답 코드 검증 (rt_cd "0"이면 정상)
-        if (!"0".equals(response.output1().rt_cd())) {
+        if (response.output1() != null && response.output1().rt_cd()
+                != null
+                && !"0".equals(response.output1().rt_cd())) {
             throw new BusinessException(ErrorCode.MARKET_API_FAILED);
         }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
@@ -20,7 +20,8 @@ public class SubscriptionManager {
                 (stockCode, k -> new AtomicInteger(0));
 
         if (count.incrementAndGet() == 1) {
-            hantuWebSocketClient.sendSubscribe(stockCode);
+            hantuWebSocketClient.sendSubscribe("H0STCNT0", stockCode);
+            hantuWebSocketClient.sendSubscribe("H0STASP0", stockCode);
         }
     }
 
@@ -32,7 +33,8 @@ public class SubscriptionManager {
         }
 
         if (count.decrementAndGet() == 0) {
-            hantuWebSocketClient.sendUnsubscribe(stockCode);
+            hantuWebSocketClient.sendUnsubscribe("H0STCNT0", stockCode);
+            hantuWebSocketClient.sendUnsubscribe("H0STASP0", stockCode);
             subscriptions.remove(stockCode);
         }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
@@ -13,7 +13,7 @@ import java.util.Map;
 @Service
 public class SubscriptionManager {
 
-    private static final int MAX_SUBSCRIPTION = 41;
+    private static final int MAX_SUBSCRIPTION = 20;
 
     private final HantuWebSocketClient hantuWebSocketClient;
     private final Map<String, Integer> subscriptions = new HashMap<>();

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
@@ -4,6 +4,8 @@ import com.solv.wefin.domain.trading.market.client.HantuWebSocketClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -12,31 +14,30 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SubscriptionManager {
 
     private final HantuWebSocketClient hantuWebSocketClient;
-    private final ConcurrentHashMap<String, AtomicInteger> subscriptions = new ConcurrentHashMap<>();
+    private final Map<String, Integer> subscriptions = new HashMap<>();
 
-    public void subscribe(String stockCode) {
+    public synchronized void subscribe(String stockCode) {
+        int count = subscriptions.merge(stockCode, 1, Integer::sum);
 
-        AtomicInteger count = subscriptions.computeIfAbsent
-                (stockCode, k -> new AtomicInteger(0));
-
-        if (count.incrementAndGet() == 1) {
+        if (count == 1) {
             hantuWebSocketClient.sendSubscribe("H0STCNT0", stockCode);
             hantuWebSocketClient.sendSubscribe("H0STASP0", stockCode);
         }
     }
 
-    public void unsubscribe(String stockCode) {
-        AtomicInteger count = subscriptions.get(stockCode);
+    public synchronized void unsubscribe(String stockCode) {
+        Integer count = subscriptions.get(stockCode);
 
-        if (count == null) {
+        if (count == null || count <= 0) {
             return;
         }
 
-        if (count.decrementAndGet() == 0) {
+        if (count == 1) {
             hantuWebSocketClient.sendUnsubscribe("H0STCNT0", stockCode);
             hantuWebSocketClient.sendUnsubscribe("H0STASP0", stockCode);
             subscriptions.remove(stockCode);
+        } else {
+            subscriptions.put(stockCode, count - 1);
         }
-
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/SubscriptionManager.java
@@ -1,22 +1,30 @@
 package com.solv.wefin.domain.trading.market.service;
 
 import com.solv.wefin.domain.trading.market.client.HantuWebSocketClient;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @RequiredArgsConstructor
 @Service
 public class SubscriptionManager {
 
+    private static final int MAX_SUBSCRIPTION = 41;
+
     private final HantuWebSocketClient hantuWebSocketClient;
     private final Map<String, Integer> subscriptions = new HashMap<>();
 
     public synchronized void subscribe(String stockCode) {
+        boolean isNew = !subscriptions.containsKey(stockCode);
+
+        if (isNew && subscriptions.size() >= MAX_SUBSCRIPTION) {
+            throw new BusinessException(ErrorCode.MARKET_SUBSCRIPTION_LIMIT_EXCEEDED);
+        }
+
         int count = subscriptions.merge(stockCode, 1, Integer::sum);
 
         if (count == 1) {

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**", "api/stocks/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**", "api/stocks/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -66,6 +66,7 @@ public enum ErrorCode {
     MARKET_API_FAILED(503, "한투 API 호출에 실패했습니다."),
     MARKET_INVALID_PERIOD_CODE(400, "유효하지 않은 기간 옵션입니다."),
     MARKET_INVALID_DATE(400, "조회 시작일자는 종료일자 이전이어야 합니다."),
+    MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 41개까지 가능합니다."),
 
     // Interest
     INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심종목입니다."),

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -66,7 +66,7 @@ public enum ErrorCode {
     MARKET_API_FAILED(503, "한투 API 호출에 실패했습니다."),
     MARKET_INVALID_PERIOD_CODE(400, "유효하지 않은 기간 옵션입니다."),
     MARKET_INVALID_DATE(400, "조회 시작일자는 종료일자 이전이어야 합니다."),
-    MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 41개까지 가능합니다."),
+    MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 20개까지 가능합니다."),
 
     // Interest
     INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심종목입니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,9 +64,9 @@ jwt:
 
 hantu:
   api:
-    baseUrl: https://openapivts.koreainvestment.com:29443
+    baseUrl: https://openapi.koreainvestment.com:9443
     appkey: ${HANTU_APPKEY:}
     appsecret: ${HANTU_APPSECRET:}
 
   ws:
-    url: ws://ops.koreainvestment.com:31000
+    url: ws://ops.koreainvestment.com:21000

--- a/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
@@ -15,7 +15,6 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.client.WebSocketClient;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -50,7 +49,7 @@ class HantuWebSocketClientTest {
     }
 
     @Test
-    void 체결_데이터_수신시_올바른_TradeResponse_전송() throws Exception {
+    void 체결_데이터_수신시_올바른_TradeResponse_전송() {
         // 46개 필드: [0]종목코드, [1]체결시간, [2]현재가, [4]전일대비, [5]등락률,
         //           [7]시가, [8]고가, [9]저가, [12]체결거래량, [13]누적거래량
         String[] fields = new String[46];
@@ -87,7 +86,7 @@ class HantuWebSocketClientTest {
     }
 
     @Test
-    void 호가_데이터_수신시_올바른_OrderbookResponse_전송() throws Exception {
+    void 호가_데이터_수신시_올바른_OrderbookResponse_전송() {
         // [0]종목코드, [3~12]매도호가1~10, [13~22]매수호가1~10,
         // [23~32]매도잔량1~10, [33~42]매수잔량1~10, [43]총매도잔량, [44]총매수잔량
         String[] fields = new String[45];
@@ -126,7 +125,7 @@ class HantuWebSocketClientTest {
     }
 
     @Test
-    void 잘못된_데이터_수신시_예외없이_처리() throws Exception {
+    void 잘못된_데이터_수신시_예외없이_처리() {
         String payload = "0|H0STCNT0|001|잘못된데이터";
 
         assertThatCode(() -> client.handleTextMessage(session, new TextMessage(payload)))

--- a/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
@@ -1,0 +1,138 @@
+package com.solv.wefin.domain.trading.market.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
+import com.solv.wefin.domain.trading.market.dto.TradeResponse;
+import com.solv.wefin.domain.trading.market.service.MarketService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.client.WebSocketClient;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HantuWebSocketClientTest {
+
+    @Mock
+    private WebSocketClient hantuWsClient;
+    @Mock
+    private HantuWebSocketKeyManager hantuWebSocketKeyManager;
+    @Mock
+    private ObjectMapper objectMapper;
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+    @Mock
+    private MarketService marketService;
+    @Mock
+    private WebSocketSession session;
+
+    private HantuWebSocketClient client;
+
+    @BeforeEach
+    void setUp() {
+        client = new HantuWebSocketClient(
+                hantuWsClient,
+                hantuWebSocketKeyManager,
+                objectMapper,
+                messagingTemplate,
+                marketService
+        );
+    }
+
+    @Test
+    void 체결_데이터_수신시_올바른_TradeResponse_전송() throws Exception {
+        // 46개 필드: [0]종목코드, [1]체결시간, [2]현재가, [4]전일대비, [5]등락률,
+        //           [7]시가, [8]고가, [9]저가, [12]체결거래량, [13]누적거래량
+        String[] fields = new String[46];
+        fields[0] = "005930";
+        fields[1] = "153005";
+        fields[2] = "97500";
+        fields[4] = "1200";
+        fields[5] = "1.25";
+        fields[7] = "96800";
+        fields[8] = "98200";
+        fields[9] = "96300";
+        fields[12] = "342";
+        fields[13] = "12340567";
+        // 나머지 필드 빈 값 채우기
+        for (int i = 0; i < fields.length; i++) {
+            if (fields[i] == null) fields[i] = "0";
+        }
+
+        String data = String.join("^", fields);
+        String payload = "0|H0STCNT0|001|" + data;
+
+        client.handleTextMessage(session, new TextMessage(payload));
+
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/stocks/005930"),
+                argThat((TradeResponse r) ->
+                        r.type().equals("TRADE")
+                                && r.stockCode().equals("005930")
+                                && r.currentPrice().intValue() == 97500
+                                && r.changePrice().intValue() == 1200
+                                && r.tradeVolume() == 342
+                )
+        );
+    }
+
+    @Test
+    void 호가_데이터_수신시_올바른_OrderbookResponse_전송() throws Exception {
+        // [0]종목코드, [3~12]매도호가1~10, [13~22]매수호가1~10,
+        // [23~32]매도잔량1~10, [33~42]매수잔량1~10, [43]총매도잔량, [44]총매수잔량
+        String[] fields = new String[45];
+        fields[0] = "005930";
+        for (int i = 1; i < 3; i++) fields[i] = "0";
+
+        // 매도호가 1~10
+        for (int i = 0; i < 10; i++) fields[3 + i] = String.valueOf(98000 + i * 100);
+        // 매수호가 1~10
+        for (int i = 0; i < 10; i++) fields[13 + i] = String.valueOf(97900 - i * 100);
+        // 매도잔량 1~10
+        for (int i = 0; i < 10; i++) fields[23 + i] = String.valueOf(100 + i);
+        // 매수잔량 1~10
+        for (int i = 0; i < 10; i++) fields[33 + i] = String.valueOf(200 + i);
+
+        fields[43] = "1045";  // 총 매도잔량
+        fields[44] = "2045";  // 총 매수잔량
+
+        String data = String.join("^", fields);
+        String payload = "0|H0STASP0|001|" + data;
+
+        client.handleTextMessage(session, new TextMessage(payload));
+
+        verify(messagingTemplate).convertAndSend(
+                eq("/topic/stocks/005930/orderbook"),
+                argThat((OrderbookResponse r) ->
+                        r.type().equals("ORDERBOOK")
+                                && r.asks().size() == 10
+                                && r.bids().size() == 10
+                                && r.asks().get(0).price() == 98000
+                                && r.bids().get(0).price() == 97900
+                                && r.totalAskQuantity() == 1045
+                                && r.totalBidQuantity() == 2045
+                )
+        );
+    }
+
+    @Test
+    void 잘못된_데이터_수신시_예외없이_처리() throws Exception {
+        String payload = "0|H0STCNT0|001|잘못된데이터";
+
+        assertThatCode(() -> client.handleTextMessage(session, new TextMessage(payload)))
+                .doesNotThrowAnyException();
+
+        verify(messagingTemplate, never()).convertAndSend(anyString(),
+                any(TradeResponse.class));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
@@ -83,6 +83,17 @@ class HantuWebSocketClientTest {
                                 && r.tradeVolume() == 342
                 )
         );
+
+        verify(marketService).updatePriceCache(
+                eq("005930"),
+                argThat(p -> p.currentPrice() == 97500
+                        && p.changePrice() == 1200
+                        && p.volume() == 12340567
+                        && p.openPrice() == 96800
+                        && p.highPrice() == 98200
+                        && p.lowPrice() == 96300
+                )
+        );
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.trading.market.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.TradeResponse;
+import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,7 +77,7 @@ class HantuWebSocketClientTest {
         verify(messagingTemplate).convertAndSend(
                 eq("/topic/stocks/005930"),
                 argThat((TradeResponse r) ->
-                        r.type().equals("TRADE")
+                        r.type() == WebSocketMessageType.TRADE
                                 && r.stockCode().equals("005930")
                                 && r.currentPrice().intValue() == 97500
                                 && r.changePrice().intValue() == 1200
@@ -124,7 +125,7 @@ class HantuWebSocketClientTest {
         verify(messagingTemplate).convertAndSend(
                 eq("/topic/stocks/005930/orderbook"),
                 argThat((OrderbookResponse r) ->
-                        r.type().equals("ORDERBOOK")
+                        r.type() == WebSocketMessageType.ORDERBOOK
                                 && r.asks().size() == 10
                                 && r.bids().size() == 10
                                 && r.asks().get(0).price() == 98000

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/SubscriptionManagerTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/SubscriptionManagerTest.java
@@ -41,7 +41,7 @@ class SubscriptionManagerTest {
 
     @Test
     void 구독_제한_초과시_예외() {
-        for (int i = 1; i <= 41; i++) {
+        for (int i = 1; i <= 20; i++) {
             subscriptionManager.subscribe(String.format("%06d", i));
         }
 
@@ -53,7 +53,7 @@ class SubscriptionManagerTest {
 
     @Test
     void 이미_구독중인_종목은_제한에_안걸림() {
-        for (int i = 1; i <= 41; i++) {
+        for (int i = 1; i <= 20; i++) {
             subscriptionManager.subscribe(String.format("%06d", i));
         }
 

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/SubscriptionManagerTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/SubscriptionManagerTest.java
@@ -1,0 +1,88 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuWebSocketClient;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class SubscriptionManagerTest {
+
+    @Mock
+    private HantuWebSocketClient hantuWebSocketClient;
+
+    @InjectMocks
+    private SubscriptionManager subscriptionManager;
+
+    @Test
+    void 첫_구독시_한투에_구독_전송() {
+        subscriptionManager.subscribe("005930");
+
+        verify(hantuWebSocketClient).sendSubscribe("H0STCNT0", "005930");
+        verify(hantuWebSocketClient).sendSubscribe("H0STASP0", "005930");
+    }
+
+    @Test
+    void 같은_종목_중복_구독시_한투에_전송_안함() {
+        subscriptionManager.subscribe("005930");
+        subscriptionManager.subscribe("005930");
+
+        verify(hantuWebSocketClient, times(1)).sendSubscribe("H0STCNT0", "005930");
+        verify(hantuWebSocketClient, times(1)).sendSubscribe("H0STASP0", "005930");
+    }
+
+    @Test
+    void 구독_제한_초과시_예외() {
+        for (int i = 1; i <= 41; i++) {
+            subscriptionManager.subscribe(String.format("%06d", i));
+        }
+
+        assertThatThrownBy(() -> subscriptionManager.subscribe("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_SUBSCRIPTION_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    void 이미_구독중인_종목은_제한에_안걸림() {
+        for (int i = 1; i <= 41; i++) {
+            subscriptionManager.subscribe(String.format("%06d", i));
+        }
+
+        assertThatCode(() -> subscriptionManager.subscribe("000001"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 마지막_구독자_해제시_한투에_해제_전송() {
+        subscriptionManager.subscribe("005930");
+        subscriptionManager.unsubscribe("005930");
+
+        verify(hantuWebSocketClient).sendUnsubscribe("H0STCNT0", "005930");
+        verify(hantuWebSocketClient).sendUnsubscribe("H0STASP0", "005930");
+    }
+
+    @Test
+    void 구독자_남아있으면_한투에_해제_안함() {
+        subscriptionManager.subscribe("005930");
+        subscriptionManager.subscribe("005930");
+        subscriptionManager.unsubscribe("005930");
+
+        verify(hantuWebSocketClient, never()).sendUnsubscribe(any(), any());
+    }
+
+    @Test
+    void 구독하지_않은_종목_해제시_무시() {
+        subscriptionManager.unsubscribe("005930");
+
+        verify(hantuWebSocketClient, never()).sendUnsubscribe(any(), any());
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
한투 Open API WebSocket을 통한 실시간 체결가(H0STCNT0)와 호가(H0STASP0) 데이터를 수신하고 파싱하여 클라이언트에 push하는 기능을 구현했습니다. 
기존 구현에서 발견된 동시성 이슈, 장애 복구, 방어 로직 부재 문제를 해결하고 단위 테스트를 추가했습니다.
<br>

## ✅ 완료한 기능 명세
### FEAT 🪄 
- [x] TradeResponse DTO — 실시간 체결가 push용
- [x] H0STCNT0/H0STASP0 구독 메시지 전송 (trId 파라미터화)
- [x] 실시간 체결가/호가 데이터 파싱 및 클라이언트 push
- [x] WebSocket 실시간 데이터로 priceCache 갱신 연동 
<br>

### FIX / REFACTOR 🐞 
- [x] 한투 WebSocket 재연결 시 기존 구독 종목 자동 복원
- [x] SubscriptionManager subscribe/unsubscribe 동시성 레이스 컨디션 해결
- [x] 한투 WebSocket 미연결 상태에서 메시지 전송 시 NPE 방지 (session null/close 체크)
- [x] 실시간 데이터 파싱 실패 시 전체 수신 중단 방지 (try-catch 보호)
- [x] 한투 WS 세션당 41종목 구독 제한 체크
- [x] 서버→클라이언트 WebSocket 응답에 type 필드 추가 (TRADE/ORDERBOOK) — 컨벤션 문서 반영
- [x] SubscriptionManager, HantuWebSocketClient 파싱 로직 단위 테스트 작성

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/9ece6c29-ebfc-40d4-acd0-7ba660dd0213


<br>

## 💭 고민과 해결과정

### FEAT 🪄 

**1. 체결가/호가 데이터 파싱**
한투 WebSocket은 JSON이 아닌 |(파이프)와 ^(캐럿)로 구분된 텍스트 데이터를 전송한다. 
parts[1]의 TR ID로 체결가(H0STCNT0)와 호가(H0STASP0)를 분기하여 각각 parseAndSendTrade, parseAndSendOrderbook으로 파싱했다.

**2. MarketDataCache 갱신 연동**
REST API의 priceCache와 WebSocket 실시간 데이터 간 가격 불일치를 방지하기 위해, 체결가 수신 시  MarketService.updatePriceCache()로 캐시를 동기화했다. 

> 향후 이벤트 기반 구조로 리팩토링하여 HantuWebSocketClient의 책임을 분리할 예정이다.

**3. 41종목 구독 제한**
한투 WS는 세션당 41건(체결가+호가 합산)까지 등록 가능하다. 
한 종목당 체결가+호가 2건을 사용하므로 실질적으로 20종목이 상한이며, SubscriptionManager에서 구독 시 제한을 검증한다.

<br>

### FIX / REFACTOR 🐞 

**1. 재연결 시 구독 복원 — 순환 의존 회피**
재구독을 위해서는 HantuWebSocketClient → SubscriptionManager 방향의 의존이 필요하지만, 이미 반대 방향이 존재한다.
이벤트 기반(ApplicationEventPublisher) 대신, HantuWebSocketClient가 자체적으로 `subscribedStocks` Set을 관리하여 재연결 시 순회하는 방식을 선택했다.

  **2. SubscriptionManager 동시성**
기존 ConcurrentHashMap + AtomicInteger 조합은 개별 연산은 원자적이나, "카운트 변경 + 맵 조작"을 묶어주지 못해 레이스 컨디션이 발생했다.
  synchronized + HashMap으로 변경하여 subscribe/unsubscribe 전체를 하나의 임계 영역으로 보호했다.
  구독/해제 빈도가 높지 않아 synchronized의 성능 영향은 무시할 수 있다고 판단했다.

  **3. type 필드 추가**
STOMP topic 경로로도 메시지 구분이 가능하나, 향후 CANDLE 등 타입 추가와 topic 구조 변경에 대비하여 컨벤션 문서대로 type 필드를 포함했다.

<br>

### 🔗 관련 이슈
Closes #71 , #72 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 실시간 거래 체결 정보 전송 및 실시간 호가 정보 전송 기능 추가
  * 연결 재설정 시 자동 재구독으로 실시간 스트림 복구

* **Improvements**
  * 실시간 구독 종목 수를 최대 20개로 제한 및 관련 검증/에러 추가
  * 시세 캐시 업데이트 API 추가 및 API 응답 검증 강화

* **Tests**
  * 실시간 데이터 수신/파싱 및 구독 관리 테스트 추가

* **Chores**
  * 외부 API 및 웹소켓 엔드포인트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->