### PR TITLE
[WEF-540] 뉴스 클러스터링 품질 튜닝

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusterMergeScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusterMergeScheduler.java
@@ -1,0 +1,49 @@
+package com.solv.wefin.domain.news.cluster.batch;
+
+import com.solv.wefin.domain.news.cluster.service.ClusterMergeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 클러스터 병합 배치 스케줄러.
+ * 6시간 간격으로 유사한 ACTIVE 클러스터를 병합하여 중복을 해소한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClusterMergeScheduler {
+
+    private final ClusterMergeService clusterMergeService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Scheduled(cron = "${clustering.merge.cron:0 0 */6 * * *}")
+    public void mergeScheduled() {
+        try {
+            execute();
+        } catch (Exception e) {
+            log.error("클러스터 병합 배치 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 수동 트리거 또는 스케줄러에서 호출한다.
+     *
+     * @return true면 실행됨, false면 이미 실행 중
+     */
+    public boolean execute() {
+        if (!running.compareAndSet(false, true)) {
+            log.warn("클러스터 병합 이미 실행 중 — 스킵");
+            return false;
+        }
+        try {
+            clusterMergeService.mergeActiveClusters();
+            return true;
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusterMergeScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/ClusterMergeScheduler.java
@@ -22,10 +22,14 @@ public class ClusterMergeScheduler {
 
     @Scheduled(cron = "${clustering.merge.cron:0 0 */6 * * *}")
     public void mergeScheduled() {
+        log.info("클러스터 병합 배치 시작");
         try {
-            execute();
+            boolean executed = execute();
+            if (executed) {
+                log.info("클러스터 병합 배치 완료");
+            }
         } catch (Exception e) {
-            log.error("클러스터 병합 배치 실패: {}", e.getMessage(), e);
+            log.error("클러스터 병합 배치 실패", e);
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -146,9 +146,7 @@ public class NewsCluster extends BaseEntity {
         }
 
         // AI 요약 재생성 필요
-        if (this.summaryStatus == SummaryStatus.GENERATED) {
-            this.summaryStatus = SummaryStatus.STALE;
-        }
+        markSummaryStale();
     }
 
     /**
@@ -196,6 +194,16 @@ public class NewsCluster extends BaseEntity {
     }
 
     /**
+     * AI 요약 재생성이 필요함을 기록한다.
+     * 클러스터에 기사가 추가/병합되어 기존 요약이 stale 상태가 된 경우 사용한다.
+     */
+    public void markSummaryStale() {
+        if (this.summaryStatus == SummaryStatus.GENERATED) {
+            this.summaryStatus = SummaryStatus.STALE;
+        }
+    }
+
+    /**
      * AI 요약 생성 실패를 기록한다.
      * 다음 요약 배치에서 재시도 대상이 된다.
      */
@@ -204,15 +212,10 @@ public class NewsCluster extends BaseEntity {
     }
 
     /**
-     * 이상치 제거 후 클러스터 집계 상태를 재계산한다.
-     *
-     * @param newArticleCount 남은 기사 수 (0일 수 있음)
-     * @param newCentroid 재계산된 centroid (남은 기사 없으면 null)
-     * @param newRepresentativeArticleId 새 대표 기사 ID (남은 기사 없으면 null — 초기화)
-     * @param newPublishedAt 새 대표 기사 발행 시각 (남은 기사 없으면 null)
-     * @param newThumbnailUrl 새 대표 기사 썸네일 (없거나 blank면 null로 초기화)
+     * 클러스터 집계 상태(articleCount, centroid, 대표 기사)를 재계산한다.
+     * 이상치 제거, 클러스터 병합 등 멤버 변경 후 호출한다.
      */
-    public void recalculateAfterOutlierRemoval(int newArticleCount, float[] newCentroid,
+    public void recalculateAggregates(int newArticleCount, float[] newCentroid,
                                                 Long newRepresentativeArticleId,
                                                 OffsetDateTime newPublishedAt,
                                                 String newThumbnailUrl) {

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
@@ -1,0 +1,112 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 클러스터 병합의 DB 작업을 담당한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClusterMergePersistenceService {
+
+    private final NewsClusterRepository newsClusterRepository;
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final ArticleVectorService articleVectorService;
+
+    /**
+     * 두 클러스터를 병합한다.
+     *
+     * loser 클러스터를 survivor 클러스터로 병합한다.
+     * loser의 기사 매핑을 survivor로 이관하되, 이미 존재하는 기사는 중복 추가하지 않는다.
+     * 병합 후 survivor의 집계 정보와 centroid를 재계산하고 summary 상태를 STALE로 변경하며,
+     * loser는 INACTIVE 처리한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void mergePair(Long survivorId, Long loserId) {
+        NewsCluster survivor = newsClusterRepository.findById(survivorId)
+                .orElseThrow(() -> new IllegalStateException("survivor 클러스터 없음: " + survivorId));
+        NewsCluster loser = newsClusterRepository.findById(loserId)
+                .orElseThrow(() -> new IllegalStateException("loser 클러스터 없음: " + loserId));
+
+        if (loser.getStatus() != ClusterStatus.ACTIVE) {
+            return;
+        }
+
+        // survivor에 이미 있는 기사 ID (중복 매핑 방어)
+        Set<Long> survivorArticleIds = clusterArticleRepository.findByNewsClusterId(survivorId).stream()
+                .map(NewsClusterArticle::getNewsArticleId)
+                .collect(Collectors.toSet());
+
+        // loser 매핑을 survivor로 이관 (중복 제외)
+        List<NewsClusterArticle> loserMappings = clusterArticleRepository.findByNewsClusterId(loserId);
+        int transferredCount = 0;
+
+        for (NewsClusterArticle mapping : loserMappings) {
+            clusterArticleRepository.deleteByNewsClusterIdAndNewsArticleId(loserId, mapping.getNewsArticleId());
+
+            if (!survivorArticleIds.contains(mapping.getNewsArticleId())) {
+                clusterArticleRepository.save(
+                        NewsClusterArticle.create(survivorId, mapping.getNewsArticleId(), 0, false));
+                survivorArticleIds.add(mapping.getNewsArticleId());
+                transferredCount++;
+            }
+        }
+
+        // survivor 집계 재계산 (이관 후 전체 매핑 기준으로 centroid 재계산)
+        List<NewsClusterArticle> allSurvivorMappings = clusterArticleRepository.findByNewsClusterId(survivorId);
+        float[] newCentroid = recalculateCentroid(allSurvivorMappings);
+
+        survivor.recalculateAggregates(
+                allSurvivorMappings.size(), newCentroid,
+                survivor.getRepresentativeArticleId(),
+                survivor.getPublishedAt(),
+                survivor.getThumbnailUrl());
+
+        survivor.markSummaryStale();
+        loser.deactivate();
+
+        log.info("클러스터 병합 — survivor: {} ({}건), loser: {} ({}건→INACTIVE), 이관: {}건, 합산: {}건",
+                survivorId, survivor.getArticleCount() - transferredCount,
+                loserId, loserMappings.size(),
+                transferredCount, allSurvivorMappings.size());
+    }
+
+    private float[] recalculateCentroid(List<NewsClusterArticle> mappings) {
+        List<float[]> vectors = mappings.stream()
+                .map(m -> articleVectorService.calculateRepresentativeVector(m.getNewsArticleId()))
+                .filter(v -> v != null)
+                .toList();
+
+        if (vectors.isEmpty()) {
+            return null;
+        }
+
+        int dimension = vectors.get(0).length;
+        float[] sum = new float[dimension];
+        for (float[] v : vectors) {
+            for (int i = 0; i < dimension; i++) {
+                sum[i] += v[i];
+            }
+        }
+        float count = vectors.size();
+        float[] centroid = new float[dimension];
+        for (int i = 0; i < dimension; i++) {
+            centroid[i] = sum[i] / count;
+        }
+        return centroid;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
@@ -80,10 +80,11 @@ public class ClusterMergePersistenceService {
         // 대표 기사 재선정 — loser에서 이관된 기사 중 더 최신이 있을 수 있으므로 전체에서 재선정
         List<Long> allArticleIds = allSurvivorMappings.stream()
                 .map(NewsClusterArticle::getNewsArticleId).toList();
-        NewsArticle representative = newsArticleRepository.findAllById(allArticleIds).stream()
+        List<NewsArticle> allArticles = newsArticleRepository.findAllById(allArticleIds);
+        NewsArticle representative = allArticles.stream()
                 .filter(a -> a.getPublishedAt() != null)
                 .max((a, b) -> a.getPublishedAt().compareTo(b.getPublishedAt()))
-                .orElseGet(() -> newsArticleRepository.findAllById(allArticleIds).stream().findAny().orElse(null));
+                .orElseGet(() -> allArticles.stream().findAny().orElse(null));
 
         survivor.recalculateAggregates(
                 allSurvivorMappings.size(), newCentroid,

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
@@ -40,14 +40,20 @@ public class ClusterMergePersistenceService {
      * loser는 INACTIVE 처리한다.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void mergePair(Long survivorId, Long loserId) {
+    public boolean mergePair(Long survivorId, Long loserId) {
+        if (java.util.Objects.equals(survivorId, loserId)) {
+            log.warn("동일 클러스터 병합 시도 무시 — id: {}", survivorId);
+            return false;
+        }
+
         NewsCluster survivor = newsClusterRepository.findById(survivorId)
                 .orElseThrow(() -> new IllegalStateException("survivor 클러스터 없음: " + survivorId));
         NewsCluster loser = newsClusterRepository.findById(loserId)
                 .orElseThrow(() -> new IllegalStateException("loser 클러스터 없음: " + loserId));
 
         if (loser.getStatus() != ClusterStatus.ACTIVE) {
-            return;
+            log.debug("loser가 이미 INACTIVE — 병합 스킵, loserId: {}", loserId);
+            return false;
         }
 
         // survivor에 이미 있는 기사 ID (중복 매핑 방어)
@@ -99,6 +105,7 @@ public class ClusterMergePersistenceService {
                 survivorId, originalSurvivorCount,
                 loserId, loserMappings.size(),
                 transferredCount, allSurvivorMappings.size());
+        return true;
     }
 
     private float[] recalculateCentroid(List<NewsClusterArticle> mappings) {

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.solv.wefin.domain.news.article.entity.NewsArticle;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,6 +28,7 @@ public class ClusterMergePersistenceService {
 
     private final NewsClusterRepository newsClusterRepository;
     private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleRepository newsArticleRepository;
     private final ArticleVectorService articleVectorService;
 
     /**
@@ -66,21 +70,32 @@ public class ClusterMergePersistenceService {
             }
         }
 
-        // survivor 집계 재계산 (이관 후 전체 매핑 기준으로 centroid 재계산)
+        // survivor 집계 재계산 (이관 후 전체 매핑 기준)
+        int originalSurvivorCount = survivor.getArticleCount();
         List<NewsClusterArticle> allSurvivorMappings = clusterArticleRepository.findByNewsClusterId(survivorId);
+
+        // centroid 재계산 (TODO: N+1 — articleVectorService에 batch 조회 메서드 추가 시 개선)
         float[] newCentroid = recalculateCentroid(allSurvivorMappings);
+
+        // 대표 기사 재선정 — loser에서 이관된 기사 중 더 최신이 있을 수 있으므로 전체에서 재선정
+        List<Long> allArticleIds = allSurvivorMappings.stream()
+                .map(NewsClusterArticle::getNewsArticleId).toList();
+        NewsArticle representative = newsArticleRepository.findAllById(allArticleIds).stream()
+                .filter(a -> a.getPublishedAt() != null)
+                .max((a, b) -> a.getPublishedAt().compareTo(b.getPublishedAt()))
+                .orElseGet(() -> newsArticleRepository.findAllById(allArticleIds).stream().findAny().orElse(null));
 
         survivor.recalculateAggregates(
                 allSurvivorMappings.size(), newCentroid,
-                survivor.getRepresentativeArticleId(),
-                survivor.getPublishedAt(),
-                survivor.getThumbnailUrl());
+                representative != null ? representative.getId() : survivor.getRepresentativeArticleId(),
+                representative != null ? representative.getPublishedAt() : survivor.getPublishedAt(),
+                representative != null ? representative.getThumbnailUrl() : survivor.getThumbnailUrl());
 
         survivor.markSummaryStale();
         loser.deactivate();
 
         log.info("클러스터 병합 — survivor: {} ({}건), loser: {} ({}건→INACTIVE), 이관: {}건, 합산: {}건",
-                survivorId, survivor.getArticleCount() - transferredCount,
+                survivorId, originalSurvivorCount,
                 loserId, loserMappings.size(),
                 transferredCount, allSurvivorMappings.size());
     }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergePersistenceService.java
@@ -51,6 +51,10 @@ public class ClusterMergePersistenceService {
         NewsCluster loser = newsClusterRepository.findById(loserId)
                 .orElseThrow(() -> new IllegalStateException("loser 클러스터 없음: " + loserId));
 
+        if (survivor.getStatus() != ClusterStatus.ACTIVE) {
+            log.debug("survivor가 이미 INACTIVE — 병합 스킵, survivorId: {}", survivorId);
+            return false;
+        }
         if (loser.getStatus() != ClusterStatus.ACTIVE) {
             log.debug("loser가 이미 INACTIVE — 병합 스킵, loserId: {}", loserId);
             return false;

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeService.java
@@ -65,8 +65,10 @@ public class ClusterMergeService {
         int mergedCount = 0;
         for (MergePair pair : pairs) {
             try {
-                mergePersistenceService.mergePair(pair.survivorId, pair.loserId);
-                mergedCount++;
+                boolean merged = mergePersistenceService.mergePair(pair.survivorId, pair.loserId);
+                if (merged) {
+                    mergedCount++;
+                }
             } catch (Exception e) {
                 log.warn("클러스터 병합 실패 — survivor: {}, loser: {}, error: {}",
                         pair.survivorId, pair.loserId, e.getMessage());

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeService.java
@@ -1,0 +1,125 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 유사한 ACTIVE 클러스터를 병합하여 중복을 해소한다.
+ *
+ * 같은 주제의 기사가 별개 클러스터로 분산되는 문제를 해결한다.
+ * centroid 유사도가 임계값 이상인 쌍을 찾아 기사 수가 많은 쪽(survivor)에
+ * 작은 쪽의 매핑을 이관하고, 작은 쪽은 INACTIVE 처리한다.
+ */
+@Slf4j
+@Service
+public class ClusterMergeService {
+
+    private final NewsClusterRepository newsClusterRepository;
+    private final ClusterMatchingService clusterMatchingService;
+    private final ClusterMergePersistenceService mergePersistenceService;
+    private final double mergeThreshold;
+
+    public ClusterMergeService(
+            NewsClusterRepository newsClusterRepository,
+            ClusterMatchingService clusterMatchingService,
+            ClusterMergePersistenceService mergePersistenceService,
+            @Value("${clustering.merge.threshold:0.85}") double mergeThreshold) {
+        this.newsClusterRepository = newsClusterRepository;
+        this.clusterMatchingService = clusterMatchingService;
+        this.mergePersistenceService = mergePersistenceService;
+        this.mergeThreshold = mergeThreshold;
+    }
+
+    /**
+     * ACTIVE 클러스터 중 유사한 쌍을 찾아 병합한다.
+     *
+     * @return 병합된 쌍 수
+     */
+    public int mergeActiveClusters() {
+        List<NewsCluster> activeClusters = newsClusterRepository.findByStatus(ClusterStatus.ACTIVE);
+        log.info("클러스터 병합 시작 — ACTIVE 클러스터: {}개", activeClusters.size());
+
+        if (activeClusters.size() < 2) {
+            return 0;
+        }
+
+        List<NewsCluster> candidates = activeClusters.stream()
+                .filter(c -> c.getCentroidVector() != null)
+                .toList();
+
+        long startTime = System.currentTimeMillis();
+        List<MergePair> pairs = findMergePairs(candidates);
+        long elapsed = System.currentTimeMillis() - startTime;
+        log.info("병합 후보 탐색 완료 — candidates: {}개, 후보 쌍: {}개, 소요: {}ms (threshold: {})",
+                candidates.size(), pairs.size(), elapsed, mergeThreshold);
+
+        int mergedCount = 0;
+        for (MergePair pair : pairs) {
+            try {
+                mergePersistenceService.mergePair(pair.survivorId, pair.loserId);
+                mergedCount++;
+            } catch (Exception e) {
+                log.warn("클러스터 병합 실패 — survivor: {}, loser: {}, error: {}",
+                        pair.survivorId, pair.loserId, e.getMessage());
+            }
+        }
+
+        log.info("클러스터 병합 완료 — 병합: {}쌍", mergedCount);
+        return mergedCount;
+    }
+
+    /**
+     * centroid 유사도가 임계값 이상인 병합 후보 쌍을 찾는다.
+     *
+     * 한 클러스터가 여러 쌍에 등장할 수 있으므로, 이미 선택된 클러스터는
+     * 후속 쌍에서 제외한다 (greedy: 유사도 높은 쌍 우선)
+     */
+    private List<MergePair> findMergePairs(List<NewsCluster> candidates) {
+        List<MergePair> allPairs = new ArrayList<>();
+
+        for (int i = 0; i < candidates.size(); i++) {
+            for (int j = i + 1; j < candidates.size(); j++) {
+                NewsCluster a = candidates.get(i);
+                NewsCluster b = candidates.get(j);
+
+                double similarity = clusterMatchingService.cosineSimilarity(
+                        a.getCentroidVector(), b.getCentroidVector());
+
+                if (similarity >= mergeThreshold) {
+                    // 기사 수가 많은 쪽이 survivor
+                    boolean aIsSurvivor = a.getArticleCount() >= b.getArticleCount();
+                    Long survivorId = aIsSurvivor ? a.getId() : b.getId();
+                    Long loserId = aIsSurvivor ? b.getId() : a.getId();
+                    allPairs.add(new MergePair(survivorId, loserId, similarity));
+                }
+            }
+        }
+
+        // 유사도 높은 순 정렬 → greedy 선택
+        allPairs.sort((p1, p2) -> Double.compare(p2.similarity, p1.similarity));
+
+        List<MergePair> selected = new ArrayList<>();
+        Set<Long> usedIds = new HashSet<>();
+
+        for (MergePair pair : allPairs) {
+            if (!usedIds.contains(pair.survivorId) && !usedIds.contains(pair.loserId)) {
+                selected.add(pair);
+                usedIds.add(pair.survivorId);
+                usedIds.add(pair.loserId);
+            }
+        }
+
+        return selected;
+    }
+
+    private record MergePair(Long survivorId, Long loserId, double similarity) {}
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -13,8 +13,8 @@ import com.solv.wefin.domain.news.cluster.service.ArticleVectorService;
 import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,15 +35,8 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class OutlierDetectionService {
 
-    // centroid와의 cosine similarity 기준
-    // → 0.7 미만이면 해당 클러스터와 의미적으로 어긋난 기사로 판단 (이상치 후보)
-    private static final double OUTLIER_SIMILARITY_THRESHOLD = 0.70;
-
-    // 클러스터 내 특정 카테고리 태그의 최대 비중 기준
-    // → 0.6 미만이면 주제가 분산된 클러스터로 판단 (경고 로그용, 제거 기준 아님)
     private static final double CATEGORY_DOMINANCE_THRESHOLD = 0.60;
 
     private final NewsClusterArticleRepository clusterArticleRepository;
@@ -53,15 +46,41 @@ public class OutlierDetectionService {
     private final ArticleVectorService articleVectorService;
     private final ClusterMatchingService clusterMatchingService;
 
+    private final double similarityThreshold;
+    private final double hardThreshold;
+    private final Set<String> broadTopicBlacklist;
+
+    public OutlierDetectionService(
+            NewsClusterArticleRepository clusterArticleRepository,
+            NewsClusterRepository newsClusterRepository,
+            NewsArticleTagRepository articleTagRepository,
+            NewsArticleRepository newsArticleRepository,
+            ArticleVectorService articleVectorService,
+            ClusterMatchingService clusterMatchingService,
+            @Value("${clustering.outlier.similarity-threshold:0.70}") double similarityThreshold,
+            @Value("${clustering.outlier.hard-threshold:0.55}") double hardThreshold,
+            @Value("${clustering.outlier.broad-topic-blacklist:}") List<String> broadTopicBlacklist) {
+        this.clusterArticleRepository = clusterArticleRepository;
+        this.newsClusterRepository = newsClusterRepository;
+        this.articleTagRepository = articleTagRepository;
+        this.newsArticleRepository = newsArticleRepository;
+        this.articleVectorService = articleVectorService;
+        this.clusterMatchingService = clusterMatchingService;
+        if (hardThreshold >= similarityThreshold) {
+            throw new IllegalArgumentException(
+                    "hardThreshold(" + hardThreshold + ")는 similarityThreshold(" + similarityThreshold + ")보다 작아야 합니다");
+        }
+        this.similarityThreshold = similarityThreshold;
+        this.hardThreshold = hardThreshold;
+        this.broadTopicBlacklist = broadTopicBlacklist.stream()
+                .filter(s -> s != null && !s.isBlank())
+                .collect(Collectors.toCollection(HashSet::new));
+    }
+
     /**
      * 클러스터에서 이상치 기사를 제거하고 집계 상태를 갱신한다.
      *
-     * <p>제거된 기사는 같은 트랜잭션 안에서 즉시 단독 클러스터로 승격되어
-     * orphan 상태가 되지 않도록 한다.</p>
-     *
-     * <p>호출자(SummaryService)는 @Transactional 없이 클러스터 엔티티를 전달하므로
-     * 파라미터는 detached 상태다. 이 메서드에서 id로 re-fetch하여 현재 트랜잭션의
-     * 영속 컨텍스트에서 관리되는 엔티티를 얻은 뒤 dirty checking으로 집계 변경을 커밋한다.</p>
+     * 제거된 기사는 같은 트랜잭션 안에서 즉시 단독 클러스터로 승격되어 orphan 상태가 되지 않도록 한다.
      *
      * @param cluster 대상 클러스터 (id 참조 용도, detached 허용)
      * @return 제거된 기사 수
@@ -89,11 +108,15 @@ public class OutlierDetectionService {
             return 0;
         }
 
-        // 3. 클러스터 태그 분산 체크 (경고 로그용, 제거 로직과는 별개)
-        checkCategoryDominance(managedCluster.getId(), mappings);
+        // 3. 태그 전체 조회 (한 번만, checkCategoryDominance + findOutliers 공유)
+        List<Long> articleIds = mappings.stream().map(NewsClusterArticle::getNewsArticleId).toList();
+        List<NewsArticleTag> allTags = articleTagRepository.findByNewsArticleIdIn(articleIds);
 
-        // 4. 유사도 + 태그 기준으로 이상치 기사 탐색
-        List<NewsClusterArticle> outliers = findOutliers(mappings, centroid);
+        // 4. 클러스터 태그 분산 체크 (경고 로그용, 제거 로직과는 별개)
+        checkCategoryDominance(managedCluster.getId(), mappings, allTags);
+
+        // 5. 유사도 + 태그 기준으로 이상치 기사 탐색
+        List<NewsClusterArticle> outliers = findOutliers(mappings, centroid, allTags);
 
 
         // 이상치 없으면 종료
@@ -126,14 +149,6 @@ public class OutlierDetectionService {
 
     /**
      * 이상치 기사를 새 단독 클러스터로 승격시킨다.
-     *
-     * <p>클러스터에서 빠진 기사가 다음 클러스터링 배치(최근 24시간 이내 기사만 대상)에서
-     * 수거되지 않을 위험이 있으므로, 이 시점에서 바로 자기 자신으로 구성된 단독 클러스터를
-     * 만들어 피드 노출과 요약 재시도가 가능한 상태로 만든다. 새 클러스터는 PENDING 상태로
-     * 시작되어 다음 요약 배치에서 자연스럽게 단독 클러스터 경로(AI 미호출, 원본 사용)로 처리된다.</p>
-     *
-     * <p>벡터 또는 기사 레코드 조회에 실패하면 승격을 스킵하고 경고 로그만 남긴다.
-     * 승격 실패가 이상치 제거 전체를 롤백시킬 만한 치명도는 아니기 때문.</p>
      */
     private void promoteToSingletonCluster(Long articleId, Long fromClusterId) {
         float[] vector = articleVectorService.calculateRepresentativeVector(articleId);
@@ -230,18 +245,9 @@ public class OutlierDetectionService {
     /**
      * 이상치 기사 탐색
      * centroid와 유사도가 낮고 태그가 클러스터와 불일치하면 → outlier로 판단
-     *
-     * <p>태그 일치 여부를 판정할 때는 후보 기사 자신의 태그는 제외한 "다른 기사들의 태그"와
-     * 비교해야 한다. 후보 자신의 태그를 포함시키면 자기 자신과는 항상 일치하게 되어
-     * 이상치 판정이 무력화된다.</p>
      */
-    private List<NewsClusterArticle> findOutliers(List<NewsClusterArticle> mappings, float[] centroid) {
-        // 클러스터 전체 기사 ID
-        List<Long> articleIds = mappings.stream().map(NewsClusterArticle::getNewsArticleId).toList();
-
-        // 모든 기사 태그 조회 (한 번에 조회해서 성능 최적화)
-        List<NewsArticleTag> allTags = articleTagRepository.findByNewsArticleIdIn(articleIds);
-
+    private List<NewsClusterArticle> findOutliers(List<NewsClusterArticle> mappings, float[] centroid,
+                                                   List<NewsArticleTag> allTags) {
         // articleId → (TagType → Set<tagCode>) 사전 인덱싱
         // 후보 기사를 제외한 "나머지 기사들의 태그 집합"을 O(1)에 구하기 위해 사용한다.
         Map<Long, Map<TagType, Set<String>>> tagsByArticle = groupTagsByArticle(allTags);
@@ -260,15 +266,18 @@ public class OutlierDetectionService {
             // centroid와 유사도 계산
             double similarity = clusterMatchingService.cosineSimilarity(vector, centroid);
 
-            // 1차 필터: 유사도 낮음
-            if (similarity < OUTLIER_SIMILARITY_THRESHOLD) {
-                // 후보 기사의 태그
-                Map<TagType, Set<String>> candidateTags = tagsByArticle.getOrDefault(candidateId, Map.of());
+            // 1단: 극단 이상치 — 유사도가 매우 낮으면 태그 검사 없이 즉시 제거
+            if (similarity < hardThreshold) {
+                log.debug("극단 이상치 제거 — articleId: {}, similarity: {}", candidateId, similarity);
+                outliers.add(mapping);
+                continue;
+            }
 
-                // 후보를 제외한 나머지 기사들의 태그 집합 (타입별 union)
+            // 2단: 중간 영역 — 유사도가 낮고 + 태그도 불일치하면 제거
+            if (similarity < similarityThreshold) {
+                Map<TagType, Set<String>> candidateTags = tagsByArticle.getOrDefault(candidateId, Map.of());
                 Map<TagType, Set<String>> otherTagsByType = unionTagsExcluding(tagsByArticle, candidateId);
 
-                // 2차 필터: 태그 불일치
                 if (isTagMismatch(candidateTags, otherTagsByType)) {
                     outliers.add(mapping);
                 }
@@ -310,10 +319,11 @@ public class OutlierDetectionService {
     }
 
     /**
-     * 기사 태그가 클러스터와 맞지 않는지 판단
+     * 기사 태그가 클러스터와 맞지 않는지 판단한다.
      *
-     * <p>STOCK, SECTOR, TOPIC 중 하나도 겹치지 않으면 mismatch로 간주한다.
-     * clusterTagsByType은 후보 기사 자신의 태그가 제외된 "나머지 기사들의 태그 집합"이어야 한다.</p>
+     * STOCK, SECTOR, TOPIC 중 하나도 겹치지 않으면 mismatch로 간주한다.
+     * TOPIC 교집합 검사 시 광범위 TOPIC 블랙리스트(ECONOMY, MARKET 등)는 제외하여,
+     * 거의 모든 기사에 붙는 상위 태그가 이상치 판정을 무력화하는 문제를 방지한다.
      */
     private boolean isTagMismatch(Map<TagType, Set<String>> candidateTagsByType,
                                   Map<TagType, Set<String>> clusterTagsByType) {
@@ -323,7 +333,7 @@ public class OutlierDetectionService {
 
         return !hasOverlap(TagType.STOCK, candidateTagsByType, clusterTagsByType)
                 && !hasOverlap(TagType.SECTOR, candidateTagsByType, clusterTagsByType)
-                && !hasOverlap(TagType.TOPIC, candidateTagsByType, clusterTagsByType);
+                && !hasTopicOverlapExcludingBlacklist(candidateTagsByType, clusterTagsByType);
     }
 
     /**
@@ -346,14 +356,43 @@ public class OutlierDetectionService {
     }
 
     /**
+     * TOPIC 교집합을 검사하되, 광범위 블랙리스트 태그를 제외한다.
+     *
+     * ECONOMY, MARKET, INDUSTRY 같은 태그는 거의 모든 기사에 붙어서 교집합이 항상 존재하는 문제를 유발한다.
+     * 이 태그들을 제거한 뒤 남은 TOPIC끼리만 교집합을 검사한다
+     */
+    private boolean hasTopicOverlapExcludingBlacklist(
+            Map<TagType, Set<String>> candidateTagsByType,
+            Map<TagType, Set<String>> clusterTagsByType) {
+        Set<String> candidateTopics = candidateTagsByType.getOrDefault(TagType.TOPIC, Collections.emptySet());
+        Set<String> clusterTopics = clusterTagsByType.getOrDefault(TagType.TOPIC, Collections.emptySet());
+
+        // 블랙리스트 제외
+        Set<String> filteredCandidate = candidateTopics.stream()
+                .filter(code -> !broadTopicBlacklist.contains(code))
+                .collect(Collectors.toSet());
+        Set<String> filteredCluster = clusterTopics.stream()
+                .filter(code -> !broadTopicBlacklist.contains(code))
+                .collect(Collectors.toSet());
+
+        if (filteredCandidate.isEmpty() || filteredCluster.isEmpty()) {
+            return false;
+        }
+        for (String code : filteredCandidate) {
+            if (filteredCluster.contains(code)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * 클러스터 태그 분산 체크 (모니터링용)
      *
      * 특정 카테고리가 충분히 지배적이지 않으면 경고 로그 출력
      */
-    private void checkCategoryDominance(Long clusterId, List<NewsClusterArticle> mappings) {
-        List<Long> articleIds = mappings.stream().map(NewsClusterArticle::getNewsArticleId).toList();
-        List<NewsArticleTag> tags = articleTagRepository.findByNewsArticleIdIn(articleIds);
-
+    private void checkCategoryDominance(Long clusterId, List<NewsClusterArticle> mappings,
+                                         List<NewsArticleTag> tags) {
         // SECTOR, TOPIC만 대상으로 분석
         // → 클러스터는 산업/주제 단위로 묶이므로 상위 개념(SECTOR, TOPIC)만 사용
         List<NewsArticleTag> categoryTags = tags.stream()

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/OutlierDetectionService.java
@@ -88,7 +88,6 @@ public class OutlierDetectionService {
     @Transactional
     public int removeOutliers(NewsCluster cluster) {
         // 0. 현재 트랜잭션의 영속 컨텍스트에서 관리되는 엔티티로 re-fetch.
-        //    이렇게 해야 recalculateAfterOutlierRemoval의 필드 변경이 dirty checking으로 커밋된다.
         NewsCluster managedCluster = newsClusterRepository.findById(cluster.getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.SUMMARY_CLUSTER_NOT_FOUND));
 
@@ -189,7 +188,7 @@ public class OutlierDetectionService {
 
         // 남은 기사 없으면 집계를 초기화하고 클러스터를 INACTIVE로 내려 재조회 대상에서 제외한다.
         if (remainingArticleIds.isEmpty()) {
-            cluster.recalculateAfterOutlierRemoval(0, null, null, null, null);
+            cluster.recalculateAggregates(0, null, null, null, null);
             cluster.deactivate();
             return;
         }
@@ -212,7 +211,7 @@ public class OutlierDetectionService {
                 .orElseGet(() -> remainingArticles.stream().findAny().orElse(null));
 
         // 4. 클러스터 상태 업데이트
-        cluster.recalculateAfterOutlierRemoval(
+        cluster.recalculateAggregates(
                 remainingArticleIds.size(),
                 newCentroid,
                 representative != null ? representative.getId() : null,

--- a/src/main/java/com/solv/wefin/web/news/ClusterMergeAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/ClusterMergeAdminController.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.news;
+
+import com.solv.wefin.domain.news.cluster.batch.ClusterMergeScheduler;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/api/admin/news/clustering")
+@RequiredArgsConstructor
+public class ClusterMergeAdminController {
+
+    private final ClusterMergeScheduler clusterMergeScheduler;
+
+    /**
+     * 클러스터 병합을 수동으로 트리거한다.
+     */
+    @PostMapping("/merge")
+    public ApiResponse<String> triggerMerge() {
+        boolean executed = clusterMergeScheduler.execute();
+        if (!executed) {
+            throw new BusinessException(ErrorCode.CLUSTERING_ALREADY_RUNNING);
+        }
+        return ApiResponse.success("클러스터 병합 완료");
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,7 +30,7 @@ news:
     client-secret: ${NAVER_CLIENT_SECRET}
     display: ${NAVER_NEWS_DISPLAY:100}
   collect:
-    cron: "0 0 */2 * * *"
+    cron: ${NEWS_COLLECT_CRON:${NEWS_BATCH_CRON:0 0 */2 * * *}}
 
 server:
   forward-headers-strategy: native
@@ -40,23 +40,23 @@ market:
     api-key: ${BOK_API_KEY:}
     base-url: ${BOK_BASE_URL:https://ecos.bok.or.kr/api}
   collect:
-    cron: "0 */5 * * * *"
+    cron: ${MARKET_COLLECT_CRON:${MARKET_BATCH_CRON:0 */5 * * * *}}
 
 embedding:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${EMBEDDING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 tagging:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${TAGGING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 clustering:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${CLUSTERING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 summary:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 websocket:
   allowed-origins:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -53,6 +53,8 @@ tagging:
 clustering:
   collect:
     cron: ${CLUSTERING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
+  merge:
+    cron: ${CLUSTER_MERGE_CRON:${NEWS_BATCH_CRON:0 0 */6 * * *}}
 
 summary:
   collect:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -54,6 +54,8 @@ tagging:
 clustering:
   collect:
     cron: ${CLUSTERING_COLLECT_CRON:-}
+  merge:
+    cron: ${CLUSTER_MERGE_CRON:-}
 
 summary:
   collect:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,7 +27,7 @@ news:
     client-secret: ${NAVER_CLIENT_SECRET}
     display: ${NAVER_NEWS_DISPLAY:100}
   collect:
-    cron: "0 0 */2 * * *"
+    cron: ${NEWS_COLLECT_CRON:${NEWS_BATCH_CRON:0 0 */2 * * *}}
 
 server:
   forward-headers-strategy: native
@@ -37,23 +37,23 @@ market:
     api-key: ${BOK_API_KEY:}
     base-url: ${BOK_BASE_URL:https://ecos.bok.or.kr/api}
   collect:
-    cron: "0 */5 * * * *"
+    cron: ${MARKET_COLLECT_CRON:${MARKET_BATCH_CRON:0 */5 * * * *}}
 
 embedding:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${EMBEDDING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 tagging:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${TAGGING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 clustering:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${CLUSTERING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 summary:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 websocket:
   allowed-origins:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -50,6 +50,8 @@ tagging:
 clustering:
   collect:
     cron: ${CLUSTERING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
+  merge:
+    cron: ${CLUSTER_MERGE_CRON:${NEWS_BATCH_CRON:0 0 */6 * * *}}
 
 summary:
   collect:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -56,6 +56,8 @@ clustering:
       - INDUSTRY
       - POLITICS
       - SOCIETY
+  merge:
+    threshold: 0.85
   collect:
     cron: "0 */30 * * * *"
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,6 +47,15 @@ clustering:
   score:
     reject-cutoff: 70
     suspicious-cutoff: 80
+  outlier:
+    similarity-threshold: 0.70
+    hard-threshold: 0.55
+    broad-topic-blacklist:
+      - ECONOMY
+      - MARKET
+      - INDUSTRY
+      - POLITICS
+      - SOCIETY
   collect:
     cron: "0 */30 * * * *"
 

--- a/src/test/java/com/solv/wefin/domain/news/cluster/entity/NewsClusterTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/entity/NewsClusterTest.java
@@ -1,0 +1,60 @@
+package com.solv.wefin.domain.news.cluster.entity;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NewsClusterTest {
+
+    @Test
+    @DisplayName("GENERATED 상태에서 markSummaryStale 호출 시 STALE로 전환된다")
+    void markSummaryStale_fromGenerated() {
+        NewsCluster cluster = createCluster(SummaryStatus.GENERATED);
+
+        cluster.markSummaryStale();
+
+        assertThat(cluster.getSummaryStatus()).isEqualTo(SummaryStatus.STALE);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태에서 markSummaryStale 호출 시 상태가 유지된다")
+    void markSummaryStale_fromPending_noChange() {
+        NewsCluster cluster = createCluster(SummaryStatus.PENDING);
+
+        cluster.markSummaryStale();
+
+        assertThat(cluster.getSummaryStatus()).isEqualTo(SummaryStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("FAILED 상태에서 markSummaryStale 호출 시 상태가 유지된다")
+    void markSummaryStale_fromFailed_noChange() {
+        NewsCluster cluster = createCluster(SummaryStatus.FAILED);
+
+        cluster.markSummaryStale();
+
+        assertThat(cluster.getSummaryStatus()).isEqualTo(SummaryStatus.FAILED);
+    }
+
+    @Test
+    @DisplayName("STALE 상태에서 markSummaryStale 호출 시 상태가 유지된다")
+    void markSummaryStale_fromStale_noChange() {
+        NewsCluster cluster = createCluster(SummaryStatus.STALE);
+
+        cluster.markSummaryStale();
+
+        assertThat(cluster.getSummaryStatus()).isEqualTo(SummaryStatus.STALE);
+    }
+
+    private NewsCluster createCluster(SummaryStatus summaryStatus) {
+        NewsCluster cluster = NewsCluster.builder()
+                .clusterType(NewsCluster.ClusterType.GENERAL)
+                .centroidVector(new float[]{1.0f})
+                .build();
+        ReflectionTestUtils.setField(cluster, "summaryStatus", summaryStatus);
+        return cluster;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeServiceTest.java
@@ -1,0 +1,178 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterMergeServiceTest {
+
+    @Mock
+    private NewsClusterRepository newsClusterRepository;
+    @Mock
+    private ClusterMatchingService clusterMatchingService;
+    @Mock
+    private ClusterMergePersistenceService mergePersistenceService;
+
+    private ClusterMergeService clusterMergeService;
+
+    @BeforeEach
+    void setUp() {
+        clusterMergeService = new ClusterMergeService(
+                newsClusterRepository, clusterMatchingService, mergePersistenceService, 0.85);
+    }
+
+    @Test
+    @DisplayName("유사도 0.85 이상인 클러스터 쌍을 병합한다")
+    void mergeActiveClusters_mergeSimilarPair() {
+        NewsCluster big = createCluster(1L, 5, new float[]{1.0f, 0.0f});
+        NewsCluster small = createCluster(2L, 2, new float[]{0.99f, 0.01f});
+
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(big, small));
+        given(clusterMatchingService.cosineSimilarity(big.getCentroidVector(), small.getCentroidVector()))
+                .willReturn(0.90);
+
+        int merged = clusterMergeService.mergeActiveClusters();
+
+        assertThat(merged).isEqualTo(1);
+        verify(mergePersistenceService).mergePair(1L, 2L); // big=survivor, small=loser
+    }
+
+    @Test
+    @DisplayName("유사도가 임계값 미만이면 병합하지 않는다")
+    void mergeActiveClusters_belowThreshold_noMerge() {
+        NewsCluster a = createCluster(1L, 3, new float[]{1.0f, 0.0f});
+        NewsCluster b = createCluster(2L, 3, new float[]{0.0f, 1.0f});
+
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(a, b));
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), b.getCentroidVector()))
+                .willReturn(0.50);
+
+        int merged = clusterMergeService.mergeActiveClusters();
+
+        assertThat(merged).isZero();
+        verify(mergePersistenceService, never()).mergePair(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("ACTIVE 클러스터가 1개 이하면 병합하지 않는다")
+    void mergeActiveClusters_singleCluster_noMerge() {
+        NewsCluster single = createCluster(1L, 3, new float[]{1.0f});
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(single));
+
+        int merged = clusterMergeService.mergeActiveClusters();
+
+        assertThat(merged).isZero();
+    }
+
+    @Test
+    @DisplayName("centroid가 없는 클러스터는 비교 대상에서 제외한다")
+    void mergeActiveClusters_nullCentroid_excluded() {
+        NewsCluster withCentroid = createCluster(1L, 3, new float[]{1.0f});
+        NewsCluster noCentroid = createCluster(2L, 3, null);
+
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE))
+                .willReturn(List.of(withCentroid, noCentroid));
+
+        int merged = clusterMergeService.mergeActiveClusters();
+
+        assertThat(merged).isZero();
+        verify(mergePersistenceService, never()).mergePair(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("greedy 선택 — 한 클러스터는 한 쌍에만 사용된다")
+    void mergeActiveClusters_greedy_noDuplicateUse() {
+        NewsCluster a = createCluster(1L, 5, new float[]{1.0f, 0.0f});
+        NewsCluster b = createCluster(2L, 3, new float[]{0.99f, 0.01f});
+        NewsCluster c = createCluster(3L, 2, new float[]{0.98f, 0.02f});
+
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(a, b, c));
+        // a-b: 0.95, a-c: 0.90, b-c: 0.88 → 모두 임계값 이상
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), b.getCentroidVector()))
+                .willReturn(0.95);
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), c.getCentroidVector()))
+                .willReturn(0.90);
+        given(clusterMatchingService.cosineSimilarity(b.getCentroidVector(), c.getCentroidVector()))
+                .willReturn(0.88);
+
+        int merged = clusterMergeService.mergeActiveClusters();
+
+        // a-b가 유사도 최고라 먼저 선택 → a,b 사용됨 → c는 남은 쌍에서 a,b 모두 사용됐으므로 선택 안 됨
+        assertThat(merged).isEqualTo(1);
+        verify(mergePersistenceService).mergePair(1L, 2L);
+    }
+
+    @Test
+    @DisplayName("기사 수가 같으면 앞 클러스터가 survivor가 된다")
+    void mergeActiveClusters_sameCount_firstIsSurvivor() {
+        NewsCluster a = createCluster(1L, 3, new float[]{1.0f, 0.0f});
+        NewsCluster b = createCluster(2L, 3, new float[]{0.99f, 0.01f});
+
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(a, b));
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), b.getCentroidVector()))
+                .willReturn(0.90);
+
+        clusterMergeService.mergeActiveClusters();
+
+        verify(mergePersistenceService).mergePair(1L, 2L); // a가 survivor (같은 수면 >= 조건)
+    }
+
+    @Test
+    @DisplayName("한 쌍 병합 실패해도 나머지는 계속 진행한다")
+    void mergeActiveClusters_partialFailure() {
+        NewsCluster a = createCluster(1L, 5, new float[]{1.0f, 0.0f});
+        NewsCluster b = createCluster(2L, 2, new float[]{0.99f, 0.01f});
+        NewsCluster c = createCluster(3L, 4, new float[]{0.0f, 1.0f});
+        NewsCluster d = createCluster(4L, 1, new float[]{0.01f, 0.99f});
+
+        given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(a, b, c, d));
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), b.getCentroidVector()))
+                .willReturn(0.95);
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), c.getCentroidVector()))
+                .willReturn(0.10);
+        given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), d.getCentroidVector()))
+                .willReturn(0.10);
+        given(clusterMatchingService.cosineSimilarity(b.getCentroidVector(), c.getCentroidVector()))
+                .willReturn(0.10);
+        given(clusterMatchingService.cosineSimilarity(b.getCentroidVector(), d.getCentroidVector()))
+                .willReturn(0.10);
+        given(clusterMatchingService.cosineSimilarity(c.getCentroidVector(), d.getCentroidVector()))
+                .willReturn(0.92);
+
+        // a-b 병합은 실패, c-d 병합은 성공
+        org.mockito.Mockito.doThrow(new RuntimeException("DB error")).when(mergePersistenceService).mergePair(1L, 2L);
+
+        int merged = clusterMergeService.mergeActiveClusters();
+
+        assertThat(merged).isEqualTo(1); // c-d만 성공
+        verify(mergePersistenceService).mergePair(1L, 2L); // 시도는 했음 (실패)
+        verify(mergePersistenceService).mergePair(3L, 4L); // 성공
+    }
+
+    private NewsCluster createCluster(long id, int articleCount, float[] centroid) {
+        NewsCluster cluster = NewsCluster.builder()
+                .clusterType(NewsCluster.ClusterType.GENERAL)
+                .centroidVector(centroid)
+                .build();
+        ReflectionTestUtils.setField(cluster, "id", id);
+        ReflectionTestUtils.setField(cluster, "articleCount", articleCount);
+        ReflectionTestUtils.setField(cluster, "status", ClusterStatus.ACTIVE);
+        return cluster;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterMergeServiceTest.java
@@ -46,11 +46,12 @@ class ClusterMergeServiceTest {
         given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(big, small));
         given(clusterMatchingService.cosineSimilarity(big.getCentroidVector(), small.getCentroidVector()))
                 .willReturn(0.90);
+        given(mergePersistenceService.mergePair(1L, 2L)).willReturn(true);
 
         int merged = clusterMergeService.mergeActiveClusters();
 
         assertThat(merged).isEqualTo(1);
-        verify(mergePersistenceService).mergePair(1L, 2L); // big=survivor, small=loser
+        verify(mergePersistenceService).mergePair(1L, 2L);
     }
 
     @Test
@@ -110,10 +111,10 @@ class ClusterMergeServiceTest {
                 .willReturn(0.90);
         given(clusterMatchingService.cosineSimilarity(b.getCentroidVector(), c.getCentroidVector()))
                 .willReturn(0.88);
+        given(mergePersistenceService.mergePair(1L, 2L)).willReturn(true);
 
         int merged = clusterMergeService.mergeActiveClusters();
 
-        // a-b가 유사도 최고라 먼저 선택 → a,b 사용됨 → c는 남은 쌍에서 a,b 모두 사용됐으므로 선택 안 됨
         assertThat(merged).isEqualTo(1);
         verify(mergePersistenceService).mergePair(1L, 2L);
     }
@@ -127,10 +128,11 @@ class ClusterMergeServiceTest {
         given(newsClusterRepository.findByStatus(ClusterStatus.ACTIVE)).willReturn(List.of(a, b));
         given(clusterMatchingService.cosineSimilarity(a.getCentroidVector(), b.getCentroidVector()))
                 .willReturn(0.90);
+        given(mergePersistenceService.mergePair(1L, 2L)).willReturn(true);
 
         clusterMergeService.mergeActiveClusters();
 
-        verify(mergePersistenceService).mergePair(1L, 2L); // a가 survivor (같은 수면 >= 조건)
+        verify(mergePersistenceService).mergePair(1L, 2L);
     }
 
     @Test
@@ -156,7 +158,8 @@ class ClusterMergeServiceTest {
                 .willReturn(0.92);
 
         // a-b 병합은 실패, c-d 병합은 성공
-        org.mockito.Mockito.doThrow(new RuntimeException("DB error")).when(mergePersistenceService).mergePair(1L, 2L);
+        given(mergePersistenceService.mergePair(1L, 2L)).willThrow(new RuntimeException("DB error"));
+        given(mergePersistenceService.mergePair(3L, 4L)).willReturn(true);
 
         int merged = clusterMergeService.mergeActiveClusters();
 


### PR DESCRIPTION
## 📌 PR 설명

여러 개 기사로 이루어진 클러스터 중에서 약 22.6%(7개/31개)에 관련 없는 기사가 섞여 있었고, 같은 주제인데도 클러스터가 따로 나뉜 경우도 3쌍 정도 발견됐습니다.
이 문제가 발생된 원인을 파악한 결과, 이상치 제거 기준이 너무 느슨했고(특히 범위가 넓은 TOPIC 태그 때문에 거의 항상 겹치는 문제가 있었음), 클러스터를 합치는 로직이 없어서 생긴 것으로 보입니다.

### 개선 사항

**1) 이상치 제거 기준을 두 단계로 강화**
centroid 유사도가 0.55보다 낮으면 바로 제거하고,
0.55~0.70 사이에서는 TOPIC 중에서도 범위가 넓은 태그(ECONOMY, MARKET 등)는 제외한 뒤 태그가 맞는지 확인해서 판단하도록 했습니다. 기존에는 0.70 기준 하나만 사용했는데, 이제는 두 단계로 나눠서 더 정확하게 걸러내도록 바꿨습니다.

**2) 클러스터 병합 기능 추가**
서로 비슷한 클러스터(centroid 유사도 0.85 이상)를 찾아서, 기사 수가 많은 클러스터에 적은 쪽을 합치고, 합쳐진 쪽은 비활성화하도록 했습니다. 이 작업은 6시간마다 자동으로 실행되게 했고, 필요하면 어드민에서 직접 실행할 수도 있습니다.


모든 임계값은 application.yml로 외부화하여 재배포 없이 튜닝 가능합니다.

## 용어 설명
* `광범위 TOPIC 블랙리스트`
  ECONOMY, MARKET처럼 대부분 기사에 붙는 태그
  → 교집합을 만들어 이상치 판정을 방해하므로 제외

* `병합 (Merge)`
  같은 주제지만 따로 나뉜 클러스터를 하나로 합치는 작업

* `merge-threshold (0.85)`
  두 클러스터의 centroid 유사도가 0.85 이상이면
  → 같은 주제로 판단하고 병합 후보로 선정

* `survivor`
  병합 시 유지되는 클러스터 (기사 수가 더 많은 쪽)

* `loser`
  병합 시 흡수되는 클러스터
  → 기사 매핑을 survivor로 옮긴 후 INACTIVE 처리

* `매핑 이관`
  loser에 속한 기사들을 survivor 클러스터로 이동시키는 과정

* `greedy 방식 선택`
  유사도가 높은 쌍부터 순차적으로 병합
  → 이미 선택된 클러스터는 중복 병합 방지


<br>

## ✅  변경 파일

1. `application.yml` — `clustering.outlier.*` + `clustering.merge.*` 설정 추가 (modified)
2. `OutlierDetectionService.java` — 2단 이상치 기준 + TOPIC 블랙리스트 + yml 주입 (modified)
3. `NewsCluster.java` — `markSummaryStale()` 추가 + `recalculateAggregates` rename (modified)
4. `ClusterMergeService.java` — 병합 오케스트레이션 (후보 탐색 + greedy 선택) (new)
5. `ClusterMergePersistenceService.java` — REQUIRES_NEW 병합 DB 작업 (매핑 이관 + 중복 방어 + 대표 재선정) (new)
6. `ClusterMergeScheduler.java` — 6시간 배치 + AtomicBoolean 중복 방지 (new)
7. `ClusterMergeAdminController.java` — 수동 트리거 (new)
8. `application-dev.yml` / `application-prod.yml` — 배치 cron 환경변수 지원 (modified)
9. `ClusterMergeServiceTest.java` — 병합 단위 테스트 7건 (new)
10. `NewsClusterTest.java` — markSummaryStale 상태 전이 테스트 4건 

<br>

## 💭 고민과 해결과정
### 1. 이상치 기준: 유사도 + 블랙리스트 조합

| 구간 | 판정 | 근거 |
|---|---|---|
| 유사도 < 0.55 | 제거 | 너무 낮은 경우라 태그를 볼 필요 없이 관련 없다고 판단 |
| 유사도 0.55~0.70 | 태그 불일치 시 제거 (블랙리스트 제외) | 애매한 구간이라 태그까지 같이 확인 |
| 유사도 ≥ 0.70 | 유지 | 기존과 동일하게 유지 |

유사도만으로 판단하면 0.55~0.70 구간에서 정상 기사도 잘못 제거될 수 있고,  
블랙리스트만 사용하면 극단적인 경우에도 불필요하게 태그 비교를 하게 됩니다.  

그래서 두 기준을 같이 사용해서 2단계로 필터링하도록 개선했습니다.


### 2. 광범위 TOPIC 블랙리스트

ECONOMY, MARKET, INDUSTRY, POLITICS, SOCIETY 같은 태그는 거의 모든 기사에 붙는 경우가 많습니다.  

이 태그들을 그대로 사용하면, 서로 관련 없는 기사라도 공통 태그 하나만으로 통과하는 문제가 생깁니다.  
예를 들어 "비트코인" 기사와 "유학생" 기사가 ECONOMY 태그 하나만으로 같은 그룹으로 묶일 수 있습니다.  

그래서 이런 광범위한 태그들은 비교 대상에서 제외하도록 했습니다.


### 3. 병합 구조 분리 (self-invocation 방지)

`ClusterMergeService.mergeActiveClusters()`와  
`ClusterMergePersistenceService.mergePair()`를 분리해서 구현했습니다.  

`mergePair()`에는 `@Transactional(REQUIRES_NEW)`를 적용해서  
클러스터 쌍마다 트랜잭션이 따로 실행되도록 했습니다.  

같은 클래스 내부에서 `@Transactional` 메서드를 호출하면 트랜잭션이 제대로 동작하지 않기 때문에
이 부분을 방지하기 위해 구조를 분리했습니다.


### 4. 병합 후보 선택 방식 (Greedy)

하나의 클러스터가 여러 병합 후보에 동시에 포함될 수 있기 때문에
유사도가 높은 순으로 정렬한 뒤 하나씩 선택하는 방식으로 처리했습니다.  

이미 선택된 클러스터는 이후 후보에서 제외해서 중복 병합을 막았습니다.  

더 복잡한 알고리즘도 있지만, 현재 요구사항에서는 이 방식이 충분하다고 판단했습니다.


### 5. 병합 시 대표 기사 재선정

병합 과정에서 loser 클러스터의 기사 중 더 최신 기사가 포함될 수 있기 때문에
병합 이후 전체 기사 중에서 가장 최신 기사를 다시 대표 기사로 선택하도록 했습니다.


### 6. 배치 cron 설정 통합

뉴스 파이프라인 전체는 `NEWS_BATCH_CRON`으로 관리하고,  
클러스터 병합은 `CLUSTER_MERGE_CRON`으로 따로 설정할 수 있도록 분리했습니다.  

또한 `"-"` 값으로 설정하면 해당 배치를 비활성화할 수 있도록 했습니다.
<br>

### 🔗 관련 이슈
Closes #170

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 유사한 뉴스 클러스터를 주기적으로 자동 병합하는 스케줄러 추가
  * 관리자용 수동 병합 트리거 엔드포인트 추가

* **개선**
  * 이상치 감지 알고리즘을 설정 가능한 임계값 및 블랙리스트 기반으로 개선
  * 병합 로직이 유사도 기준과 그리디 선택으로 충돌 없이 처리되도록 향상

* **테스트**
  * 클러스터 병합 시나리오 및 요약 상태 전환에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->