### PR TITLE
[WEF-541] 뉴스 단독 클러스터 제목 재생성

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.news.summary.client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.news.config.dto.OpenAiChatApiResponse;
+import lombok.extern.slf4j.Slf4j;
 import com.solv.wefin.domain.news.summary.dto.SummaryResult;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +24,7 @@ import java.util.Map;
  * 한 클러스터에 묶인 여러 기사를 종합하여 하나의 title + summary 브리핑을 만든다.
  * 프롬프트에서 팩트, 분석, 전망, 영향 등을 다각도에서 정리하도록 유도한다.
  */
+@Slf4j
 @Component
 public class OpenAiSummaryClient {
     private static final String OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
@@ -31,6 +33,22 @@ public class OpenAiSummaryClient {
 
     // 클러스터당 프롬프트에 포함할 최대 기사 수
     private static final int MAX_ARTICLES_PER_CLUSTER = 10;
+
+    private static final String SINGLE_TITLE_PROMPT = """
+            당신은 금융 뉴스 전문 에디터입니다.
+            기사 한 건의 제목을 깔끔하게 다듬어주세요.
+
+            규칙:
+            1. 50자 이내 한글로 작성
+            2. 언론사 코너명([경제D톡스], [기자수첩] 등)이나 특수 기호(①②③ 등)는 제거
+            3. 핵심 내용만 남기되, 원본의 의미를 훼손하지 말 것
+            4. 말줄임표로 잘린 문장이면 본문을 참고하여 완결된 문장으로 작성
+
+            반드시 아래 JSON 형식으로만 응답하세요:
+            {
+              "title": "다듬어진 제목"
+            }
+            """;
 
     private static final String SYSTEM_PROMPT = """
             당신은 금융 뉴스 전문 에디터입니다.
@@ -158,6 +176,64 @@ public class OpenAiSummaryClient {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * 단독 클러스터용 — 기사 한 건의 title을 AI로 정제한다.
+     *
+     * <p>규칙 기반 클렌징으로 처리 불가한 경우(너무 짧은 제목 등)의 fallback으로 사용된다.
+     * summary는 건드리지 않고 title만 재생성한다.</p>
+     *
+     * @param originalTitle 원본 제목
+     * @param content 기사 본문 (제목이 잘린 경우 본문 참고용)
+     * @return 정제된 title. 실패 시 null.
+     */
+    public String generateSingleTitle(String originalTitle, String content) {
+        try {
+            String truncatedContent = content != null && content.length() > MAX_ARTICLE_LENGTH
+                    ? content.substring(0, MAX_ARTICLE_LENGTH) : (content != null ? content : "");
+            String userMessage = "제목: " + originalTitle + "\n\n본문: " + truncatedContent;
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.setBearerAuth(apiKey);
+
+            Map<String, Object> body = Map.of(
+                    "model", model,
+                    "response_format", Map.of("type", "json_object"),
+                    "messages", List.of(
+                            Map.of("role", "system", "content", SINGLE_TITLE_PROMPT),
+                            Map.of("role", "user", "content", userMessage)
+                    )
+            );
+
+            HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+            OpenAiChatApiResponse response;
+            try {
+                response = restTemplate.postForObject(OPENAI_CHAT_URL, request, OpenAiChatApiResponse.class);
+            } catch (HttpStatusCodeException e) {
+                throw new OpenAiClientException("OpenAI Single Title API HTTP 오류: " + e.getStatusCode(), e.getStatusCode(), e);
+            } catch (RestClientException e) {
+                throw new OpenAiClientException("OpenAI Single Title API 호출 실패: " + e.getMessage(), null, e);
+            }
+
+            if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
+                return null;
+            }
+
+            OpenAiChatApiResponse.Choice firstChoice = response.getChoices().get(0);
+            if (firstChoice == null || firstChoice.getMessage() == null || firstChoice.getMessage().getContent() == null) {
+                return null;
+            }
+
+            SummaryResult result = parseSummaryResult(firstChoice.getMessage().getContent());
+            return result.getTitle() != null && !result.getTitle().isBlank() ? result.getTitle() : null;
+        } catch (OpenAiClientException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("단독 title AI 재생성 실패: {}", e.getMessage());
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -227,7 +227,11 @@ public class OpenAiSummaryClient {
             }
 
             SummaryResult result = parseSummaryResult(firstChoice.getMessage().getContent());
-            return result.getTitle() != null && !result.getTitle().isBlank() ? result.getTitle() : null;
+            String title = result.getTitle();
+            if (title == null || title.isBlank()) {
+                return null;
+            }
+            return title.trim();
         } catch (OpenAiClientException e) {
             throw e;
         } catch (Exception e) {

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -137,12 +137,43 @@ public class SummaryService {
         }
 
         var article = articleOpt.get();
-        String title = article.getTitle();
-
-        // summary가 null일 수 있으므로 title을 fallback
-        String summary = article.getSummary() != null ? article.getSummary() : article.getTitle();
+        String title = resolveTitle(article);
+        String summary = article.getSummary() != null ? article.getSummary() : title;
         persistenceService.markGenerated(cluster.getId(), title, summary);
         return true;
+    }
+
+    /**
+     * 단독 클러스터 title을 3단계 fallback으로 결정한다.
+     * 1단계: 규칙 기반 클렌징 → 2단계: AI 재생성 → 3단계: 원본 그대로
+     */
+    private String resolveTitle(com.solv.wefin.domain.news.article.entity.NewsArticle article) {
+        String original = article.getTitle();
+
+        // 1단계: 규칙 기반 클렌징
+        String cleansed = TitleCleanser.cleanse(original);
+
+        if (!TitleCleanser.needsAiFallback(cleansed)) {
+            if (!cleansed.equals(original)) {
+                log.debug("단독 title 클렌징 — articleId: {}, before: {}, after: {}", article.getId(), original, cleansed);
+            }
+            return cleansed;
+        }
+
+        // 2단계: AI fallback (클렌징 결과가 너무 짧음)
+        log.info("단독 title AI fallback — articleId: {}, cleansed: '{}' ({}자)", article.getId(), cleansed, cleansed.length());
+        try {
+            String aiTitle = openAiSummaryClient.generateSingleTitle(original, article.getContent());
+            if (aiTitle != null && !aiTitle.isBlank()) {
+                log.info("단독 title AI 재생성 성공 — articleId: {}, title: {}", article.getId(), aiTitle);
+                return aiTitle;
+            }
+        } catch (Exception e) {
+            log.warn("단독 title AI 재생성 실패 — articleId: {}", article.getId(), e);
+        }
+
+        // 3단계: 원본 그대로
+        return original;
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -153,7 +153,7 @@ public class SummaryService {
         // 1단계: 규칙 기반 클렌징
         String cleansed = TitleCleanser.cleanse(original);
 
-        if (!TitleCleanser.needsAiFallback(cleansed)) {
+        if (!TitleCleanser.needsAiFallback(cleansed, original)) {
             if (!cleansed.equals(original)) {
                 log.debug("단독 title 클렌징 — articleId: {}, before: {}, after: {}", article.getId(), original, cleansed);
             }
@@ -163,8 +163,9 @@ public class SummaryService {
         // 2단계: AI fallback (클렌징 결과가 너무 짧음)
         log.info("단독 title AI fallback — articleId: {}, cleansed: '{}' ({}자)", article.getId(), cleansed, cleansed.length());
         try {
-            String aiTitle = openAiSummaryClient.generateSingleTitle(original, article.getContent());
-            if (aiTitle != null && !aiTitle.isBlank()) {
+            String rawAiTitle = openAiSummaryClient.generateSingleTitle(original, article.getContent());
+            String aiTitle = TitleCleanser.sanitizeAiTitle(rawAiTitle);
+            if (aiTitle != null) {
                 log.info("단독 title AI 재생성 성공 — articleId: {}, title: {}", article.getId(), aiTitle);
                 return aiTitle;
             }

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
@@ -11,10 +11,11 @@ import java.util.regex.Pattern;
 public class TitleCleanser {
 
     static final int MIN_CLEAN_LENGTH = 10;
+    static final int MAX_TITLE_LENGTH = 50;
 
-    // [경제D톡스], [기자수첩], [전쟁이 삼킨 증시①] 같은 접두사 대괄호 제거
-    // 제목 시작 부분의 [...] 만 제거 (본문 중간의 [삼성전자] 같은 건 유지)
-    private static final Pattern BRACKET_PREFIX = Pattern.compile("^\\s*\\[.*?]\\s*");
+    // [경제D톡스], [속보][단독] 같은 접두사 대괄호를 1개 이상 연속 제거
+    // 제목 시작 부분의 [...][...] 만 제거 (본문 중간의 [삼성전자] 같은 건 유지)
+    private static final Pattern BRACKET_PREFIX = Pattern.compile("^(\\s*\\[.*?])+\\s*");
 
     // 특수 기호 제거: ①②③④⑤⑥⑦⑧⑨⑩☞★▶▷◆◇■□●○△▲▽▼◁◀
     private static final Pattern SPECIAL_CHARS = Pattern.compile("[①②③④⑤⑥⑦⑧⑨⑩☞★▶▷◆◇■□●○△▲▽▼◁◀]");
@@ -57,7 +58,42 @@ public class TitleCleanser {
      *
      * @return true면 AI로 title 재생성 필요
      */
-    public static boolean needsAiFallback(String cleansedTitle) {
-        return cleansedTitle == null || cleansedTitle.length() < MIN_CLEAN_LENGTH;
+    /**
+     * AI fallback이 필요한지 판단한다.
+     *
+     * @param cleansedTitle 클렌징된 title
+     * @param originalTitle 클렌징 전 원본 title (말줄임표 절단 감지용)
+     * @return true면 AI로 title 재생성 필요
+     */
+    public static boolean needsAiFallback(String cleansedTitle, String originalTitle) {
+        if (cleansedTitle == null || cleansedTitle.length() < MIN_CLEAN_LENGTH) {
+            return true;
+        }
+        // 원본이 "..." 또는 "…"로 끝나면 뉴스 소스가 제목을 잘랐다는 의미 → AI가 완결된 title 생성
+        return originalTitle != null && (originalTitle.endsWith("...") || originalTitle.endsWith("…"));
+    }
+
+    /**
+     * AI가 생성한 title을 검증 + 정제한다.
+     * 클렌징 적용 후 50자 초과면 안전 절단한다.
+     *
+     * @return 유효한 title, 검증 실패 시 null
+     */
+    public static String sanitizeAiTitle(String aiTitle) {
+        if (aiTitle == null || aiTitle.isBlank()) {
+            return null;
+        }
+
+        String sanitized = cleanse(aiTitle);
+
+        if (sanitized.isEmpty() || sanitized.length() < MIN_CLEAN_LENGTH) {
+            return null;
+        }
+
+        if (sanitized.length() > MAX_TITLE_LENGTH) {
+            sanitized = sanitized.substring(0, MAX_TITLE_LENGTH);
+        }
+
+        return sanitized;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
@@ -1,0 +1,63 @@
+package com.solv.wefin.domain.news.summary.service;
+
+import java.util.regex.Pattern;
+
+/**
+ * 단독 클러스터 title에서 언론사 태그, 특수 기호, 말줄임표를 제거한다.
+ *
+ * <p>규칙 기반 클렌징으로, AI 호출 없이 대부분의 제목을 정제할 수 있다.
+ * 클렌징 후 결과가 너무 짧으면(MIN_CLEAN_LENGTH 미만) AI fallback이 필요하다는 신호.</p>
+ */
+public class TitleCleanser {
+
+    static final int MIN_CLEAN_LENGTH = 10;
+
+    // [경제D톡스], [기자수첩], [전쟁이 삼킨 증시①] 같은 접두사 대괄호 제거
+    // 제목 시작 부분의 [...] 만 제거 (본문 중간의 [삼성전자] 같은 건 유지)
+    private static final Pattern BRACKET_PREFIX = Pattern.compile("^\\s*\\[.*?]\\s*");
+
+    // 특수 기호 제거: ①②③④⑤⑥⑦⑧⑨⑩☞★▶▷◆◇■□●○△▲▽▼◁◀
+    private static final Pattern SPECIAL_CHARS = Pattern.compile("[①②③④⑤⑥⑦⑧⑨⑩☞★▶▷◆◇■□●○△▲▽▼◁◀]");
+
+    // 시작 말줄임표 제거: "...불안 부추기는"
+    private static final Pattern LEADING_ELLIPSIS = Pattern.compile("^\\.{2,}\\s*");
+
+    // 끝 말줄임표 정리: "가짜뉴스까지 기..." → "가짜뉴스까지 기"
+    private static final Pattern TRAILING_ELLIPSIS = Pattern.compile("\\s*\\.{2,}$");
+
+    // 연속 공백 정리
+    private static final Pattern MULTIPLE_SPACES = Pattern.compile("\\s{2,}");
+
+    /**
+     * title을 정제한다.
+     *
+     * @return 정제된 title. null이나 빈 문자열이 들어오면 그대로 반환.
+     */
+    public static String cleanse(String title) {
+        if (title == null) {
+            return null;
+        }
+        if (title.isBlank()) {
+            return "";
+        }
+
+        String result = title;
+        result = BRACKET_PREFIX.matcher(result).replaceAll("");
+        result = SPECIAL_CHARS.matcher(result).replaceAll("");
+        result = LEADING_ELLIPSIS.matcher(result).replaceAll("");
+        result = TRAILING_ELLIPSIS.matcher(result).replaceAll("");
+        result = MULTIPLE_SPACES.matcher(result).replaceAll(" ");
+        result = result.trim();
+
+        return result;
+    }
+
+    /**
+     * 클렌징 후 AI fallback이 필요한지 판단한다.
+     *
+     * @return true면 AI로 title 재생성 필요
+     */
+    public static boolean needsAiFallback(String cleansedTitle) {
+        return cleansedTitle == null || cleansedTitle.length() < MIN_CLEAN_LENGTH;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
@@ -4,9 +4,6 @@ import java.util.regex.Pattern;
 
 /**
  * 단독 클러스터 title에서 언론사 태그, 특수 기호, 말줄임표를 제거한다.
- *
- * <p>규칙 기반 클렌징으로, AI 호출 없이 대부분의 제목을 정제할 수 있다.
- * 클렌징 후 결과가 너무 짧으면(MIN_CLEAN_LENGTH 미만) AI fallback이 필요하다는 신호.</p>
  */
 public class TitleCleanser {
 
@@ -20,11 +17,14 @@ public class TitleCleanser {
     // 특수 기호 제거: ①②③④⑤⑥⑦⑧⑨⑩☞★▶▷◆◇■□●○△▲▽▼◁◀
     private static final Pattern SPECIAL_CHARS = Pattern.compile("[①②③④⑤⑥⑦⑧⑨⑩☞★▶▷◆◇■□●○△▲▽▼◁◀]");
 
-    // 시작 말줄임표 제거: "...불안 부추기는"
-    private static final Pattern LEADING_ELLIPSIS = Pattern.compile("^\\.{2,}\\s*");
+    // 시작 말줄임표 제거: "...불안 부추기는" 또는 "…불안 부추기는"
+    private static final Pattern LEADING_ELLIPSIS = Pattern.compile("^(\\.{2,}|…)\\s*");
 
-    // 끝 말줄임표 정리: "가짜뉴스까지 기..." → "가짜뉴스까지 기"
-    private static final Pattern TRAILING_ELLIPSIS = Pattern.compile("\\s*\\.{2,}$");
+    // 끝 말줄임표 정리: "가짜뉴스까지 기..." 또는 "가짜뉴스까지 기…"
+    private static final Pattern TRAILING_ELLIPSIS = Pattern.compile("\\s*(\\.{2,}|…)\\s*$");
+
+    // 절단 감지용 — 원본 title 끝이 말줄임표인지 (needsAiFallback에서 사용)
+    private static final Pattern TRUNCATION_SUFFIX = Pattern.compile("(\\.{2,}|…)\\s*$");
 
     // 연속 공백 정리
     private static final Pattern MULTIPLE_SPACES = Pattern.compile("\\s{2,}");
@@ -54,11 +54,6 @@ public class TitleCleanser {
     }
 
     /**
-     * 클렌징 후 AI fallback이 필요한지 판단한다.
-     *
-     * @return true면 AI로 title 재생성 필요
-     */
-    /**
      * AI fallback이 필요한지 판단한다.
      *
      * @param cleansedTitle 클렌징된 title
@@ -69,8 +64,8 @@ public class TitleCleanser {
         if (cleansedTitle == null || cleansedTitle.length() < MIN_CLEAN_LENGTH) {
             return true;
         }
-        // 원본이 "..." 또는 "…"로 끝나면 뉴스 소스가 제목을 잘랐다는 의미 → AI가 완결된 title 생성
-        return originalTitle != null && (originalTitle.endsWith("...") || originalTitle.endsWith("…"));
+        // 원본이 말줄임표로 끝나면 뉴스 소스가 제목을 잘랐다는 의미 → AI가 완결된 title 생성
+        return originalTitle != null && TRUNCATION_SUFFIX.matcher(originalTitle).find();
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/TitleCleanser.java
@@ -87,8 +87,13 @@ public class TitleCleanser {
 
         if (sanitized.length() > MAX_TITLE_LENGTH) {
             sanitized = sanitized.substring(0, MAX_TITLE_LENGTH);
+            // 단어 중간 절단 방지 — 마지막 공백 기준으로 자름
+            int lastSpace = sanitized.lastIndexOf(' ');
+            if (lastSpace > MIN_CLEAN_LENGTH) {
+                sanitized = sanitized.substring(0, lastSpace);
+            }
         }
 
-        return sanitized;
+        return sanitized.trim();
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers("/api/admin/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
@@ -85,10 +85,11 @@ class TitleCleanserTest {
     }
 
     @Test
-    @DisplayName("null은 null, blank는 빈 문자열로 반환한다")
+    @DisplayName("null은 null, blank/공백만 있는 문자열은 빈 문자열로 반환한다")
     void cleanse_nullOrBlank() {
         assertThat(TitleCleanser.cleanse(null)).isNull();
         assertThat(TitleCleanser.cleanse("")).isEqualTo("");
+        assertThat(TitleCleanser.cleanse(" ")).isEqualTo("");
         assertThat(TitleCleanser.cleanse("  ")).isEqualTo("");
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
@@ -1,0 +1,93 @@
+package com.solv.wefin.domain.news.summary.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TitleCleanserTest {
+
+    @Test
+    @DisplayName("[경제D톡스] 접두사를 제거한다")
+    void cleanse_bracketPrefix() {
+        assertThat(TitleCleanser.cleanse("[경제D톡스] 1500원 넘는 고환율 지속"))
+                .isEqualTo("1500원 넘는 고환율 지속");
+    }
+
+    @Test
+    @DisplayName("[기자수첩] 접두사를 제거한다")
+    void cleanse_reporterNote() {
+        assertThat(TitleCleanser.cleanse("[기자수첩] '뉴노멀'이라는 말장난...1400·1500원 환율은 '비정상'이다"))
+                .isEqualTo("'뉴노멀'이라는 말장난...1400·1500원 환율은 '비정상'이다");
+    }
+
+    @Test
+    @DisplayName("[전쟁이 삼킨 증시①] 숫자 기호가 포함된 접두사도 제거한다")
+    void cleanse_bracketWithSymbol() {
+        assertThat(TitleCleanser.cleanse("[전쟁이 삼킨 증시①] 공포 정점 지났나"))
+                .isEqualTo("공포 정점 지났나");
+    }
+
+    @Test
+    @DisplayName("특수 기호 ①②③를 제거한다")
+    void cleanse_specialChars() {
+        assertThat(TitleCleanser.cleanse("반도체 TOP3① 삼성전자 실적"))
+                .isEqualTo("반도체 TOP3 삼성전자 실적");
+    }
+
+    @Test
+    @DisplayName("끝 말줄임표를 제거한다")
+    void cleanse_trailingEllipsis() {
+        assertThat(TitleCleanser.cleanse("불안 부추기는 가짜뉴스까지 기..."))
+                .isEqualTo("불안 부추기는 가짜뉴스까지 기");
+    }
+
+    @Test
+    @DisplayName("시작 말줄임표를 제거한다")
+    void cleanse_leadingEllipsis() {
+        assertThat(TitleCleanser.cleanse("...삼성전자 실적 발표"))
+                .isEqualTo("삼성전자 실적 발표");
+    }
+
+    @Test
+    @DisplayName("연속 공백을 하나로 줄인다")
+    void cleanse_multipleSpaces() {
+        assertThat(TitleCleanser.cleanse("삼성전자   실적   발표"))
+                .isEqualTo("삼성전자 실적 발표");
+    }
+
+    @Test
+    @DisplayName("이미 깨끗한 제목은 그대로 반환한다")
+    void cleanse_alreadyClean() {
+        String clean = "중동발 유가 상승, 인플레이션 우려 확산";
+        assertThat(TitleCleanser.cleanse(clean)).isEqualTo(clean);
+    }
+
+    @Test
+    @DisplayName("null은 null, blank는 빈 문자열로 반환한다")
+    void cleanse_nullOrBlank() {
+        assertThat(TitleCleanser.cleanse(null)).isNull();
+        assertThat(TitleCleanser.cleanse("")).isEqualTo("");
+        assertThat(TitleCleanser.cleanse("  ")).isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("복합 패턴 — 접두사 + 특수기호 + 말줄임표")
+    void cleanse_combined() {
+        assertThat(TitleCleanser.cleanse("[HD포토] ☞ 벚꽃 만개한 정읍천 벚꼴길..."))
+                .isEqualTo("벚꽃 만개한 정읍천 벚꼴길");
+    }
+
+    @Test
+    @DisplayName("10자 미만이면 AI fallback 필요로 판단한다")
+    void needsAiFallback_shortTitle() {
+        assertThat(TitleCleanser.needsAiFallback("미국환율")).isTrue();
+        assertThat(TitleCleanser.needsAiFallback(null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("10자 이상이면 AI fallback 불필요")
+    void needsAiFallback_longEnough() {
+        assertThat(TitleCleanser.needsAiFallback("중동발 유가 상승, 인플레이션 우려 확산")).isFalse();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
@@ -43,9 +43,30 @@ class TitleCleanserTest {
     }
 
     @Test
-    @DisplayName("시작 말줄임표를 제거한다")
+    @DisplayName("시작 말줄임표를 제거한다 (ASCII)")
     void cleanse_leadingEllipsis() {
         assertThat(TitleCleanser.cleanse("...삼성전자 실적 발표"))
+                .isEqualTo("삼성전자 실적 발표");
+    }
+
+    @Test
+    @DisplayName("시작 Unicode 말줄임표를 제거한다")
+    void cleanse_leadingUnicodeEllipsis() {
+        assertThat(TitleCleanser.cleanse("…삼성전자 실적 발표"))
+                .isEqualTo("삼성전자 실적 발표");
+    }
+
+    @Test
+    @DisplayName("끝 Unicode 말줄임표를 제거한다")
+    void cleanse_trailingUnicodeEllipsis() {
+        assertThat(TitleCleanser.cleanse("가짜뉴스까지 기…"))
+                .isEqualTo("가짜뉴스까지 기");
+    }
+
+    @Test
+    @DisplayName("끝 말줄임표 뒤 공백도 함께 제거한다")
+    void cleanse_trailingEllipsisWithSpaces() {
+        assertThat(TitleCleanser.cleanse("삼성전자 실적 발표...  "))
                 .isEqualTo("삼성전자 실적 발표");
     }
 
@@ -130,9 +151,11 @@ class TitleCleanserTest {
     }
 
     @Test
-    @DisplayName("10자 이상이라도 원본이 ...로 끝나면 AI fallback 필요 (절단 감지)")
+    @DisplayName("10자 이상이라도 원본이 말줄임표로 끝나면 AI fallback 필요 (절단 감지)")
     void needsAiFallback_truncatedOriginal() {
         assertThat(TitleCleanser.needsAiFallback("불안 부추기는 가짜뉴스까지 기", "불안 부추기는 가짜뉴스까지 기...")).isTrue();
         assertThat(TitleCleanser.needsAiFallback("삼성전자 실적 발표", "삼성전자 실적 발표…")).isTrue();
+        assertThat(TitleCleanser.needsAiFallback("삼성전자 실적 발표", "삼성전자 실적 발표..")).isTrue();
+        assertThat(TitleCleanser.needsAiFallback("삼성전자 실적 발표", "삼성전자 실적 발표…  ")).isTrue();
     }
 }

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/TitleCleanserTest.java
@@ -79,15 +79,60 @@ class TitleCleanserTest {
     }
 
     @Test
-    @DisplayName("10자 미만이면 AI fallback 필요로 판단한다")
-    void needsAiFallback_shortTitle() {
-        assertThat(TitleCleanser.needsAiFallback("미국환율")).isTrue();
-        assertThat(TitleCleanser.needsAiFallback(null)).isTrue();
+    @DisplayName("[속보][단독] 연속 대괄호 접두사를 모두 제거한다")
+    void cleanse_consecutiveBrackets() {
+        assertThat(TitleCleanser.cleanse("[속보][단독] 삼성전자 1분기 실적 발표"))
+                .isEqualTo("삼성전자 1분기 실적 발표");
     }
 
     @Test
-    @DisplayName("10자 이상이면 AI fallback 불필요")
+    @DisplayName("sanitizeAiTitle — 정상 title은 클렌징 후 반환한다")
+    void sanitizeAiTitle_normal() {
+        assertThat(TitleCleanser.sanitizeAiTitle("삼성전자 1분기 실적, 시장 기대 상회"))
+                .isEqualTo("삼성전자 1분기 실적, 시장 기대 상회");
+    }
+
+    @Test
+    @DisplayName("sanitizeAiTitle — AI가 대괄호를 포함해도 제거된다")
+    void sanitizeAiTitle_withBracket() {
+        assertThat(TitleCleanser.sanitizeAiTitle("[요약] 삼성전자 실적 발표"))
+                .isEqualTo("삼성전자 실적 발표");
+    }
+
+    @Test
+    @DisplayName("sanitizeAiTitle — 50자 초과면 절단한다")
+    void sanitizeAiTitle_truncate() {
+        String longTitle = "삼성전자가 2026년 1분기 영업이익 6조 6천억원을 기록하며 시장 기대를 크게 상회하는 실적을 발표했다";
+        String result = TitleCleanser.sanitizeAiTitle(longTitle);
+        assertThat(result).isNotNull();
+        assertThat(result.length()).isLessThanOrEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("sanitizeAiTitle — null/blank/짧은 결과는 null 반환")
+    void sanitizeAiTitle_invalid() {
+        assertThat(TitleCleanser.sanitizeAiTitle(null)).isNull();
+        assertThat(TitleCleanser.sanitizeAiTitle("")).isNull();
+        assertThat(TitleCleanser.sanitizeAiTitle("짧음")).isNull();
+    }
+
+    @Test
+    @DisplayName("10자 미만이면 AI fallback 필요로 판단한다")
+    void needsAiFallback_shortTitle() {
+        assertThat(TitleCleanser.needsAiFallback("미국환율", "미국환율")).isTrue();
+        assertThat(TitleCleanser.needsAiFallback(null, null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("10자 이상 + 원본에 말줄임표 없으면 AI fallback 불필요")
     void needsAiFallback_longEnough() {
-        assertThat(TitleCleanser.needsAiFallback("중동발 유가 상승, 인플레이션 우려 확산")).isFalse();
+        assertThat(TitleCleanser.needsAiFallback("중동발 유가 상승, 인플레이션 우려 확산", "중동발 유가 상승, 인플레이션 우려 확산")).isFalse();
+    }
+
+    @Test
+    @DisplayName("10자 이상이라도 원본이 ...로 끝나면 AI fallback 필요 (절단 감지)")
+    void needsAiFallback_truncatedOriginal() {
+        assertThat(TitleCleanser.needsAiFallback("불안 부추기는 가짜뉴스까지 기", "불안 부추기는 가짜뉴스까지 기...")).isTrue();
+        assertThat(TitleCleanser.needsAiFallback("삼성전자 실적 발표", "삼성전자 실적 발표…")).isTrue();
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
단독 클러스터(기사 1건)의 경우, 비용을 줄이기 위해 AI를 호출하지 않고 기사 원본 title을 그대로 사용하고 있었습니다.  
그러나 `[경제D톡스]` 같은 언론사 태그, `①②③` 같은 특수 기호, 말줄임표로 잘린 문장이 그대로 노출되는 문제가 있었습니다.

이 문제를 해결하기 위해, 이번 PR에서는 title을 3단계로 정제하도록 개선했습니다.

1. 규칙 기반 클렌징: 간단한 패턴 매칭으로 대부분의 불필요한 요소를 제거합니다.
    - 대괄호로 된 접두사 제거 (예: `[경제D톡스]`)
    - 특수 기호 제거 (예: `①②③`)
    - 말줄임표로 잘린 표현 정리
2. AI fallback
    - 클렌징 이후 title 길이가 10자 미만인 경우에는,  정보가 부족하다고 판단하여 `gpt-4o-mini`를 사용해 title을 다시 생성합니다.
3. 원본 fallback
    - AI 호출이 실패하거나 결과가 비정상적인 경우에는,  최소한의 안전 장치로 원본 title을 그대로 사용합니다. (빈 title이 되는 상황 방지)

**개선 효과**
대부분의 단독 클러스터는 1단계 규칙 기반 클렌징만으로 충분히 정리되기 때문에 AI 호출은 일부 예외적인 경우에만 발생합니다.  따라서 품질은 개선하면서도 비용 증가를 최소화할 수 있었습니다.

<br>

## ✅ 변경 파일
1. `TitleCleanser.java` — 규칙 기반 정제 유틸 (new)
2. `OpenAiSummaryClient.java` — `generateSingleTitle()` + `SINGLE_TITLE_PROMPT` 추가 (modified)
3. `SummaryService.java` — `resolveTitle()` 3단계 fallback 연동 (modified)
4. `TitleCleanserTest.java` — 단위 테스트 12건 (new)


<br>

## 💭 고민과 해결과정
### 1. 전략 선택: D (A + B 조합)
| 전략 | 장점 | 단점 |
|---|---|---|
| A. 규칙만 | 비용 없음, 빠름 | 너무 짧은 제목 같은 경우 처리 어려움 |
| B. AI만 | 품질 좋음 | 모든 경우에 API 호출 → 비용 증가 |
| C. AI로 title + summary | 가장 안정적인 품질 | 비용이 가장 큼 |
| D. A + B 조합 | 규칙 우선 + AI는 일부만 사용 | 코드가 조금 복잡해짐 |

대부분의 경우 규칙 기반으로 충분히 처리할 수 있고 AI는 "미국환율 달러 엔화"처럼 정보가 부족한 극단적인 경우에만 사용하면 된다고 판단했습니다. D 방법을 통하여 비용은 줄이면서도 필요한 경우에는 품질을 보완할 수 있습니다.

### 2. 접두사 대괄호만 제거
`[삼성전자]`처럼 제목 앞에 붙는 대괄호는 제거하되, 본문 중간에 있는 대괄호는 그대로 유지하도록 했습니다. 이를 위해 정규식 `^\\s*\\[.*?]\\s*`를 사용해서 제목 시작 부분의 대괄호만 제거하도록 처리했습니다.


### 3. 중간 말줄임표는 유지
예를 들어 `"뉴노멀"...1400원 환율` 같은 경우, 중간의 `...`은 의미를 담고 있을 수 있기 때문에 유지했습니다. 대신, 제목의 시작이나 끝에 있는 말줄임표만 제거하도록 했습니다.



<br>

### 🔗 관련 이슈
Closes #172 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * AI 단일 제목 생성 기능 추가: 기사 원제와 본문을 바탕으로 단일 제목을 생성해 제공

* **개선**
  * 규칙 기반 제목 정리 → 필요시 AI 보완 순서로 제목 품질 향상
  * AI 출력 검증 및 길이/형식 제한 적용, 실패 시 안전하게 원제 복귀
  * 요약이 없을 때는 정제된(또는 재생성된) 제목을 대체로 사용

* **테스트**
  * 제목 정리·검증·재생성 관련 단위 테스트 추가

* **변경**
  * 일부 관리자 API 접근 허용 규칙 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->