### PR TITLE
[WEF-380] 최근 체결내역, 체결강도 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.trading.market.client;
 import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -92,5 +93,20 @@ public class HantuMarketClient {
                 .header("tr_id", "FHKST03010100")
                 .header("custtype", "P")
                 .retrieve().body(HantuCandleApiResponse.class);
+    }
+
+    public HantuRecentTradeApiResponse fetchRecentTrades(String stockCode) {
+        return hantuRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-ccnl")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .build())
+                .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST01010300")
+                .header("custtype", "P")
+                .retrieve().body(HantuRecentTradeApiResponse.class);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuRecentTradeApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuRecentTradeApiResponse.java
@@ -3,8 +3,16 @@ package com.solv.wefin.domain.trading.market.client.dto;
 import java.util.List;
 
 public record HantuRecentTradeApiResponse(
+        Output1 output1,
         List<Output> output
 ) {
+
+    public record Output1(
+        String rt_cd,
+        String msg_cd,
+        String msg1
+    ) {}
+
     public record Output(
             String stck_cntg_hour,   // 체결 시간
             String stck_prpr,        // 체결가

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuRecentTradeApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuRecentTradeApiResponse.java
@@ -1,0 +1,17 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import java.util.List;
+
+public record HantuRecentTradeApiResponse(
+        List<Output> output
+) {
+    public record Output(
+            String stck_cntg_hour,   // 체결 시간
+            String stck_prpr,        // 체결가
+            String prdy_vrss,        // 전일 대비
+            String prdy_vrss_sign,   // 전일 대비 부호
+            String cntg_vol,         // 체결 수량
+            String tday_rltv,        // 체결강도
+            String prdy_ctrt         // 전일 대비율
+    ) {}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/CandleResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/CandleResponse.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.trading.market.dto;
 
 import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
+import com.solv.wefin.global.util.ParseUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -17,20 +18,11 @@ public record CandleResponse(
     public static CandleResponse from(HantuCandleApiResponse.Output2 output2) {
         return new CandleResponse(
                 LocalDate.parse(output2.stck_bsop_date(), DateTimeFormatter.ofPattern("yyyyMMdd")),
-                parseBigDecimal(output2.stck_oprc()),
-                parseBigDecimal(output2.stck_hgpr()),
-                parseBigDecimal(output2.stck_lwpr()),
-                parseBigDecimal(output2.stck_clpr()),
-                parseLong(output2.acml_vol())
+                ParseUtils.parseBigDecimal(output2.stck_oprc()),
+                ParseUtils.parseBigDecimal(output2.stck_hgpr()),
+                ParseUtils.parseBigDecimal(output2.stck_lwpr()),
+                ParseUtils.parseBigDecimal(output2.stck_clpr()),
+                ParseUtils.parseLong(output2.acml_vol())
         );
     }
-
-    private static BigDecimal parseBigDecimal(String value) {
-        return new BigDecimal(value == null || value.isBlank() ? "0" : value);
-    }
-
-    private static Long parseLong(String value) {
-        return value == null || value.isBlank() ? 0L : Long.parseLong(value);
-    }
-
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/CandleResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/CandleResponse.java
@@ -26,11 +26,11 @@ public record CandleResponse(
     }
 
     private static BigDecimal parseBigDecimal(String value) {
-        return new BigDecimal(value.isBlank() ? "0" : value);
+        return new BigDecimal(value == null || value.isBlank() ? "0" : value);
     }
 
     private static Long parseLong(String value) {
-        return value.isBlank() ? 0L : Long.parseLong(value);
+        return value == null || value.isBlank() ? 0L : Long.parseLong(value);
     }
 
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/RecentTradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/RecentTradeResponse.java
@@ -16,12 +16,24 @@ public record RecentTradeResponse(
     public static RecentTradeResponse from(HantuRecentTradeApiResponse.Output output) {
         return new RecentTradeResponse(
                 output.stck_cntg_hour(),
-                new BigDecimal(output.stck_prpr()),
-                new BigDecimal(output.prdy_vrss()),
+                parseBigDecimal(output.stck_prpr()),
+                parseBigDecimal(output.prdy_vrss()),
                 output.prdy_vrss_sign(),
-                Float.parseFloat(output.prdy_ctrt()),
-                Long.parseLong(output.cntg_vol()),
-                Float.parseFloat(output.tday_rltv())
+                parseFloat(output.prdy_ctrt()),
+                parseLong(output.cntg_vol()),
+                parseFloat(output.tday_rltv())
         );
+    }
+
+    private static BigDecimal parseBigDecimal(String value) {
+        return new BigDecimal(value == null || value.isBlank() ? "0" : value);
+    }
+
+    private static Long parseLong(String value) {
+        return value == null || value.isBlank() ? 0L : Long.parseLong(value);
+    }
+
+    private static float parseFloat(String value) {
+        return value == null || value.isBlank() ? 0F : Float.parseFloat(value);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/RecentTradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/RecentTradeResponse.java
@@ -1,0 +1,27 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
+
+import java.math.BigDecimal;
+
+public record RecentTradeResponse(
+        String tradeTime,
+        BigDecimal price,
+        BigDecimal changePrice,
+        String changeSign,
+        float changeRate,
+        long volume,
+        float tradeStrength
+) {
+    public static RecentTradeResponse from(HantuRecentTradeApiResponse.Output output) {
+        return new RecentTradeResponse(
+                output.stck_cntg_hour(),
+                new BigDecimal(output.stck_prpr()),
+                new BigDecimal(output.prdy_vrss()),
+                output.prdy_vrss_sign(),
+                Float.parseFloat(output.prdy_ctrt()),
+                Long.parseLong(output.cntg_vol()),
+                Float.parseFloat(output.tday_rltv())
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/RecentTradeResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/RecentTradeResponse.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.trading.market.dto;
 
 import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
+import com.solv.wefin.global.util.ParseUtils;
 
 import java.math.BigDecimal;
 
@@ -16,24 +17,12 @@ public record RecentTradeResponse(
     public static RecentTradeResponse from(HantuRecentTradeApiResponse.Output output) {
         return new RecentTradeResponse(
                 output.stck_cntg_hour(),
-                parseBigDecimal(output.stck_prpr()),
-                parseBigDecimal(output.prdy_vrss()),
+                ParseUtils.parseBigDecimal(output.stck_prpr()),
+                ParseUtils.parseBigDecimal(output.prdy_vrss()),
                 output.prdy_vrss_sign(),
-                parseFloat(output.prdy_ctrt()),
-                parseLong(output.cntg_vol()),
-                parseFloat(output.tday_rltv())
+                ParseUtils.parseFloat(output.prdy_ctrt()),
+                ParseUtils.parseLong(output.cntg_vol()),
+                ParseUtils.parseFloat(output.tday_rltv())
         );
-    }
-
-    private static BigDecimal parseBigDecimal(String value) {
-        return new BigDecimal(value == null || value.isBlank() ? "0" : value);
-    }
-
-    private static Long parseLong(String value) {
-        return value == null || value.isBlank() ? 0L : Long.parseLong(value);
-    }
-
-    private static float parseFloat(String value) {
-        return value == null || value.isBlank() ? 0F : Float.parseFloat(value);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -176,9 +176,21 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     public List<RecentTradeResponse> getRecentTrades(String stockCode) {
         validateStockCode(stockCode);
 
-        List<HantuRecentTradeApiResponse.Output> outputs = hantuMarketClient.fetchRecentTrades(stockCode).output();
+        HantuRecentTradeApiResponse response = hantuMarketClient.fetchRecentTrades(stockCode);
 
-        return outputs.stream()
+        if (response == null) {
+            return List.of();
+        }
+
+        if (response.output1() != null && response.output1().rt_cd() != null && !"0".equals(response.output1().rt_cd())) {
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+
+        if (response.output() == null) {
+            return List.of();
+        }
+
+        return response.output().stream()
                 .map(RecentTradeResponse::from)
                 .toList();
     }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -5,10 +5,12 @@ import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
 import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
 import com.solv.wefin.domain.trading.market.dto.CandleResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
+import com.solv.wefin.domain.trading.market.dto.RecentTradeResponse;
 import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -169,6 +171,16 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
                     .map(CandleResponse::from)
                     .toList();
 
+    }
+
+    public List<RecentTradeResponse> getRecentTrades(String stockCode) {
+        validateStockCode(stockCode);
+
+        List<HantuRecentTradeApiResponse.Output> outputs = hantuMarketClient.fetchRecentTrades(stockCode).output();
+
+        return outputs.stream()
+                .map(RecentTradeResponse::from)
+                .toList();
     }
 
     private void validateStockCode(String stockCode) {

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -157,10 +157,8 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         }
 
         // 한투 API 응답 코드 검증 (rt_cd "0"이면 정상)
-        if (response.output1() != null && response.output1().rt_cd()
-                != null
-                && !"0".equals(response.output1().rt_cd())) {
-            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        if (response.output1() != null) {
+            validateRtCode(response.output1().rt_cd());
         }
 
         if (response.output2() == null) {
@@ -182,8 +180,8 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             return List.of();
         }
 
-        if (response.output1() != null && response.output1().rt_cd() != null && !"0".equals(response.output1().rt_cd())) {
-            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        if (response.output1() != null) {
+            validateRtCode(response.output1().rt_cd());
         }
 
         if (response.output() == null) {
@@ -204,5 +202,11 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     public void updatePriceCache(String stockCode, PriceResponse response) {
         priceCache.put(stockCode, response);
         priceCacheTimestamp.put(stockCode, System.currentTimeMillis());
+    }
+
+    private void validateRtCode(String rtCd) {
+        if (rtCd != null && !"0".equals(rtCd)) {
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/global/util/ParseUtils.java
+++ b/src/main/java/com/solv/wefin/global/util/ParseUtils.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.global.util;
+
+import java.math.BigDecimal;
+
+public class ParseUtils {
+
+    private ParseUtils() {}
+
+    public static BigDecimal parseBigDecimal(String value) {
+        return new BigDecimal(value == null || value.isBlank() ? "0" : value);
+    }
+
+    public static long parseLong(String value) {
+        return value == null || value.isBlank() ? 0L : Long.parseLong(value);
+    }
+
+    public static float parseFloat(String value) {
+        return value == null || value.isBlank() ? 0f : Float.parseFloat(value);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
+++ b/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.trading.market;
 import com.solv.wefin.domain.trading.market.dto.CandleResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
+import com.solv.wefin.domain.trading.market.dto.RecentTradeResponse;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import com.solv.wefin.domain.trading.stock.dto.StockSearchResponse;
 import com.solv.wefin.domain.trading.stock.service.StockService;
@@ -47,4 +48,10 @@ public class MarketController {
             @RequestParam String periodCode) {
         return ApiResponse.success(marketService.getCandles(code, start, end, periodCode));
     }
+
+    @GetMapping("/{code}/trades/recent")
+    public ApiResponse<List<RecentTradeResponse>> getRecentTrades(@PathVariable String code) {
+        return ApiResponse.success(marketService.getRecentTrades(code));
+    }
+
 }

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
@@ -144,7 +144,7 @@ class MarketServiceTest {
         // given
         given(stockService.existsByCode("005930")).willReturn(true);
         given(hantuMarketClient.fetchRecentTrades("005930")).willReturn(
-                new HantuRecentTradeApiResponse(List.of(
+                new HantuRecentTradeApiResponse(null, List.of(
                         new HantuRecentTradeApiResponse.Output(
                                 "104610", "97500", "1200", "2", "1", "106.78", "1.25"
                         ),

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
@@ -163,4 +163,47 @@ class MarketServiceTest {
         assertThat(result.get(0).tradeStrength()).isEqualTo(106.78f);
         assertThat(result.get(1).tradeTime()).isEqualTo("104611");
     }
+
+    /**
+     * 정상 응답 (rt_cd = "0"):
+     */
+    @Test
+    void 최근체결_정상응답코드_조회() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchRecentTrades("005930")).willReturn(
+                new HantuRecentTradeApiResponse(
+                        new HantuRecentTradeApiResponse.Output1("0", "KIOK0530", "정상처리"),
+                        List.of(
+                                new HantuRecentTradeApiResponse.Output(
+                                        "104610", "97500", "1200", "2", "1", "106.78", "1.25"
+                                )
+                        ))
+        );
+
+        // when
+        List<RecentTradeResponse> result = marketService.getRecentTrades("005930");
+
+        // then
+        assertThat(result).hasSize(1);
+    }
+
+    /**
+     * 에러 응답 (rt_cd != "0"):
+     */
+    @Test
+    void 최근체결_API에러시_예외발생() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchRecentTrades("005930")).willReturn(
+                new HantuRecentTradeApiResponse(
+                        new HantuRecentTradeApiResponse.Output1("1", "KIOK0000", "오류 발생"),
+                                List.of()
+                        )
+                );
+
+        // when & then
+        assertThatThrownBy(() -> marketService.getRecentTrades("005930"))
+                .isInstanceOf(BusinessException.class);
+    }
 }

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
@@ -1,0 +1,166 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
+import com.solv.wefin.domain.trading.market.dto.PriceResponse;
+import com.solv.wefin.domain.trading.market.dto.RecentTradeResponse;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MarketServiceTest {
+
+    @Mock
+    private HantuMarketClient hantuMarketClient;
+
+    @Mock
+    private StockService stockService;
+
+    @InjectMocks
+    private MarketService marketService;
+
+
+    // === getPrice 테스트 ===
+
+    @Test
+    void 현재가_정상조회() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchCurrentPrice("005930")).willReturn(
+                new HantuPriceApiResponse(new HantuPriceApiResponse.Output(
+                        "97500", "1200", "2", "1.25",
+                        "12340567", "1200000000000",
+                        "96800", "98200", "96300",
+                        "126700", "68100",
+                        "15.2", "1.8", "580000000"
+                ))
+        );
+
+        // when
+        PriceResponse result = marketService.getPrice("005930");
+
+        // then
+        assertThat(result.currentPrice()).isEqualTo(97500);
+        assertThat(result.stockCode()).isEqualTo("005930");
+    }
+
+    @Test
+    void 현재가_캐시히트시_API_호출안함() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchCurrentPrice("005930")).willReturn(
+                new HantuPriceApiResponse(new HantuPriceApiResponse.Output(
+                        "97500", "1200", "2", "1.25",
+                        "12340567", "1200000000000",
+                        "96800", "98200", "96300",
+                        "126700", "68100",
+                        "15.2", "1.8", "580000000"
+                ))
+        );
+
+        // when
+        marketService.getPrice("005930"); // 첫 호출 — API 호출
+        marketService.getPrice("005930"); // 두 번째 — 캐시 히트
+
+        // then
+        verify(hantuMarketClient, times(1)).fetchCurrentPrice("005930");
+    }
+
+    @Test
+    void 존재하지_않는_종목코드로_현재가_조회시_예외() {
+        // given
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> marketService.getPrice("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+
+
+    // === getCandles 테스트 ===
+
+    @Test
+    void 캔들_시작일이_종료일보다_늦으면_예외() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> marketService.getCandles(
+                "005930", LocalDate.of(2026, 4, 10), LocalDate.of(2026, 4, 1), "D"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_INVALID_DATE);
+    }
+
+    @Test
+    void 유효하지_않은_기간코드로_캔들_조회시_예외() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> marketService.getCandles(
+                "005930", LocalDate.of(2026, 4, 1), LocalDate.of(2026, 4, 10), "X"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_INVALID_PERIOD_CODE);
+    }
+
+
+
+    // === getRecentTrades 테스트 ===
+
+        @Test
+    void 존재하지_않는_종목코드로_최근체결_조회시_예외() {
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        assertThatThrownBy(() -> marketService.getRecentTrades("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+    @Test
+    void 최근체결_정상조회() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchRecentTrades("005930")).willReturn(
+                new HantuRecentTradeApiResponse(List.of(
+                        new HantuRecentTradeApiResponse.Output(
+                                "104610", "97500", "1200", "2", "1", "106.78", "1.25"
+                        ),
+                        new HantuRecentTradeApiResponse.Output(
+                                "104611", "97600", "1300", "2", "3", "106.80", "1.32"
+                        )
+                ))
+        );
+
+        // when
+        List<RecentTradeResponse> result = marketService.getRecentTrades("005930");
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).price()).isEqualByComparingTo(new BigDecimal("97500"));
+        assertThat(result.get(0).tradeStrength()).isEqualTo(106.78f);
+        assertThat(result.get(1).tradeTime()).isEqualTo("104611");
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
체결강도, 매수/매도(판매대기/구매대기) 비율, 최근 체결 내역 API를 구현했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] GET /api/stocks/{code}/trades/recent — 최근 체결 내역 + 체결강도 조회
- [x] 한투 REST API (FHKST01010300) 연동
- [x] HantuRecentTradeApiResponse DTO + RecentTradeResponse 팩토리 메서드
- [x] MarketService 단위 테스트 (최근 체결, 현재가 캐싱, 캔들 검증)
- [x] 구매대기/판매대기 비율은 기존 OrderbookResponse의 totalAskQuantity/totalBidQuantity로 프론트에서 계산

<br>

## 📸 스크린샷
<img width="1820" height="294" alt="image" src="https://github.com/user-attachments/assets/8a42560d-8fec-4da6-9f4b-ee2b518666b6" />


<br>

## 💭 고민과 해결과정

### **1. 체결강도를 별도 API로 분리하지 않은 이유**
  체결강도(tradeStrength)는 한투 최근 체결 API(FHKST01010300) 응답에 이미 포함되어 있다. 
별도 엔드포인트를 만들면 같은 한투 API를 중복 호출하게 되므로, trades/recent 응답에 포함시키고 프론트에서 data[0].tradeStrength로 접근하는 방식을 선택했다.

###   **2. 매수/매도 비율은 호가 데이터 활용**
토스증권의 판매대기/구매대기 비율은 체결 건수가 아닌 호가 잔량 기반이다. 
이미 WebSocket으로 실시간 push 중인 OrderbookResponse에 totalAskQuantity/totalBidQuantity가 있으므로, 
프론트에서 비율을 계산하면 되어 백엔드 추가 작업이 불필요했다.

###   **3. 가격 필드는 BigDecimal, 비율 필드는 float**
프로젝트에서 가격(price, changePrice)은 BigDecimal을 사용하고, 비율(changeRate, tradeStrength)은 float를 사용한다. 
금액 계산의 정밀도가 중요한 필드와 표시용 비율 필드를 구분하여 적용했다.

<br>

### 🔗 관련 이슈
Closes #158 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 특정 종목의 최근 체결 목록을 반환하는 공개 API 엔드포인트 추가 (체결시간, 가격, 변동가/부호, 변동률, 거래량, 강도 포함).

* **버그 수정**
  * 숫자 파싱의 null/빈값 처리 개선으로 안정성 향상.

* **리팩터**
  * 공통 숫자 파싱 로직을 중앙 유틸로 통합해 중복 제거 및 일관성 확보.

* **테스트**
  * 시장 관련 서비스의 단위 테스트 확대(가격, 캔들, 최근 체결 경로 및 오류 처리 포함).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->