### PR TITLE
[WEF-555] 채팅 페이지네이션 적용

### DIFF
--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatMessagesInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatMessagesInfo.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.chat.aiChat.dto.info;
+
+import java.util.List;
+
+public record AiChatMessagesInfo(
+        List<AiChatInfo> messages,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
@@ -17,5 +17,5 @@ public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Lo
             Pageable pageable
     );
 
-    List<AiChatMessage> findTop10ByUser_UserIdOrderByCreatedAtDesc(UUID userId);
+    List<AiChatMessage> findTop10ByUser_UserIdOrderByMessageIdDesc(UUID userId);
 }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/repository/AiChatMessageRepository.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.chat.aiChat.repository;
 
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -8,7 +9,13 @@ import java.util.UUID;
 
 public interface AiChatMessageRepository extends JpaRepository<AiChatMessage, Long> {
 
-    List<AiChatMessage> findByUser_UserIdOrderByCreatedAtAsc(UUID userId);
+    List<AiChatMessage> findByUser_UserIdOrderByMessageIdDesc(UUID userId, Pageable pageable);
+
+    List<AiChatMessage> findByUser_UserIdAndMessageIdLessThanOrderByMessageIdDesc(
+            UUID userId,
+            Long beforeMessageId,
+            Pageable pageable
+    );
 
     List<AiChatMessage> findTop10ByUser_UserIdOrderByCreatedAtDesc(UUID userId);
 }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatMessagePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatMessagePersistenceService.java
@@ -34,7 +34,7 @@ public class AiChatMessagePersistenceService {
     }
 
     public List<AiChatMessage> getRecentHistory(UUID userId) {
-        return aiChatMessageRepository.findTop10ByUser_UserIdOrderByCreatedAtDesc(userId);
+        return aiChatMessageRepository.findTop10ByUser_UserIdOrderByMessageIdDesc(userId);
     }
 
     @Transactional

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatMessagePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatMessagePersistenceService.java
@@ -4,6 +4,8 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
 import com.solv.wefin.domain.chat.aiChat.repository.AiChatMessageRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,8 +19,18 @@ public class AiChatMessagePersistenceService {
 
     private final AiChatMessageRepository aiChatMessageRepository;
 
-    public List<AiChatMessage> getMessages(UUID userId) {
-        return aiChatMessageRepository.findByUser_UserIdOrderByCreatedAtAsc(userId);
+    public List<AiChatMessage> getMessages(UUID userId, Long beforeMessageId, int size) {
+        Pageable pageable = PageRequest.of(0, size + 1);
+
+        if(beforeMessageId == null) {
+            return aiChatMessageRepository.findByUser_UserIdOrderByMessageIdDesc(userId, pageable);
+        }
+
+        return aiChatMessageRepository.findByUser_UserIdAndMessageIdLessThanOrderByMessageIdDesc(
+                userId,
+                beforeMessageId,
+                pageable
+        );
     }
 
     public List<AiChatMessage> getRecentHistory(UUID userId) {

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -39,14 +39,14 @@ public class AiChatService {
             fetched = fetched.subList(0, pageSize);
         }
 
+        Long nextCursor = hasNext && !fetched.isEmpty()
+                ? fetched.get(fetched.size() - 1).getMessageId()
+                :null;
+
         List<AiChatInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(AiChatMessage::getMessageId))
                 .map(this::toInfo)
                 .toList();
-
-        Long nextCursor = hasNext && !messages.isEmpty()
-                ? messages.get(0).messageId()
-                :null;
 
         return new AiChatMessagesInfo(messages, nextCursor, hasNext);
     }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -5,12 +5,14 @@ import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,18 +21,34 @@ import java.util.UUID;
 public class AiChatService {
 
     private static final int MAX_MESSAGE_LENGTH = 1000;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final OpenAiChatClient openAiChatClient;
     private final AiChatMessagePersistenceService aiChatMessagePersistenceService;
     private final UserRepository userRepository;
 
-    public List<AiChatInfo> getMessages(UUID userId) {
+    public AiChatMessagesInfo getMessages(UUID userId, Long beforeMessageId, int size) {
         validateUserId(userId);
 
-        return aiChatMessagePersistenceService.getMessages(userId)
-                .stream()
+        int pageSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
+
+        List<AiChatMessage> fetched = aiChatMessagePersistenceService.getMessages(userId, beforeMessageId, pageSize);
+
+        boolean hasNext = fetched.size() > pageSize;
+        if (hasNext) {
+            fetched = fetched.subList(0, pageSize);
+        }
+
+        List<AiChatInfo> messages = fetched.stream()
+                .sorted(Comparator.comparing(AiChatMessage::getMessageId))
                 .map(this::toInfo)
                 .toList();
+
+        Long nextCursor = hasNext && !messages.isEmpty()
+                ? messages.get(0).messageId()
+                :null;
+
+        return new AiChatMessagesInfo(messages, nextCursor, hasNext);
     }
 
     public AiChatInfo sendMessage(AiChatCommand command, UUID userId) {

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/dto/info/GlobalChatMessagesInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/dto/info/GlobalChatMessagesInfo.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.chat.globalChat.dto.info;
+
+import java.util.List;
+
+public record GlobalChatMessagesInfo(
+        List<GlobalChatMessageInfo> messages,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/repository/GlobalChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/repository/GlobalChatMessageRepository.java
@@ -17,7 +17,16 @@ public interface GlobalChatMessageRepository extends JpaRepository<GlobalChatMes
         left join fetch m.user
         order by m.id desc
     """)
-    List<GlobalChatMessage> findRecentMessages(Pageable pageable);
+    List<GlobalChatMessage> findMessages(Pageable pageable);
+
+    @Query("""
+        select m
+        from GlobalChatMessage m
+        left join fetch m.user
+        where m.id < :beforeMessageId
+        order by m.id desc 
+    """)
+    List<GlobalChatMessage> findMessagesBefore(Long beforeMessageId, Pageable pageable);
 
     long countByUser_UserIdAndCreatedAtAfter(UUID userId, OffsetDateTime time);
 }

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
@@ -38,6 +38,7 @@ public class GlobalChatService {
     private static final long SPAM_WINDOW_SECONDS = 3L;
     private static final String SYSTEM = "시스템";
     private static final int MAX_MESSAGE_LENGTH = 1000;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final Map<String, Object> chatLocks = new ConcurrentHashMap<>();
     @Transactional
@@ -136,7 +137,7 @@ public class GlobalChatService {
 
     public GlobalChatMessagesInfo getMessages(Long beforeMessageId, int size) {
 
-        int pageSize = Math.min(Math.max(size, 1), 100);
+        int pageSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
         Pageable pageable = PageRequest.of(0, pageSize + 1);
 
         List<GlobalChatMessage> fetched = beforeMessageId == null
@@ -148,14 +149,14 @@ public class GlobalChatService {
             fetched = fetched.subList(0, pageSize);
         }
 
+        Long nextCursor = hasNext && !fetched.isEmpty()
+                ? fetched.get(fetched.size() - 1).getId()
+                :null;
+
         List<GlobalChatMessageInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(GlobalChatMessage::getId))
                 .map(this::toInfo)
                 .toList();
-
-        Long nextCursor = hasNext && !messages.isEmpty()
-                ? messages.get(0).messageId()
-                : null;
 
         return new GlobalChatMessagesInfo(messages, nextCursor, hasNext);
     }

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.globalChat.dto.command.GlobalProfitShareCommand;
 import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessageInfo;
+import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
 import com.solv.wefin.domain.chat.globalChat.entity.ChatRole;
 import com.solv.wefin.domain.chat.globalChat.entity.GlobalChatMessage;
 import com.solv.wefin.domain.chat.globalChat.event.GlobalChatMessageCreatedEvent;
@@ -130,17 +131,30 @@ public class GlobalChatService {
         }
     }
 
-    public List<GlobalChatMessageInfo> getRecentMessages(int limit) {
+    public GlobalChatMessagesInfo getMessages(Long beforeMessageId, int size) {
 
-        int size = Math.min(Math.max(limit, 1), 100);
-        Pageable pageable = PageRequest.of(0, size);
+        int pageSize = Math.min(Math.max(size, 1), 100);
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
 
-        List<GlobalChatMessage> messages = globalChatMessageRepository.findRecentMessages(pageable);
+        List<GlobalChatMessage> fetched = beforeMessageId == null
+                ? globalChatMessageRepository.findMessages(pageable)
+                : globalChatMessageRepository.findMessagesBefore(beforeMessageId, pageable);
 
-        return messages.stream()
+        boolean hasNext = fetched.size() > pageSize;
+        if (hasNext) {
+            fetched = fetched.subList(0, pageSize);
+        }
+
+        List<GlobalChatMessageInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(GlobalChatMessage::getId))
                 .map(this::toInfo)
                 .toList();
+
+        Long nextCursor = hasNext && !messages.isEmpty()
+                ? messages.get(0).messageId()
+                : null;
+
+        return new GlobalChatMessagesInfo(messages, nextCursor, hasNext);
     }
 
     // 수익 메시지 변환

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatService.java
@@ -83,13 +83,7 @@ public class GlobalChatService {
     @Transactional
     public void sendSystemMessage(String content) {
 
-        validateMessage(content);
-
-        GlobalChatMessage savedMessage = globalChatMessageRepository.save(
-                GlobalChatMessage.createSystemMessage(content)
-        );
-
-        eventPublisher.publishEvent(toEvent(savedMessage));
+        saveSystemMessage(content);
     }
 
     @Transactional
@@ -98,6 +92,15 @@ public class GlobalChatService {
         sendSystemMessage(content);
     }
 
+    private void saveSystemMessage(String content) {
+        validateMessage(content);
+
+        GlobalChatMessage savedMessage = globalChatMessageRepository.save(
+                GlobalChatMessage.createSystemMessage(content)
+        );
+
+        eventPublisher.publishEvent(toEvent(savedMessage));
+    }
 
     private GlobalChatMessageInfo toInfo(GlobalChatMessage message) {
         return new GlobalChatMessageInfo(

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/ChatMessagesInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/ChatMessagesInfo.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.chat.groupChat.dto.info;
+
+import java.util.List;
+
+public record ChatMessagesInfo(
+        List<ChatMessageInfo> messages,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
@@ -23,7 +23,24 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         where m.group.id = :groupId
         order by m.id desc
     """)
-    List<ChatMessage> findRecentMessagesByGroupId(@Param("groupId") Long groupId, Pageable pageable);
+    List<ChatMessage> findMessagesByGroupId(@Param("groupId") Long groupId, Pageable pageable);
+
+    @Query("""
+        select m
+        from ChatMessage m
+        left join fetch m.user
+        left join fetch m.group
+        left join fetch m.replyToMessage
+        left join fetch m.replyToMessage.user
+        where m.group.id = :groupId
+            and m.id < :beforeMessageId
+        order by m.id desc
+    """)
+    List<ChatMessage> findMessagesByGroupIdBefore(
+            @Param("groupId") Long groupId,
+            @Param("beforeMessageId") Long beforeMessageId,
+            Pageable pageable
+    );
 
     long countByGroup_IdAndUser_UserIdAndCreatedAtAfter(Long groupId, UUID userId, OffsetDateTime time);
 

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
 import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
@@ -85,20 +86,33 @@ public class ChatMessageService {
     }
 
 
-    public List<ChatMessageInfo> getRecentMessages(UUID userId, int limit) {
+    public ChatMessagesInfo getMessages(UUID userId, Long beforeMessageId, int size) {
 
         Group group = findActiveUserGroup(userId);
         Long groupId = group.getId();
 
-        int size = Math.min(Math.max(limit, 1), 100);
-        Pageable pageable = PageRequest.of(0, size);
+        int pageSize = Math.min(Math.max(size, 1), 100);
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
 
-        List<ChatMessage> messages = chatMessageRepository.findRecentMessagesByGroupId(groupId, pageable);
+        List<ChatMessage> fetched = beforeMessageId == null
+                ? chatMessageRepository.findMessagesByGroupId(groupId, pageable)
+                : chatMessageRepository.findMessagesByGroupIdBefore(groupId, beforeMessageId, pageable);
 
-        return messages.stream()
+        boolean hasNext = fetched.size() > pageSize;
+        if (hasNext) {
+            fetched = fetched.subList(0, pageSize);
+        }
+
+        List<ChatMessageInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(ChatMessage::getId))
                 .map(this::toInfo)
                 .toList();
+
+        Long nextCursor = hasNext && !messages.isEmpty()
+                ? messages.get(0).messageId()
+                : null;
+
+        return new ChatMessagesInfo(messages, nextCursor, hasNext);
     }
 
     private ChatMessageInfo toInfo(ChatMessage message) {

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -44,6 +44,7 @@ public class ChatMessageService {
     private static final long SPAM_WINDOW_SECONDS = 3L;
     private static final String SYSTEM = "시스템";
     private static final int MAX_MESSAGE_LENGTH = 1000;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final Map<String, Object> chatLocks = new ConcurrentHashMap<>();
 
@@ -91,7 +92,7 @@ public class ChatMessageService {
         Group group = findActiveUserGroup(userId);
         Long groupId = group.getId();
 
-        int pageSize = Math.min(Math.max(size, 1), 100);
+        int pageSize = Math.min(Math.max(size, 1), MAX_PAGE_SIZE);
         Pageable pageable = PageRequest.of(0, pageSize + 1);
 
         List<ChatMessage> fetched = beforeMessageId == null
@@ -103,14 +104,14 @@ public class ChatMessageService {
             fetched = fetched.subList(0, pageSize);
         }
 
+        Long nextCursor = hasNext && !fetched.isEmpty()
+                ? fetched.get(fetched.size() - 1).getId()
+                :null;
+
         List<ChatMessageInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(ChatMessage::getId))
                 .map(this::toInfo)
                 .toList();
-
-        Long nextCursor = hasNext && !messages.isEmpty()
-                ? messages.get(0).messageId()
-                : null;
 
         return new ChatMessagesInfo(messages, nextCursor, hasNext);
     }

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
@@ -10,13 +10,16 @@ import com.solv.wefin.web.chat.aiChat.dto.request.AiChatRequest;
 import com.solv.wefin.web.chat.aiChat.dto.response.AiChatMessagesResponse;
 import com.solv.wefin.web.chat.aiChat.dto.response.AiChatResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat/ai")
@@ -43,18 +46,10 @@ public class AiChatController {
     public ApiResponse<AiChatMessagesResponse> getMessages(
             @AuthenticationPrincipal UUID userId,
             @RequestParam(required = false) Long beforeMessageId,
-            @RequestParam(defaultValue = "30") int size
+            @RequestParam(defaultValue = "30") @Min(1) @Max(100) int size
     ) {
         AiChatMessagesInfo info = aiChatService.getMessages(userId, beforeMessageId, size);
 
-        List<AiChatResponse> messages = info.messages().stream()
-                .map(AiChatResponse::from)
-                .toList();
-
-        return ApiResponse.success(new AiChatMessagesResponse(
-                messages,
-                info.nextCursor(),
-                info.hasNext()
-        ));
+        return ApiResponse.success(AiChatMessagesResponse.from(info));
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/AiChatController.java
@@ -1,11 +1,13 @@
 package com.solv.wefin.web.chat.aiChat;
 
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
 import com.solv.wefin.domain.chat.aiChat.service.AiChatService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.chat.aiChat.dto.request.AiChatRequest;
+import com.solv.wefin.web.chat.aiChat.dto.response.AiChatMessagesResponse;
 import com.solv.wefin.web.chat.aiChat.dto.response.AiChatResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -38,14 +40,21 @@ public class AiChatController {
     }
 
     @GetMapping("/messages")
-    public ApiResponse<List<AiChatResponse>> getMessages(
-            @AuthenticationPrincipal UUID userId
+    public ApiResponse<AiChatMessagesResponse> getMessages(
+            @AuthenticationPrincipal UUID userId,
+            @RequestParam(required = false) Long beforeMessageId,
+            @RequestParam(defaultValue = "30") int size
     ) {
-        List<AiChatResponse> messages = aiChatService.getMessages(userId)
-                .stream()
+        AiChatMessagesInfo info = aiChatService.getMessages(userId, beforeMessageId, size);
+
+        List<AiChatResponse> messages = info.messages().stream()
                 .map(AiChatResponse::from)
                 .toList();
 
-        return ApiResponse.success(messages);
+        return ApiResponse.success(new AiChatMessagesResponse(
+                messages,
+                info.nextCursor(),
+                info.hasNext()
+        ));
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatMessagesResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatMessagesResponse.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.web.chat.aiChat.dto.response;
+
+import java.util.List;
+
+public record AiChatMessagesResponse(
+        List<AiChatResponse> messages,
+        Long nextCursor,
+        boolean hasNext
+) {
+
+}

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatMessagesResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatMessagesResponse.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.web.chat.aiChat.dto.response;
 
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
+
 import java.util.List;
 
 public record AiChatMessagesResponse(
@@ -7,5 +9,13 @@ public record AiChatMessagesResponse(
         Long nextCursor,
         boolean hasNext
 ) {
-
+    public static AiChatMessagesResponse from(AiChatMessagesInfo info) {
+        return new AiChatMessagesResponse(
+                info.messages().stream()
+                        .map(AiChatResponse::from)
+                        .toList(),
+                info.nextCursor(),
+                info.hasNext()
+        );
+    }
 }

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
@@ -1,10 +1,12 @@
 package com.solv.wefin.web.chat.globalChat;
 
 import com.solv.wefin.domain.chat.globalChat.dto.command.GlobalProfitShareCommand;
+import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
 import com.solv.wefin.domain.chat.globalChat.service.GlobalChatService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.chat.globalChat.dto.request.GlobalProfitShareRequest;
 import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
+import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessagesResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -21,13 +23,21 @@ public class GlobalChatController {
     private final GlobalChatService globalChatService;
 
     @GetMapping("/messages")
-    public ApiResponse<List<GlobalChatMessageResponse>> getRecentMessage(@RequestParam(defaultValue = "50") int limit) {
-        List<GlobalChatMessageResponse> messages = globalChatService.getRecentMessages(limit)
-                .stream()
+    public ApiResponse<GlobalChatMessagesResponse> getRecentMessage(
+            @RequestParam(required = false) Long beforeMessageId,
+            @RequestParam(defaultValue = "30") int size
+    ) {
+        GlobalChatMessagesInfo info = globalChatService.getMessages(beforeMessageId, size);
+
+        List<GlobalChatMessageResponse> messages = info.messages().stream()
                 .map(GlobalChatMessageResponse::from)
                 .toList();
 
-        return ApiResponse.success(messages);
+        return ApiResponse.success(new GlobalChatMessagesResponse(
+                messages,
+                info.nextCursor(),
+                info.hasNext()
+        ));
     }
 
     @PostMapping("/profit-share")

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
@@ -5,16 +5,16 @@ import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
 import com.solv.wefin.domain.chat.globalChat.service.GlobalChatService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.chat.globalChat.dto.request.GlobalProfitShareRequest;
-import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessageResponse;
 import com.solv.wefin.web.chat.globalChat.dto.response.GlobalChatMessagesResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.text.NumberFormat;
-import java.util.List;
-import java.util.Locale;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat/global")
@@ -25,19 +25,11 @@ public class GlobalChatController {
     @GetMapping("/messages")
     public ApiResponse<GlobalChatMessagesResponse> getRecentMessage(
             @RequestParam(required = false) Long beforeMessageId,
-            @RequestParam(defaultValue = "30") int size
+            @RequestParam(defaultValue = "30") @Min(1) @Max(100) int size
     ) {
         GlobalChatMessagesInfo info = globalChatService.getMessages(beforeMessageId, size);
 
-        List<GlobalChatMessageResponse> messages = info.messages().stream()
-                .map(GlobalChatMessageResponse::from)
-                .toList();
-
-        return ApiResponse.success(new GlobalChatMessagesResponse(
-                messages,
-                info.nextCursor(),
-                info.hasNext()
-        ));
+        return ApiResponse.success(GlobalChatMessagesResponse.from(info));
     }
 
     @PostMapping("/profit-share")

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/dto/response/GlobalChatMessagesResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/dto/response/GlobalChatMessagesResponse.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.web.chat.globalChat.dto.response;
+
+import java.util.List;
+
+public record GlobalChatMessagesResponse(
+        List<GlobalChatMessageResponse> messages,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/dto/response/GlobalChatMessagesResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/dto/response/GlobalChatMessagesResponse.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.web.chat.globalChat.dto.response;
 
+import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
+
 import java.util.List;
 
 public record GlobalChatMessagesResponse(
@@ -7,4 +9,13 @@ public record GlobalChatMessagesResponse(
         Long nextCursor,
         boolean hasNext
 ) {
+    public static GlobalChatMessagesResponse from(GlobalChatMessagesInfo info) {
+        return new GlobalChatMessagesResponse(
+                info.messages().stream()
+                        .map(GlobalChatMessageResponse::from)
+                        .toList(),
+                info.nextCursor(),
+                info.hasNext()
+        );
+    }
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
@@ -1,9 +1,11 @@
 package com.solv.wefin.web.chat.groupChat;
 
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.ChatMessageResponse;
+import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMessagesResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMetaResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,15 +22,22 @@ public class GroupChatController {
     private final ChatMessageService chatMessageService;
 
     @GetMapping("/messages")
-    public ApiResponse<List<ChatMessageResponse>> getRecentMessages(
+    public ApiResponse<GroupChatMessagesResponse> getRecentMessages(
             @AuthenticationPrincipal UUID userId,
-            @RequestParam(defaultValue = "50") int limit) {
-        List<ChatMessageResponse> messages = chatMessageService.getRecentMessages(userId, limit)
-                .stream()
+            @RequestParam(required = false) Long beforeMessageId,
+            @RequestParam(defaultValue = "30") int size
+    ) {
+        ChatMessagesInfo info = chatMessageService.getMessages(userId, beforeMessageId, size);
+
+        List<ChatMessageResponse> messages = info.messages().stream()
                 .map(ChatMessageResponse::from)
                 .toList();
 
-        return ApiResponse.success(messages);
+        return ApiResponse.success(new GroupChatMessagesResponse(
+                messages,
+                info.nextCursor(),
+                info.hasNext()
+        ));
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
@@ -4,16 +4,18 @@ import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.common.ApiResponse;
-import com.solv.wefin.web.chat.groupChat.dto.response.ChatMessageResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMessagesResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMetaResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.UUID;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/chat/group")
@@ -25,19 +27,11 @@ public class GroupChatController {
     public ApiResponse<GroupChatMessagesResponse> getRecentMessages(
             @AuthenticationPrincipal UUID userId,
             @RequestParam(required = false) Long beforeMessageId,
-            @RequestParam(defaultValue = "30") int size
+            @RequestParam(defaultValue = "30") @Min(1) @Max(100) int size
     ) {
         ChatMessagesInfo info = chatMessageService.getMessages(userId, beforeMessageId, size);
 
-        List<ChatMessageResponse> messages = info.messages().stream()
-                .map(ChatMessageResponse::from)
-                .toList();
-
-        return ApiResponse.success(new GroupChatMessagesResponse(
-                messages,
-                info.nextCursor(),
-                info.hasNext()
-        ));
+        return ApiResponse.success(GroupChatMessagesResponse.from(info));
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/GroupChatMessagesResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/GroupChatMessagesResponse.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.web.chat.groupChat.dto.response;
 
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
+
 import java.util.List;
 
 public record GroupChatMessagesResponse(
@@ -7,4 +9,13 @@ public record GroupChatMessagesResponse(
         Long nextCursor,
         boolean hasNext
 ) {
+    public static GroupChatMessagesResponse from(ChatMessagesInfo info) {
+        return new GroupChatMessagesResponse(
+                info.messages().stream()
+                        .map(ChatMessageResponse::from)
+                        .toList(),
+                info.nextCursor(),
+                info.hasNext()
+        );
+    }
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/GroupChatMessagesResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/GroupChatMessagesResponse.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.web.chat.groupChat.dto.response;
+
+import java.util.List;
+
+public record GroupChatMessagesResponse(
+        List<ChatMessageResponse> messages,
+        Long nextCursor,
+        boolean hasNext
+) {
+}

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -265,4 +265,40 @@ class AiChatServiceTest {
         ReflectionTestUtils.setField(user, "userId", userId);
         return user;
     }
+
+    @Test
+    @DisplayName("AI 채팅 메시지 조회 시 hasNext와 nextCursor를 계산한다")
+    void getMessages_success_with_hasNext_and_nextCursor() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+
+        AiChatMessage latestMessage = AiChatMessage.createAiMessage(user, "세 번째 메시지");
+        ReflectionTestUtils.setField(latestMessage, "messageId", 3L);
+        ReflectionTestUtils.setField(latestMessage, "createdAt", OffsetDateTime.now());
+
+        AiChatMessage middleMessage = AiChatMessage.createUserMessage(user, "두 번째 메시지");
+        ReflectionTestUtils.setField(middleMessage, "messageId", 2L);
+        ReflectionTestUtils.setField(middleMessage, "createdAt", OffsetDateTime.now().minusMinutes(1));
+
+        AiChatMessage oldestMessage = AiChatMessage.createUserMessage(user, "첫 번째 메시지");
+        ReflectionTestUtils.setField(oldestMessage, "messageId", 1L);
+        ReflectionTestUtils.setField(oldestMessage, "createdAt", OffsetDateTime.now().minusMinutes(2));
+
+        when(aiChatMessagePersistenceService.getMessages(userId, null, 2))
+                .thenReturn(List.of(latestMessage, middleMessage, oldestMessage));
+
+        // when
+        AiChatMessagesInfo result = aiChatService.getMessages(userId, null, 2);
+
+        // then
+        assertEquals(2, result.messages().size());
+        assertEquals(true, result.hasNext());
+        assertEquals(2L, result.nextCursor());
+
+        assertEquals(2L, result.messages().get(0).messageId());
+        assertEquals("두 번째 메시지", result.messages().get(0).content());
+        assertEquals(3L, result.messages().get(1).messageId());
+        assertEquals("세 번째 메시지", result.messages().get(1).content());
+    }
 }

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -62,18 +63,20 @@ class AiChatServiceTest {
         ReflectionTestUtils.setField(secondMessage, "messageId", 2L);
         ReflectionTestUtils.setField(secondMessage, "createdAt", OffsetDateTime.now());
 
-        when(aiChatMessagePersistenceService.getMessages(userId))
-                .thenReturn(List.of(firstMessage, secondMessage));
+        when(aiChatMessagePersistenceService.getMessages(userId, null, 30))
+                .thenReturn(List.of(secondMessage, firstMessage));
 
         // when
-        List<AiChatInfo> result = aiChatService.getMessages(userId);
+        AiChatMessagesInfo result = aiChatService.getMessages(userId, null, 30);
 
         // then
-        assertEquals(2, result.size());
-        assertEquals("USER", result.get(0).role());
-        assertEquals("삼성전자 어때?", result.get(0).content());
-        assertEquals("AI", result.get(1).role());
-        assertEquals("최근 실적 기준으로 설명드릴게요.", result.get(1).content());
+        assertEquals(2, result.messages().size());
+        assertEquals("USER", result.messages().get(0).role());
+        assertEquals("삼성전자 어때?", result.messages().get(0).content());
+        assertEquals("AI", result.messages().get(1).role());
+        assertEquals("최근 실적 기준으로 설명드릴게요.", result.messages().get(1).content());
+        assertEquals(false, result.hasNext());
+        assertEquals(null, result.nextCursor());
     }
 
     @Test
@@ -84,7 +87,7 @@ class AiChatServiceTest {
         AiChatCommand command = new AiChatCommand("삼성전자 전망 알려줘");
         User user = createUser(userId);
 
-        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "이전에 나눈 질문");
+        AiChatMessage historyUserMessage = AiChatMessage.createUserMessage(user, "이전 대화 질문");
         ReflectionTestUtils.setField(historyUserMessage, "messageId", 1L);
         ReflectionTestUtils.setField(historyUserMessage, "createdAt", OffsetDateTime.now().minusSeconds(10));
 
@@ -118,7 +121,7 @@ class AiChatServiceTest {
 
         List<AiChatMessage> history = historyCaptor.getValue();
         assertEquals(1, history.size());
-        assertEquals("이전에 나눈 질문", history.get(0).getContent());
+        assertEquals("이전 대화 질문", history.get(0).getContent());
 
         assertEquals(3L, result.messageId());
         assertEquals(userId, result.userId());

--- a/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.globalChat.dto.command.GlobalProfitShareCommand;
+import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
 import com.solv.wefin.domain.chat.globalChat.entity.ChatRole;
 import com.solv.wefin.domain.chat.globalChat.entity.GlobalChatMessage;
 import com.solv.wefin.domain.chat.globalChat.event.GlobalChatMessageCreatedEvent;
@@ -16,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.OffsetDateTime;
@@ -50,11 +52,11 @@ public class GlobalChatServiceTest {
     }
 
     @Test
-    @DisplayName("전체 채팅 사용자 메시지 전송 시 이벤트를 발행한다")
+    @DisplayName("Send message publishes event")
     void sendMessage_success() {
         // given
         UUID userId = UUID.randomUUID();
-        String content = "안녕하세요";
+        String content = "hello";
 
         User user = User.builder()
                 .email("test1@test.com")
@@ -91,7 +93,7 @@ public class GlobalChatServiceTest {
     }
 
     @Test
-    @DisplayName("메시지가 비어 있으면 예외가 발생한다")
+    @DisplayName("Blank message throws exception")
     void sendMessage_fail_blank() {
         // given
         UUID userId = UUID.randomUUID();
@@ -102,7 +104,7 @@ public class GlobalChatServiceTest {
     }
 
     @Test
-    @DisplayName("메시지가 1000자를 초과하면 예외가 발생한다")
+    @DisplayName("Too long message throws exception")
     void sendMessage_fail_tooLong() {
         // given
         UUID userId = UUID.randomUUID();
@@ -114,11 +116,11 @@ public class GlobalChatServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 사용자면 USER_NOT_FOUND 예외가 발생한다")
+    @DisplayName("Unknown user throws USER_NOT_FOUND")
     void sendMessage_fail_userNotFound() {
         // given
         UUID userId = UUID.randomUUID();
-        String content = "안녕하세요";
+        String content = "hello";
 
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
@@ -132,8 +134,8 @@ public class GlobalChatServiceTest {
     }
 
     @Test
-    @DisplayName("최근 메시지 조회 시 domain info로 변환한다")
-    void getRecentMessages_success() {
+    @DisplayName("Get messages returns paged info")
+    void getMessages_success() {
         // given
         UUID userId = UUID.randomUUID();
 
@@ -147,38 +149,40 @@ public class GlobalChatServiceTest {
         GlobalChatMessage message = GlobalChatMessage.builder()
                 .user(user)
                 .role(ChatRole.USER)
-                .content("최근 메시지")
+                .content("recent")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(message, "id", 10L);
 
-        when(globalChatMessageRepository.findRecentMessages(any()))
+        when(globalChatMessageRepository.findMessages(any(Pageable.class)))
                 .thenReturn(List.of(message));
 
         // when
-        var result = globalChatService.getRecentMessages(1);
+        GlobalChatMessagesInfo result = globalChatService.getMessages(null, 30);
 
         // then
-        assertEquals(1, result.size());
-        assertEquals("testUser1", result.get(0).sender());
-        assertEquals("USER", result.get(0).role());
+        assertEquals(1, result.messages().size());
+        assertEquals("testUser1", result.messages().get(0).sender());
+        assertEquals("USER", result.messages().get(0).role());
+        assertFalse(result.hasNext());
+        assertNull(result.nextCursor());
     }
 
     @Test
-    @DisplayName("수익 공유 시스템 메시지를 저장하고 이벤트를 발생한다")
+    @DisplayName("Profit share stores system message and publishes event")
     void sendProfitShareMessage_profit_success() {
         // given
         GlobalProfitShareCommand command = GlobalProfitShareCommand.builder()
                 .type("PROFIT_ALERT")
                 .userNickname("tico")
-                .stockName("삼성전자")
+                .stockName("samsung")
                 .profitAmount(523000L)
                 .build();
 
         GlobalChatMessage savedMessage = GlobalChatMessage.builder()
                 .user(null)
                 .role(ChatRole.SYSTEM)
-                .content("축하합니다! tico님이 삼성전자에서 523,000원의 수익을 달성하셨습니다!")
+                .content("system message")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(savedMessage, "id", 1L);
@@ -197,19 +201,19 @@ public class GlobalChatServiceTest {
 
         GlobalChatMessage capturedMessage = captor.getValue();
         assertEquals(ChatRole.SYSTEM, capturedMessage.getRole());
-        assertEquals("축하합니다! tico님이 삼성전자에서 523,000원의 수익을 달성하셨습니다!", capturedMessage.getContent());
+        assertTrue(capturedMessage.getContent().contains("tico"));
+        assertTrue(capturedMessage.getContent().contains("523,000"));
         assertNull(capturedMessage.getUser());
     }
 
-
     @Test
-    @DisplayName("손익이 0원이면 예외가 발생한다")
+    @DisplayName("Zero profit amount throws exception")
     void sendProfitShareMessage_fail_when_profitAmount_zero() {
         // given
         GlobalProfitShareCommand command = GlobalProfitShareCommand.builder()
                 .type("PROFIT_ALERT")
                 .userNickname("tico")
-                .stockName("삼성전자")
+                .stockName("samsung")
                 .profitAmount(0L)
                 .build();
 

--- a/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
@@ -226,4 +226,59 @@ public class GlobalChatServiceTest {
         verify(globalChatMessageRepository, never()).save(any());
         verify(eventPublisher, never()).publishEvent(any());
     }
+
+    @Test
+    @DisplayName("전체 채팅 메시지 조회 시 hasNext와 nextCursor를 계산한다")
+    void getMessages_success_with_hasNext_and_nextCursor() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test1@test.com")
+                .nickname("testUser1")
+                .password("password1")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        GlobalChatMessage latestMessage = GlobalChatMessage.builder()
+                .user(user)
+                .role(ChatRole.USER)
+                .content("세 번째 메시지")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(latestMessage, "id", 3L);
+
+        GlobalChatMessage middleMessage = GlobalChatMessage.builder()
+                .user(user)
+                .role(ChatRole.USER)
+                .content("두 번째 메시지")
+                .createdAt(OffsetDateTime.now().minusMinutes(1))
+                .build();
+        ReflectionTestUtils.setField(middleMessage, "id", 2L);
+
+        GlobalChatMessage oldestMessage = GlobalChatMessage.builder()
+                .user(user)
+                .role(ChatRole.USER)
+                .content("첫 번째 메시지")
+                .createdAt(OffsetDateTime.now().minusMinutes(2))
+                .build();
+        ReflectionTestUtils.setField(oldestMessage, "id", 1L);
+
+        when(globalChatMessageRepository.findMessages(any(Pageable.class)))
+                .thenReturn(List.of(latestMessage, middleMessage, oldestMessage));
+
+        // when
+        GlobalChatMessagesInfo result = globalChatService.getMessages(null, 2);
+
+        // then
+        assertEquals(2, result.messages().size());
+        assertTrue(result.hasNext());
+        assertEquals(2L, result.nextCursor());
+
+        assertEquals(2L, result.messages().get(0).messageId());
+        assertEquals("두 번째 메시지", result.messages().get(0).content());
+        assertEquals(3L, result.messages().get(1).messageId());
+        assertEquals("세 번째 메시지", result.messages().get(1).content());
+    }
+
 }

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -27,10 +27,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -357,4 +354,76 @@ class ChatMessageServiceTest {
         assertEquals(ErrorCode.CHAT_MESSAGE_NOT_FOUND, exception.getErrorCode());
         verify(chatMessageRepository, never()).save(any());
     }
+
+    @Test
+    @DisplayName("그룹 채팅 메시지 조회 시 hasNext와 nextCursor를 계산한다")
+    void getMessages_success_with_hasNext_and_nextCursor() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("groupUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        Group group = Group.builder()
+                .name("1조")
+                .build();
+        ReflectionTestUtils.setField(group, "id", 3L);
+
+        GroupMember groupMember = GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMember.GroupMemberRole.MEMBER)
+                .status(GroupMember.GroupMemberStatus.ACTIVE)
+                .build();
+
+        ChatMessage latestMessage = ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.CHAT)
+                .content("세 번째 메시지")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(latestMessage, "id", 3L);
+
+        ChatMessage middleMessage = ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.CHAT)
+                .content("두 번째 메시지")
+                .createdAt(OffsetDateTime.now().minusMinutes(1))
+                .build();
+        ReflectionTestUtils.setField(middleMessage, "id", 2L);
+
+        ChatMessage oldestMessage = ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.CHAT)
+                .content("첫 번째 메시지")
+                .createdAt(OffsetDateTime.now().minusMinutes(2))
+                .build();
+        ReflectionTestUtils.setField(oldestMessage, "id", 1L);
+
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(chatMessageRepository.findMessagesByGroupId(eq(3L), any(Pageable.class)))
+                .thenReturn(List.of(latestMessage, middleMessage, oldestMessage));
+
+        // when
+        ChatMessagesInfo result = chatMessageService.getMessages(userId, null, 2);
+
+        // then
+        assertEquals(2, result.messages().size());
+        assertTrue(result.hasNext());
+        assertEquals(2L, result.nextCursor());
+
+        assertEquals(2L, result.messages().get(0).messageId());
+        assertEquals("두 번째 메시지", result.messages().get(0).content());
+        assertEquals(3L, result.messages().get(1).messageId());
+        assertEquals("세 번째 메시지", result.messages().get(1).content());
+    }
+
 }

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -4,7 +4,7 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
-import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
 import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
 import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -198,19 +198,21 @@ class ChatMessageServiceTest {
 
         when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
                 .thenReturn(Optional.of(groupMember));
-        when(chatMessageRepository.findRecentMessagesByGroupId(eq(3L), any(Pageable.class)))
+        when(chatMessageRepository.findMessagesByGroupId(eq(3L), any(Pageable.class)))
                 .thenReturn(List.of(message));
 
         // when
-        List<ChatMessageInfo> result = chatMessageService.getRecentMessages(userId, 50);
+        ChatMessagesInfo result = chatMessageService.getMessages(userId, null, 30);
 
         // then
-        assertEquals(1, result.size());
-        assertEquals(7L, result.get(0).messageId());
-        assertEquals(3L, result.get(0).groupId());
-        assertEquals("groupUser", result.get(0).sender());
-        assertEquals("CHAT", result.get(0).messageType());
-        assertNull(result.get(0).replyTo());
+        assertEquals(1, result.messages().size());
+        assertEquals(7L, result.messages().get(0).messageId());
+        assertEquals(3L, result.messages().get(0).groupId());
+        assertEquals("groupUser", result.messages().get(0).sender());
+        assertEquals("CHAT", result.messages().get(0).messageType());
+        assertNull(result.messages().get(0).replyTo());
+        assertEquals(false, result.hasNext());
+        assertEquals(null, result.nextCursor());
     }
 
     @Test
@@ -355,5 +357,4 @@ class ChatMessageServiceTest {
         assertEquals(ErrorCode.CHAT_MESSAGE_NOT_FOUND, exception.getErrorCode());
         verify(chatMessageRepository, never()).save(any());
     }
-
 }

--- a/src/test/java/com/solv/wefin/web/chat/aiChat/AiChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/aiChat/AiChatControllerTest.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.chat.aiChat;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
 import com.solv.wefin.domain.chat.aiChat.service.AiChatService;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
@@ -134,22 +135,26 @@ class AiChatControllerTest {
         UUID userId = UUID.randomUUID();
         OffsetDateTime createdAt = OffsetDateTime.now();
 
-        when(aiChatService.getMessages(userId))
-                .thenReturn(List.of(
-                        new AiChatInfo(
-                                1L,
-                                userId,
-                                "USER",
-                                "삼성전자 전망 알려줘",
-                                createdAt.minusMinutes(1)
+        when(aiChatService.getMessages(userId, null, 30))
+                .thenReturn(new AiChatMessagesInfo(
+                        List.of(
+                                new AiChatInfo(
+                                        1L,
+                                        userId,
+                                        "USER",
+                                        "삼성전자 전망 알려줘",
+                                        createdAt.minusMinutes(1)
+                                ),
+                                new AiChatInfo(
+                                        2L,
+                                        userId,
+                                        "AI",
+                                        "최근 실적 기준으로 설명드릴게요.",
+                                        createdAt
+                                )
                         ),
-                        new AiChatInfo(
-                                2L,
-                                userId,
-                                "AI",
-                                "최근 실적 기준으로 설명드릴게요.",
-                                createdAt
-                        )
+                        null,
+                        false
                 ));
 
         // when // then
@@ -157,11 +162,12 @@ class AiChatControllerTest {
                         .with(authentication(new UsernamePasswordAuthenticationToken(userId, null, AuthorityUtils.NO_AUTHORITIES))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data[0].messageId").value(1))
-                .andExpect(jsonPath("$.data[0].role").value("USER"))
-                .andExpect(jsonPath("$.data[0].content").value("삼성전자 전망 알려줘"))
-                .andExpect(jsonPath("$.data[1].messageId").value(2))
-                .andExpect(jsonPath("$.data[1].role").value("AI"))
-                .andExpect(jsonPath("$.data[1].content").value("최근 실적 기준으로 설명드릴게요."));
+                .andExpect(jsonPath("$.data.messages[0].messageId").value(1))
+                .andExpect(jsonPath("$.data.messages[0].role").value("USER"))
+                .andExpect(jsonPath("$.data.messages[0].content").value("삼성전자 전망 알려줘"))
+                .andExpect(jsonPath("$.data.messages[1].messageId").value(2))
+                .andExpect(jsonPath("$.data.messages[1].role").value("AI"))
+                .andExpect(jsonPath("$.data.messages[1].content").value("최근 실적 기준으로 설명드릴게요."))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 }

--- a/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.web.chat.groupChat;
 
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.config.security.JwtProvider;
@@ -60,8 +61,12 @@ class GroupChatControllerTest {
                 null
         );
 
-        when(chatMessageService.getRecentMessages(userId, 50))
-                .thenReturn(List.of(info));
+        when(chatMessageService.getMessages(userId, null, 30))
+                .thenReturn(new ChatMessagesInfo(
+                        List.of(info),
+                        null,
+                        false
+                ));
 
         // when // then
         mockMvc.perform(get("/api/chat/group/messages")
@@ -70,14 +75,14 @@ class GroupChatControllerTest {
                                 userId,
                                 null,
                                 AuthorityUtils.NO_AUTHORITIES
-                        )))
-                        .param("limit", "50"))
+                        ))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
-                .andExpect(jsonPath("$.data[0].messageId").value(1))
-                .andExpect(jsonPath("$.data[0].groupId").value(3))
-                .andExpect(jsonPath("$.data[0].sender").value("groupUser"))
-                .andExpect(jsonPath("$.data[0].content").value("안녕하세요"));
+                .andExpect(jsonPath("$.data.messages[0].messageId").value(1))
+                .andExpect(jsonPath("$.data.messages[0].groupId").value(3))
+                .andExpect(jsonPath("$.data.messages[0].sender").value("groupUser"))
+                .andExpect(jsonPath("$.data.messages[0].content").value("안녕하세요"))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 
     @Test
@@ -88,7 +93,7 @@ class GroupChatControllerTest {
 
         doThrow(new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN))
                 .when(chatMessageService)
-                .getRecentMessages(userId, 50);
+                .getMessages(userId, null, 30);
 
         // when // then
         mockMvc.perform(get("/api/chat/group/messages")
@@ -97,8 +102,7 @@ class GroupChatControllerTest {
                                 userId,
                                 null,
                                 AuthorityUtils.NO_AUTHORITIES
-                        )))
-                        .param("limit", "50"))
+                        ))))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.status").value(403))
                 .andExpect(jsonPath("$.code").value("GROUP_MEMBER_FORBIDDEN"));


### PR DESCRIPTION
## 📌 PR 설명

AI 채팅, 전체 채팅, 그룹 채팅의 과거 메시지 조회 API에 cursor 기반 페이지네이션을 적용했습니다.  
기존에는 전체 조회 또는 최근 N개 제한 조회 형태였는데, 이번 변경으로 최신 메시지 묶음을 먼저 불러오고 `beforeMessageId`를 기준으로 더 오래된 메시지를 이어서 조회할 수 있도록 구조를 개선했습니다.

채팅 도메인 특성상 offset/page 방식보다 이전 메시지를 자연스럽게 이어 불러오는 방식이 더 적합하다고 판단해, `messageId` 기반 cursor pagination으로 구현했습니다.  
응답도 단순 배열 대신 `messages`, `nextCursor`, `hasNext`를 포함하는 slice 형태로 통일해 프론트에서 무한 스크롤이나 “이전 대화 더 보기” 흐름에 쉽게 연결할 수 있도록 정리했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[WEF-555] 채팅 메시지 조회 cursor 페이지네이션 적용**
- [x] AI 채팅 메시지 조회 API에 cursor 기반 페이지네이션 적용
- [x] 전체 채팅 메시지 조회 API에 cursor 기반 페이지네이션 적용
- [x] 그룹 채팅 메시지 조회 API에 cursor 기반 페이지네이션 적용
- [x] `beforeMessageId`, `size` 기반 조회 구조로 컨트롤러/서비스/레포지토리 정리
- [x] `messages`, `nextCursor`, `hasNext` 형태의 공통 응답 구조 반영
- [x] AI/전체/그룹 채팅 관련 서비스 테스트 및 컨트롤러 테스트 수정

<br>

## 💭 고민과 해결과정

기존 채팅 조회 구조는 채널마다 조금씩 달랐습니다.  
AI 채팅은 사용자별 전체 이력을 한 번에 조회하고 있었고, 전체 채팅과 그룹 채팅은 최근 N개 제한 조회에 가까운 형태였습니다. 이 방식은 초기 구현에는 단순하지만, 메시지가 누적될수록 응답 크기와 조회 비용이 커지고 이전 메시지를 단계적으로 불러오기 어렵다는 한계가 있었습니다.

이번에는 세 채팅 도메인을 모두 같은 방향으로 정리하기 위해 cursor 기반 페이지네이션을 도입했습니다.  
채팅은 일반 목록형 데이터보다 “최신 메시지를 먼저 보고, 더 오래된 메시지를 위로 이어서 불러오는 흐름”이 자연스럽기 때문에 offset/page 방식보다 cursor 방식이 더 적절하다고 판단했습니다.

cursor 기준 컬럼으로는 `createdAt` 대신 `messageId`를 사용했습니다.  
`createdAt`은 동시간대 저장 시 경계가 애매해질 수 있지만, `messageId`는 증가 순서가 명확하고 유일해서 `beforeMessageId` 기반 조회에 더 안정적입니다. 따라서 조회는 `messageId desc`로 가져오고, 응답 직전에 다시 오래된 순으로 정렬해 프론트 렌더링 순서도 자연스럽게 맞췄습니다.

또한 응답 구조도 단순 리스트가 아니라 `messages`, `nextCursor`, `hasNext`를 포함하는 형태로 통일했습니다.  
이렇게 하면 프론트는 첫 조회 시 최신 메시지 묶음을 받고, `hasNext=true`일 때 `nextCursor`를 사용해 더 이전 메시지를 요청하는 흐름으로 쉽게 연결할 수 있습니다.

페이지네이션 적용 과정에서 컨트롤러 테스트와 서비스 테스트도 함께 정리해,  
AI 채팅, 전체 채팅, 그룹 채팅 모두 새 응답 구조와 새 조회 시그니처를 기준으로 동작하도록 맞췄습니다.

<br>

### 🔗 관련 이슈
Closes #161 

<br>


[WEF-555]: https://sol-v.atlassian.net/browse/WEF-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI/글로벌/그룹 채팅에 커서 기반 페이지네이션 도입 — beforeMessageId와 size로 페이지 이동 가능.
  * 메시지 응답에 messages 목록과 함께 nextCursor 및 hasNext 메타데이터 포함.
  * 컨트롤러 요청 파라미터에 페이징 제한(최소/최대) 검증 추가.
* **테스트**
  * 서비스·컨트롤러 테스트 전면 수정 — 새 페이징 응답 형태 및 파라미터 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->