### PR TITLE
[WEF-487] @AuthenticationPrincipal 적용 및 시세 API permitAll 추가

### DIFF
--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**", "/api/stocks/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**", "/api/stocks/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/solv/wefin/web/trading/account/AccountController.java
+++ b/src/main/java/com/solv/wefin/web/trading/account/AccountController.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.trading.account;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,20 +25,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AccountController {
 
-	private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
-
 	private final VirtualAccountService accountService;
 
 	@GetMapping
-	public ApiResponse<AccountResponse> getAccount() {
-		VirtualAccount account = accountService.getAccountByUserId(TEMP_USER_ID);
+	public ApiResponse<AccountResponse> getAccount(@AuthenticationPrincipal UUID userId) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
 		AccountResponse response = AccountResponse.from(account);
 		return ApiResponse.success(response);
 	}
 
 	@GetMapping("/buying-power")
-	public ApiResponse<BuyingPowerResponse> buyingPower(@RequestParam @Min(1) BigDecimal price) {
-		VirtualAccount account = accountService.getAccountByUserId(TEMP_USER_ID);
+	public ApiResponse<BuyingPowerResponse> buyingPower(@AuthenticationPrincipal UUID userId,
+														@RequestParam @Min(1) BigDecimal price) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
 		Integer quantity = accountService.calculateBuyingPower(account.getVirtualAccountId(), price);
 		return ApiResponse.success(new BuyingPowerResponse(quantity));
 	}

--- a/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
@@ -2,6 +2,7 @@ package com.solv.wefin.web.trading.order;
 
 import java.util.UUID;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,14 +25,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class OrderController {
 
-	private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
-
 	private final OrderService orderService;
 	private final VirtualAccountService accountService;
 
 	@PostMapping("/buy")
-	public ApiResponse<OrderResponse> buy(@Valid @RequestBody OrderBuyRequest request) {
-		VirtualAccount account = accountService.getAccountByUserId(TEMP_USER_ID);
+	public ApiResponse<OrderResponse> buy(@AuthenticationPrincipal UUID userId,
+										  @Valid @RequestBody OrderBuyRequest request) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
 		OrderInfo orderInfo = orderService.buyMarket(account.getVirtualAccountId(),
 			request.stockId(), request.quantity());
 		OrderResponse response = OrderResponse.from(orderInfo);
@@ -39,8 +39,9 @@ public class OrderController {
 	}
 
 	@PostMapping("/sell")
-	public ApiResponse<OrderResponse> sell(@Valid @RequestBody OrderSellRequest request) {
-		VirtualAccount account = accountService.getAccountByUserId(TEMP_USER_ID);
+	public ApiResponse<OrderResponse> sell(@AuthenticationPrincipal UUID userId,
+										   @Valid @RequestBody OrderSellRequest request) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
 		OrderInfo orderInfo = orderService.sellMarket(account.getVirtualAccountId(),
 			request.stockId(), request.quantity());
 		OrderResponse response = OrderResponse.from(orderInfo);

--- a/src/main/java/com/solv/wefin/web/trading/portfolio/PortfolioController.java
+++ b/src/main/java/com/solv/wefin/web/trading/portfolio/PortfolioController.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.trading.portfolio;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,14 +22,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PortfolioController {
 
-	private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
-
 	private final PortfolioService portfolioService;
 	private final VirtualAccountService accountService;
 
 	@GetMapping
-	public ApiResponse<List<PortfolioResponse>> getPortfolios() {
-		VirtualAccount account = accountService.getAccountByUserId(TEMP_USER_ID);
+	public ApiResponse<List<PortfolioResponse>> getPortfolios(@AuthenticationPrincipal UUID userId) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
 		List<PortfolioInfo> infos = portfolioService.getPortfolioInfos(account.getVirtualAccountId());
 		List<PortfolioResponse> response = infos.stream()
 			.map(PortfolioResponse::from)

--- a/src/test/java/com/solv/wefin/web/trading/account/AccountControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/account/AccountControllerTest.java
@@ -5,12 +5,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
 
 import com.solv.wefin.global.config.security.JwtProvider;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -29,8 +34,13 @@ class AccountControllerTest {
 	@MockitoBean
 	private JwtProvider jwtProvider;
 
+	private UUID testUserId;
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+	}
+
 	@Test
-	@WithMockUser
 	void 계좌_조회_성공() throws Exception {
 		// given
 		VirtualAccount mockAccount = mock(VirtualAccount.class);
@@ -40,13 +50,15 @@ class AccountControllerTest {
 		given(accountService.getAccountByUserId(any())).willReturn(mockAccount);
 
 		// when & then
-		mockMvc.perform(get("/api/account"))
+		mockMvc.perform(get("/api/account")
+				.with(SecurityMockMvcRequestPostProcessors.authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.balance").value(10000000));
 	}
 
 	@Test
-	@WithMockUser
 	void 주문가능수량_조회_성공() throws Exception {
 		// given
 		VirtualAccount mockAccount = mock(VirtualAccount.class);
@@ -56,7 +68,10 @@ class AccountControllerTest {
 
 		// when & then
 		mockMvc.perform(get("/api/account/buying-power")
-				.param("price", "186000"))
+				.param("price", "186000")
+				.with(SecurityMockMvcRequestPostProcessors.authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.maxQuantity").value(100));
 	}

--- a/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import com.solv.wefin.global.config.security.JwtProvider;
@@ -16,7 +17,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -43,16 +45,17 @@ class OrderControllerTest {
 	private JwtProvider jwtProvider;
 
 	private VirtualAccount mockAccount;
+	private UUID testUserId;
 
 	@BeforeEach
 	void setUp() {
+		testUserId = UUID.randomUUID();
 		mockAccount = mock(VirtualAccount.class);
 		given(mockAccount.getVirtualAccountId()).willReturn(1L);
 		given(accountService.getAccountByUserId(any())).willReturn(mockAccount);
 	}
 
 	@Test
-	@WithMockUser
 	void 매수_성공() throws Exception {
 		// given
 		Order mockOrder = mock(Order.class);
@@ -75,7 +78,10 @@ class OrderControllerTest {
 		mockMvc.perform(post("/api/order/buy")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{\"stockId\": 1, \"quantity\": 10}")
-				.with(csrf()))
+				.with(csrf())
+				.with(SecurityMockMvcRequestPostProcessors.authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.side").value("BUY"))
 			.andExpect(jsonPath("$.data.stockCode").value("005930"))
@@ -83,7 +89,6 @@ class OrderControllerTest {
 	}
 
 	@Test
-	@WithMockUser
 	void 매도_성공() throws Exception {
 		// given
 		Order mockOrder = mock(Order.class);
@@ -106,7 +111,10 @@ class OrderControllerTest {
 		mockMvc.perform(post("/api/order/sell")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{\"stockId\": 1, \"quantity\": 10}")
-				.with(csrf()))
+				.with(csrf())
+				.with(SecurityMockMvcRequestPostProcessors.authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.side").value("SELL"))
 			.andExpect(jsonPath("$.data.tax").value(3204))

--- a/src/test/java/com/solv/wefin/web/trading/portfolio/PortfolioControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/portfolio/PortfolioControllerTest.java
@@ -6,12 +6,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.UUID;
 
 import com.solv.wefin.global.config.security.JwtProvider;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -34,8 +38,14 @@ class PortfolioControllerTest {
 	@MockitoBean
 	private JwtProvider jwtProvider;
 
+	private UUID testUserId;
+
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+	}
+
 	@Test
-	@WithMockUser
 	void 포트폴리오_조회_성공() throws Exception {
 		// given
 		VirtualAccount mockAccount = mock(VirtualAccount.class);
@@ -50,7 +60,10 @@ class PortfolioControllerTest {
 		given(portfolioService.getPortfolioInfos(1L)).willReturn(List.of(info));
 
 		// when & then
-		mockMvc.perform(get("/api/portfolio"))
+		mockMvc.perform(get("/api/portfolio")
+				.with(SecurityMockMvcRequestPostProcessors.authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data[0].stockCode").value("005930"))
 			.andExpect(jsonPath("$.data[0].quantity").value(10));


### PR DESCRIPTION
## 📌 PR 설명
  Trading Controller에서 하드코딩된 TEMP_USER_ID를 제거하고 JWT 기반 @AuthenticationPrincipal로 교체한다.

  <br>

  ## ✅ 완료한 기능 명세

  - [x] **[WEF-487]** OrderController — TEMP_USER_ID 제거, @AuthenticationPrincipal UUID userId 적용
  - [x] **[WEF-487]** AccountController — 동일 적용
  - [x] **[WEF-487]** PortfolioController — 동일 적용
  - [x] **[WEF-487]** 슬라이스 테스트 — @WithMockUser → UsernamePasswordAuthenticationToken 방식으로 변경
  - [x] **[WEF-487]** SecurityConfig — /api/stocks/** GET permitAll 추가

  <br>

  ## 📸 스크린샷

  Postman 검증 결과:

- 토큰 없이 POST /api/order/buy → 401 (인증 필요)
<img width="543" height="338" alt="스크린샷 2026-04-07 오전 9 43 00" src="https://github.com/user-attachments/assets/4dc2e94e-b48d-4b90-bbcc-218bfa93e614" />


<br>


- 토큰 넣고 POST /api/order/buy → 404 (인증 통과, 계좌 미생성)
<img width="543" height="419" alt="스크린샷 2026-04-07 오전 9 57 43" src="https://github.com/user-attachments/assets/cee392bb-6b34-4e7d-b40c-f5c804c5cfd1" />


- 토큰 없이 GET /api/stocks/005930/price → 404 (인증 통과, 데이터 없음)
<img width="543" height="420" alt="스크린샷 2026-04-07 오전 9 53 02" src="https://github.com/user-attachments/assets/319be3ad-61e6-4cbe-aafc-6cb35b500acb" />


  <br>

  ## 💭 고민과 해결과정

  ### TEMP_USER_ID 제거
  - 기존에는 인증팀 PR 머지 전이라 하드코딩된 UUID로 개발했음
  - 인증팀 JWT 로직이 머지되어 @AuthenticationPrincipal로 교체 가능해짐
  - JwtAuthenticationFilter가 principal에 UUID를 넣는 구조라 @AuthenticationPrincipal UUID userId로 바로 추출 가능

  ### 슬라이스 테스트 인증 방식 변경
  - 기존 @WithMockUser는 principal이 문자열("user")이라 @AuthenticationPrincipal UUID와 타입 불일치
  - UsernamePasswordAuthenticationToken에 UUID를 직접 넣는 방식으로 변경
  - JwtAuthenticationFilter와 동일한 Authentication 구조를 테스트에서도 사용

  ### SecurityConfig 시세 경로 추가
  - 시세 API 경로가 /api/market/** 과 /api/stocks/** 두 가지인데, /api/stocks/**가 permitAll에 빠져있었음
  - GET /api/stocks/** 추가하여 비로그인 시세 조회 허용

  ### 계좌 자동 생성 미연동
  - 현재 회원가입 시 가상계좌가 자동 생성되지 않음
  - AuthService.signup()에서 virtualAccountService.createAccount(userId) 호출 필요
  - 인증팀에 요청 예정

  <br>

  ### 🔗 관련 이슈
  Closes #128

[WEF-487]: https://sol-v.atlassian.net/browse/WEF-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-487]: https://sol-v.atlassian.net/browse/WEF-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-487]: https://sol-v.atlassian.net/browse/WEF-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-487]: https://sol-v.atlassian.net/browse/WEF-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WEF-487]: https://sol-v.atlassian.net/browse/WEF-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * API 엔드포인트가 하드코딩된 사용자 식별자 대신 인증된 사용자 정보를 사용하도록 업데이트되었습니다. 계정, 주문, 포트폴리오 관련 엔드포인트의 요청 처리 흐름이 개선되었습니다.

* **Tests**
  * 컨트롤러 테스트가 명시적인 인증 설정을 사용하도록 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->