### PR TITLE
[WEF-529] 뉴스 클러스터 피드 목록 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -14,6 +14,20 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
     boolean existsByDedupKey(String dedupKey);
 
     /**
+     * 출처 표시용 — 엔티티 전체가 아닌 publisherName + originalUrl만 조회한다.
+     * content(TEXT) 등 불필요한 대용량 컬럼 로딩을 방지.
+     */
+    @Query("SELECT a.id AS id, a.publisherName AS publisherName, a.originalUrl AS originalUrl " +
+            "FROM NewsArticle a WHERE a.id IN :ids")
+    List<SourceProjection> findSourceInfoByIdIn(@Param("ids") List<Long> ids);
+
+    interface SourceProjection {
+        Long getId();
+        String getPublisherName();
+        String getOriginalUrl();
+    }
+
+    /**
      * 재판정 가능한 PENDING 기사를 id 오름차순으로 조회한다.
      */
     @Query("SELECT a FROM NewsArticle a " +

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
@@ -15,6 +15,12 @@ public interface NewsArticleTagRepository extends JpaRepository<NewsArticleTag, 
     List<NewsArticleTag> findByNewsArticleIdIn(List<Long> newsArticleIds);
 
     /**
+     * 여러 기사의 특정 타입 태그만 조회한다.
+     * 피드에서 STOCK 태그만 필요할 때 전체 조회 후 Java 필터링 대신 DB에서 필터링.
+     */
+    List<NewsArticleTag> findByNewsArticleIdInAndTagType(List<Long> newsArticleIds, NewsArticleTag.TagType tagType);
+
+    /**
      * 특정 기사의 태그를 전부 삭제한다. 재태깅 시 기존 태그 정리에 사용한다.
      */
     void deleteByNewsArticleId(Long newsArticleId);

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterFeedback.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterFeedback.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "user_news_cluster_feedback",
         uniqueConstraints = @UniqueConstraint(
-                name = "uk_user_news_cluster_feedback",
+                name = "uk_user_news_cluster_feedback_user_cluster",
                 columnNames = {"user_id", "news_cluster_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterFeedback.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterFeedback.java
@@ -1,0 +1,50 @@
+package com.solv.wefin.domain.news.cluster.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_news_cluster_feedback",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_news_cluster_feedback",
+                columnNames = {"user_id", "news_cluster_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNewsClusterFeedback {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_news_cluster_feedback_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "news_cluster_id", nullable = false)
+    private Long newsClusterId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "feedback_type", nullable = false, length = 20)
+    private FeedbackType feedbackType;
+
+    @Column(name = "submitted_at", nullable = false)
+    private OffsetDateTime submittedAt;
+
+    public enum FeedbackType {
+        HELPFUL, NOT_HELPFUL
+    }
+
+    public static UserNewsClusterFeedback create(UUID userId, Long newsClusterId, FeedbackType feedbackType) {
+        UserNewsClusterFeedback feedback = new UserNewsClusterFeedback();
+        feedback.userId = userId;
+        feedback.newsClusterId = newsClusterId;
+        feedback.feedbackType = feedbackType;
+        feedback.submittedAt = OffsetDateTime.now();
+        return feedback;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterRead.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterRead.java
@@ -1,0 +1,41 @@
+package com.solv.wefin.domain.news.cluster.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_news_cluster_read",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_news_cluster_read",
+                columnNames = {"user_id", "news_cluster_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNewsClusterRead {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_news_cluster_read_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "news_cluster_id", nullable = false)
+    private Long newsClusterId;
+
+    @Column(name = "read_at", nullable = false)
+    private OffsetDateTime readAt;
+
+    public static UserNewsClusterRead create(UUID userId, Long newsClusterId) {
+        UserNewsClusterRead read = new UserNewsClusterRead();
+        read.userId = userId;
+        read.newsClusterId = newsClusterId;
+        read.readAt = OffsetDateTime.now();
+        return read;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterRead.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/UserNewsClusterRead.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Entity
 @Table(name = "user_news_cluster_read",
         uniqueConstraints = @UniqueConstraint(
-                name = "uk_user_news_cluster_read",
+                name = "uk_user_news_cluster_read_user_cluster",
                 columnNames = {"user_id", "news_cluster_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterArticleRepository.java
@@ -19,6 +19,11 @@ public interface NewsClusterArticleRepository extends JpaRepository<NewsClusterA
     List<NewsClusterArticle> findByNewsClusterIdOrderByCreatedAtDesc(Long newsClusterId, Pageable pageable);
 
     /**
+     * 여러 클러스터의 소속 기사 매핑을 일괄 조회한다.
+     */
+    List<NewsClusterArticle> findByNewsClusterIdIn(List<Long> newsClusterIds);
+
+    /**
      * 특정 클러스터의 소속 기사 수를 조회한다.
      */
     int countByNewsClusterId(Long newsClusterId);

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -30,10 +30,8 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
                                                      List<NewsCluster.SummaryStatus> statuses,
                                                      Pageable pageable);
 
-    /**
-     * 피드 목록용 커서 기반 페이지네이션.
-     * ACTIVE + 요약 완료(GENERATED/STALE) 클러스터를 최신순으로 조회한다.
-     */
+    // --- 피드 목록: 전체 탭 (태그 필터 없음) ---
+
     @Query("SELECT c FROM NewsCluster c " +
             "WHERE c.status = :status " +
             "AND c.summaryStatus IN :summaryStatuses " +
@@ -48,9 +46,6 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
             @Param("cursorId") Long cursorId,
             Pageable pageable);
 
-    /**
-     * 피드 목록용 첫 페이지 (커서 없음).
-     */
     @Query("SELECT c FROM NewsCluster c " +
             "WHERE c.status = :status " +
             "AND c.summaryStatus IN :summaryStatuses " +
@@ -59,5 +54,39 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
     List<NewsCluster> findForFeedFirstPage(
             @Param("status") ClusterStatus status,
             @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            Pageable pageable);
+
+    // --- 피드 목록: 탭 필터 (특정 태그 타입을 가진 기사를 포함하는 클러스터만) ---
+
+    @Query("SELECT DISTINCT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "AND EXISTS (SELECT 1 FROM NewsClusterArticle nca " +
+            "            JOIN NewsArticleTag t ON t.newsArticleId = nca.newsArticleId " +
+            "            WHERE nca.newsClusterId = c.id AND t.tagType = :tagType) " +
+            "AND (c.publishedAt < :cursorPublishedAt " +
+            "     OR (c.publishedAt = :cursorPublishedAt AND c.id < :cursorId)) " +
+            "ORDER BY c.publishedAt DESC, c.id DESC")
+    List<NewsCluster> findForFeedByTagTypeAfterCursor(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            @Param("tagType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType tagType,
+            @Param("cursorPublishedAt") OffsetDateTime cursorPublishedAt,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable);
+
+    @Query("SELECT DISTINCT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "AND EXISTS (SELECT 1 FROM NewsClusterArticle nca " +
+            "            JOIN NewsArticleTag t ON t.newsArticleId = nca.newsArticleId " +
+            "            WHERE nca.newsClusterId = c.id AND t.tagType = :tagType) " +
+            "ORDER BY c.publishedAt DESC, c.id DESC")
+    List<NewsCluster> findForFeedByTagTypeFirstPage(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            @Param("tagType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType tagType,
             Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -2,8 +2,11 @@ package com.solv.wefin.domain.news.cluster.repository;
 
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -26,4 +29,35 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
     List<NewsCluster> findByStatusAndSummaryStatusIn(ClusterStatus status,
                                                      List<NewsCluster.SummaryStatus> statuses,
                                                      Pageable pageable);
+
+    /**
+     * 피드 목록용 커서 기반 페이지네이션.
+     * ACTIVE + 요약 완료(GENERATED/STALE) 클러스터를 최신순으로 조회한다.
+     */
+    @Query("SELECT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "AND (c.publishedAt < :cursorPublishedAt " +
+            "     OR (c.publishedAt = :cursorPublishedAt AND c.id < :cursorId)) " +
+            "ORDER BY c.publishedAt DESC, c.id DESC")
+    List<NewsCluster> findForFeedAfterCursor(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            @Param("cursorPublishedAt") OffsetDateTime cursorPublishedAt,
+            @Param("cursorId") Long cursorId,
+            Pageable pageable);
+
+    /**
+     * 피드 목록용 첫 페이지 (커서 없음).
+     */
+    @Query("SELECT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "ORDER BY c.publishedAt DESC, c.id DESC")
+    List<NewsCluster> findForFeedFirstPage(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -56,7 +56,7 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
             @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
             Pageable pageable);
 
-    // --- 피드 목록: 탭 필터 (특정 태그 타입을 가진 기사를 포함하는 클러스터만) ---
+    // --- 피드 목록: 카테고리 필터 (대분류 SECTOR 태그코드로 필터) ---
 
     @Query("SELECT DISTINCT c FROM NewsCluster c " +
             "WHERE c.status = :status " +
@@ -64,14 +64,17 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
             "AND c.title IS NOT NULL " +
             "AND EXISTS (SELECT 1 FROM NewsClusterArticle nca " +
             "            JOIN NewsArticleTag t ON t.newsArticleId = nca.newsArticleId " +
-            "            WHERE nca.newsClusterId = c.id AND t.tagType = :tagType) " +
+            "            WHERE nca.newsClusterId = c.id " +
+            "            AND t.tagType = :sectorType " +
+            "            AND t.tagCode = :categoryCode) " +
             "AND (c.publishedAt < :cursorPublishedAt " +
             "     OR (c.publishedAt = :cursorPublishedAt AND c.id < :cursorId)) " +
             "ORDER BY c.publishedAt DESC, c.id DESC")
-    List<NewsCluster> findForFeedByTagTypeAfterCursor(
+    List<NewsCluster> findForFeedByCategoryAfterCursor(
             @Param("status") ClusterStatus status,
             @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
-            @Param("tagType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType tagType,
+            @Param("sectorType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType sectorType,
+            @Param("categoryCode") String categoryCode,
             @Param("cursorPublishedAt") OffsetDateTime cursorPublishedAt,
             @Param("cursorId") Long cursorId,
             Pageable pageable);
@@ -82,11 +85,14 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
             "AND c.title IS NOT NULL " +
             "AND EXISTS (SELECT 1 FROM NewsClusterArticle nca " +
             "            JOIN NewsArticleTag t ON t.newsArticleId = nca.newsArticleId " +
-            "            WHERE nca.newsClusterId = c.id AND t.tagType = :tagType) " +
+            "            WHERE nca.newsClusterId = c.id " +
+            "            AND t.tagType = :sectorType " +
+            "            AND t.tagCode = :categoryCode) " +
             "ORDER BY c.publishedAt DESC, c.id DESC")
-    List<NewsCluster> findForFeedByTagTypeFirstPage(
+    List<NewsCluster> findForFeedByCategoryFirstPage(
             @Param("status") ClusterStatus status,
             @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
-            @Param("tagType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType tagType,
+            @Param("sectorType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType sectorType,
+            @Param("categoryCode") String categoryCode,
             Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/UserNewsClusterFeedbackRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/UserNewsClusterFeedbackRepository.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.news.cluster.repository;
+
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserNewsClusterFeedbackRepository extends JpaRepository<UserNewsClusterFeedback, Long> {
+
+    boolean existsByUserIdAndNewsClusterId(UUID userId, Long newsClusterId);
+
+    Optional<UserNewsClusterFeedback> findByUserIdAndNewsClusterId(UUID userId, Long newsClusterId);
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/UserNewsClusterReadRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/UserNewsClusterReadRepository.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.news.cluster.repository;
+
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserNewsClusterReadRepository extends JpaRepository<UserNewsClusterRead, Long> {
+
+    boolean existsByUserIdAndNewsClusterId(UUID userId, Long newsClusterId);
+
+    List<UserNewsClusterRead> findByUserIdAndNewsClusterIdIn(UUID userId, List<Long> newsClusterIds);
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -36,6 +36,9 @@ public class NewsClusterQueryService {
 
     private static final List<SummaryStatus> VISIBLE_STATUSES = List.of(SummaryStatus.GENERATED, SummaryStatus.STALE);
     private static final int MAX_SOURCES_PER_CLUSTER = 3;
+    // ETC는 "전체" 탭에서만 노출되므로 탭 필터 대상에서 제외
+    private static final Set<String> VALID_CATEGORIES = Set.of(
+            "FINANCE", "TECH", "INDUSTRY", "ENERGY", "BIO", "CRYPTO");
 
     private final NewsClusterRepository newsClusterRepository;
     private final NewsClusterArticleRepository clusterArticleRepository;
@@ -53,14 +56,14 @@ public class NewsClusterQueryService {
      * @return 클러스터 목록 + 부가 정보
      */
     /**
-     * @param tab "ALL" / "SECTOR" / "STOCK" — null이면 ALL 취급
+     * @param tab "ALL" / "FINANCE" / "TECH" / "INDUSTRY" / "ENERGY" / "BIO" / "CRYPTO" — null이면 ALL 취급
      */
     public ClusterFeedResult getFeed(OffsetDateTime cursorPublishedAt, Long cursorId,
                                      int pageSize, UUID userId, String tab) {
         int fetchSize = pageSize + 1;
-        TagType tagTypeFilter = resolveTabFilter(tab);
+        String categoryCode = resolveCategoryCode(tab);
 
-        List<NewsCluster> clusters = fetchClusters(cursorPublishedAt, cursorId, fetchSize, tagTypeFilter);
+        List<NewsCluster> clusters = fetchClusters(cursorPublishedAt, cursorId, fetchSize, categoryCode);
 
         // 다음 페이지 존재 여부
         boolean hasNext = clusters.size() > pageSize;
@@ -89,8 +92,10 @@ public class NewsClusterQueryService {
         // 출처 / 종목 / 읽음 여부 일괄 조회 (빈 리스트면 IN 절 오류 방지)
         Map<Long, List<SourceInfo>> sourcesMap = allArticleIds.isEmpty()
                 ? Map.of() : getSourcesMap(clusterArticleMap, allArticleIds);
-        Map<Long, List<String>> stocksMap = allArticleIds.isEmpty()
+        Map<Long, List<StockInfo>> stocksMap = allArticleIds.isEmpty()
                 ? Map.of() : getRelatedStocksMap(clusterArticleMap, allArticleIds);
+        Map<Long, List<String>> topicsMap = allArticleIds.isEmpty()
+                ? Map.of() : getMarketTagsMap(clusterArticleMap, allArticleIds);
         Set<Long> readClusterIds = getReadClusterIds(clusterIds, userId);
 
         // 클러스터 → 응답 DTO 변환
@@ -104,6 +109,7 @@ public class NewsClusterQueryService {
                         c.getArticleCount(),
                         sourcesMap.getOrDefault(c.getId(), List.of()),
                         stocksMap.getOrDefault(c.getId(), List.of()),
+                        topicsMap.getOrDefault(c.getId(), List.of()),
                         readClusterIds.contains(c.getId())
                 ))
                 .toList();
@@ -126,41 +132,40 @@ public class NewsClusterQueryService {
     }
 
     /**
-     * tab 파라미터를 TagType으로 변환한다. ALL이면 null (필터 없음).
+     * tab 파라미터를 대분류 카테고리 코드로 변환한다. ALL이면 null (필터 없음).
      */
-    private TagType resolveTabFilter(String tab) {
+    private String resolveCategoryCode(String tab) {
         if (tab == null || tab.isBlank() || "ALL".equalsIgnoreCase(tab)) {
             return null;
         }
-        return switch (tab.toUpperCase()) {
-            case "SECTOR" -> TagType.SECTOR;
-            case "STOCK" -> TagType.STOCK;
-            case "TOPIC" -> TagType.TOPIC;
-            default -> null;
-        };
+        String upper = tab.toUpperCase();
+        if (!VALID_CATEGORIES.contains(upper)) {
+            throw new com.solv.wefin.global.error.BusinessException(
+                    com.solv.wefin.global.error.ErrorCode.INVALID_INPUT,
+                    "지원하지 않는 tab 값입니다: " + tab);
+        }
+        return upper;
     }
 
     /**
-     * 탭 필터 + 커서 조건에 따라 클러스터를 조회한다.
+     * 카테고리 필터 + 커서 조건에 따라 클러스터를 조회한다.
      */
     private List<NewsCluster> fetchClusters(OffsetDateTime cursorPublishedAt, Long cursorId,
-                                             int fetchSize, TagType tagTypeFilter) {
+                                             int fetchSize, String categoryCode) {
         boolean hasCursor = cursorPublishedAt != null && cursorId != null;
 
-        if (tagTypeFilter == null) {
-            // 전체 탭
+        if (categoryCode == null) {
             return hasCursor
                     ? newsClusterRepository.findForFeedAfterCursor(
                             ClusterStatus.ACTIVE, VISIBLE_STATUSES, cursorPublishedAt, cursorId, PageRequest.of(0, fetchSize))
                     : newsClusterRepository.findForFeedFirstPage(
                             ClusterStatus.ACTIVE, VISIBLE_STATUSES, PageRequest.of(0, fetchSize));
         } else {
-            // 탭 필터 (SECTOR/STOCK/TOPIC)
             return hasCursor
-                    ? newsClusterRepository.findForFeedByTagTypeAfterCursor(
-                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, tagTypeFilter, cursorPublishedAt, cursorId, PageRequest.of(0, fetchSize))
-                    : newsClusterRepository.findForFeedByTagTypeFirstPage(
-                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, tagTypeFilter, PageRequest.of(0, fetchSize));
+                    ? newsClusterRepository.findForFeedByCategoryAfterCursor(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, TagType.SECTOR, categoryCode, cursorPublishedAt, cursorId, PageRequest.of(0, fetchSize))
+                    : newsClusterRepository.findForFeedByCategoryFirstPage(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, TagType.SECTOR, categoryCode, PageRequest.of(0, fetchSize));
         }
     }
 
@@ -204,36 +209,46 @@ public class NewsClusterQueryService {
     }
 
     /**
-     * 클러스터별 관련 STOCK 태그를 조회한다.
+     * 클러스터별 관련 STOCK 태그를 조회한다. (code + name)
      */
-    private Map<Long, List<String>> getRelatedStocksMap(Map<Long, List<Long>> clusterArticleMap,
-                                                        List<Long> allArticleIds) {
-        // STOCK 태그만 DB에서 조회
+    private Map<Long, List<StockInfo>> getRelatedStocksMap(Map<Long, List<Long>> clusterArticleMap,
+                                                            List<Long> allArticleIds) {
         List<NewsArticleTag> stockTags = articleTagRepository.findByNewsArticleIdInAndTagType(
                 allArticleIds, TagType.STOCK);
-
-        // articleId → STOCK 태그 목록 매핑
         Map<Long, List<NewsArticleTag>> tagsByArticle = stockTags.stream()
                 .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
 
-        Map<Long, List<String>> result = new HashMap<>();
-
-        // clusterId별로 순회
+        Map<Long, List<StockInfo>> result = new HashMap<>();
         for (var entry : clusterArticleMap.entrySet()) {
-            Set<String> stocks = new LinkedHashSet<>(); // 종목명 dedup + 순서 유지
-
-            // 해당 클러스터에 포함된 기사 순회
+            Map<String, StockInfo> seen = new LinkedHashMap<>();
             for (Long articleId : entry.getValue()) {
-
-                // 해당 기사에 매핑된 STOCK 태그 조회
-                List<NewsArticleTag> tags =
-                        tagsByArticle.getOrDefault(articleId, List.of());
-
-                // 태그명만 추출하여 Set에 추가 (중복 자동 제거)
-                tags.forEach(t -> stocks.add(t.getTagName()));
+                tagsByArticle.getOrDefault(articleId, List.of()).forEach(t ->
+                        seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName())));
             }
 
-            result.put(entry.getKey(), new ArrayList<>(stocks));
+            result.put(entry.getKey(), new ArrayList<>(seen.values()));
+        }
+        return result;
+    }
+
+    /**
+     * 클러스터별 TOPIC 태그(marketTags)를 조회한다.
+     */
+    private Map<Long, List<String>> getMarketTagsMap(Map<Long, List<Long>> clusterArticleMap,
+                                                      List<Long> allArticleIds) {
+        List<NewsArticleTag> topicTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                allArticleIds, TagType.TOPIC);
+        Map<Long, List<NewsArticleTag>> tagsByArticle = topicTags.stream()
+                .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
+
+        Map<Long, List<String>> result = new HashMap<>();
+        for (var entry : clusterArticleMap.entrySet()) {
+            Set<String> topics = new LinkedHashSet<>();
+            for (Long articleId : entry.getValue()) {
+                tagsByArticle.getOrDefault(articleId, List.of())
+                        .forEach(t -> topics.add(t.getTagName()));
+            }
+            result.put(entry.getKey(), new ArrayList<>(topics));
         }
         return result;
     }
@@ -278,12 +293,15 @@ public class NewsClusterQueryService {
             String summary,
             String thumbnailUrl,
             OffsetDateTime publishedAt,
-            int sourceCount, // 클러스터에 포함된 전체 기사 수
-            List<SourceInfo> sources, // 대표 출처 (최대 3개)
-            List<String> relatedStocks, // 관련 종목 태그
-            boolean isRead // 사용자 읽음 여부
+            int sourceCount,
+            List<SourceInfo> sources,
+            List<StockInfo> relatedStocks,
+            List<String> marketTags,
+            boolean isRead
     ) {
     }
+
+    public record StockInfo(String code, String name) {}
 
     /**
      * 출처 정보 (언론사, 원본 URL)

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -1,0 +1,262 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * 뉴스 클러스터 피드 목록 조회 서비스
+ * <p>
+ * 커서 기반 페이지네이션으로 ACTIVE + 요약 완료 클러스터를 최신순으로 반환한다.
+ * 각 클러스터에 출처(publisher) 집계, 관련 종목(STOCK 태그), 읽음 여부를 포함한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsClusterQueryService {
+
+    private static final List<SummaryStatus> VISIBLE_STATUSES = List.of(SummaryStatus.GENERATED, SummaryStatus.STALE);
+    private static final int MAX_SOURCES_PER_CLUSTER = 3;
+
+    private final NewsClusterRepository newsClusterRepository;
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleRepository newsArticleRepository;
+    private final NewsArticleTagRepository articleTagRepository;
+    private final UserNewsClusterReadRepository readRepository;
+
+    /**
+     * 피드 목록을 커서 기반으로 조회한다.
+     *
+     * @param cursorPublishedAt 커서 시각 (null이면 첫 페이지)
+     * @param cursorId          커서 ID (null이면 첫 페이지)
+     * @param pageSize          페이지 크기
+     * @param userId            사용자 ID (null이면 isRead 항상 false)
+     * @return 클러스터 목록 + 부가 정보
+     */
+    public ClusterFeedResult getFeed(OffsetDateTime cursorPublishedAt, Long cursorId,
+                                     int pageSize, UUID userId) {
+        int fetchSize = pageSize + 1;
+
+        List<NewsCluster> clusters;
+
+        // 커서가 있으면 이후 데이터, 없으면 첫 페이지 조회
+        if (cursorPublishedAt != null && cursorId != null) {
+            clusters = newsClusterRepository.findForFeedAfterCursor(
+                    ClusterStatus.ACTIVE, VISIBLE_STATUSES,
+                    cursorPublishedAt, cursorId,
+                    PageRequest.of(0, fetchSize));
+        } else {
+            clusters = newsClusterRepository.findForFeedFirstPage(
+                    ClusterStatus.ACTIVE, VISIBLE_STATUSES,
+                    PageRequest.of(0, fetchSize));
+        }
+
+        // 다음 페이지 존재 여부
+        boolean hasNext = clusters.size() > pageSize;
+
+        // pageSize만큼 실제 반환
+        if (hasNext) {
+            clusters = clusters.subList(0, pageSize);
+        }
+
+        // 결과 없으면 빈 응답 반환
+        if (clusters.isEmpty()) {
+            return ClusterFeedResult.empty();
+        }
+
+        /* 부가 정보 일괄 조회 */
+
+        // 클러스터 ID 목록
+        List<Long> clusterIds = clusters.stream().map(NewsCluster::getId).toList();
+
+        // clusterId → articleIds 매핑
+        Map<Long, List<Long>> clusterArticleMap = buildClusterArticleMap(clusterIds);
+
+        // 모든 기사 ID flat 추출 (중복 제거)
+        List<Long> allArticleIds = clusterArticleMap.values().stream().flatMap(List::stream).distinct().toList();
+
+        // 출처 / 종목 / 읽음 여부 일괄 조회 (빈 리스트면 IN 절 오류 방지)
+        Map<Long, List<SourceInfo>> sourcesMap = allArticleIds.isEmpty()
+                ? Map.of() : getSourcesMap(clusterArticleMap, allArticleIds);
+        Map<Long, List<String>> stocksMap = allArticleIds.isEmpty()
+                ? Map.of() : getRelatedStocksMap(clusterArticleMap, allArticleIds);
+        Set<Long> readClusterIds = getReadClusterIds(clusterIds, userId);
+
+        // 클러스터 → 응답 DTO 변환
+        List<ClusterFeedItem> items = clusters.stream()
+                .map(c -> new ClusterFeedItem(
+                        c.getId(),
+                        c.getTitle(),
+                        c.getSummary(),
+                        c.getThumbnailUrl(),
+                        c.getPublishedAt(),
+                        c.getArticleCount(),
+                        sourcesMap.getOrDefault(c.getId(), List.of()),
+                        stocksMap.getOrDefault(c.getId(), List.of()),
+                        readClusterIds.contains(c.getId())
+                ))
+                .toList();
+
+        // 다음 커서 생성 (마지막 데이터 기준)
+        NewsCluster last = clusters.get(clusters.size() - 1);
+
+        return new ClusterFeedResult(items, hasNext, last.getPublishedAt(), last.getId());
+    }
+
+    /**
+     * 클러스터-기사 매핑을 한 번에 조회하여 clusterId → articleIds Map 생성
+     */
+    private Map<Long, List<Long>> buildClusterArticleMap(List<Long> clusterIds) {
+        List<NewsClusterArticle> allMappings = clusterArticleRepository.findByNewsClusterIdIn(clusterIds);
+        return allMappings.stream()
+                .collect(Collectors.groupingBy(
+                        NewsClusterArticle::getNewsClusterId,
+                        Collectors.mapping(NewsClusterArticle::getNewsArticleId, Collectors.toList())));
+    }
+
+    /**
+     * 클러스터별 출처(publisher) 상위 N개를 조회한다.
+     * <p>
+     * 정책:
+     * - 같은 언론사는 1번만 포함 (publisherName 기준 dedup)
+     * - 최대 MAX_SOURCES_PER_CLUSTER 개까지만 노출
+     */
+    private Map<Long, List<SourceInfo>> getSourcesMap(Map<Long, List<Long>> clusterArticleMap,
+                                                      List<Long> allArticleIds) {
+        // projection 조회 (엔티티 전체 로딩 방지)
+        Map<Long, NewsArticleRepository.SourceProjection> projectionMap =
+                newsArticleRepository.findSourceInfoByIdIn(allArticleIds).stream()
+                        .collect(Collectors.toMap(NewsArticleRepository.SourceProjection::getId, p -> p));
+
+        Map<Long, List<SourceInfo>> result = new HashMap<>();
+
+        // clusterId별로 순회
+        for (var entry : clusterArticleMap.entrySet()) {
+            Set<String> seenPublishers = new HashSet<>(); // publisherName 기준 중복 제거용 Set
+            List<SourceInfo> sources = new ArrayList<>(); // 최종 출처 리스트
+
+            for (Long articleId : entry.getValue()) {
+                var projection = projectionMap.get(articleId); // O(1)로 projection 조회
+
+                // null 방어 + publisher 기준 dedup
+                if (projection != null && seenPublishers.add(projection.getPublisherName())) {
+
+                    // 출처 정보 추가
+                    sources.add(new SourceInfo(projection.getPublisherName(), projection.getOriginalUrl()));
+
+                    // 최대 개수 제한
+                    if (sources.size() >= MAX_SOURCES_PER_CLUSTER) break;
+                }
+            }
+            result.put(entry.getKey(), sources);
+        }
+        return result;
+    }
+
+    /**
+     * 클러스터별 관련 STOCK 태그를 조회한다.
+     */
+    private Map<Long, List<String>> getRelatedStocksMap(Map<Long, List<Long>> clusterArticleMap,
+                                                        List<Long> allArticleIds) {
+        // STOCK 태그만 DB에서 조회
+        List<NewsArticleTag> stockTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                allArticleIds, TagType.STOCK);
+
+        // articleId → STOCK 태그 목록 매핑
+        Map<Long, List<NewsArticleTag>> tagsByArticle = stockTags.stream()
+                .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
+
+        Map<Long, List<String>> result = new HashMap<>();
+
+        // clusterId별로 순회
+        for (var entry : clusterArticleMap.entrySet()) {
+            Set<String> stocks = new LinkedHashSet<>(); // 종목명 dedup + 순서 유지
+
+            // 해당 클러스터에 포함된 기사 순회
+            for (Long articleId : entry.getValue()) {
+
+                // 해당 기사에 매핑된 STOCK 태그 조회
+                List<NewsArticleTag> tags =
+                        tagsByArticle.getOrDefault(articleId, List.of());
+
+                // 태그명만 추출하여 Set에 추가 (중복 자동 제거)
+                tags.forEach(t -> stocks.add(t.getTagName()));
+            }
+
+            result.put(entry.getKey(), new ArrayList<>(stocks));
+        }
+        return result;
+    }
+
+    /**
+     * 사용자가 읽은 클러스터 ID Set을 반환한다.
+     */
+    private Set<Long> getReadClusterIds(List<Long> clusterIds, UUID userId) {
+
+        // 비회원인 경우 읽음 여부 계산 불필요 → 빈 Set 반환
+        if (userId == null) {
+            return Set.of();
+        }
+
+        return readRepository.findByUserIdAndNewsClusterIdIn(userId, clusterIds).stream()
+                .map(UserNewsClusterRead::getNewsClusterId)
+                .collect(Collectors.toSet());
+    }
+
+    // --- Result Records ---
+
+    /**
+     * 커서 기반 페이징 결과
+     */
+    public record ClusterFeedResult(
+            List<ClusterFeedItem> items,
+            boolean hasNext,
+            OffsetDateTime nextCursorPublishedAt,
+            Long nextCursorId
+    ) {
+        public static ClusterFeedResult empty() {
+            return new ClusterFeedResult(List.of(), false, null, null);
+        }
+    }
+
+    /**
+     * 클러스터 피드 아이템
+     */
+    public record ClusterFeedItem(
+            Long clusterId,
+            String title,
+            String summary,
+            String thumbnailUrl,
+            OffsetDateTime publishedAt,
+            int sourceCount, // 클러스터에 포함된 전체 기사 수
+            List<SourceInfo> sources, // 대표 출처 (최대 3개)
+            List<String> relatedStocks, // 관련 종목 태그
+            boolean isRead // 사용자 읽음 여부
+    ) {
+    }
+
+    /**
+     * 출처 정보 (언론사, 원본 URL)
+     */
+    public record SourceInfo(String publisherName, String url) {
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -12,6 +12,8 @@ import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -24,7 +26,6 @@ import java.util.stream.Collectors;
 
 /**
  * 뉴스 클러스터 피드 목록 조회 서비스
- * <p>
  * 커서 기반 페이지네이션으로 ACTIVE + 요약 완료 클러스터를 최신순으로 반환한다.
  * 각 클러스터에 출처(publisher) 집계, 관련 종목(STOCK 태그), 읽음 여부를 포함한다.
  */
@@ -140,8 +141,7 @@ public class NewsClusterQueryService {
         }
         String upper = tab.toUpperCase();
         if (!VALID_CATEGORIES.contains(upper)) {
-            throw new com.solv.wefin.global.error.BusinessException(
-                    com.solv.wefin.global.error.ErrorCode.INVALID_INPUT,
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
                     "지원하지 않는 tab 값입니다: " + tab);
         }
         return upper;
@@ -171,7 +171,7 @@ public class NewsClusterQueryService {
 
     /**
      * 클러스터별 출처(publisher) 상위 N개를 조회한다.
-     * <p>
+     *
      * 정책:
      * - 같은 언론사는 1번만 포함 (publisherName 기준 dedup)
      * - 최대 MAX_SOURCES_PER_CLUSTER 개까지만 노출
@@ -193,8 +193,9 @@ public class NewsClusterQueryService {
             for (Long articleId : entry.getValue()) {
                 var projection = projectionMap.get(articleId); // O(1)로 projection 조회
 
-                // null 방어 + publisher 기준 dedup
-                if (projection != null && seenPublishers.add(projection.getPublisherName())) {
+                if (projection != null
+                        && projection.getPublisherName() != null
+                        && seenPublishers.add(projection.getPublisherName())) {
 
                     // 출처 정보 추가
                     sources.add(new SourceInfo(projection.getPublisherName(), projection.getOriginalUrl()));

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -52,23 +52,15 @@ public class NewsClusterQueryService {
      * @param userId            사용자 ID (null이면 isRead 항상 false)
      * @return 클러스터 목록 + 부가 정보
      */
+    /**
+     * @param tab "ALL" / "SECTOR" / "STOCK" — null이면 ALL 취급
+     */
     public ClusterFeedResult getFeed(OffsetDateTime cursorPublishedAt, Long cursorId,
-                                     int pageSize, UUID userId) {
+                                     int pageSize, UUID userId, String tab) {
         int fetchSize = pageSize + 1;
+        TagType tagTypeFilter = resolveTabFilter(tab);
 
-        List<NewsCluster> clusters;
-
-        // 커서가 있으면 이후 데이터, 없으면 첫 페이지 조회
-        if (cursorPublishedAt != null && cursorId != null) {
-            clusters = newsClusterRepository.findForFeedAfterCursor(
-                    ClusterStatus.ACTIVE, VISIBLE_STATUSES,
-                    cursorPublishedAt, cursorId,
-                    PageRequest.of(0, fetchSize));
-        } else {
-            clusters = newsClusterRepository.findForFeedFirstPage(
-                    ClusterStatus.ACTIVE, VISIBLE_STATUSES,
-                    PageRequest.of(0, fetchSize));
-        }
+        List<NewsCluster> clusters = fetchClusters(cursorPublishedAt, cursorId, fetchSize, tagTypeFilter);
 
         // 다음 페이지 존재 여부
         boolean hasNext = clusters.size() > pageSize;
@@ -131,6 +123,45 @@ public class NewsClusterQueryService {
                 .collect(Collectors.groupingBy(
                         NewsClusterArticle::getNewsClusterId,
                         Collectors.mapping(NewsClusterArticle::getNewsArticleId, Collectors.toList())));
+    }
+
+    /**
+     * tab 파라미터를 TagType으로 변환한다. ALL이면 null (필터 없음).
+     */
+    private TagType resolveTabFilter(String tab) {
+        if (tab == null || tab.isBlank() || "ALL".equalsIgnoreCase(tab)) {
+            return null;
+        }
+        return switch (tab.toUpperCase()) {
+            case "SECTOR" -> TagType.SECTOR;
+            case "STOCK" -> TagType.STOCK;
+            case "TOPIC" -> TagType.TOPIC;
+            default -> null;
+        };
+    }
+
+    /**
+     * 탭 필터 + 커서 조건에 따라 클러스터를 조회한다.
+     */
+    private List<NewsCluster> fetchClusters(OffsetDateTime cursorPublishedAt, Long cursorId,
+                                             int fetchSize, TagType tagTypeFilter) {
+        boolean hasCursor = cursorPublishedAt != null && cursorId != null;
+
+        if (tagTypeFilter == null) {
+            // 전체 탭
+            return hasCursor
+                    ? newsClusterRepository.findForFeedAfterCursor(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, cursorPublishedAt, cursorId, PageRequest.of(0, fetchSize))
+                    : newsClusterRepository.findForFeedFirstPage(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, PageRequest.of(0, fetchSize));
+        } else {
+            // 탭 필터 (SECTOR/STOCK/TOPIC)
+            return hasCursor
+                    ? newsClusterRepository.findForFeedByTagTypeAfterCursor(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, tagTypeFilter, cursorPublishedAt, cursorId, PageRequest.of(0, fetchSize))
+                    : newsClusterRepository.findForFeedByTagTypeFirstPage(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, tagTypeFilter, PageRequest.of(0, fetchSize));
+        }
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -139,7 +139,7 @@ public class NewsClusterQueryService {
         if (tab == null || tab.isBlank() || "ALL".equalsIgnoreCase(tab)) {
             return null;
         }
-        String upper = tab.toUpperCase();
+        String upper = tab.toUpperCase(java.util.Locale.ROOT);
         if (!VALID_CATEGORIES.contains(upper)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
                     "지원하지 않는 tab 값입니다: " + tab);

--- a/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
@@ -40,9 +40,23 @@ public class OpenAiTaggingClient {
             - 각 카테고리는 최대 5개까지
             - 확실한 것만 포함 (추측 금지)
             - 종목 코드는 한국 종목이면 6자리 숫자, 미국 종목이면 티커 심볼
-            - sector 코드는 대문자 영문 (예: SEMICONDUCTOR, FINANCE, ENERGY)
             - topic 코드는 대문자 영문 (예: EARNINGS, AI, REGULATION, IPO)
             - summary는 한글로 작성, 50자 이내
+
+            sectors 규칙:
+            - 기사의 핵심 주제 분야만 태깅하세요. 단순히 언급된 종목의 업종이 아닙니다.
+              예: "개인 투자자 순매도" 기사에 삼천당제약이 언급되더라도, 기사 주제가 증시 동향이면 BIO가 아닌 FINANCE입니다.
+            - 아래 대분류 중 반드시 1개를 sectors 첫 번째에 포함하세요:
+              · FINANCE (금융/은행/보험/증권/채권/외환/증시 동향)
+              · TECH (기술/반도체/IT/AI/전자/소프트웨어)
+              · INDUSTRY (산업/자동차/건설/부동산/제조/방산/철강/운송)
+              · ENERGY (에너지/화학/원자재)
+              · BIO (바이오/제약/헬스케어)
+              · CRYPTO (암호화폐/디지털자산)
+              · ETC (위에 해당하지 않는 경우)
+            - 대분류 외 세부 섹터(SEMICONDUCTOR, BANKING 등)는 자유롭게 추가 가능
+            - 암호화폐 토큰(비트코인, 리플 등)은 stocks가 아닌 sectors의 CRYPTO로 분류
+            - sector 코드는 대문자 영문
 
             relevance 판정 규칙:
             - "FINANCIAL": 기사가 주식, 채권, 환율, 금리, 부동산, 기업 실적, 산업 동향, 투자, 거시경제 등
@@ -55,7 +69,7 @@ public class OpenAiTaggingClient {
             반드시 아래 JSON 형식으로만 응답하세요:
             {
               "stocks": [{"code": "005930", "name": "삼성전자"}],
-              "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
+              "sectors": [{"code": "TECH", "name": "기술"}, {"code": "SEMICONDUCTOR", "name": "반도체"}],
               "topics": [{"code": "EARNINGS", "name": "실적"}],
               "summary": "삼성전자가 2분기 반도체 실적 호조를 발표했다.",
               "relevance": "FINANCIAL"

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -55,7 +55,7 @@ public class NewsClusterController {
                 cursorPublishedAt = OffsetDateTime.ofInstant(
                         Instant.ofEpochMilli(Long.parseLong(parts[0])), ZoneOffset.UTC);
                 cursorId = Long.parseLong(parts[1]);
-            } catch (NumberFormatException e) {
+            } catch (NumberFormatException | java.time.DateTimeException e) {
                 throw new BusinessException(ErrorCode.INVALID_INPUT, "잘못된 cursor 형식입니다: " + cursor);
             }
         }

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -46,9 +46,12 @@ public class NewsClusterController {
         OffsetDateTime cursorPublishedAt = null;
         Long cursorId = null;
 
-        if (cursor != null && cursor.contains("_")) {
+        if (cursor != null) {
             try {
                 String[] parts = cursor.split("_", 2);
+                if (parts.length != 2) {
+                    throw new NumberFormatException("underscore missing");
+                }
                 cursorPublishedAt = OffsetDateTime.ofInstant(
                         Instant.ofEpochMilli(Long.parseLong(parts[0])), ZoneOffset.UTC);
                 cursorId = Long.parseLong(parts[1]);

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -37,7 +37,7 @@ public class NewsClusterController {
     @GetMapping
     public ApiResponse<ClusterFeedResponse> getFeed(
             @RequestParam(name = "cursor", required = false) String cursor,
-            @RequestParam(name = "pageSize", defaultValue = "" + DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) int pageSize,
             @RequestParam(name = "tab", defaultValue = "ALL") String tab,
             @RequestHeader(name = "X-User-Id", required = false) UUID userId
     ) {

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -1,0 +1,64 @@
+package com.solv.wefin.web.news.controller;
+
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.news.dto.response.ClusterFeedResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * 뉴스 클러스터 조회 API
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/news/clusters")
+public class NewsClusterController {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int MAX_PAGE_SIZE = 50;
+
+    private final NewsClusterQueryService newsClusterQueryService;
+
+    /**
+     * 뉴스 클러스터 피드 목록을 조회한다.
+     *
+     * @param cursor "timestamp_id" 형식의 커서 (첫 페이지면 null)
+     * @param pageSize 페이지 크기 (기본 10, 최대 50)
+     * @param userId 사용자 ID (인증 시 헤더에서 주입, 없으면 null)
+     */
+    @GetMapping
+    public ApiResponse<ClusterFeedResponse> getFeed(
+            @RequestParam(name = "cursor", required = false) String cursor,
+            @RequestParam(name = "pageSize", defaultValue = "" + DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestHeader(name = "X-User-Id", required = false) UUID userId
+    ) {
+        pageSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
+
+        OffsetDateTime cursorPublishedAt = null;
+        Long cursorId = null;
+
+        if (cursor != null && cursor.contains("_")) {
+            try {
+                String[] parts = cursor.split("_", 2);
+                cursorPublishedAt = OffsetDateTime.ofInstant(
+                        Instant.ofEpochMilli(Long.parseLong(parts[0])), ZoneOffset.UTC);
+                cursorId = Long.parseLong(parts[1]);
+            } catch (NumberFormatException e) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT, "잘못된 cursor 형식입니다: " + cursor);
+            }
+        }
+
+        ClusterFeedResult result = newsClusterQueryService.getFeed(
+                cursorPublishedAt, cursorId, pageSize, userId);
+
+        return ApiResponse.success(ClusterFeedResponse.from(result));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -38,6 +38,7 @@ public class NewsClusterController {
     public ApiResponse<ClusterFeedResponse> getFeed(
             @RequestParam(name = "cursor", required = false) String cursor,
             @RequestParam(name = "pageSize", defaultValue = "" + DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(name = "tab", defaultValue = "ALL") String tab,
             @RequestHeader(name = "X-User-Id", required = false) UUID userId
     ) {
         pageSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
@@ -57,7 +58,7 @@ public class NewsClusterController {
         }
 
         ClusterFeedResult result = newsClusterQueryService.getFeed(
-                cursorPublishedAt, cursorId, pageSize, userId);
+                cursorPublishedAt, cursorId, pageSize, userId, tab);
 
         return ApiResponse.success(ClusterFeedResponse.from(result));
     }

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.news.dto.response;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedItem;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.SourceInfo;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.StockInfo;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -12,7 +13,6 @@ import java.util.List;
  *
  * - Service 레이어의 ClusterFeedResult를 API 응답 형태로 변환
  * - 커서 기반 페이지네이션 정보를 문자열 형태로 가공하여 전달
- * - publishedAt + id를 조합하여 커서 생성 (정렬 기준과 동일)
  */
 public record ClusterFeedResponse(
         List<ClusterItemResponse> items,
@@ -51,15 +51,12 @@ public record ClusterFeedResponse(
             String summary,
             String thumbnailUrl,
             OffsetDateTime publishedAt,
-            int sourceCount, // 해당 클러스터에 포함된 전체 기사 수
-            List<SourceResponse> sources, // 대표 출처 리스트 (최대 3개)
-            List<String> relatedStocks, // 관련 종목 태그 목록
-            boolean isRead // 사용자의 읽음 여부
+            int sourceCount,
+            List<SourceResponse> sources,
+            List<StockResponse> relatedStocks,
+            List<String> marketTags,
+            boolean isRead
     ) {
-
-        /**
-         * Service DTO → Response DTO 변환
-         */
         public static ClusterItemResponse from(ClusterFeedItem item) {
             return new ClusterItemResponse(
                     item.clusterId(),
@@ -71,7 +68,8 @@ public record ClusterFeedResponse(
                     item.sources().stream()
                             .map(SourceResponse::from)
                             .toList(),
-                    item.relatedStocks(),
+                    item.relatedStocks().stream().map(StockResponse::from).toList(),
+                    item.marketTags(),
                     item.isRead()
             );
         }
@@ -93,6 +91,12 @@ public record ClusterFeedResponse(
                     source.publisherName(),
                     source.url()
             );
+        }
+    }
+
+    public record StockResponse(String code, String name) {
+        public static StockResponse from(StockInfo stock) {
+            return new StockResponse(stock.code(), stock.name());
         }
     }
 }

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
@@ -1,0 +1,98 @@
+package com.solv.wefin.web.news.dto.response;
+
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedItem;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.SourceInfo;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 클러스터 피드 API 응답 DTO
+ *
+ * - Service 레이어의 ClusterFeedResult를 API 응답 형태로 변환
+ * - 커서 기반 페이지네이션 정보를 문자열 형태로 가공하여 전달
+ * - publishedAt + id를 조합하여 커서 생성 (정렬 기준과 동일)
+ */
+public record ClusterFeedResponse(
+        List<ClusterItemResponse> items,
+        boolean hasNext,
+        String nextCursor
+) {
+
+    /**
+     * Service 결과 → API 응답 DTO 변환
+     *
+     * 1) 내부 ClusterFeedItem → ClusterItemResponse로 변환
+     * 2) nextCursor를 문자열로 인코딩
+     */
+    public static ClusterFeedResponse from(ClusterFeedResult result) {
+
+        // 각 클러스터 아이템을 응답 DTO로 변환
+        List<ClusterItemResponse> items = result.items().stream()
+                .map(ClusterItemResponse::from)
+                .toList();
+
+        // 다음 커서 생성
+        String nextCursor = result.hasNext() && result.nextCursorPublishedAt() != null
+                ? result.nextCursorPublishedAt().toInstant().toEpochMilli()
+                + "_" + result.nextCursorId()
+                : null;
+
+        return new ClusterFeedResponse(items, result.hasNext(), nextCursor);
+    }
+
+    /**
+     * 클러스터 단일 아이템 응답 DTO
+     */
+    public record ClusterItemResponse(
+            Long clusterId,
+            String title,
+            String summary,
+            String thumbnailUrl,
+            OffsetDateTime publishedAt,
+            int sourceCount, // 해당 클러스터에 포함된 전체 기사 수
+            List<SourceResponse> sources, // 대표 출처 리스트 (최대 3개)
+            List<String> relatedStocks, // 관련 종목 태그 목록
+            boolean isRead // 사용자의 읽음 여부
+    ) {
+
+        /**
+         * Service DTO → Response DTO 변환
+         */
+        public static ClusterItemResponse from(ClusterFeedItem item) {
+            return new ClusterItemResponse(
+                    item.clusterId(),
+                    item.title(),
+                    item.summary(),
+                    item.thumbnailUrl(),
+                    item.publishedAt(),
+                    item.sourceCount(),
+                    item.sources().stream()
+                            .map(SourceResponse::from)
+                            .toList(),
+                    item.relatedStocks(),
+                    item.isRead()
+            );
+        }
+    }
+
+    /**
+     * 출처 정보 응답 DTO
+     *
+     * - publisherName: 언론사 이름
+     * - url: 원본 기사 링크
+     */
+    public record SourceResponse(String publisherName, String url) {
+
+        /**
+         * Service SourceInfo → Response DTO 변환
+         */
+        public static SourceResponse from(SourceInfo source) {
+            return new SourceResponse(
+                    source.publisherName(),
+                    source.url()
+            );
+        }
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -1,0 +1,173 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository.SourceProjection;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class NewsClusterQueryServiceTest {
+
+    @Mock private NewsClusterRepository newsClusterRepository;
+    @Mock private NewsClusterArticleRepository clusterArticleRepository;
+    @Mock private NewsArticleRepository newsArticleRepository;
+    @Mock private NewsArticleTagRepository articleTagRepository;
+    @Mock private UserNewsClusterReadRepository readRepository;
+
+    private NewsClusterQueryService queryService;
+
+    @BeforeEach
+    void setUp() {
+        queryService = new NewsClusterQueryService(
+                newsClusterRepository, clusterArticleRepository,
+                newsArticleRepository, articleTagRepository, readRepository);
+    }
+
+    @Test
+    @DisplayName("첫 페이지 조회 — 클러스터 목록을 반환한다")
+    void getFeed_firstPage() {
+        NewsCluster cluster = createCluster(1L, "삼성전자 실적 호조", "반도체 부문 회복...",
+                OffsetDateTime.now(), 3);
+
+        given(newsClusterRepository.findForFeedFirstPage(any(), any(), any()))
+                .willReturn(List.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterIdIn(any()))
+                .willReturn(List.of(NewsClusterArticle.create(1L, 100L, 0, false)));
+        given(newsArticleRepository.findSourceInfoByIdIn(any()))
+                .willReturn(List.of(createSourceProjection(100L, "매일경제", "https://example.com/100")));
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), any()))
+                .willReturn(List.of(createTag(100L, TagType.STOCK, "005930", "삼성전자")));
+
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, null);
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).title()).isEqualTo("삼성전자 실적 호조");
+        assertThat(result.items().get(0).sourceCount()).isEqualTo(3);
+        assertThat(result.items().get(0).sources()).hasSize(1);
+        assertThat(result.items().get(0).relatedStocks()).containsExactly("삼성전자");
+        assertThat(result.items().get(0).isRead()).isFalse();
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("hasNext — pageSize+1 건이면 true")
+    void getFeed_hasNext() {
+        NewsCluster c1 = createCluster(1L, "title1", "summary1", OffsetDateTime.now(), 2);
+        NewsCluster c2 = createCluster(2L, "title2", "summary2", OffsetDateTime.now().minusMinutes(1), 1);
+
+        // pageSize=1이면 2건 조회 → hasNext=true
+        given(newsClusterRepository.findForFeedFirstPage(any(), any(), any()))
+                .willReturn(List.of(c1, c2));
+        given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
+
+        ClusterFeedResult result = queryService.getFeed(null, null, 1, null);
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.hasNext()).isTrue();
+        assertThat(result.nextCursorId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("읽음 상태 — userId가 있으면 isRead 반영")
+    void getFeed_withReadStatus() {
+        UUID userId = UUID.randomUUID();
+        NewsCluster cluster = createCluster(1L, "title", "summary", OffsetDateTime.now(), 1);
+
+        given(newsClusterRepository.findForFeedFirstPage(any(), any(), any()))
+                .willReturn(List.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
+        given(readRepository.findByUserIdAndNewsClusterIdIn(eq(userId), any()))
+                .willReturn(List.of(UserNewsClusterRead.create(userId, 1L)));
+
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, userId);
+
+        assertThat(result.items().get(0).isRead()).isTrue();
+    }
+
+    @Test
+    @DisplayName("빈 결과")
+    void getFeed_empty() {
+        given(newsClusterRepository.findForFeedFirstPage(any(), any(), any()))
+                .willReturn(List.of());
+
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, null);
+
+        assertThat(result.items()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("커서 기반 다음 페이지 조회")
+    void getFeed_withCursor() {
+        OffsetDateTime cursor = OffsetDateTime.now().minusHours(1);
+        NewsCluster cluster = createCluster(5L, "older", "summary", cursor.minusMinutes(10), 1);
+
+        given(newsClusterRepository.findForFeedAfterCursor(any(), any(), eq(cursor), eq(10L), any()))
+                .willReturn(List.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
+
+        ClusterFeedResult result = queryService.getFeed(cursor, 10L, 10, null);
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).clusterId()).isEqualTo(5L);
+    }
+
+    private NewsCluster createCluster(long id, String title, String summary,
+                                       OffsetDateTime publishedAt, int articleCount) {
+        NewsCluster cluster = NewsCluster.builder()
+                .clusterType(NewsCluster.ClusterType.GENERAL)
+                .centroidVector(new float[]{1.0f})
+                .build();
+        ReflectionTestUtils.setField(cluster, "id", id);
+        ReflectionTestUtils.setField(cluster, "title", title);
+        ReflectionTestUtils.setField(cluster, "summary", summary);
+        ReflectionTestUtils.setField(cluster, "publishedAt", publishedAt);
+        ReflectionTestUtils.setField(cluster, "articleCount", articleCount);
+        ReflectionTestUtils.setField(cluster, "status", ClusterStatus.ACTIVE);
+        ReflectionTestUtils.setField(cluster, "summaryStatus", SummaryStatus.GENERATED);
+        return cluster;
+    }
+
+    private SourceProjection createSourceProjection(long id, String publisherName, String url) {
+        return new SourceProjection() {
+            @Override public Long getId() { return id; }
+            @Override public String getPublisherName() { return publisherName; }
+            @Override public String getOriginalUrl() { return url; }
+        };
+    }
+
+    private NewsArticleTag createTag(long articleId, TagType type, String code, String name) {
+        return NewsArticleTag.builder()
+                .newsArticleId(articleId)
+                .tagType(type)
+                .tagCode(code)
+                .tagName(name)
+                .build();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -70,7 +70,9 @@ class NewsClusterQueryServiceTest {
         assertThat(result.items().get(0).title()).isEqualTo("삼성전자 실적 호조");
         assertThat(result.items().get(0).sourceCount()).isEqualTo(3);
         assertThat(result.items().get(0).sources()).hasSize(1);
-        assertThat(result.items().get(0).relatedStocks()).containsExactly("삼성전자");
+        assertThat(result.items().get(0).relatedStocks()).hasSize(1);
+        assertThat(result.items().get(0).relatedStocks().get(0).code()).isEqualTo("005930");
+        assertThat(result.items().get(0).relatedStocks().get(0).name()).isEqualTo("삼성전자");
         assertThat(result.items().get(0).isRead()).isFalse();
         assertThat(result.hasNext()).isFalse();
     }

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -64,7 +64,7 @@ class NewsClusterQueryServiceTest {
         given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), any()))
                 .willReturn(List.of(createTag(100L, TagType.STOCK, "005930", "삼성전자")));
 
-        ClusterFeedResult result = queryService.getFeed(null, null, 10, null);
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, null, null);
 
         assertThat(result.items()).hasSize(1);
         assertThat(result.items().get(0).title()).isEqualTo("삼성전자 실적 호조");
@@ -86,7 +86,7 @@ class NewsClusterQueryServiceTest {
                 .willReturn(List.of(c1, c2));
         given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
 
-        ClusterFeedResult result = queryService.getFeed(null, null, 1, null);
+        ClusterFeedResult result = queryService.getFeed(null, null, 1, null, null);
 
         assertThat(result.items()).hasSize(1);
         assertThat(result.hasNext()).isTrue();
@@ -105,7 +105,7 @@ class NewsClusterQueryServiceTest {
         given(readRepository.findByUserIdAndNewsClusterIdIn(eq(userId), any()))
                 .willReturn(List.of(UserNewsClusterRead.create(userId, 1L)));
 
-        ClusterFeedResult result = queryService.getFeed(null, null, 10, userId);
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, userId, null);
 
         assertThat(result.items().get(0).isRead()).isTrue();
     }
@@ -116,7 +116,7 @@ class NewsClusterQueryServiceTest {
         given(newsClusterRepository.findForFeedFirstPage(any(), any(), any()))
                 .willReturn(List.of());
 
-        ClusterFeedResult result = queryService.getFeed(null, null, 10, null);
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, null, null);
 
         assertThat(result.items()).isEmpty();
         assertThat(result.hasNext()).isFalse();
@@ -132,7 +132,7 @@ class NewsClusterQueryServiceTest {
                 .willReturn(List.of(cluster));
         given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
 
-        ClusterFeedResult result = queryService.getFeed(cursor, 10L, 10, null);
+        ClusterFeedResult result = queryService.getFeed(cursor, 10L, 10, null, null);
 
         assertThat(result.items()).hasSize(1);
         assertThat(result.items().get(0).clusterId()).isEqualTo(5L);


### PR DESCRIPTION
## 📌 PR 설명
뉴스 클러스터 피드 목록 조회 API를 구현했습니다. API를 통해 FE에서 클러스터링된 뉴스 데이터를 조회할 수 있습니다!
커서 기반 페이지네이션으로 ACTIVE + 요약 완료 클러스터를 최신순으로 반환하며, 각 클러스터에 출처(publisher) 집계, 관련 종목(code + name), 마켓 태그(TOPIC), 사용자별 읽음 여부를 포함합니다. 카테고리 탭(금융/기술/산업/에너지/바이오/코인) 필터링을 지원합니다.

- `GET /api/news/clusters` — 커서 기반 피드 목록 API
- `(publishedAt, id)` 복합 커서로 결정적 정렬 보장
- 카테고리 탭 필터링 — 태깅 시 대분류 SECTOR 태그(FINANCE/TECH/INDUSTRY/ENERGY/BIO/CRYPTO) 필수 부여 → 해당 태그코드로 필터
- 클러스터-기사 매핑 batch 조회 (1회)로 N+1 방지
- article 조회 시 interface projection으로 필요한 컬럼(publisherName, url)만 조회 (content TEXT 로딩 방지)
- STOCK/TOPIC 태그 DB 레벨 필터링 (Java 후처리 제거)
- 관련 종목은 `{ code, name }` 구조로 반환하여 FE가 시세 API로 현재가/등락률 조회 가능
- 잘못된 cursor/tab 입력 시 400 Bad Request 반환
- 다음 PR에서 상세 조회 + 읽음/피드백 + 전체 출처 API 후속 구현 예정

### API 스펙
```json
GET /api/news/clusters?cursor={cursor}&pageSize=10&tab=ALL
Header: X-User-Id (optional)

탭 값: ALL (기본) / FINANCE / TECH / INDUSTRY / ENERGY / BIO / CRYPTO

Response:
{
  "status": 200,
  "data": {
    "items": [
      {
        "clusterId": 135,
        "title": "한은 총재 후보 지명에 금리 정책 방향 주목",
        "summary": "신임 한은 총재 후보 지명으로 향후 기준금리 정책 변화 가능성에...",
        "thumbnailUrl": "https://...",
        "publishedAt": "2026-04-07T10:30:00+09:00",
        "sourceCount": 3,
        "sources": [
          { "publisherName": "매일경제", "url": "https://..." },
          { "publisherName": "한국경제", "url": "https://..." }
        ],
        "relatedStocks": [
          { "code": "005930", "name": "삼성전자" },
          { "code": "000660", "name": "SK하이닉스" }
        ],
        "marketTags": ["금리", "통화정책", "반도체"],
        "isRead": false
      }
    ],
    "hasNext": true,
    "nextCursor": "1712345678000_42"
  }
}
```

<br>

## ✅ 변경 파일
1. `OpenAiTaggingClient.java` — 태깅 프롬프트에 대분류 카테고리 규칙 추가 (modified)
2. `UserNewsClusterRead.java` — 읽음 상태 Entity (new)
3. `UserNewsClusterFeedback.java` — 피드백 Entity, PR-2에서 사용 예정 (new)
4. `UserNewsClusterReadRepository.java` — 읽음 조회 (new)
5. `UserNewsClusterFeedbackRepository.java` — 피드백 조회/중복 체크 (new)
6. `NewsArticleRepository.java` — SourceProjection interface + findSourceInfoByIdIn 추가 (modified)
7. `NewsArticleTagRepository.java` — findByNewsArticleIdInAndTagType 추가 (modified)
8. `NewsClusterArticleRepository.java` — findByNewsClusterIdIn batch 조회 추가 (modified)
9. `NewsClusterRepository.java` — 커서 기반 피드 쿼리 + 카테고리 필터 쿼리 (modified)
10. `NewsClusterQueryService.java` — 피드 목록 오케스트레이션 (new)
11. `ClusterFeedResponse.java` — 응답 DTO (new)
12. `NewsClusterController.java` — `GET /api/news/clusters` (new)
13. `NewsClusterQueryServiceTest.java` — 단위 테스트 5건 (new)

<br>

## 💭 고민과 해결과정
### 1. 커서 기반 페이지네이션
처음에는 offset 기반 페이지네이션을 사용할까 고민했지만, 데이터가 많아질수록 성능이 떨어지고 중간에 데이터가 추가되면 중복이나 누락이 발생할 수 있다는 문제를 알게 되었습니다. 그래서 `(publishedAt, id)`를 기준으로 하는 커서 기반 페이지네이션을 적용했습니다.
publishedAt이 동일한 경우에도 id를 함께 사용하여 정렬의 일관성을 보장할 수 있도록 했습니다. 커서 포맷은 `"1712345678000_42"` (timestamp_id) 형태로 구성했고, 프론트는 받은 값을 그대로 다음 데이터 요청에 사용하면 됩니다.




### 2. N+1 문제 개선 — batch 조회
초기에는 클러스터별로 `findByNewsClusterId`를 각각 호출하는 방식으로 구현했습니다. 하지만 이 방식은 클러스터 개수가 늘어날수록 쿼리 수가 증가하는 N+1 문제가 발생했습니다. 그래서 `findByNewsClusterIdIn`으로 batch 조회하도록 수정했습니다. 결과적으로 여러 클러스터를 조회하더라도 관련 데이터를 한 번에 가져올 수 있게 되었고, 쿼리 수를 크게 줄일 수 있었습니다.
|            | Before                  | After  |
| ---------- | ----------------------- | ------ |
| 클러스터-기사 매핑 | 20회 (sources+stocks 각각) | **1회** |
| 기사 조회      | 1회                      | 1회     |
| 태그 조회      | 1회                      | 1회     |



### 3. 쿼리 최적화 — 필요한 데이터만 조회
출처 정보를 조회할 때 처음에는 `NewsArticle` 엔티티 전체를 가져오는 방식으로 구현했습니다. 하지만 이 경우 `content` 같은 큰 컬럼까지 함께 조회되어 비효율적이라는 점을 알게 되었습니다. 그래서 interface projection을 사용하여 필요한 컬럼만 조회하도록 개선했습니다.
```java
// Before: 엔티티 전체 조회
List<NewsArticle> articles = newsArticleRepository.findAllById(allArticleIds);

// After: 필요한 컬럼만 조회
List<SourceProjection> sources = newsArticleRepository.findSourceInfoByIdIn(allArticleIds);
```

관련 종목 조회도 동일하게 개선했습니다. 기존에는 모든 태그를 가져온 뒤 Java에서 STOCK 타입만 필터링했지만, 이제는 DB에서 STOCK 태그만 조회하도록 변경했습니다.
```java
// Before: 전체 태그 조회 후 필터링
List<NewsArticleTag> allTags = tagRepository.findByNewsArticleIdIn(ids);
allTags.stream().filter(t -> t.getTagType() == STOCK)...

// After: DB에서 STOCK만 조회
List<NewsArticleTag> stockTags = tagRepository.findByNewsArticleIdInAndTagType(ids, STOCK);
```

또한 `allArticleIds`가 비어 있을 경우 발생할 수 있는 `IN ()` 쿼리 오류를 방지하기 위해, 빈 리스트에 대한 예외 처리도 추가했습니다.



### 4. 피드 노출 기준

사용자에게 보여줄 클러스터는 다음 조건을 만족하는 경우로 제한했습니다.

```sql
WHERE status = 'ACTIVE'
AND summary_status IN ('GENERATED', 'STALE')
AND title IS NOT NULL
```

요약이 아직 생성되지 않은 상태(PENDING, FAILED)의 클러스터는 제외하고, 기존 요약이 존재하는 STALE 상태는 재생성 전이라도 사용자에게 보여줄 수 있다고 판단하여 포함했습니다.



### 5. 카테고리 탭 필터링
태깅 프롬프트에 대분류 카테고리(FINANCE/TECH/INDUSTRY/ENERGY/BIO/CRYPTO/ETC) 중 반드시 1개를 SECTOR 태그에 포함하도록 지시했습니다. 피드 API에서 `tab=TECH`이면 SECTOR 태그코드가 TECH인 기사를 포함하는 클러스터만 EXISTS 서브쿼리로 필터합니다. ETC는 전체 탭에서만 노출되며 별도 탭으로 제공하지 않습니다. 미지원 tab 값은 400으로 거부합니다.

<br>

### 🔗 관련 이슈
#133

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 뉴스 클러스터 피드 API 추가 — 커서 기반 페이지네이션, 탭(카테고리) 필터, 페이지 크기 제한
  * 클러스터별 대표 출판사(상한), 관련 주식 태그 및 마켓 토픽 노출
  * 사용자별 읽음 표시 및 클러스터별 피드백(유용/유용하지 않음) 저장 지원
  * AI 태깅 규칙 업데이트 — 섹터 우선 규칙 도입 및 CRYPTO 분류 변경

* **Tests**
  * 뉴스 클러스터 조회 서비스 단위 테스트 추가 (페이징, 읽음 상태, 빈 결과 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->