### PR TITLE
[WEF-364] 캔들 생성기 구현 (체결가 → 분봉)

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -129,7 +129,8 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     }
 
     private void sendMessage(String trId, String stockCode, String trType) {
-        if (session == null || !session.isOpen()) {
+        WebSocketSession s = this.session;
+        if (s == null || !s.isOpen()) {
             log.warn("한투 웹소켓 미연결 상태. 메시지 전송 스킵: {}", stockCode);
             return;
         }
@@ -150,7 +151,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
                     )
             );
 
-            session.sendMessage(new TextMessage(objectMapper.writeValueAsString(message)));
+            s.sendMessage(new TextMessage(objectMapper.writeValueAsString(message)));
         } catch (Exception e) {
             log.error("한투 웹소켓 메시지 전송 실패: {}", stockCode, e);
         }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
+import com.solv.wefin.domain.trading.market.service.CandleGenerator;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -48,6 +49,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private final SimpMessagingTemplate messagingTemplate;
     private final MarketService marketService;
     private final Set<String> subscribedStocks = ConcurrentHashMap.newKeySet();
+    private final CandleGenerator candleGenerator;
 
     // 한투 WS에 연결
     @EventListener(ApplicationReadyEvent.class)
@@ -179,6 +181,13 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
                         fields[offset + 21]                       // tradeSide
                 );
                 messagingTemplate.convertAndSend("/topic/stocks/" + response.stockCode(), response);
+
+                candleGenerator.onTrade(
+                        response.stockCode(),
+                        response.currentPrice(),
+                        response.tradeVolume(),
+                        response.tradeTime()
+                );
 
                 PriceResponse priceResponse = new PriceResponse(
                         fields[offset],

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/MinuteCandleResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/MinuteCandleResponse.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record MinuteCandleResponse(
+        WebSocketMessageType type,
+        String stockCode,
+        LocalDateTime time,
+        BigDecimal openPrice,
+        BigDecimal highPrice,
+        BigDecimal lowPrice,
+        BigDecimal closePrice,
+        long volume
+) {}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/WebSocketMessageType.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/WebSocketMessageType.java
@@ -2,5 +2,6 @@ package com.solv.wefin.domain.trading.market.dto;
 
 public enum WebSocketMessageType {
     TRADE,
-    ORDERBOOK
+    ORDERBOOK,
+    CANDLE
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -1,0 +1,92 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.dto.MinuteCandleResponse;
+import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CandleGenerator {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    // 종목별 현재 생성중인 분봉
+    private final ConcurrentHashMap<String, MinuteCandleData> currentCandles = new ConcurrentHashMap<>();
+
+    // 체결가 수신 시 호출
+    public void onTrade(String stockCode, BigDecimal price, long volume, String tradeTime) {
+        // tradeTime "112654" → 분 키 "1126" 추출
+        String minuteKey = tradeTime.substring(0, 4);
+
+        // onTrade 시작: 체결 수신 확인
+        // log.debug("캔들 체결 수신: {} price={} minute={}", stockCode, price, minuteKey);
+
+        currentCandles.compute(stockCode, (key, existing) -> {
+            if (existing == null || !existing.minuteKey.equals(minuteKey)) {
+                if (existing != null) {
+                    pushCandle(stockCode, existing);
+                }
+                return new MinuteCandleData(minuteKey, price, price, price, price, volume);
+            }
+
+            existing.update(price, volume);
+            return existing;
+        });
+    }
+
+    private void pushCandle(String stockCode, MinuteCandleData data) {
+        // pushCandle: 분봉 확정 push
+        log.info("분봉 확정 push: {} time={} O={} H={} L={} C={} V={}",
+                stockCode, data.minuteKey, data.open, data.high, data.low, data.close, data.volume);
+
+        // "1126" → 오늘 날짜 11:26:00
+        LocalDateTime time = LocalDate.now()
+                .atTime(Integer.parseInt(data.minuteKey.substring(0, 2)),
+                        Integer.parseInt(data.minuteKey.substring(2, 4)));
+
+        MinuteCandleResponse response = new MinuteCandleResponse(
+                WebSocketMessageType.CANDLE,
+                stockCode,
+                time,
+                data.open, data.high, data.low, data.close,
+                data.volume
+        );
+        messagingTemplate.convertAndSend("/topic/stocks/" + stockCode + "/candle", response);
+    }
+
+
+    // 분봉 데이터를 담는 내부 클래스
+    private static class MinuteCandleData {
+        String minuteKey;  // "1126"
+        BigDecimal open, high, low, close;
+        long volume;
+
+        MinuteCandleData(String minuteKey, BigDecimal open, BigDecimal high, BigDecimal low,
+                         BigDecimal close, long volume) {
+            this.minuteKey = minuteKey;
+            this.open = open;
+            this.high = high;
+            this.low = low;
+            this.close = close;
+            this.volume = volume;
+        }
+
+        void update(BigDecimal price, long tradeVolume) {
+            if (price.compareTo(high) > 0) high = price;
+            if (price.compareTo(low) < 0) low = price;
+            close = price;
+            volume += tradeVolume;
+        }
+
+    }
+}
+

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
 @Service
@@ -36,12 +37,12 @@ public class CandleGenerator {
         // onTrade 시작: 체결 수신 확인
         // log.debug("캔들 체결 수신: {} price={} minute={}", stockCode, price, minuteKey);
 
-        final MinuteCandleData[] toPush = {null};
+        final AtomicReference<MinuteCandleData> toPush = new AtomicReference<>();
 
         currentCandles.compute(stockCode, (key, existing) -> {
             if (existing == null || !existing.minuteKey.equals(minuteKey)) {
                 if (existing != null) {
-                    toPush[0] = existing;
+                    toPush.set(existing);
                 }
                 return new MinuteCandleData(minuteKey, price, price, price, price, volume);
             }
@@ -49,8 +50,8 @@ public class CandleGenerator {
             return existing;
         });
 
-        if (toPush[0] != null) {
-            pushCandle(stockCode, toPush[0]);
+        if (toPush.get() != null) {
+            pushCandle(stockCode, toPush.get());
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -24,7 +25,7 @@ public class CandleGenerator {
 
     // 체결가 수신 시 호출
     public void onTrade(String stockCode, BigDecimal price, long volume, String tradeTime) {
-        if (tradeTime == null || tradeTime.length() < 4) {
+        if (tradeTime == null || tradeTime.length() < 4 || !tradeTime.substring(0, 4).matches("\\d{4}")) {
             log.warn("유효하지 않은 tradeTime: stockCode={}, tradeTime={}", stockCode, tradeTime);
             return;
         }
@@ -58,7 +59,7 @@ public class CandleGenerator {
                 stockCode, data.minuteKey, data.open, data.high, data.low, data.close, data.volume);
 
         // "1126" → 오늘 날짜 11:26:00
-        LocalDateTime time = LocalDate.now()
+        LocalDateTime time = LocalDate.now(ZoneId.of("Asia/Seoul"))
                 .atTime(Integer.parseInt(data.minuteKey.substring(0, 2)),
                         Integer.parseInt(data.minuteKey.substring(2, 4)));
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -73,7 +74,6 @@ public class CandleGenerator {
         messagingTemplate.convertAndSend("/topic/stocks/" + stockCode + "/candle", response);
     }
 
-
     // 분봉 데이터를 담는 내부 클래스
     private static class MinuteCandleData {
         String minuteKey;  // "1126"
@@ -96,7 +96,14 @@ public class CandleGenerator {
             close = price;
             volume += tradeVolume;
         }
+    }
 
+    @Scheduled(cron = "0 30 15 * * MON-FRI", zone = "Asia/Seoul")
+    public void flushAll() {
+        log.info("장 마감 분봉 flush 시작");
+        currentCandles.forEach((stockCode, data) -> {
+            pushCandle(stockCode, data);
+        });
+        currentCandles.clear();
     }
 }
-

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -24,6 +24,10 @@ public class CandleGenerator {
 
     // 체결가 수신 시 호출
     public void onTrade(String stockCode, BigDecimal price, long volume, String tradeTime) {
+        if (tradeTime == null || tradeTime.length() < 4) {
+            log.warn("유효하지 않은 tradeTime: stockCode={}, tradeTime={}", stockCode, tradeTime);
+            return;
+        }
         // tradeTime "112654" → 분 키 "1126" 추출
         String minuteKey = tradeTime.substring(0, 4);
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -34,17 +34,22 @@ public class CandleGenerator {
         // onTrade 시작: 체결 수신 확인
         // log.debug("캔들 체결 수신: {} price={} minute={}", stockCode, price, minuteKey);
 
+        final MinuteCandleData[] toPush = {null};
+
         currentCandles.compute(stockCode, (key, existing) -> {
             if (existing == null || !existing.minuteKey.equals(minuteKey)) {
                 if (existing != null) {
-                    pushCandle(stockCode, existing);
+                    toPush[0] = existing;
                 }
                 return new MinuteCandleData(minuteKey, price, price, price, price, volume);
             }
-
             existing.update(price, volume);
             return existing;
         });
+
+        if (toPush[0] != null) {
+            pushCandle(stockCode, toPush[0]);
+        }
     }
 
     private void pushCandle(String stockCode, MinuteCandleData data) {

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**", "/api/stocks/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/WebSocketConfig.java
@@ -1,13 +1,18 @@
 package com.solv.wefin.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSocketMessageBroker
@@ -17,6 +22,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
     private final WebSocketProperties webSocketProperties;
+    private final ObjectMapper objectMapper;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
@@ -37,5 +43,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
         registration.interceptors(stompAuthChannelInterceptor);
+    }
+
+    @Override
+    public boolean configureMessageConverters(List<MessageConverter> messageConverters) {
+        MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+        converter.setObjectMapper(objectMapper);
+        messageConverters.add(converter);
+        return false;
     }
 }

--- a/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
+import com.solv.wefin.domain.trading.market.service.CandleGenerator;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,8 @@ class HantuWebSocketClientTest {
     private MarketService marketService;
     @Mock
     private WebSocketSession session;
+    @Mock
+    private CandleGenerator candleGenerator;
 
     private HantuWebSocketClient client;
 
@@ -45,7 +48,8 @@ class HantuWebSocketClientTest {
                 hantuWebSocketKeyManager,
                 objectMapper,
                 messagingTemplate,
-                marketService
+                marketService,
+                candleGenerator
         );
     }
 


### PR DESCRIPTION
## 📌 PR 설명
실시간 체결 데이터를 기반으로 1분봉을 생성하여 WebSocket으로 클라이언트에 push하는 기능을 구현합니다.
한투 WebSocket에서 체결이 수신될 때마다 CandleGenerator가 분 단위로 OHLCV를 집계하고, 분이 전환되면 이전 분봉을 확정하여 전송합니다.

> `/api/stocks/{code}/candles`에 분봉 interval을 추가하는 작업은, /stocks-detail 페이지 구현 시 진행 예정

<br>

## ✅ 완료한 기능 명세

- [x] CandleGenerator ㅡ 1분 단위 open/high/low/close/volume 집계 (tradeTime 기준)
- [x] HantuWebSocketClient ㅡ candleGenerator.onTrade() 호출 연결
- [x] WebSocketClient ㅡ 'CANDLE' enum 도입
- [x] 분봉 완성 시 클라이언트 push (CANDLE 타입)
- [x] SecurityConfig ㅡ `/api/stocks/**` 경로 permitAll 설정

<br>

## 📸 스크린샷
<img width="1872" height="151" alt="image" src="https://github.com/user-attachments/assets/0d83e4a4-efb7-4d23-9fa2-6f0cbe933a02" />

<br>

## 💭 고민과 해결과정

### 1. 동시성 환경에서 락 점유 시간 최소화
ConcurrentHashMap.compute()는 실행 중 해당 버킷에 락을 잡는데, 초기 구현에서는 그 안에서messagingTemplate.convertAndSend()(네트워크 I/O)를 호출하고 있었습니다. 
I/O 지연만큼 락이 유지되어 같은 종목의 후속 체결 처리가 블로킹되는 문제가 있어, push할 캔들 데이터를 compute() 내부에서 캡처만 하고 외부에서 전송하는 구조로 분리했습니다.

### 2. 외부 API 데이터 경계 검증
한투 API에서 수신되는 tradeTime에 substring(0, 4)를 바로 호출하면 비정상 데이터에서 StringIndexOutOfBoundsException이 발생할 수 있습니다. 
실시간 스트리밍 특성상 단건 오류로 전체 시세 수신이 중단되면 안 되므로, 예외를 던지는 대신 경고 로그를 남기고 해당 건만 skip하도록 처리했습니다.

### 3. WebSocket 메시지의 LocalDateTime 직렬화
MinuteCandleResponse의 LocalDateTime 필드가 WebSocket 전송 시 숫자 배열로 직렬화되는 문제가 있었습니다. 
Spring Boot가 REST용 ObjectMapper에는 JavaTimeModule을 자동 등록하지만 WebSocket 메시지 컨버터에는 적용되지 않아, WebSocketConfig에서 configureMessageConverters()를 오버라이드하여 기존 ObjectMapper 빈을 주입받도록 설정했습니다.

<br>

### 🔗 관련 이슈
Closes #73

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 실시간 거래를 집계해 분 단위 캔들(분봉)을 생성하고 종목별로 분봉을 WebSocket으로 스트리밍 제공
  * WebSocket 메시지 유형에 분봉(CANDLE) 추가

* **개선 사항**
  * 공개 API 엔드포인트(/api/stocks/**)에 대한 인증 없이 접근 가능
  * WebSocket 메시지 직렬화가 지정된 매퍼로 통일되어 클라이언트 수신 형식 안정화

* **테스트**
  * 분봉 생성 연동을 반영해 관련 테스트 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->