### PR TITLE
[WEF-80] 초대 코드 기반 그룹 참여

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/entity/User.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/User.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.auth.entity;
 
+import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -34,11 +35,19 @@ public class User extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     private UserStatus status;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "home_group_id")
+    private Group homeGroup;
+
     @Builder
     public User(String email, String nickname, String password) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
         this.status = UserStatus.ACTIVE;
+    }
+
+    public void setHomeGroup(Group homeGroup) {
+        this.homeGroup = homeGroup;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.entity.UserStatus;
 import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
@@ -73,7 +74,10 @@ public class AuthService {
                     .build();
 
             User savedUser = userRepository.save(user);
-            groupService.createDefaultGroup(savedUser);
+
+            Group homeGroup = groupService.createDefaultGroup(savedUser);
+            savedUser.setHomeGroup(homeGroup);
+            userRepository.save(savedUser);
 
             return new SignupInfo(
                     savedUser.getUserId(),

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -77,7 +77,6 @@ public class AuthService {
 
             Group homeGroup = groupService.createDefaultGroup(savedUser);
             savedUser.setHomeGroup(homeGroup);
-            userRepository.save(savedUser);
 
             return new SignupInfo(
                     savedUser.getUserId(),

--- a/src/main/java/com/solv/wefin/domain/group/dto/GroupMemberInfo.java
+++ b/src/main/java/com/solv/wefin/domain/group/dto/GroupMemberInfo.java
@@ -1,23 +1,23 @@
 package com.solv.wefin.domain.group.dto;
 
 import com.solv.wefin.domain.group.entity.GroupMember;
-import lombok.Builder;
-import lombok.Getter;
 
 import java.util.UUID;
 
-@Getter
-@Builder
-public class GroupMemberInfo {
-    private UUID userId;
-    private String nickname;
-    private String role;
-
+public record GroupMemberInfo(
+        UUID userId,
+        Long groupId,
+        String groupName,
+        String nickname,
+        String role
+) {
     public static GroupMemberInfo from(GroupMember groupMember) {
-        return GroupMemberInfo.builder()
-                .userId(groupMember.getUser().getUserId())
-                .nickname(groupMember.getUser().getNickname())
-                .role(groupMember.getRole().name())
-                .build();
+        return new GroupMemberInfo(
+                groupMember.getUser().getUserId(),
+                groupMember.getGroup().getId(),
+                groupMember.getGroup().getName(),
+                groupMember.getUser().getNickname(),
+                groupMember.getRole().name()
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> {
+
     boolean existsByUserAndGroup(User user, Group group);
 
     Optional<GroupMember> findByUser_UserIdAndStatus(
@@ -34,4 +35,6 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             """)
     List<GroupMember> findByGroupAndStatusWithUser(@Param("group") Group group,
                                                    @Param("status") GroupMember.GroupMemberStatus status);
+
+    long countByGroupAndStatus(Group group, GroupMember.GroupMemberStatus status);
 }

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupRepository.java
@@ -5,10 +5,13 @@ import com.solv.wefin.domain.group.entity.Group;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    Optional<Group> findById(Long groupId);
+    @Query("SELECT g FROM Group g WHERE g.id = :groupId")
+    Optional<Group> findByIdForUpdate(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupRepository.java
@@ -2,7 +2,13 @@ package com.solv.wefin.domain.group.repository;
 
 
 import com.solv.wefin.domain.group.entity.Group;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+
+import java.util.Optional;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Group> findById(Long groupId);
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -92,7 +92,12 @@ public class GroupService {
             throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
         }
 
-        Group targetGroup = invite.getGroup();
+        if (invite.getStatus() == GroupInvite.InviteStatus.ACCEPTED) {
+            throw new BusinessException(ErrorCode.GROUP_INVITE_ALREADY_USED);
+        }
+
+        Group targetGroup = groupRepository.findById(invite.getGroup().getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -127,6 +132,7 @@ public class GroupService {
                 .build();
 
         groupMemberRepository.save(newMember);
+        invite.markAccepted();
 
         return GroupMemberInfo.from(newMember);
     }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -88,7 +88,6 @@ public class GroupService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_INVITE_NOT_FOUND));
 
         if (invite.getExpiredAt().isBefore(java.time.OffsetDateTime.now())) {
-            invite.expire();
             throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
         }
 

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -92,11 +92,15 @@ public class GroupService {
             throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
         }
 
+        if (invite.getStatus() == GroupInvite.InviteStatus.EXPIRED) {
+            throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
+        }
+
         if (invite.getStatus() == GroupInvite.InviteStatus.ACCEPTED) {
             throw new BusinessException(ErrorCode.GROUP_INVITE_ALREADY_USED);
         }
 
-        Group targetGroup = groupRepository.findById(invite.getGroup().getId())
+        Group targetGroup = groupRepository.findByIdForUpdate(invite.getGroup().getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
 
         User user = userRepository.findById(userId)

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -29,7 +29,7 @@ public class GroupService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void createDefaultGroup(User user) {
+    public Group createDefaultGroup(User user) {
         Group group = Group.builder()
                 .name(user.getNickname() + "의 그룹")
                 .build();
@@ -43,6 +43,7 @@ public class GroupService {
                 .build();
 
         groupMemberRepository.save(groupMember);
+        return savedGroup;
     }
 
     public List<GroupMemberInfo> getActiveMembers(Long groupId) {
@@ -79,5 +80,54 @@ public class GroupService {
         GroupInvite saved = groupInviteRepository.save(invite);
 
         return GroupInviteInfo.from(saved);
+    }
+
+    @Transactional
+    public GroupMemberInfo joinGroup(UUID userId, UUID inviteCode) {
+        GroupInvite invite = groupInviteRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_INVITE_NOT_FOUND));
+
+        if (invite.getExpiredAt().isBefore(java.time.OffsetDateTime.now())) {
+            invite.expire();
+            throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
+        }
+
+        Group targetGroup = invite.getGroup();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember currentActiveMember = groupMemberRepository
+                .findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE)
+                .orElse(null);
+
+        if (currentActiveMember != null
+                && currentActiveMember.getGroup().getId().equals(targetGroup.getId())) {
+            throw new BusinessException(ErrorCode.ALREADY_JOINED_GROUP);
+        }
+
+        long activeMemberCount = groupMemberRepository.countByGroupAndStatus(
+                targetGroup,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        if (activeMemberCount >= 6) {
+            throw new BusinessException(ErrorCode.GROUP_FULL);
+        }
+
+        if (currentActiveMember != null) {
+            currentActiveMember.leave();
+        }
+
+        GroupMember newMember = GroupMember.builder()
+                .user(user)
+                .group(targetGroup)
+                .role(GroupMember.GroupMemberRole.MEMBER)
+                .status(GroupMember.GroupMemberStatus.ACTIVE)
+                .build();
+
+        groupMemberRepository.save(newMember);
+
+        return GroupMemberInfo.from(newMember);
     }
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     GROUP_INVITE_NOT_FOUND(404, "초대 코드를 찾을 수 없습니다."),
     GROUP_INVITE_EXPIRED(400, "만료된 초대 코드입니다."),
     GROUP_INVITE_ALREADY_USED(400, "이미 사용된 초대 코드입니다."),
+    GROUP_FULL(400, "그룹 인원이 가득 찼습니다."),
+    ALREADY_JOINED_GROUP(409, "이미 참여한 그룹입니다."),
 
     // Chat
     CHAT_MESSAGE_EMPTY(400, "메시지 내용은 비어 있을 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/group/GroupController.java
+++ b/src/main/java/com/solv/wefin/web/group/GroupController.java
@@ -1,10 +1,14 @@
 package com.solv.wefin.web.group;
 
 import com.solv.wefin.domain.group.dto.GroupInviteInfo;
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.group.dto.CreateGroupInviteResponse;
 import com.solv.wefin.web.group.dto.GroupMemberResponse;
+import com.solv.wefin.web.group.dto.JoinGroupRequest;
+import com.solv.wefin.web.group.dto.JoinGroupResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -35,5 +39,16 @@ public class GroupController {
     ) {
         GroupInviteInfo inviteInfo = groupService.createInviteCode(groupId, userId);
         return ApiResponse.success(CreateGroupInviteResponse.from(inviteInfo));
+    }
+
+    @PostMapping("/join")
+    public ApiResponse<JoinGroupResponse> joinGroup(
+            @RequestBody @Valid JoinGroupRequest request,
+            @AuthenticationPrincipal UUID userId
+    ) {
+        GroupMemberInfo info = groupService.joinGroup(userId, request.inviteCode());
+        return ApiResponse.success(
+                JoinGroupResponse.from(info)
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/web/group/dto/GroupMemberResponse.java
+++ b/src/main/java/com/solv/wefin/web/group/dto/GroupMemberResponse.java
@@ -11,9 +11,9 @@ public record GroupMemberResponse(
 ) {
     public static GroupMemberResponse from(GroupMemberInfo info) {
         return new GroupMemberResponse(
-                info.getUserId(),
-                info.getNickname(),
-                info.getRole()
+                info.userId(),
+                info.nickname(),
+                info.role()
         );
     }
 }

--- a/src/main/java/com/solv/wefin/web/group/dto/JoinGroupRequest.java
+++ b/src/main/java/com/solv/wefin/web/group/dto/JoinGroupRequest.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.web.group.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record JoinGroupRequest(
+        @NotNull UUID inviteCode
+) {}

--- a/src/main/java/com/solv/wefin/web/group/dto/JoinGroupResponse.java
+++ b/src/main/java/com/solv/wefin/web/group/dto/JoinGroupResponse.java
@@ -1,0 +1,19 @@
+package com.solv.wefin.web.group.dto;
+
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+
+public record JoinGroupResponse(
+        Long groupId,
+        String groupName,
+        String role,
+        String status
+) {
+    public static JoinGroupResponse from(GroupMemberInfo info) {
+        return new JoinGroupResponse(
+                info.groupId(),
+                info.groupName(),
+                info.role(),
+                "ACTIVE"
+        );
+    }
+}

--- a/src/main/resources/db/migration/V20__add_home_group_to_users_and_update_news_columns.sql
+++ b/src/main/resources/db/migration/V20__add_home_group_to_users_and_update_news_columns.sql
@@ -1,0 +1,15 @@
+ALTER TABLE users
+    ADD COLUMN home_group_id BIGINT;
+
+ALTER TABLE users
+    ADD CONSTRAINT fk_user_home_group
+        FOREIGN KEY (home_group_id)
+            REFERENCES groups(group_id);
+
+ALTER TABLE game_news_archive RENAME COLUMN "Field8" TO created_at;
+
+ALTER TABLE game_news_archive ALTER COLUMN source SET NOT NULL;
+ALTER TABLE game_news_archive ALTER COLUMN published_at SET NOT NULL;
+ALTER TABLE game_news_archive ALTER COLUMN created_at SET NOT NULL;
+
+ALTER TABLE briefing_cache RENAME COLUMN "text" TO briefing_text;

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -97,17 +97,16 @@ class AuthServiceTest {
             );
 
             ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
-            verify(userRepository, times(2)).save(captor.capture());
+            verify(userRepository).save(captor.capture());
             verify(groupService).createDefaultGroup(savedUser);
 
-            User firstSavedUser = captor.getAllValues().get(0);
-            User secondSavedUser = captor.getAllValues().get(1);
+            User capturedUser = captor.getValue();
 
             assertAll(
-                    () -> assertThat(firstSavedUser.getEmail()).isEqualTo("test@example.com"),
-                    () -> assertThat(firstSavedUser.getNickname()).isEqualTo("testuser"),
-                    () -> assertThat(firstSavedUser.getPassword()).isEqualTo("encoded-password"),
-                    () -> assertThat(secondSavedUser.getHomeGroup()).isEqualTo(homeGroup),
+                    () -> assertThat(capturedUser.getEmail()).isEqualTo("test@example.com"),
+                    () -> assertThat(capturedUser.getNickname()).isEqualTo("testuser"),
+                    () -> assertThat(capturedUser.getPassword()).isEqualTo("encoded-password"),
+                    () -> assertThat(savedUser.getHomeGroup()).isEqualTo(homeGroup),
                     () -> assertThat(response.userId()).isEqualTo(userId),
                     () -> assertThat(response.email()).isEqualTo("test@example.com"),
                     () -> assertThat(response.nickname()).isEqualTo("testuser")

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.entity.UserStatus;
 import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
@@ -85,20 +86,28 @@ class AuthServiceTest {
 
             when(userRepository.save(any(User.class))).thenReturn(savedUser);
 
+            Group homeGroup = Group.builder()
+                    .name("testuser의 그룹")
+                    .build();
+
+            when(groupService.createDefaultGroup(savedUser)).thenReturn(homeGroup);
+
             SignupInfo response = authService.signup(
                     new SignupCommand(rawEmail, rawNickname, rawPassword)
             );
 
             ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
-            verify(userRepository).save(captor.capture());
+            verify(userRepository, times(2)).save(captor.capture());
             verify(groupService).createDefaultGroup(savedUser);
 
-            User user = captor.getValue();
+            User firstSavedUser = captor.getAllValues().get(0);
+            User secondSavedUser = captor.getAllValues().get(1);
 
             assertAll(
-                    () -> assertThat(user.getEmail()).isEqualTo("test@example.com"),
-                    () -> assertThat(user.getNickname()).isEqualTo("testuser"),
-                    () -> assertThat(user.getPassword()).isEqualTo("encoded-password"),
+                    () -> assertThat(firstSavedUser.getEmail()).isEqualTo("test@example.com"),
+                    () -> assertThat(firstSavedUser.getNickname()).isEqualTo("testuser"),
+                    () -> assertThat(firstSavedUser.getPassword()).isEqualTo("encoded-password"),
+                    () -> assertThat(secondSavedUser.getHomeGroup()).isEqualTo(homeGroup),
                     () -> assertThat(response.userId()).isEqualTo(userId),
                     () -> assertThat(response.email()).isEqualTo("test@example.com"),
                     () -> assertThat(response.nickname()).isEqualTo("testuser")

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -99,12 +99,12 @@ class GroupServiceTest {
             // then
             assertAll(
                     () -> assertThat(result).hasSize(2),
-                    () -> assertThat(result.get(0).getUserId()).isEqualTo(leaderUser.getUserId()),
-                    () -> assertThat(result.get(0).getNickname()).isEqualTo("리더"),
-                    () -> assertThat(result.get(0).getRole()).isEqualTo("LEADER"),
-                    () -> assertThat(result.get(1).getUserId()).isEqualTo(memberUser.getUserId()),
-                    () -> assertThat(result.get(1).getNickname()).isEqualTo("멤버"),
-                    () -> assertThat(result.get(1).getRole()).isEqualTo("MEMBER")
+                    () -> assertThat(result.get(0).userId()).isEqualTo(leaderUser.getUserId()),
+                    () -> assertThat(result.get(0).nickname()).isEqualTo("리더"),
+                    () -> assertThat(result.get(0).role()).isEqualTo("LEADER"),
+                    () -> assertThat(result.get(1).userId()).isEqualTo(memberUser.getUserId()),
+                    () -> assertThat(result.get(1).nickname()).isEqualTo("멤버"),
+                    () -> assertThat(result.get(1).role()).isEqualTo("MEMBER")
             );
 
             verify(groupRepository).findById(1L);

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -47,16 +47,20 @@ class GroupControllerTest {
 
         given(groupService.getActiveMembers(1L))
                 .willReturn(List.of(
-                        GroupMemberInfo.builder()
-                                .userId(leaderId)
-                                .nickname("리더")
-                                .role("LEADER")
-                                .build(),
-                        GroupMemberInfo.builder()
-                                .userId(memberId)
-                                .nickname("멤버")
-                                .role("MEMBER")
-                                .build()
+                        new GroupMemberInfo(
+                                leaderId,
+                                1L,
+                                "테스트 그룹",
+                                "리더",
+                                "LEADER"
+                        ),
+                        new GroupMemberInfo(
+                                memberId,
+                                1L,
+                                "테스트 그룹",
+                                "멤버",
+                                "MEMBER"
+                        )
                 ));
 
         // when & then


### PR DESCRIPTION
…ber structure (#121)

## 📌 PR 설명
초대 코드 기반 그룹 참여 기능을 구현하고 사용자 중심의 그룹 관리 구조를 개선.
회원가입 시 기본 그룹(homeGroup)을 생성하고 그룹 참여 시 기존 그룹에서 자동으로 전환되도록 설계.
<br>

## ✅ 완료한 기능 명세

- [x] 초대 코드 기반 그룹 참여 API 구현 (/api/groups/join)

- [x] 그룹 참여 시 기존 ACTIVE 그룹 → LEFT 전환 로직 구현

- [x] 그룹 정원 제한(최대 6명) 검증 로직 추가

- [x] 초대 코드 만료 및 중복 참여 검증 로직 구현

- [x] 회원가입 시 기본 그룹(homeGroup) 생성 및 연결 구조 개선

- [x] 관련 테스트 코드(AuthServiceTest, GroupServiceTest, GroupControllerTest) 수정 및 검증


- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

- 사용자는 항상 하나의 ACTIVE 그룹만 가져야 하는가에 대한 설계 고민
→ user 기준으로 단일 ACTIVE 그룹을 유지하고, 그룹 전환 시 기존 그룹을 LEFT 처리하도록 설계

- 탈퇴 및 그룹 이동 시 기준 그룹 필요성
→ 회원가입 시 기본 그룹(homeGroup)을 생성하여, 향후 탈퇴 시 fallback 그룹으로 활용 가능하도록 구조 설계

<br>

### 🔗 관련 이슈
Closes #121 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 초대 코드로 그룹에 참여하는 API(/groups/join) 추가
  * 회원 가입 시 기본 그룹이 자동 생성되어 계정에 연결됨
  * 그룹 멤버 응답에 그룹 ID 및 그룹명 정보 포함

* **버그 수정 / 제약**
  * 동일 그룹 중복 참여 차단 및 그룹 인원 최대 6명 제한 적용
  * 만료되거나 이미 사용된 초대 코드 처리 강화

* **데이터베이스**
  * 사용자에 홈 그룹 컬럼 추가 및 외래키 제약 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->