### PR TITLE
[WEF-82] 회원정보 조회

### DIFF
--- a/src/main/java/com/solv/wefin/domain/user/dto/MyPageInfo.java
+++ b/src/main/java/com/solv/wefin/domain/user/dto/MyPageInfo.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.user.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record MyPageInfo(
+        UUID userId,
+        String email,
+        String nickname,
+        OffsetDateTime createdAt
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/user/service/UserService.java
+++ b/src/main/java/com/solv/wefin/domain/user/service/UserService.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.domain.user.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.user.dto.MyPageInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public MyPageInfo getMyPage(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return new MyPageInfo(
+                user.getUserId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/user/UserController.java
+++ b/src/main/java/com/solv/wefin/web/user/UserController.java
@@ -1,0 +1,27 @@
+package com.solv.wefin.web.user;
+
+import com.solv.wefin.domain.user.dto.MyPageInfo;
+import com.solv.wefin.domain.user.service.UserService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.user.dto.MyPageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ApiResponse<MyPageResponse> getMyPage(@AuthenticationPrincipal UUID userId) {
+        MyPageInfo info = userService.getMyPage(userId);
+        return ApiResponse.success(MyPageResponse.from(info));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/user/dto/MyPageResponse.java
+++ b/src/main/java/com/solv/wefin/web/user/dto/MyPageResponse.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.web.user.dto;
+
+import com.solv.wefin.domain.user.dto.MyPageInfo;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record MyPageResponse(
+        UUID userId,
+        String email,
+        String nickname,
+        OffsetDateTime createdAt
+) {
+    public static MyPageResponse from(MyPageInfo info) {
+        return new MyPageResponse(
+                info.userId(),
+                info.email(),
+                info.nickname(),
+                info.createdAt()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/user/UserServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/user/UserServiceTest.java
@@ -1,0 +1,73 @@
+package com.solv.wefin.domain.user.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.user.dto.MyPageInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("마이페이지 조회 성공")
+    void getMyPage_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime createdAt = OffsetDateTime.parse("2026-04-01T09:00:00+09:00");
+
+        User user = User.builder()
+                .email("user@example.com")
+                .nickname("희민")
+                .password("encodedPassword")
+                .build();
+
+        ReflectionTestUtils.setField(user, "userId", userId);
+        ReflectionTestUtils.setField(user, "createdAt", createdAt);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        // when
+        MyPageInfo result = userService.getMyPage(userId);
+
+        // then
+        assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.email()).isEqualTo("user@example.com");
+        assertThat(result.nickname()).isEqualTo("희민");
+        assertThat(result.createdAt()).isEqualTo(createdAt);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자면 USER_NOT_FOUND 예외가 발생한다")
+    void getMyPage_userNotFound() {
+        // given
+        UUID userId = UUID.randomUUID();
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getMyPage(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/solv/wefin/web/user/UserControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/user/UserControllerTest.java
@@ -6,6 +6,8 @@ import com.solv.wefin.global.config.SecurityConfig;
 import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
 import com.solv.wefin.global.config.security.JwtAuthenticationFilter;
 import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,5 +94,26 @@ class UserControllerTest {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value("AUTH_INVALID_TOKEN"))
                 .andExpect(jsonPath("$.message").value("유효하지 않은 인증 토큰입니다."));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자면 404를 반환한다")
+    void getMyPage_userNotFound() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        String token = "valid-access-token";
+
+        given(jwtProvider.isValid(token)).willReturn(true);
+        given(jwtProvider.isAccessToken(token)).willReturn(true);
+        given(jwtProvider.getUserId(token)).willReturn(userId);
+        given(userService.getMyPage(userId))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("USER_NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/test/java/com/solv/wefin/web/user/UserControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/user/UserControllerTest.java
@@ -1,0 +1,96 @@
+package com.solv.wefin.web.user;
+
+import com.solv.wefin.domain.user.dto.MyPageInfo;
+import com.solv.wefin.domain.user.service.UserService;
+import com.solv.wefin.global.config.SecurityConfig;
+import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
+import com.solv.wefin.global.config.security.JwtAuthenticationFilter;
+import com.solv.wefin.global.config.security.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        JwtAuthenticationEntryPoint.class
+})
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("인증된 사용자는 마이페이지를 조회할 수 있다")
+    void getMyPage_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        String token = "valid-access-token";
+        OffsetDateTime createdAt = OffsetDateTime.parse("2026-04-01T09:00:00+09:00");
+
+        MyPageInfo info = new MyPageInfo(
+                userId,
+                "user@example.com",
+                "희민",
+                createdAt
+        );
+
+        given(jwtProvider.isValid(token)).willReturn(true);
+        given(jwtProvider.isAccessToken(token)).willReturn(true);
+        given(jwtProvider.getUserId(token)).willReturn(userId);
+        given(userService.getMyPage(userId)).willReturn(info);
+
+        // when & then
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.userId").value(userId.toString()))
+                .andExpect(jsonPath("$.data.email").value("user@example.com"))
+                .andExpect(jsonPath("$.data.nickname").value("희민"))
+                .andExpect(jsonPath("$.data.createdAt").value("2026-04-01T09:00:00+09:00"));
+    }
+
+    @Test
+    @DisplayName("인증 헤더가 없으면 401을 반환한다")
+    void getMyPage_unauthorized() throws Exception {
+        mockMvc.perform(get("/api/users/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 토큰이면 401을 반환한다")
+    void getMyPage_invalidToken() throws Exception {
+        // given
+        String token = "invalid-token";
+
+        given(jwtProvider.isValid(token)).willReturn(false);
+
+        // when & then
+        mockMvc.perform(get("/api/users/me")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_INVALID_TOKEN"))
+                .andExpect(jsonPath("$.message").value("유효하지 않은 인증 토큰입니다."));
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
JWT 인증을 기반으로 사용자 식별을 수행하고 현재 로그인한 사용자의 기본 프로필 정보(이메일, 닉네임)와 가입 정보(가입일)를 조회하여 반환.

회원정보 수정, 구독 관리 등 계정 관련 기능의 기반이 되는 조회 기능을 제공.
<br>

## ✅ 완료한 기능 명세

- [x] 로그인 사용자 정보 조회 (GET /api/users/me)

- [x] JWT 기반 사용자 식별 처리 

- [x] 사용자 기본 정보 반환 (email, nickname)

- [x] 가입 정보 반환 (createdAt)

- [x] 응답 DTO 구성 

- [x] Service 계층 구현

- [x] Controller 구현 

- [x] 단위 테스트 작성
- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
- JWT 필터에서 UUID를 principal로 설정하고 있어 컨트롤러에서@AuthenticationPrincipal UUID userId로 직접 주입받도록 구현

- 테스트 환경에서 JWT 필터를 유지하면서 JwtProvider만 mock 처리하여 실제 인증 흐름과 유사하게 검증
<br>

### 🔗 관련 이슈
Closes #165 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 인증된 사용자가 자신의 프로필 정보(사용자 ID, 이메일, 닉네임, 생성일)를 조회하는 GET /api/users/me API 추가
  * 프로필 응답을 위한 읽기 전용 데이터 구조 및 매핑 추가

* **테스트**
  * 서비스 계층과 컨트롤러의 정상/오류 흐름(미인증, 유효하지 않은 토큰, 사용자 미존재 등)을 검증하는 단위 및 웹 계층 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->