### PR TITLE
[WEF-443] ai채팅 저장 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/client/OpenAiChatClient.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/client/OpenAiChatClient.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.chat.aiChat.client;
 
+import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage.AiChatRole;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.Getter;
@@ -13,36 +15,39 @@ import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
 @Component
 public class OpenAiChatClient {
 
-    @Value("${openai.chat.url}")
-    private String openAiChatUrl;
-
     private final RestTemplate restTemplate;
     private final String apiKey;
     private final String model;
+    private final String chatUrl;
 
     private static final String SYSTEM_PROMPT = """
-    너는 친절한 투자 도우미다.
-    금융 관련 질문에 대해 쉽게 설명하되, 확정적인 투자 권유는 피하고 불확실성을 함께 알려줘.
-    """;
+            너는 친절한 투자 도우미다.
+            사용자의 질문에 대해 이해하기 쉽게 설명하되, 확정적인 투자 권유는 피하고
+            불확실성과 주의사항을 함께 알려줘.
+            """;
 
 
     public OpenAiChatClient(
             @Qualifier("chatRestTemplate") RestTemplate restTemplate,
             @Value("${openai.api-key}") String apiKey,
-            @Value("${openai.chat.model}") String model
+            @Value("${openai.chat.model}") String model,
+            @Value("${openai.chat.url}") String chatUrl
     ) {
         this.restTemplate = restTemplate;
         this.apiKey = apiKey;
         this.model = model;
+        this.chatUrl = chatUrl;
     }
 
-    public String ask(String userMessage) {
+    public String ask(List<AiChatMessage> history) {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -50,15 +55,12 @@ public class OpenAiChatClient {
 
             Map<String, Object> body = Map.of(
                     "model", model,
-                    "messages", List.of(
-                            Map.of("role", "system", "content", SYSTEM_PROMPT),
-                            Map.of("role", "user", "content", userMessage)
-                    )
+                    "messages", toOpenAiMessages(history)
             );
 
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
             ChatResponse response = restTemplate.postForObject(
-                    openAiChatUrl,
+                    chatUrl,
                     request,
                     ChatResponse.class
             );
@@ -78,6 +80,28 @@ public class OpenAiChatClient {
         } catch (RestClientException e) {
             throw new BusinessException(ErrorCode.AI_CHAT_REQUEST_FAILED);
         }
+    }
+
+    private List<Map<String, String>> toOpenAiMessages(List<AiChatMessage> history) {
+        List<Map<String, String>> messages = new ArrayList<>();
+
+        messages.add(Map.of(
+                "role", "system",
+                "content", SYSTEM_PROMPT
+        ));
+
+        history.stream()
+                .sorted(Comparator.comparing(AiChatMessage::getCreatedAt))
+                .forEach(message -> messages.add(Map.of(
+                        "role", toOpenAiRole(message.getRole()),
+                        "content", message.getContent()
+                )));
+
+        return messages;
+    }
+
+    private String toOpenAiRole(AiChatMessage.AiChatRole role) {
+        return role == AiChatRole.USER ? "user" : "assistant";
     }
 
     @Getter

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/client/OpenAiChatClient.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/client/OpenAiChatClient.java
@@ -47,7 +47,7 @@ public class OpenAiChatClient {
         this.chatUrl = chatUrl;
     }
 
-    public String ask(List<AiChatMessage> history) {
+    public String ask(List<AiChatMessage> history, String currentQuestion) {
         try {
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -55,7 +55,7 @@ public class OpenAiChatClient {
 
             Map<String, Object> body = Map.of(
                     "model", model,
-                    "messages", toOpenAiMessages(history)
+                    "messages", toOpenAiMessages(history, currentQuestion)
             );
 
             HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
@@ -82,7 +82,7 @@ public class OpenAiChatClient {
         }
     }
 
-    private List<Map<String, String>> toOpenAiMessages(List<AiChatMessage> history) {
+    private List<Map<String, String>> toOpenAiMessages(List<AiChatMessage> history, String currentQuestion) {
         List<Map<String, String>> messages = new ArrayList<>();
 
         messages.add(Map.of(
@@ -96,6 +96,11 @@ public class OpenAiChatClient {
                         "role", toOpenAiRole(message.getRole()),
                         "content", message.getContent()
                 )));
+
+        messages.add(Map.of(
+                "role", "user",
+                "content", currentQuestion
+        ));
 
         return messages;
     }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatInfo.java
@@ -1,6 +1,13 @@
 package com.solv.wefin.domain.chat.aiChat.dto.info;
 
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 public record AiChatInfo(
-        String answer
+        Long messageId,
+        UUID userId,
+        String role,
+        String content,
+        OffsetDateTime createdAt
 ) {
 }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/entity/AiChatMessage.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/entity/AiChatMessage.java
@@ -1,0 +1,67 @@
+package com.solv.wefin.domain.chat.aiChat.entity;
+
+import com.solv.wefin.domain.auth.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "ai_chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiChatMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long messageId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private AiChatRole role;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    public AiChatMessage(User user, AiChatRole role, String content, OffsetDateTime createdAt) {
+        this.user = user;
+        this.role = role;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public static AiChatMessage createUserMessage(User user, String content) {
+        return AiChatMessage.builder()
+                .user(user)
+                .role(AiChatRole.USER)
+                .content(content)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+
+    public static AiChatMessage createAiMessage(User user, String content) {
+        return AiChatMessage.builder()
+                .user(user)
+                .role(AiChatRole.AI)
+                .content(content)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+
+    public enum AiChatRole {
+        USER, AI
+    }
+}
+

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
@@ -1,6 +1,5 @@
 package com.solv.wefin.domain.chat.aiChat.repository;
 
-import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.chat.aiChat.repository;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Long> {
+
+    List<AiChatMessage> findByUser_UserIdOrderByCreatedAtAsc(UUID userId);
+
+    List<AiChatMessage> findTop10ByUser_UserIdOrderByCreatedAtDesc(UUID userId);
+}

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatMessagePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatMessagePersistenceService.java
@@ -1,0 +1,41 @@
+package com.solv.wefin.domain.chat.aiChat.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import com.solv.wefin.domain.chat.aiChat.repository.AiChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AiChatMessagePersistenceService {
+
+    private final AiChatMessageRepository aiChatMessageRepository;
+
+    public List<AiChatMessage> getMessages(UUID userId) {
+        return aiChatMessageRepository.findByUser_UserIdOrderByCreatedAtAsc(userId);
+    }
+
+    public List<AiChatMessage> getRecentHistory(UUID userId) {
+        return aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Transactional
+    public AiChatMessage saveUserMessage(User user, String message) {
+        return aiChatMessageRepository.save(
+                AiChatMessage.createUserMessage(user, message)
+        );
+    }
+
+    @Transactional
+    public AiChatMessage saveAiMessage(User user, String answer) {
+        return aiChatMessageRepository.save(
+                AiChatMessage.createAiMessage(user, answer)
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -26,6 +26,7 @@ public class AiChatService {
     private final AiChatMessageRepository aiChatMessageRepository;
     private final UserRepository userRepository;
 
+    @Transactional(readOnly = true)
     public List<AiChatInfo> getMessages(UUID userId) {
         validateUserId(userId);
 

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -44,14 +44,14 @@ public class AiChatService {
         User user = userRepository.findById(userId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        aiChatMessageRepository.save(
-                AiChatMessage.createUserMessage(user, command.message())
-        );
-
         List<AiChatMessage> history = aiChatMessageRepository
                 .findTop10ByUser_UserIdOrderByCreatedAtDesc(userId);
 
-        String answer = openAiChatClient.ask(history);
+        String answer = openAiChatClient.ask(history, command.message());
+
+        aiChatMessageRepository.save(
+                AiChatMessage.createUserMessage(user, command.message())
+        );
 
         AiChatMessage aiMessage = aiChatMessageRepository.save(
                 AiChatMessage.createAiMessage(user, answer)

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -6,12 +6,10 @@ import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
-import com.solv.wefin.domain.chat.aiChat.repository.AiChatMessageRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -20,42 +18,34 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AiChatService {
 
-    private final OpenAiChatClient openAiChatClient;
-
     private static final int MAX_MESSAGE_LENGTH = 1000;
-    private final AiChatMessageRepository aiChatMessageRepository;
+
+    private final OpenAiChatClient openAiChatClient;
+    private final AiChatMessagePersistenceService aiChatMessagePersistenceService;
     private final UserRepository userRepository;
 
-    @Transactional(readOnly = true)
     public List<AiChatInfo> getMessages(UUID userId) {
         validateUserId(userId);
 
-        return aiChatMessageRepository.findByUser_UserIdOrderByCreatedAtAsc(userId)
+        return aiChatMessagePersistenceService.getMessages(userId)
                 .stream()
                 .map(this::toInfo)
                 .toList();
     }
 
-    @Transactional
     public AiChatInfo sendMessage(AiChatCommand command, UUID userId) {
         validateUserId(userId);
         validateCommand(command);
 
         User user = userRepository.findById(userId)
-                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        List<AiChatMessage> history = aiChatMessageRepository
-                .findTop10ByUser_UserIdOrderByCreatedAtDesc(userId);
+        List<AiChatMessage> history = aiChatMessagePersistenceService.getRecentHistory(userId);
 
         String answer = openAiChatClient.ask(history, command.message());
 
-        aiChatMessageRepository.save(
-                AiChatMessage.createUserMessage(user, command.message())
-        );
-
-        AiChatMessage aiMessage = aiChatMessageRepository.save(
-                AiChatMessage.createAiMessage(user, answer)
-        );
+        aiChatMessagePersistenceService.saveUserMessage(user, command.message());
+        AiChatMessage aiMessage = aiChatMessagePersistenceService.saveAiMessage(user, answer);
 
         return toInfo(aiMessage);
     }
@@ -91,5 +81,4 @@ public class AiChatService {
                 message.getCreatedAt()
         );
     }
-
 }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -1,12 +1,20 @@
 package com.solv.wefin.domain.chat.aiChat.service;
 
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import com.solv.wefin.domain.chat.aiChat.repository.AiChatMessageRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -15,20 +23,55 @@ public class AiChatService {
     private final OpenAiChatClient openAiChatClient;
 
     private static final int MAX_MESSAGE_LENGTH = 1000;
+    private final AiChatMessageRepository aiChatMessageRepository;
+    private final UserRepository userRepository;
 
-    public AiChatInfo sendMessage(AiChatCommand command) {
+    public List<AiChatInfo> getMessages(UUID userId) {
+        validateUserId(userId);
+
+        return aiChatMessageRepository.findByUser_UserIdOrderByCreatedAtAsc(userId)
+                .stream()
+                .map(this::toInfo)
+                .toList();
+    }
+
+    @Transactional
+    public AiChatInfo sendMessage(AiChatCommand command, UUID userId) {
+        validateUserId(userId);
+        validateCommand(command);
+
+        User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        aiChatMessageRepository.save(
+                AiChatMessage.createUserMessage(user, command.message())
+        );
+
+        List<AiChatMessage> history = aiChatMessageRepository
+                .findTop10ByUser_UserIdOrderByCreatedAtDesc(userId);
+
+        String answer = openAiChatClient.ask(history);
+
+        AiChatMessage aiMessage = aiChatMessageRepository.save(
+                AiChatMessage.createAiMessage(user, answer)
+        );
+
+        return toInfo(aiMessage);
+    }
+
+    private void validateUserId(UUID userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    private void validateCommand(AiChatCommand command) {
         if (command == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
 
-        validateMessage(command.message());
+        String message = command.message();
 
-        String answer = openAiChatClient.ask(command.message());
-
-        return new AiChatInfo(answer);
-    }
-
-    private void validateMessage(String message) {
         if (message == null || message.isBlank()) {
             throw new BusinessException(ErrorCode.CHAT_MESSAGE_EMPTY);
         }
@@ -37,4 +80,15 @@ public class AiChatService {
             throw new BusinessException(ErrorCode.CHAT_MESSAGE_TOO_LONG);
         }
     }
+
+    private AiChatInfo toInfo(AiChatMessage message) {
+        return new AiChatInfo(
+                message.getMessageId(),
+                message.getUser().getUserId(),
+                message.getRole().name(),
+                message.getContent(),
+                message.getCreatedAt()
+        );
+    }
+
 }

--- a/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
@@ -61,7 +61,13 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
                 throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
             }
 
-            UUID userId = jwtProvider.getUserId(token);
+            UUID userId;
+            try {
+                userId = jwtProvider.getUserId(token);
+            } catch (RuntimeException e) {
+                throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+            }
+
 
             boolean exists = userRepository.existsById(userId);
 

--- a/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.global.config;
 
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +23,12 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
-    // 메시지가 채널로 보내지기 직전 호출 -> 조건에 안맞으면 차단(지금은 안함), 사용자 정보 넣기
+    // 메시지가 채널로 보내지기 직전 호출 -> 조건에 안맞으면 차단, 사용자 정보 넣기
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor =
@@ -36,20 +40,28 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
         // CONNECT 일때 id를 웹소켓 사용자로 저장
         if(StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String userIdHeader = accessor.getFirstNativeHeader("userId");
+            String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
 
             // jwt 토큰 검증
-//            String token = accessor.getFirstNativeHeader("Authorization");
-            if (userIdHeader == null || userIdHeader.isBlank()) {
-                throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+            if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
+                throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
             }
 
-            UUID userId;
+            String token = authorizationHeader.substring(BEARER_PREFIX.length());
+
+            boolean validAccessToken;
+
             try {
-                userId = UUID.fromString(userIdHeader);
-            } catch (IllegalArgumentException e) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT);
+                validAccessToken = jwtProvider.isValid(token) && jwtProvider.isAccessToken(token);
+            } catch (RuntimeException e) {
+                validAccessToken = false;
             }
+
+            if (!validAccessToken) {
+                throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+            }
+
+            UUID userId = jwtProvider.getUserId(token);
 
             boolean exists = userRepository.existsById(userId);
 

--- a/src/main/java/com/solv/wefin/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/solv/wefin/global/error/GlobalExceptionHandler.java
@@ -4,12 +4,14 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import com.solv.wefin.global.common.ApiResponse;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -48,4 +50,15 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(error.getStatus()).body(error);
     }
 
+    @ExceptionHandler(MissingRequestHeaderException.class)
+    public ResponseEntity<ApiResponse<?>> handleMissingRequestHeaderException(MissingRequestHeaderException e) {
+        ApiResponse<Object> error = ApiResponse.error(ErrorCode.INVALID_INPUT);
+        return ResponseEntity.status(error.getStatus()).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        ApiResponse<Object> error = ApiResponse.error(ErrorCode.INVALID_INPUT);
+        return ResponseEntity.status(error.getStatus()).body(error);
+    }
 }

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
@@ -9,10 +9,10 @@ import com.solv.wefin.web.chat.aiChat.dto.request.AiChatRequest;
 import com.solv.wefin.web.chat.aiChat.dto.response.AiChatResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,14 +22,29 @@ public class AiChatController {
     private final AiChatService aiChatService;
 
     @PostMapping("/messages")
-    public ApiResponse<AiChatResponse> sendMessage(@Valid @RequestBody AiChatRequest request) {
+    public ApiResponse<AiChatResponse> sendMessage(
+            @RequestHeader("X-User-Id") UUID userId,
+            @Valid @RequestBody AiChatRequest request
+    ) {
 
         if (request == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
 
-        AiChatInfo info = aiChatService.sendMessage(request.toCommand());
+        AiChatInfo info = aiChatService.sendMessage(request.toCommand(), userId);
 
         return ApiResponse.success(AiChatResponse.from(info));
+    }
+
+    @GetMapping("/messages")
+    public ApiResponse<List<AiChatResponse>> getMessages(
+            @RequestHeader("X-User-Id") UUID userId
+    ) {
+        List<AiChatResponse> messages = aiChatService.getMessages(userId)
+                .stream()
+                .map(AiChatResponse::from)
+                .toList();
+
+        return ApiResponse.success(messages);
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
@@ -9,6 +9,7 @@ import com.solv.wefin.web.chat.aiChat.dto.request.AiChatRequest;
 import com.solv.wefin.web.chat.aiChat.dto.response.AiChatResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,7 +24,7 @@ public class AiChatController {
 
     @PostMapping("/messages")
     public ApiResponse<AiChatResponse> sendMessage(
-            @RequestHeader("X-User-Id") UUID userId,
+            @AuthenticationPrincipal UUID userId,
             @Valid @RequestBody AiChatRequest request
     ) {
 
@@ -38,7 +39,7 @@ public class AiChatController {
 
     @GetMapping("/messages")
     public ApiResponse<List<AiChatResponse>> getMessages(
-            @RequestHeader("X-User-Id") UUID userId
+            @AuthenticationPrincipal UUID userId
     ) {
         List<AiChatResponse> messages = aiChatService.getMessages(userId)
                 .stream()

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatResponse.java
@@ -2,10 +2,23 @@ package com.solv.wefin.web.chat.aiChat.dto.response;
 
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
 
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
 public record AiChatResponse(
-        String answer
+        Long messageId,
+        UUID userId,
+        String role,
+        String content,
+        OffsetDateTime createdAt
 ) {
     public static AiChatResponse from(AiChatInfo info) {
-        return new AiChatResponse(info.answer());
+        return new AiChatResponse(
+                info.messageId(),
+                info.userId(),
+                info.role(),
+                info.content(),
+                info.createdAt()
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
@@ -6,6 +6,7 @@ import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.ChatMessageResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMetaResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -20,7 +21,7 @@ public class GroupChatController {
 
     @GetMapping("/messages")
     public ApiResponse<List<ChatMessageResponse>> getRecentMessages(
-            @RequestHeader("X-User-Id") UUID userId,
+            @AuthenticationPrincipal UUID userId,
             @RequestParam(defaultValue = "50") int limit) {
         List<ChatMessageResponse> messages = chatMessageService.getRecentMessages(userId, limit)
                 .stream()
@@ -32,7 +33,7 @@ public class GroupChatController {
 
     @GetMapping("/me")
     public ApiResponse<GroupChatMetaResponse> getMyGroup(
-            @RequestHeader("X-User-Id") UUID userId
+            @AuthenticationPrincipal UUID userId
     ) {
         Group group = chatMessageService.getMyGroup(userId);
 

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -6,7 +6,6 @@ import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
-import com.solv.wefin.domain.chat.aiChat.repository.AiChatMessageRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,30 +21,28 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AiChatServiceTest {
 
-    private AiChatMessageRepository aiChatMessageRepository;
+    private AiChatMessagePersistenceService aiChatMessagePersistenceService;
     private UserRepository userRepository;
     private OpenAiChatClient openAiChatClient;
     private AiChatService aiChatService;
 
     @BeforeEach
     void setUp() {
-        aiChatMessageRepository = mock(AiChatMessageRepository.class);
+        aiChatMessagePersistenceService = mock(AiChatMessagePersistenceService.class);
         userRepository = mock(UserRepository.class);
         openAiChatClient = mock(OpenAiChatClient.class);
 
         aiChatService = new AiChatService(
                 openAiChatClient,
-                aiChatMessageRepository,
+                aiChatMessagePersistenceService,
                 userRepository
         );
     }
@@ -65,7 +62,7 @@ class AiChatServiceTest {
         ReflectionTestUtils.setField(secondMessage, "messageId", 2L);
         ReflectionTestUtils.setField(secondMessage, "createdAt", OffsetDateTime.now());
 
-        when(aiChatMessageRepository.findByUser_UserIdOrderByCreatedAtAsc(userId))
+        when(aiChatMessagePersistenceService.getMessages(userId))
                 .thenReturn(List.of(firstMessage, secondMessage));
 
         // when
@@ -100,29 +97,24 @@ class AiChatServiceTest {
         ReflectionTestUtils.setField(savedAiMessage, "createdAt", OffsetDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
+        when(aiChatMessagePersistenceService.getRecentHistory(userId))
                 .thenReturn(List.of(historyUserMessage));
         when(openAiChatClient.ask(anyList(), eq(command.message())))
                 .thenReturn("최근 실적 기준으로 설명드릴게요.");
-        when(aiChatMessageRepository.save(any(AiChatMessage.class)))
-                .thenReturn(savedUserMessage)
+        when(aiChatMessagePersistenceService.saveUserMessage(user, command.message()))
+                .thenReturn(savedUserMessage);
+        when(aiChatMessagePersistenceService.saveAiMessage(user, "최근 실적 기준으로 설명드릴게요."))
                 .thenReturn(savedAiMessage);
 
-        ArgumentCaptor<AiChatMessage> messageCaptor = ArgumentCaptor.forClass(AiChatMessage.class);
         ArgumentCaptor<List<AiChatMessage>> historyCaptor = ArgumentCaptor.forClass(List.class);
 
         // when
         AiChatInfo result = aiChatService.sendMessage(command, userId);
 
         // then
-        verify(aiChatMessageRepository, times(2)).save(messageCaptor.capture());
+        verify(aiChatMessagePersistenceService).saveUserMessage(user, command.message());
+        verify(aiChatMessagePersistenceService).saveAiMessage(user, "최근 실적 기준으로 설명드릴게요.");
         verify(openAiChatClient).ask(historyCaptor.capture(), eq(command.message()));
-
-        List<AiChatMessage> savedMessages = messageCaptor.getAllValues();
-        assertEquals("USER", savedMessages.get(0).getRole().name());
-        assertEquals("삼성전자 전망 알려줘", savedMessages.get(0).getContent());
-        assertEquals("AI", savedMessages.get(1).getRole().name());
-        assertEquals("최근 실적 기준으로 설명드릴게요.", savedMessages.get(1).getContent());
 
         List<AiChatMessage> history = historyCaptor.getValue();
         assertEquals(1, history.size());
@@ -222,7 +214,7 @@ class AiChatServiceTest {
         ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
+        when(aiChatMessagePersistenceService.getRecentHistory(userId))
                 .thenReturn(List.of(historyUserMessage));
         when(openAiChatClient.ask(anyList(), eq(command.message())))
                 .thenThrow(new BusinessException(ErrorCode.AI_CHAT_REQUEST_FAILED));
@@ -248,7 +240,7 @@ class AiChatServiceTest {
         ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
+        when(aiChatMessagePersistenceService.getRecentHistory(userId))
                 .thenReturn(List.of(historyUserMessage));
         when(openAiChatClient.ask(anyList(), eq(command.message())))
                 .thenThrow(new BusinessException(ErrorCode.AI_CHAT_TIMEOUT));

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -1,73 +1,276 @@
 package com.solv.wefin.domain.chat.aiChat.service;
 
-
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import com.solv.wefin.domain.chat.aiChat.repository.AiChatMessageRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 
-public class AiChatServiceTest {
+class AiChatServiceTest {
 
+    private AiChatMessageRepository aiChatMessageRepository;
+    private UserRepository userRepository;
     private OpenAiChatClient openAiChatClient;
     private AiChatService aiChatService;
 
     @BeforeEach
     void setUp() {
+        aiChatMessageRepository = mock(AiChatMessageRepository.class);
+        userRepository = mock(UserRepository.class);
         openAiChatClient = mock(OpenAiChatClient.class);
-        aiChatService = new AiChatService(openAiChatClient);
+
+        aiChatService = new AiChatService(
+                openAiChatClient,
+                aiChatMessageRepository,
+                userRepository
+        );
     }
 
     @Test
-    @DisplayName("ai 채팅 요청 시 답변 정보를 반환한다.")
-    void sendMessage_success() {
+    @DisplayName("현재 사용자의 AI 채팅 메시지 목록을 반환한다")
+    void getMessages_success() {
         // given
-        AiChatCommand command = new AiChatCommand("삼성전자 전망 알려줘");
-        when(openAiChatClient.ask("삼성전자 전망 알려줘"))
-                .thenReturn("삼성전자는 최근 실적 기준으로...");
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("ai-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        AiChatMessage firstMessage = AiChatMessage.createUserMessage(user, "삼성전자 어때?");
+        ReflectionTestUtils.setField(firstMessage, "messageId", 1L);
+        ReflectionTestUtils.setField(firstMessage, "createdAt", OffsetDateTime.now().minusMinutes(1));
+
+        AiChatMessage secondMessage = AiChatMessage.createAiMessage(user, "최근 실적 기준으로 설명드릴게요.");
+        ReflectionTestUtils.setField(secondMessage, "messageId", 2L);
+        ReflectionTestUtils.setField(secondMessage, "createdAt", OffsetDateTime.now());
+
+        when(aiChatMessageRepository.findByUser_UserIdOrderByCreatedAtAsc(userId))
+                .thenReturn(List.of(firstMessage, secondMessage));
 
         // when
-        AiChatInfo result = aiChatService.sendMessage(command);
+        List<AiChatInfo> result = aiChatService.getMessages(userId);
 
         // then
-        assertEquals("삼성전자는 최근 실적 기준으로...", result.answer());
+        assertEquals(2, result.size());
+        assertEquals("USER", result.get(0).role());
+        assertEquals("삼성전자 어때?", result.get(0).content());
+        assertEquals("AI", result.get(1).role());
+        assertEquals("최근 실적 기준으로 설명드릴게요.", result.get(1).content());
     }
 
     @Test
-    @DisplayName("메시지가 비어있을 시 예외가 발생한다.")
+    @DisplayName("AI 채팅 요청 시 사용자 메시지와 AI 메시지를 저장하고 AI 답변을 반환한다")
+    void sendMessage_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        AiChatCommand command = new AiChatCommand("삼성전자 전망 알려줘");
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("ai-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "삼성전자 전망 알려줘");
+        ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
+        ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now().minusSeconds(10));
+
+        AiChatMessage savedAiMessage = AiChatMessage.createAiMessage(user, "최근 실적 기준으로 설명드릴게요.");
+        ReflectionTestUtils.setField(savedAiMessage, "messageId", 2L);
+        ReflectionTestUtils.setField(savedAiMessage, "createdAt", OffsetDateTime.now());
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(historyUserMessage));
+        when(openAiChatClient.ask(any()))
+                .thenReturn("최근 실적 기준으로 설명드릴게요.");
+        when(aiChatMessageRepository.save(any(AiChatMessage.class)))
+                .thenReturn(historyUserMessage)
+                .thenReturn(savedAiMessage);
+
+        ArgumentCaptor<AiChatMessage> messageCaptor = ArgumentCaptor.forClass(AiChatMessage.class);
+
+        // when
+        AiChatInfo result = aiChatService.sendMessage(command, userId);
+
+        // then
+        verify(aiChatMessageRepository, times(2)).save(messageCaptor.capture());
+        verify(openAiChatClient, times(1)).ask(any());
+
+        List<AiChatMessage> savedMessages = messageCaptor.getAllValues();
+        assertEquals("USER", savedMessages.get(0).getRole().name());
+        assertEquals("삼성전자 전망 알려줘", savedMessages.get(0).getContent());
+        assertEquals("AI", savedMessages.get(1).getRole().name());
+        assertEquals("최근 실적 기준으로 설명드릴게요.", savedMessages.get(1).getContent());
+
+        assertEquals(2L, result.messageId());
+        assertEquals(userId, result.userId());
+        assertEquals("AI", result.role());
+        assertEquals("최근 실적 기준으로 설명드릴게요.", result.content());
+    }
+
+    @Test
+    @DisplayName("입력 메시지가 비어 있으면 예외가 발생한다")
     void sendMessage_fail_blank() {
         // given
+        UUID userId = UUID.randomUUID();
         AiChatCommand command = new AiChatCommand(" ");
 
         // when
         BusinessException exception = assertThrows(BusinessException.class,
-                () -> aiChatService.sendMessage(command));
+                () -> aiChatService.sendMessage(command, userId));
 
         // then
         assertEquals(ErrorCode.CHAT_MESSAGE_EMPTY, exception.getErrorCode());
     }
 
     @Test
-    @DisplayName("AI 클라이언트 호출 실패 시 예외를 발생한다.")
-    void sendMessage_fail_when_client_throws() {
+    @DisplayName("입력 메시지가 최대 길이를 초과하면 예외가 발생한다")
+    void sendMessage_fail_too_long() {
+        // given
+        UUID userId = UUID.randomUUID();
+        String longMessage = "a".repeat(1001);
+        AiChatCommand command = new AiChatCommand(longMessage);
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> aiChatService.sendMessage(command, userId));
+
+        // then
+        assertEquals(ErrorCode.CHAT_MESSAGE_TOO_LONG, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("command가 null이면 예외가 발생한다")
+    void sendMessage_fail_null_command() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> aiChatService.sendMessage(null, userId));
+
+        // then
+        assertEquals(ErrorCode.INVALID_INPUT, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 예외가 발생한다")
+    void sendMessage_fail_null_userId() {
         // given
         AiChatCommand command = new AiChatCommand("질문");
-        when(openAiChatClient.ask("질문"))
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> aiChatService.sendMessage(command, null));
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 예외가 발생한다")
+    void sendMessage_fail_user_not_found() {
+        // given
+        UUID userId = UUID.randomUUID();
+        AiChatCommand command = new AiChatCommand("질문");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> aiChatService.sendMessage(command, userId));
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("AI 클라이언트 호출 실패 시 예외를 전파한다")
+    void sendMessage_fail_when_client_throws() {
+        // given
+        UUID userId = UUID.randomUUID();
+        AiChatCommand command = new AiChatCommand("질문");
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("ai-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "질문");
+        ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
+        ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now());
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(aiChatMessageRepository.save(any(AiChatMessage.class))).thenReturn(historyUserMessage);
+        when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(historyUserMessage));
+        when(openAiChatClient.ask(any()))
                 .thenThrow(new BusinessException(ErrorCode.AI_CHAT_REQUEST_FAILED));
 
         // when
         BusinessException exception = assertThrows(BusinessException.class,
-                () -> aiChatService.sendMessage(command));
+                () -> aiChatService.sendMessage(command, userId));
 
         // then
         assertEquals(ErrorCode.AI_CHAT_REQUEST_FAILED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("AI 응답 시간이 초과되면 예외를 전파한다")
+    void sendMessage_fail_timeout() {
+        // given
+        UUID userId = UUID.randomUUID();
+        AiChatCommand command = new AiChatCommand("질문");
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("ai-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "질문");
+        ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
+        ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now());
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(aiChatMessageRepository.save(any(AiChatMessage.class))).thenReturn(historyUserMessage);
+        when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(historyUserMessage));
+        when(openAiChatClient.ask(any()))
+                .thenThrow(new BusinessException(ErrorCode.AI_CHAT_TIMEOUT));
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> aiChatService.sendMessage(command, userId));
+
+        // then
+        assertEquals(ErrorCode.AI_CHAT_TIMEOUT, exception.getErrorCode());
     }
 }

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -23,7 +23,12 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AiChatServiceTest {
 
@@ -50,13 +55,7 @@ class AiChatServiceTest {
     void getMessages_success() {
         // given
         UUID userId = UUID.randomUUID();
-
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("ai-user")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
+        User user = createUser(userId);
 
         AiChatMessage firstMessage = AiChatMessage.createUserMessage(user, "삼성전자 어때?");
         ReflectionTestUtils.setField(firstMessage, "messageId", 1L);
@@ -81,44 +80,43 @@ class AiChatServiceTest {
     }
 
     @Test
-    @DisplayName("AI 채팅 요청 시 사용자 메시지와 AI 메시지를 저장하고 AI 답변을 반환한다")
+    @DisplayName("과거 history와 현재 질문을 분리해 AI에 전달하고 사용자와 AI 메시지를 저장한다")
     void sendMessage_success() {
         // given
         UUID userId = UUID.randomUUID();
         AiChatCommand command = new AiChatCommand("삼성전자 전망 알려줘");
+        User user = createUser(userId);
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("ai-user")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "삼성전자 전망 알려줘");
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "이전에 나눈 질문");
         ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
         ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now().minusSeconds(10));
 
+        AiChatMessage savedUserMessage = AiChatMessage.createUserMessage(user, command.message());
+        ReflectionTestUtils.setField(savedUserMessage, "messageId", 2L);
+        ReflectionTestUtils.setField(savedUserMessage, "createdAt", OffsetDateTime.now().minusSeconds(5));
+
         AiChatMessage savedAiMessage = AiChatMessage.createAiMessage(user, "최근 실적 기준으로 설명드릴게요.");
-        ReflectionTestUtils.setField(savedAiMessage, "messageId", 2L);
+        ReflectionTestUtils.setField(savedAiMessage, "messageId", 3L);
         ReflectionTestUtils.setField(savedAiMessage, "createdAt", OffsetDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
                 .thenReturn(List.of(historyUserMessage));
-        when(openAiChatClient.ask(any()))
+        when(openAiChatClient.ask(anyList(), eq(command.message())))
                 .thenReturn("최근 실적 기준으로 설명드릴게요.");
         when(aiChatMessageRepository.save(any(AiChatMessage.class)))
-                .thenReturn(historyUserMessage)
+                .thenReturn(savedUserMessage)
                 .thenReturn(savedAiMessage);
 
         ArgumentCaptor<AiChatMessage> messageCaptor = ArgumentCaptor.forClass(AiChatMessage.class);
+        ArgumentCaptor<List<AiChatMessage>> historyCaptor = ArgumentCaptor.forClass(List.class);
 
         // when
         AiChatInfo result = aiChatService.sendMessage(command, userId);
 
         // then
         verify(aiChatMessageRepository, times(2)).save(messageCaptor.capture());
-        verify(openAiChatClient, times(1)).ask(any());
+        verify(openAiChatClient).ask(historyCaptor.capture(), eq(command.message()));
 
         List<AiChatMessage> savedMessages = messageCaptor.getAllValues();
         assertEquals("USER", savedMessages.get(0).getRole().name());
@@ -126,7 +124,11 @@ class AiChatServiceTest {
         assertEquals("AI", savedMessages.get(1).getRole().name());
         assertEquals("최근 실적 기준으로 설명드릴게요.", savedMessages.get(1).getContent());
 
-        assertEquals(2L, result.messageId());
+        List<AiChatMessage> history = historyCaptor.getValue();
+        assertEquals(1, history.size());
+        assertEquals("이전에 나눈 질문", history.get(0).getContent());
+
+        assertEquals(3L, result.messageId());
         assertEquals(userId, result.userId());
         assertEquals("AI", result.role());
         assertEquals("최근 실적 기준으로 설명드릴게요.", result.content());
@@ -152,8 +154,7 @@ class AiChatServiceTest {
     void sendMessage_fail_too_long() {
         // given
         UUID userId = UUID.randomUUID();
-        String longMessage = "a".repeat(1001);
-        AiChatCommand command = new AiChatCommand(longMessage);
+        AiChatCommand command = new AiChatCommand("a".repeat(1001));
 
         // when
         BusinessException exception = assertThrows(BusinessException.class,
@@ -214,23 +215,16 @@ class AiChatServiceTest {
         // given
         UUID userId = UUID.randomUUID();
         AiChatCommand command = new AiChatCommand("질문");
+        User user = createUser(userId);
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("ai-user")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "질문");
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "이전 질문");
         ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
         ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(aiChatMessageRepository.save(any(AiChatMessage.class))).thenReturn(historyUserMessage);
         when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
                 .thenReturn(List.of(historyUserMessage));
-        when(openAiChatClient.ask(any()))
+        when(openAiChatClient.ask(anyList(), eq(command.message())))
                 .thenThrow(new BusinessException(ErrorCode.AI_CHAT_REQUEST_FAILED));
 
         // when
@@ -247,23 +241,16 @@ class AiChatServiceTest {
         // given
         UUID userId = UUID.randomUUID();
         AiChatCommand command = new AiChatCommand("질문");
+        User user = createUser(userId);
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("ai-user")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "질문");
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "이전 질문");
         ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
         ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now());
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(aiChatMessageRepository.save(any(AiChatMessage.class))).thenReturn(historyUserMessage);
         when(aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId))
                 .thenReturn(List.of(historyUserMessage));
-        when(openAiChatClient.ask(any()))
+        when(openAiChatClient.ask(anyList(), eq(command.message())))
                 .thenThrow(new BusinessException(ErrorCode.AI_CHAT_TIMEOUT));
 
         // when
@@ -272,5 +259,15 @@ class AiChatServiceTest {
 
         // then
         assertEquals(ErrorCode.AI_CHAT_TIMEOUT, exception.getErrorCode());
+    }
+
+    private User createUser(UUID userId) {
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("ai-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
     }
 }

--- a/src/test/java/com/solv/wefin/web/chat/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/aiChat/AiChatControllerTest.java
@@ -11,10 +11,13 @@ import com.solv.wefin.global.error.GlobalExceptionHandler;
 import com.solv.wefin.web.chat.aiChat.dto.request.AiChatRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,11 +25,13 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -34,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AiChatController.class)
 @Import(GlobalExceptionHandler.class)
-public class AiChatControllerTest {
+class AiChatControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -68,8 +73,7 @@ public class AiChatControllerTest {
         // when // then
         mockMvc.perform(post("/api/chat/ai/messages")
                         .with(csrf())
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(userId, null, AuthorityUtils.NO_AUTHORITIES)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -78,10 +82,14 @@ public class AiChatControllerTest {
                 .andExpect(jsonPath("$.data.userId").value(userId.toString()))
                 .andExpect(jsonPath("$.data.role").value("AI"))
                 .andExpect(jsonPath("$.data.content").value("최근 실적 기준으로 설명드릴게요."));
+
+        ArgumentCaptor<AiChatCommand> captor = ArgumentCaptor.forClass(AiChatCommand.class);
+        verify(aiChatService).sendMessage(captor.capture(), eq(userId));
+        assertEquals(request.message(), captor.getValue().message());
     }
 
     @Test
-    @DisplayName("입력 메시지가 비어 있으면 INVALID_INPUT으로 400을 반환한다")
+    @DisplayName("입력 메시지가 비어 있으면 INVALID_INPUT을 반환한다")
     void sendMessage_fail_blank() throws Exception {
         // given
         UUID userId = UUID.randomUUID();
@@ -90,8 +98,7 @@ public class AiChatControllerTest {
         // when // then
         mockMvc.perform(post("/api/chat/ai/messages")
                         .with(csrf())
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(userId, null, AuthorityUtils.NO_AUTHORITIES)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
@@ -112,8 +119,7 @@ public class AiChatControllerTest {
         // when // then
         mockMvc.perform(post("/api/chat/ai/messages")
                         .with(csrf())
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(userId, null, AuthorityUtils.NO_AUTHORITIES)))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isGatewayTimeout())
@@ -134,7 +140,7 @@ public class AiChatControllerTest {
                                 1L,
                                 userId,
                                 "USER",
-                                "삼성전자 어때?",
+                                "삼성전자 전망 알려줘",
                                 createdAt.minusMinutes(1)
                         ),
                         new AiChatInfo(
@@ -148,13 +154,12 @@ public class AiChatControllerTest {
 
         // when // then
         mockMvc.perform(get("/api/chat/ai/messages")
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString()))
+                        .with(authentication(new UsernamePasswordAuthenticationToken(userId, null, AuthorityUtils.NO_AUTHORITIES))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data[0].messageId").value(1))
                 .andExpect(jsonPath("$.data[0].role").value("USER"))
-                .andExpect(jsonPath("$.data[0].content").value("삼성전자 어때?"))
+                .andExpect(jsonPath("$.data[0].content").value("삼성전자 전망 알려줘"))
                 .andExpect(jsonPath("$.data[1].messageId").value(2))
                 .andExpect(jsonPath("$.data[1].role").value("AI"))
                 .andExpect(jsonPath("$.data[1].content").value("최근 실적 기준으로 설명드릴게요."));

--- a/src/test/java/com/solv/wefin/web/chat/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/aiChat/AiChatControllerTest.java
@@ -18,10 +18,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -43,61 +49,114 @@ public class AiChatControllerTest {
     private JwtProvider jwtProvider;
 
     @Test
-    @DisplayName("AI 채팅 요청이 들어오면 답변을 반환한다")
+    @DisplayName("AI 채팅 요청이 들어오면 저장된 AI 메시지를 반환한다")
     void sendMessage_success() throws Exception {
         // given
+        UUID userId = UUID.randomUUID();
         AiChatRequest request = new AiChatRequest("삼성전자 전망 알려줘");
-        when(aiChatService.sendMessage(any(AiChatCommand.class)))
-                .thenReturn(new AiChatInfo("최근 실적 기준으로..."));
+        OffsetDateTime createdAt = OffsetDateTime.now();
+
+        when(aiChatService.sendMessage(any(AiChatCommand.class), eq(userId)))
+                .thenReturn(new AiChatInfo(
+                        1L,
+                        userId,
+                        "AI",
+                        "최근 실적 기준으로 설명드릴게요.",
+                        createdAt
+                ));
 
         // when // then
         mockMvc.perform(post("/api/chat/ai/messages")
-                    .with(csrf())
-                    .with(user("test"))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
+                        .with(csrf())
+                        .with(user("test"))
+                        .header("X-User-Id", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data.answer").value("최근 실적 기준으로..."));
+                .andExpect(jsonPath("$.data.messageId").value(1))
+                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.data.role").value("AI"))
+                .andExpect(jsonPath("$.data.content").value("최근 실적 기준으로 설명드릴게요."));
     }
 
     @Test
-    @DisplayName("입력 메시지가 비어 있으면 INVALID_INPUT으로 400을 반환한다.")
+    @DisplayName("입력 메시지가 비어 있으면 INVALID_INPUT으로 400을 반환한다")
     void sendMessage_fail_blank() throws Exception {
         // given
+        UUID userId = UUID.randomUUID();
         AiChatRequest request = new AiChatRequest(" ");
-
-        when(aiChatService.sendMessage(any(AiChatCommand.class)))
-                .thenThrow(new BusinessException(ErrorCode.CHAT_MESSAGE_EMPTY));
 
         // when // then
         mockMvc.perform(post("/api/chat/ai/messages")
-                    .with(csrf())
-                    .with(user("test"))
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(objectMapper.writeValueAsString(request)))
+                        .with(csrf())
+                        .with(user("test"))
+                        .header("X-User-Id", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400))
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
 
     @Test
-    @DisplayName("AI 응답 시간이 초과되면 504를 반환한다.")
+    @DisplayName("AI 응답 시간이 초과되면 504를 반환한다")
     void sendMessage_fail_timeout() throws Exception {
         // given
+        UUID userId = UUID.randomUUID();
         AiChatRequest request = new AiChatRequest("질문");
 
-        when(aiChatService.sendMessage(any(AiChatCommand.class)))
+        when(aiChatService.sendMessage(any(AiChatCommand.class), eq(userId)))
                 .thenThrow(new BusinessException(ErrorCode.AI_CHAT_TIMEOUT));
 
         // when // then
         mockMvc.perform(post("/api/chat/ai/messages")
-                .with(csrf())
-                .with(user("test"))
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .with(csrf())
+                        .with(user("test"))
+                        .header("X-User-Id", userId.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isGatewayTimeout())
                 .andExpect(jsonPath("$.status").value(504))
                 .andExpect(jsonPath("$.code").value("AI_CHAT_TIMEOUT"));
+    }
+
+    @Test
+    @DisplayName("현재 사용자의 AI 채팅 메시지 목록을 반환한다")
+    void getMessages_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime createdAt = OffsetDateTime.now();
+
+        when(aiChatService.getMessages(userId))
+                .thenReturn(List.of(
+                        new AiChatInfo(
+                                1L,
+                                userId,
+                                "USER",
+                                "삼성전자 어때?",
+                                createdAt.minusMinutes(1)
+                        ),
+                        new AiChatInfo(
+                                2L,
+                                userId,
+                                "AI",
+                                "최근 실적 기준으로 설명드릴게요.",
+                                createdAt
+                        )
+                ));
+
+        // when // then
+        mockMvc.perform(get("/api/chat/ai/messages")
+                        .with(user("test"))
+                        .header("X-User-Id", userId.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data[0].messageId").value(1))
+                .andExpect(jsonPath("$.data[0].role").value("USER"))
+                .andExpect(jsonPath("$.data[0].content").value("삼성전자 어때?"))
+                .andExpect(jsonPath("$.data[1].messageId").value(2))
+                .andExpect(jsonPath("$.data[1].role").value("AI"))
+                .andExpect(jsonPath("$.data[1].content").value("최근 실적 기준으로 설명드릴게요."));
     }
 }

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.solv.wefin.common.WebSocketIntegrationTestBase;
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,9 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
     @Autowired
     private PlatformTransactionManager transactionManager;
 
+    @Autowired
+    private JwtProvider jwtProvider;
+
     @LocalServerPort
     private int port;
 
@@ -67,6 +71,7 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
         });
 
         UUID userId = savedUserIdRef.get();
+        String accessToken = jwtProvider.generateAccessToken(userId);
 
         // SockJS + WebSocket 기반 STOMP 클라이언트 생성
         List<Transport> transports = List.of(
@@ -91,7 +96,7 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
 
         // CONNECT 시 userId 해더 전달
         StompHeaders connectHeaders = new StompHeaders();
-        connectHeaders.add("userId", userId.toString());
+        connectHeaders.add("Authorization", "Bearer " + accessToken);
 
         // WebSocket 연결
         StompSession session = stompClient

--- a/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -22,8 +24,8 @@ import java.util.UUID;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -64,8 +66,11 @@ class GroupChatControllerTest {
         // when // then
         mockMvc.perform(get("/api/chat/group/messages")
                         .with(csrf())
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        )))
                         .param("limit", "50"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
@@ -88,8 +93,11 @@ class GroupChatControllerTest {
         // when // then
         mockMvc.perform(get("/api/chat/group/messages")
                         .with(csrf())
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        )))
                         .param("limit", "50"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value(403))
@@ -112,8 +120,11 @@ class GroupChatControllerTest {
         // when // then
         mockMvc.perform(get("/api/chat/group/me")
                         .with(csrf())
-                        .with(user("test"))
-                        .header("X-User-Id", userId.toString()))
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.groupId").value(7))


### PR DESCRIPTION
## 📌 PR 설명

사용자별 AI 채팅 내역을 저장하고 다시 조회할 수 있도록 AI 채팅 기록 기능을 구현했습니다.  
현재 프로젝트에서는 유저당 하나의 AI 채팅방을 사용하는 방향으로 정리해, 별도의 세션 테이블 없이 `ai_chat_message` 기준으로 사용자 메시지와 AI 응답을 순차적으로 저장하고 조회할 수 있도록 구성했습니다.

또한 로컬 환경에서 실제 AI 호출까지 확인해, 사용자 메시지 저장 → 최근 대화 history 포함 요청 → OpenAI 응답 생성 → AI 응답 저장 흐름이 정상 동작하는 것도 함께 검증했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[WEF-443] AI 채팅 메시지 저장 및 조회 구현**
- [x] AI 채팅 메시지 엔티티 및 저장 구조 구현
- [x] 사용자 메시지 저장 후 최근 대화 history를 포함해 AI 응답 생성하도록 서비스 확장
- [x] AI 응답 메시지 저장 처리 구현
- [x] 사용자별 AI 채팅 전체 내역 조회 API 구현
- [x] AI 채팅 메시지 응답 DTO를 저장/조회 공용 구조로 정리
- [x] AI 채팅 서비스 테스트 및 컨트롤러 테스트 추가
- [x] 로컬 환경에서 AI 채팅 API 수동 호출 테스트 완료

<br>

## 📸 스크린샷

### open ai api 테스트

<img width="1445" height="163" alt="스크린샷 2026-04-07 160843" src="https://github.com/user-attachments/assets/dae278a7-cd82-4536-9131-45b1078ed1a3" />

<img width="1800" height="563" alt="image" src="https://github.com/user-attachments/assets/d8e8c908-a8af-415c-a49a-f1d2c417e8b5" />

<br>

## 💭 고민과 해결과정

처음에는 AI 채팅도 세션 단위로 분리해서 `session` 테이블을 추가하는 방향을 고려했습니다.  
하지만 현재 요구사항을 다시 정리해보니 “유저당 하나의 AI 채팅방을 유지하면서 이전 대화를 이어간다”는 흐름이 더 적합해, 세션 테이블을 추가하지 않고 `ai_chat_message` 하나로 관리하는 방식으로 단순화했습니다.

이 구조에서는 사용자의 모든 AI 대화가 하나의 히스토리로 누적되기 때문에, 조회 API도 `userId` 기준 전체 메시지를 시간순으로 반환하도록 구현했습니다.  
또한 AI 응답 생성 시에도 같은 사용자 기준 최근 대화 일부를 함께 OpenAI에 전달해, 이전 문맥을 유지한 상태에서 자연스럽게 답변할 수 있도록 했습니다.

즉 이번 구현은 “세션을 나누는 구조”보다 “사용자별 단일 AI 채팅 히스토리 관리”에 초점을 맞춘 방향이고, 추후 실제 요구사항이 바뀌어 여러 대화방 또는 새 대화 시작 기능이 필요해지면 그때 세션 구조를 별도로 확장할 수 있도록 여지를 남겼습니다.

또한 컨트롤러 응답 구조는 전송 API와 조회 API가 같은 메시지 형태를 사용하도록 통일해, 프론트에서 저장된 과거 메시지와 방금 생성된 AI 메시지를 같은 방식으로 렌더링할 수 있도록 정리했습니다.

수동 검증은 로컬 서버 실행 후 `POST /api/chat/ai/messages`, `GET /api/chat/ai/messages` 호출 방식으로 진행했습니다.  
이 과정에서 실제로 사용자 메시지 저장, AI 응답 반환, 응답 메시지 DB 저장, 전체 이력 조회가 모두 동작하는 것을 확인했습니다.  
Windows PowerShell 환경에서는 한글 요청 본문 인코딩 이슈가 있어 UTF-8 바이트 바디로 요청하는 방식으로 테스트를 진행했고, 해당 방식에서는 한글 메시지 저장까지 정상 동작함을 확인했습니다.

<br>

### 🔗 관련 이슈
Closes #80

<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI 채팅 메시지 영구 저장 및 사용자별 최근 대화 이력 기반 응답
  * 인증된 사용자 대상 채팅 메시지 조회 API(GET /messages) 추가

* **Improvements**
  * 응답에 메시지 ID, 사용자 ID, 역할, 내용, 생성시간 포함으로 응답 구조 강화
  * 요청에 대화 이력 포함해 컨텍스트 기반 응답으로 일관성 향상
  * 컨트롤러 인증 방식 및 STOMP 연결의 토큰 기반 인증 적용

* **Bug Fixes / Reliability**
  * 요청 바인딩/타입 오류에 대한 전역 예외 처리 추가

* **Tests**
  * 인증/인수 흐름과 저장·조회 로직을 반영한 단위·통합 테스트 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[WEF-443]: https://sol-v.atlassian.net/browse/WEF-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ