### PR TITLE
[WEF-87] 결제 요청 생성

### DIFF
--- a/src/main/java/com/solv/wefin/domain/payment/dto/CreatePaymentCommand.java
+++ b/src/main/java/com/solv/wefin/domain/payment/dto/CreatePaymentCommand.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.payment.dto;
+
+public record CreatePaymentCommand (
+        Long planId,
+        String provider
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/payment/dto/PaymentReadyInfo.java
+++ b/src/main/java/com/solv/wefin/domain/payment/dto/PaymentReadyInfo.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.domain.payment.dto;
+
+import com.solv.wefin.domain.payment.entity.Payment;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record PaymentReadyInfo(
+        Long paymentId,
+        String orderId,
+        Long planId,
+        String planName,
+        String billingCycle,
+        BigDecimal amount,
+        String provider,
+        String status,
+        OffsetDateTime requestedAt
+) {
+    public static PaymentReadyInfo from(Payment payment) {
+        return new PaymentReadyInfo(
+                payment.getPaymentId(),
+                payment.getOrderId(),
+                payment.getPlan().getPlanId(),
+                payment.getPlan().getPlanName(),
+                payment.getPlan().getBillingCycle().name(),
+                payment.getAmount(),
+                payment.getProvider().name(),
+                payment.getStatus().name(),
+                payment.getRequestedAt()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/BillingCycle.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/BillingCycle.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.payment.entity;
+
+public enum BillingCycle {
+    MONTHLY,
+    YEARLY
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/Payment.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/Payment.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.payment.entity;
 
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -18,7 +19,7 @@ import java.time.OffsetDateTime;
                 @UniqueConstraint(name = "uk_payment_order_id", columnNames = "order_id")
         }
 )
-public class Payment {
+public class Payment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -62,12 +63,6 @@ public class Payment {
     @Column(name = "failure_reason", length = 200)
     private String failureReason;
 
-    @Column(name = "created_at", nullable = false)
-    private OffsetDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private OffsetDateTime updatedAt;
-
     private Payment(
             SubscriptionPlan plan,
             User user,
@@ -82,10 +77,7 @@ public class Payment {
         this.amount = amount;
         this.status = PaymentStatus.READY;
 
-        OffsetDateTime now = OffsetDateTime.now();
-        this.requestedAt = now;
-        this.createdAt = now;
-        this.updatedAt = now;
+        this.requestedAt = OffsetDateTime.now();
     }
 
     public static Payment createReady(
@@ -102,7 +94,6 @@ public class Payment {
         this.providerPaymentKey = providerPaymentKey;
         this.status = PaymentStatus.PAID;
         this.approvedAt = OffsetDateTime.now();
-        this.updatedAt = this.approvedAt;
         this.failedAt = null;
         this.failureReason = null;
     }
@@ -110,13 +101,11 @@ public class Payment {
     public void markFailed(String failureReason) {
         this.status = PaymentStatus.FAILED;
         this.failedAt = OffsetDateTime.now();
-        this.updatedAt = this.failedAt;
         this.failureReason = failureReason;
     }
 
     public void markCanceled() {
         this.status = PaymentStatus.CANCELED;
-        this.updatedAt = OffsetDateTime.now();
     }
 
     public boolean isReady() {

--- a/src/main/java/com/solv/wefin/domain/payment/entity/Payment.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/Payment.java
@@ -1,0 +1,129 @@
+package com.solv.wefin.domain.payment.entity;
+
+import com.solv.wefin.domain.auth.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "payment",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_order_id", columnNames = "order_id")
+        }
+)
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long paymentId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private SubscriptionPlan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "order_id", nullable = false, length = 100)
+    private String orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 50)
+    private PaymentProvider provider;
+
+    @Column(name = "provider_payment_key", length = 200)
+    private String providerPaymentKey;
+
+    @Column(name = "amount", nullable = false, precision = 12, scale = 2)
+    private BigDecimal amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PaymentStatus status;
+
+    @Column(name = "requested_at", nullable = false)
+    private OffsetDateTime requestedAt;
+
+    @Column(name = "approved_at")
+    private OffsetDateTime approvedAt;
+
+    @Column(name = "failed_at")
+    private OffsetDateTime failedAt;
+
+    @Column(name = "failure_reason", length = 200)
+    private String failureReason;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    private Payment(
+            SubscriptionPlan plan,
+            User user,
+            String orderId,
+            PaymentProvider provider,
+            BigDecimal amount
+    ) {
+        this.plan = plan;
+        this.user = user;
+        this.orderId = orderId;
+        this.provider = provider;
+        this.amount = amount;
+        this.status = PaymentStatus.READY;
+
+        OffsetDateTime now = OffsetDateTime.now();
+        this.requestedAt = now;
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    public static Payment createReady(
+            SubscriptionPlan plan,
+            User user,
+            String orderId,
+            PaymentProvider provider,
+            BigDecimal amount
+    ) {
+        return new Payment(plan, user, orderId, provider, amount);
+    }
+
+    public void markPaid(String providerPaymentKey) {
+        this.providerPaymentKey = providerPaymentKey;
+        this.status = PaymentStatus.PAID;
+        this.approvedAt = OffsetDateTime.now();
+        this.updatedAt = this.approvedAt;
+        this.failedAt = null;
+        this.failureReason = null;
+    }
+
+    public void markFailed(String failureReason) {
+        this.status = PaymentStatus.FAILED;
+        this.failedAt = OffsetDateTime.now();
+        this.updatedAt = this.failedAt;
+        this.failureReason = failureReason;
+    }
+
+    public void markCanceled() {
+        this.status = PaymentStatus.CANCELED;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public boolean isReady() {
+        return this.status == PaymentStatus.READY;
+    }
+
+    public boolean isOwnedBy(java.util.UUID userId) {
+        return this.user.getUserId().equals(userId);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/PaymentProvider.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/PaymentProvider.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.payment.entity;
+
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+
+import java.util.Arrays;
+
+public enum PaymentProvider {
+    TOSS;
+
+    public static PaymentProvider from(String value) {
+        if (value == null || value.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_PROVIDER);
+        }
+
+        return Arrays.stream(values())
+                .filter(provider -> provider.name().equalsIgnoreCase(value.trim()))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PROVIDER));
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.solv.wefin.domain.payment.entity;
+
+public enum PaymentStatus {
+    READY,
+    PAID,
+    FAILED,
+    CANCELED
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/Subscription.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/Subscription.java
@@ -1,0 +1,83 @@
+package com.solv.wefin.domain.payment.entity;
+
+import com.solv.wefin.domain.auth.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "subscription")
+public class Subscription {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "subscription_id")
+    private Long subscriptionId;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "plan_id", nullable = false)
+    private SubscriptionPlan plan;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private SubscriptionStatus status;
+
+    @Column(name = "started_at", nullable = false)
+    private OffsetDateTime startedAt;
+
+    @Column(name = "expired_at")
+    private OffsetDateTime expiredAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    private Subscription(
+            SubscriptionPlan plan,
+            User user,
+            OffsetDateTime startedAt,
+            OffsetDateTime expiredAt
+    ) {
+        this.plan = plan;
+        this.user = user;
+        this.status = SubscriptionStatus.ACTIVE;
+        this.startedAt = startedAt;
+        this.expiredAt = expiredAt;
+        this.createdAt = startedAt;
+        this.updatedAt = startedAt;
+    }
+
+    public static Subscription createActive(
+            SubscriptionPlan plan,
+            User user,
+            OffsetDateTime startedAt,
+            OffsetDateTime expiredAt
+    ) {
+        return new Subscription(plan, user, startedAt, expiredAt);
+    }
+
+    public void cancel() {
+        this.status = SubscriptionStatus.CANCELED;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public void expire() {
+        this.status = SubscriptionStatus.EXPIRED;
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public boolean isActive() {
+        return this.status == SubscriptionStatus.ACTIVE;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/SubscriptionPlan.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/SubscriptionPlan.java
@@ -1,0 +1,47 @@
+package com.solv.wefin.domain.payment.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "subscription_plan")
+public class SubscriptionPlan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id")
+    private Long planId;
+
+    @Column(name = "plan_name", nullable = false, length = 100)
+    private String planName;
+
+    @Column(name = "price", nullable = false, precision = 12, scale = 2)
+    private BigDecimal price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "billing_cycle", nullable = false, length = 20)
+    private BillingCycle billingCycle;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public boolean isAvailable() {
+        return isActive;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/SubscriptionStatus.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/SubscriptionStatus.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.payment.entity;
+
+public enum SubscriptionStatus {
+    ACTIVE,
+    CANCELED,
+    EXPIRED
+}

--- a/src/main/java/com/solv/wefin/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/solv/wefin/domain/payment/repository/PaymentRepository.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.payment.repository;
 
 import com.solv.wefin.domain.payment.entity.Payment;
+import com.solv.wefin.domain.payment.entity.PaymentProvider;
 import com.solv.wefin.domain.payment.entity.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -14,9 +15,10 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     Optional<Payment> findByOrderId(String orderId);
 
     // 같은 사용자 / 같은 플랜의 기존 READY결제 재사용 여부 확인
-    Optional<Payment> findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
+    Optional<Payment> findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
             UUID userId,
             Long planId,
+            PaymentProvider provider,
             PaymentStatus status
     );
 }

--- a/src/main/java/com/solv/wefin/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/solv/wefin/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.domain.payment.repository;
+
+import com.solv.wefin.domain.payment.entity.Payment;
+import com.solv.wefin.domain.payment.entity.PaymentStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    boolean existsByOrderId(String orderId);
+
+    Optional<Payment> findByOrderId(String orderId);
+
+    // 같은 사용자 / 같은 플랜의 기존 READY결제 재사용 여부 확인
+    Optional<Payment> findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
+            UUID userId,
+            Long planId,
+            PaymentStatus status
+    );
+}

--- a/src/main/java/com/solv/wefin/domain/payment/repository/SubscriptionPlanRepository.java
+++ b/src/main/java/com/solv/wefin/domain/payment/repository/SubscriptionPlanRepository.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.payment.repository;
+
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionPlanRepository extends JpaRepository<SubscriptionPlan, Long> {
+}

--- a/src/main/java/com/solv/wefin/domain/payment/repository/SubscriptionRepository.java
+++ b/src/main/java/com/solv/wefin/domain/payment/repository/SubscriptionRepository.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.payment.repository;
+
+import com.solv.wefin.domain.payment.entity.Subscription;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long> {
+
+    boolean existsByUserUserIdAndStatus(UUID userId, SubscriptionStatus status);
+
+    Optional<Subscription> findByUserUserIdAndStatus(UUID userId, SubscriptionStatus status);
+}

--- a/src/main/java/com/solv/wefin/domain/payment/service/OrderIdGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/OrderIdGenerator.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.domain.payment.service;
+
+import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class OrderIdGenerator {
+
+    private final PaymentRepository paymentRepository;
+
+    public String generate() {
+        String date = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
+        String orderId;
+        do {
+            String suffix = UUID.randomUUID()
+                    .toString()
+                    .replace("-", "")
+                    .substring(0, 8)
+                    .toUpperCase();
+
+            orderId = "ORDER-" + date + "-" + suffix;
+        } while (paymentRepository.existsByOrderId(orderId));
+
+        return orderId;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -17,7 +17,6 @@ import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -30,9 +29,8 @@ public class PaymentService {
     private final SubscriptionPlanRepository subscriptionPlanRepository;
     private final SubscriptionRepository subscriptionRepository;
     private final UserRepository userRepository;
-    private final OrderIdGenerator orderIdGenerator;
+    private final PaymentWriter paymentWriter;
 
-    @Transactional
     public PaymentReadyInfo createPayment(UUID userId, CreatePaymentCommand command) {
 
         PaymentProvider provider = PaymentProvider.from(command.provider());
@@ -80,18 +78,8 @@ public class PaymentService {
             PaymentProvider provider
     ) {
         for (int i = 0; i < 3; i++) {
-            String orderId = orderIdGenerator.generate();
-
-            Payment payment = Payment.createReady(
-                    plan,
-                    user,
-                    orderId,
-                    provider,
-                    plan.getPrice()
-            );
-
             try {
-                return paymentRepository.save(payment);
+                return paymentWriter.saveReadyPayment(plan, user, provider);
             } catch (DataIntegrityViolationException e) {
                 Optional<Payment> concurrentReady =
                         paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -1,0 +1,84 @@
+package com.solv.wefin.domain.payment.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.payment.dto.CreatePaymentCommand;
+import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
+import com.solv.wefin.domain.payment.entity.Payment;
+import com.solv.wefin.domain.payment.entity.PaymentProvider;
+import com.solv.wefin.domain.payment.entity.PaymentStatus;
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
+import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final SubscriptionPlanRepository subscriptionPlanRepository;
+    private final SubscriptionRepository subscriptionRepository;
+    private final UserRepository userRepository;
+    private final OrderIdGenerator orderIdGenerator;
+
+    @Transactional
+    public PaymentReadyInfo createPayment(UUID userId, CreatePaymentCommand command) {
+
+        PaymentProvider provider = PaymentProvider.from(command.provider());
+
+        SubscriptionPlan plan = subscriptionPlanRepository.findById(command.planId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PLAN_NOT_FOUND));
+
+        if (!plan.isAvailable()) {
+            throw new BusinessException(ErrorCode.PLAN_INACTIVE);
+        }
+
+        boolean hasActiveSubscription =
+                subscriptionRepository.existsByUserUserIdAndStatus(
+                        userId,
+                        SubscriptionStatus.ACTIVE
+                );
+
+        if (hasActiveSubscription) {
+            throw new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
+        }
+
+        Optional<Payment> existingReady =
+                paymentRepository.findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
+                        userId,
+                        plan.getPlanId(),
+                        PaymentStatus.READY
+                );
+
+        if (existingReady.isPresent()) {
+            return PaymentReadyInfo.from(existingReady.get());
+        }
+
+        String orderId = orderIdGenerator.generate();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Payment payment = Payment.createReady(
+                plan,
+                user,
+                orderId,
+                provider,
+                plan.getPrice()
+        );
+
+        Payment saved = paymentRepository.save(payment);
+
+        return PaymentReadyInfo.from(saved);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -93,6 +93,18 @@ public class PaymentService {
             try {
                 return paymentRepository.save(payment);
             } catch (DataIntegrityViolationException e) {
+                Optional<Payment> concurrentReady =
+                        paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                                user.getUserId(),
+                                plan.getPlanId(),
+                                provider,
+                                PaymentStatus.READY
+                        );
+
+                if (concurrentReady.isPresent()) {
+                    return concurrentReady.get();
+                }
+
                 if (i == 2) {
                     throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
                 }

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -94,7 +94,7 @@ public class PaymentService {
                 return paymentRepository.save(payment);
             } catch (DataIntegrityViolationException e) {
                 if (i == 2) {
-                    throw e;
+                    throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
                 }
             }
         }

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -15,6 +15,7 @@ import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,9 +55,10 @@ public class PaymentService {
         }
 
         Optional<Payment> existingReady =
-                paymentRepository.findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
+                paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
                         userId,
                         plan.getPlanId(),
+                        provider,
                         PaymentStatus.READY
                 );
 
@@ -64,21 +66,39 @@ public class PaymentService {
             return PaymentReadyInfo.from(existingReady.get());
         }
 
-        String orderId = orderIdGenerator.generate();
-
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        Payment payment = Payment.createReady(
-                plan,
-                user,
-                orderId,
-                provider,
-                plan.getPrice()
-        );
-
-        Payment saved = paymentRepository.save(payment);
+        Payment saved = savePaymentWithRetry(plan, user, provider);
 
         return PaymentReadyInfo.from(saved);
+    }
+
+    private Payment savePaymentWithRetry(
+            SubscriptionPlan plan,
+            User user,
+            PaymentProvider provider
+    ) {
+        for (int i = 0; i < 3; i++) {
+            String orderId = orderIdGenerator.generate();
+
+            Payment payment = Payment.createReady(
+                    plan,
+                    user,
+                    orderId,
+                    provider,
+                    plan.getPrice()
+            );
+
+            try {
+                return paymentRepository.save(payment);
+            } catch (DataIntegrityViolationException e) {
+                if (i == 2) {
+                    throw e;
+                }
+            }
+        }
+
+        throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentWriter.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentWriter.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.payment.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.payment.entity.Payment;
+import com.solv.wefin.domain.payment.entity.PaymentProvider;
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentWriter {
+    private final PaymentRepository paymentRepository;
+    private final OrderIdGenerator orderIdGenerator;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Payment saveReadyPayment(
+            SubscriptionPlan plan,
+            User user,
+            PaymentProvider provider
+    ) {
+        String orderId = orderIdGenerator.generate();
+
+        Payment payment = Payment.createReady(
+                plan,
+                user,
+                orderId,
+                provider,
+                plan.getPrice()
+        );
+
+        return paymentRepository.saveAndFlush(payment);
+    }
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -45,6 +45,12 @@ public enum ErrorCode {
     AUTH_INVALID_TOKEN(401, "유효하지 않은 인증 토큰입니다."),
     AUTH_UNAUTHORIZED(401, "인증이 필요합니다."),
 
+    // Payment
+    PLAN_NOT_FOUND(404, "구독 상품을 찾을 수 없습니다."),
+    PLAN_INACTIVE(400, "비활성화된 구독 상품입니다."),
+    ACTIVE_SUBSCRIPTION_ALREADY_EXISTS(409, "이미 활성 구독이 존재합니다."),
+    INVALID_PROVIDER(400, "지원하지 않는 결제사입니다."),
+
     // Order - BUY
     ORDER_INSUFFICIENT_BALANCE(400, "예수금이 부족합니다."),
     ORDER_INVALID_QUANTITY(400, "주문 수량은 1 이상이어야 합니다."),

--- a/src/main/java/com/solv/wefin/web/payment/PaymentController.java
+++ b/src/main/java/com/solv/wefin/web/payment/PaymentController.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.web.payment;
+
+import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
+import com.solv.wefin.domain.payment.service.PaymentService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.payment.dto.CreatePaymentRequest;
+import com.solv.wefin.web.payment.dto.CreatePaymentResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping
+    public ApiResponse<CreatePaymentResponse> createPayment(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody CreatePaymentRequest request
+    ) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        PaymentReadyInfo info = paymentService.createPayment(
+                userId,
+                request.toCommand()
+        );
+
+        return ApiResponse.success(CreatePaymentResponse.from(info));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/payment/dto/CreatePaymentRequest.java
+++ b/src/main/java/com/solv/wefin/web/payment/dto/CreatePaymentRequest.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.web.payment.dto;
+
+import com.solv.wefin.domain.payment.dto.CreatePaymentCommand;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreatePaymentRequest (
+        @NotNull Long planId,
+        @NotBlank String provider
+) {
+    public CreatePaymentCommand toCommand() {
+        return new CreatePaymentCommand(planId, provider);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/payment/dto/CreatePaymentRequest.java
+++ b/src/main/java/com/solv/wefin/web/payment/dto/CreatePaymentRequest.java
@@ -3,9 +3,10 @@ package com.solv.wefin.web.payment.dto;
 import com.solv.wefin.domain.payment.dto.CreatePaymentCommand;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
-public record CreatePaymentRequest (
-        @NotNull Long planId,
+public record CreatePaymentRequest(
+        @NotNull @Positive Long planId,
         @NotBlank String provider
 ) {
     public CreatePaymentCommand toCommand() {

--- a/src/main/java/com/solv/wefin/web/payment/dto/CreatePaymentResponse.java
+++ b/src/main/java/com/solv/wefin/web/payment/dto/CreatePaymentResponse.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.payment.dto;
+
+import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record CreatePaymentResponse(
+        Long paymentId,
+        String orderId,
+        Long planId,
+        String planName,
+        String billingCycle,
+        BigDecimal amount,
+        String provider,
+        String status,
+        OffsetDateTime requestedAt
+) {
+    public static CreatePaymentResponse from(PaymentReadyInfo info) {
+        return new CreatePaymentResponse(
+                info.paymentId(),
+                info.orderId(),
+                info.planId(),
+                info.planName(),
+                info.billingCycle(),
+                info.amount(),
+                info.provider(),
+                info.status(),
+                info.requestedAt()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V22__add_unique_constraint_payment_ready.sql
+++ b/src/main/resources/db/migration/V22__add_unique_constraint_payment_ready.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX uk_payment_ready_unique
+    ON payment (user_id, plan_id, provider)
+    WHERE status = 'READY';

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
@@ -178,7 +178,6 @@ class PaymentServiceTest {
         given(plan.getPlanId()).willReturn(1L);
         given(plan.getPlanName()).willReturn("월간 이용권");
         given(plan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
-        given(plan.getPrice()).willReturn(new BigDecimal("9900"));
 
         given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
                 .willReturn(false);
@@ -266,7 +265,6 @@ class PaymentServiceTest {
                 .willReturn(Optional.of(plan));
         given(plan.isAvailable()).willReturn(true);
         given(plan.getPlanId()).willReturn(1L);
-        given(plan.getPrice()).willReturn(new BigDecimal("9900"));
 
         given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
                 .willReturn(false);

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
@@ -1,0 +1,215 @@
+package com.solv.wefin.domain.payment;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.payment.dto.CreatePaymentCommand;
+import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
+import com.solv.wefin.domain.payment.entity.BillingCycle;
+import com.solv.wefin.domain.payment.entity.Payment;
+import com.solv.wefin.domain.payment.entity.PaymentProvider;
+import com.solv.wefin.domain.payment.entity.PaymentStatus;
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
+import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
+import com.solv.wefin.domain.payment.service.OrderIdGenerator;
+import com.solv.wefin.domain.payment.service.PaymentService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private SubscriptionPlanRepository subscriptionPlanRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OrderIdGenerator orderIdGenerator;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private UUID userId;
+    private CreatePaymentCommand command;
+    private SubscriptionPlan plan;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        command = new CreatePaymentCommand(1L, "TOSS");
+
+        plan = mock(SubscriptionPlan.class);
+        user = mock(User.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 플랜이면 PLAN_NOT_FOUND 예외가 발생한다")
+    void createPayment_fail_whenPlanNotFound() {
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> paymentService.createPayment(userId, command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_NOT_FOUND);
+
+        verify(subscriptionPlanRepository).findById(command.planId());
+        verifyNoInteractions(subscriptionRepository, userRepository, orderIdGenerator, paymentRepository);
+    }
+
+    @Test
+    @DisplayName("비활성 플랜이면 PLAN_INACTIVE 예외가 발생한다")
+    void createPayment_fail_whenPlanInactive() {
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.of(plan));
+        given(plan.isAvailable()).willReturn(false);
+
+        assertThatThrownBy(() -> paymentService.createPayment(userId, command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.PLAN_INACTIVE);
+
+        verify(subscriptionPlanRepository).findById(command.planId());
+        verify(plan).isAvailable();
+        verifyNoInteractions(subscriptionRepository, userRepository, orderIdGenerator, paymentRepository);
+    }
+
+    @Test
+    @DisplayName("이미 활성 구독이 있으면 ACTIVE_SUBSCRIPTION_ALREADY_EXISTS 예외가 발생한다")
+    void createPayment_fail_whenActiveSubscriptionExists() {
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.of(plan));
+        given(plan.isAvailable()).willReturn(true);
+        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(true);
+
+        assertThatThrownBy(() -> paymentService.createPayment(userId, command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
+
+        verify(subscriptionRepository).existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
+        verifyNoInteractions(userRepository, orderIdGenerator);
+        verify(paymentRepository, never())
+                .findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(any(), any(), any());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("기존 READY 결제가 있으면 새로 생성하지 않고 기존 결제를 반환한다")
+    void createPayment_returnsExistingReadyPayment() {
+        Payment existingPayment = mock(Payment.class);
+        OffsetDateTime requestedAt = OffsetDateTime.now();
+
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.of(plan));
+        given(plan.isAvailable()).willReturn(true);
+        given(plan.getPlanId()).willReturn(1L);
+        given(plan.getPlanName()).willReturn("월간 이용권");
+        given(plan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
+
+        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(false);
+        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
+                userId, 1L, PaymentStatus.READY))
+                .willReturn(Optional.of(existingPayment));
+
+        given(existingPayment.getPaymentId()).willReturn(10L);
+        given(existingPayment.getOrderId()).willReturn("ORDER-20260408-EXIST123");
+        given(existingPayment.getPlan()).willReturn(plan);
+        given(existingPayment.getAmount()).willReturn(new BigDecimal("9900"));
+        given(existingPayment.getProvider()).willReturn(PaymentProvider.TOSS);
+        given(existingPayment.getStatus()).willReturn(PaymentStatus.READY);
+        given(existingPayment.getRequestedAt()).willReturn(requestedAt);
+
+        PaymentReadyInfo result = paymentService.createPayment(userId, command);
+
+        assertThat(result.paymentId()).isEqualTo(10L);
+        assertThat(result.orderId()).isEqualTo("ORDER-20260408-EXIST123");
+        assertThat(result.planId()).isEqualTo(1L);
+        assertThat(result.planName()).isEqualTo("월간 이용권");
+        assertThat(result.billingCycle()).isEqualTo("MONTHLY");
+        assertThat(result.amount()).isEqualByComparingTo("9900");
+        assertThat(result.provider()).isEqualTo("TOSS");
+        assertThat(result.status()).isEqualTo("READY");
+        assertThat(result.requestedAt()).isEqualTo(requestedAt);
+
+        verify(orderIdGenerator, never()).generate();
+        verify(userRepository, never()).findById(any());
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("정상 요청이면 READY 결제를 생성하고 반환한다")
+    void createPayment_success() {
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.of(plan));
+        given(plan.isAvailable()).willReturn(true);
+        given(plan.getPlanId()).willReturn(1L);
+        given(plan.getPlanName()).willReturn("월간 이용권");
+        given(plan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
+        given(plan.getPrice()).willReturn(new BigDecimal("9900"));
+
+        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(false);
+        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
+                userId, 1L, PaymentStatus.READY))
+                .willReturn(Optional.empty());
+        given(orderIdGenerator.generate()).willReturn("ORDER-20260408-NEW12345");
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        given(paymentRepository.save(paymentCaptor.capture()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        PaymentReadyInfo result = paymentService.createPayment(userId, command);
+
+        Payment savedPayment = paymentCaptor.getValue();
+
+        assertThat(savedPayment.getOrderId()).isEqualTo("ORDER-20260408-NEW12345");
+        assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.TOSS);
+        assertThat(savedPayment.getAmount()).isEqualByComparingTo("9900");
+        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.READY);
+        assertThat(savedPayment.getPlan()).isEqualTo(plan);
+        assertThat(savedPayment.getUser()).isEqualTo(user);
+
+        assertThat(result.orderId()).isEqualTo("ORDER-20260408-NEW12345");
+        assertThat(result.planId()).isEqualTo(1L);
+        assertThat(result.planName()).isEqualTo("월간 이용권");
+        assertThat(result.billingCycle()).isEqualTo("MONTHLY");
+        assertThat(result.amount()).isEqualByComparingTo("9900");
+        assertThat(result.provider()).isEqualTo("TOSS");
+        assertThat(result.status()).isEqualTo("READY");
+
+        verify(paymentRepository).save(any(Payment.class));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
@@ -25,6 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -120,7 +121,7 @@ class PaymentServiceTest {
         verify(subscriptionRepository).existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
         verifyNoInteractions(userRepository, orderIdGenerator);
         verify(paymentRepository, never())
-                .findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(any(), any(), any());
+                .findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(any(), any(), any(), any());
         verify(paymentRepository, never()).save(any(Payment.class));
     }
 
@@ -139,8 +140,8 @@ class PaymentServiceTest {
 
         given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
                 .willReturn(false);
-        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
-                userId, 1L, PaymentStatus.READY))
+        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY))
                 .willReturn(Optional.of(existingPayment));
 
         given(existingPayment.getPaymentId()).willReturn(10L);
@@ -181,8 +182,8 @@ class PaymentServiceTest {
 
         given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
                 .willReturn(false);
-        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndStatusOrderByRequestedAtDesc(
-                userId, 1L, PaymentStatus.READY))
+        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY))
                 .willReturn(Optional.empty());
         given(orderIdGenerator.generate()).willReturn("ORDER-20260408-NEW12345");
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -211,5 +212,40 @@ class PaymentServiceTest {
         assertThat(result.status()).isEqualTo("READY");
 
         verify(paymentRepository).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("결제 저장 시 orderId unique 충돌이 발생하면 재시도 후 저장한다")
+    void createPayment_retries_whenOrderIdConflictOccurs() {
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.of(plan));
+        given(plan.isAvailable()).willReturn(true);
+        given(plan.getPlanId()).willReturn(1L);
+        given(plan.getPlanName()).willReturn("월간 이용권");
+        given(plan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
+        given(plan.getPrice()).willReturn(new BigDecimal("9900"));
+
+        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(false);
+        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY))
+                .willReturn(Optional.empty());
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        given(orderIdGenerator.generate())
+                .willReturn("ORDER-20260408-CONFLICT1")
+                .willReturn("ORDER-20260408-SUCCESS2");
+
+        given(paymentRepository.save(any(Payment.class)))
+                .willThrow(new DataIntegrityViolationException("unique constraint violation"))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        PaymentReadyInfo result = paymentService.createPayment(userId, command);
+
+        assertThat(result.orderId()).isEqualTo("ORDER-20260408-SUCCESS2");
+        assertThat(result.status()).isEqualTo("READY");
+
+        verify(orderIdGenerator, times(2)).generate();
+        verify(paymentRepository, times(2)).save(any(Payment.class));
     }
 }

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentServiceTest.java
@@ -13,15 +13,14 @@ import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
 import com.solv.wefin.domain.payment.repository.PaymentRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
-import com.solv.wefin.domain.payment.service.OrderIdGenerator;
 import com.solv.wefin.domain.payment.service.PaymentService;
+import com.solv.wefin.domain.payment.service.PaymentWriter;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -53,7 +52,7 @@ class PaymentServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private OrderIdGenerator orderIdGenerator;
+    private PaymentWriter paymentWriter;
 
     @InjectMocks
     private PaymentService paymentService;
@@ -84,7 +83,7 @@ class PaymentServiceTest {
                 .isEqualTo(ErrorCode.PLAN_NOT_FOUND);
 
         verify(subscriptionPlanRepository).findById(command.planId());
-        verifyNoInteractions(subscriptionRepository, userRepository, orderIdGenerator, paymentRepository);
+        verifyNoInteractions(subscriptionRepository, userRepository, paymentWriter, paymentRepository);
     }
 
     @Test
@@ -101,7 +100,7 @@ class PaymentServiceTest {
 
         verify(subscriptionPlanRepository).findById(command.planId());
         verify(plan).isAvailable();
-        verifyNoInteractions(subscriptionRepository, userRepository, orderIdGenerator, paymentRepository);
+        verifyNoInteractions(subscriptionRepository, userRepository, paymentWriter, paymentRepository);
     }
 
     @Test
@@ -119,10 +118,9 @@ class PaymentServiceTest {
                 .isEqualTo(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
 
         verify(subscriptionRepository).existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
-        verifyNoInteractions(userRepository, orderIdGenerator);
+        verifyNoInteractions(userRepository, paymentWriter);
         verify(paymentRepository, never())
                 .findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(any(), any(), any(), any());
-        verify(paymentRepository, never()).save(any(Payment.class));
     }
 
     @Test
@@ -164,14 +162,16 @@ class PaymentServiceTest {
         assertThat(result.status()).isEqualTo("READY");
         assertThat(result.requestedAt()).isEqualTo(requestedAt);
 
-        verify(orderIdGenerator, never()).generate();
         verify(userRepository, never()).findById(any());
-        verify(paymentRepository, never()).save(any(Payment.class));
+        verifyNoInteractions(paymentWriter);
     }
 
     @Test
     @DisplayName("정상 요청이면 READY 결제를 생성하고 반환한다")
     void createPayment_success() {
+        Payment savedPayment = mock(Payment.class);
+        OffsetDateTime requestedAt = OffsetDateTime.now();
+
         given(subscriptionPlanRepository.findById(command.planId()))
                 .willReturn(Optional.of(plan));
         given(plan.isAvailable()).willReturn(true);
@@ -185,24 +185,22 @@ class PaymentServiceTest {
         given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
                 userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY))
                 .willReturn(Optional.empty());
-        given(orderIdGenerator.generate()).willReturn("ORDER-20260408-NEW12345");
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
-        given(paymentRepository.save(paymentCaptor.capture()))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        given(paymentWriter.saveReadyPayment(plan, user, PaymentProvider.TOSS))
+                .willReturn(savedPayment);
+
+        given(savedPayment.getPaymentId()).willReturn(11L);
+        given(savedPayment.getOrderId()).willReturn("ORDER-20260408-NEW12345");
+        given(savedPayment.getPlan()).willReturn(plan);
+        given(savedPayment.getAmount()).willReturn(new BigDecimal("9900"));
+        given(savedPayment.getProvider()).willReturn(PaymentProvider.TOSS);
+        given(savedPayment.getStatus()).willReturn(PaymentStatus.READY);
+        given(savedPayment.getRequestedAt()).willReturn(requestedAt);
 
         PaymentReadyInfo result = paymentService.createPayment(userId, command);
 
-        Payment savedPayment = paymentCaptor.getValue();
-
-        assertThat(savedPayment.getOrderId()).isEqualTo("ORDER-20260408-NEW12345");
-        assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.TOSS);
-        assertThat(savedPayment.getAmount()).isEqualByComparingTo("9900");
-        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.READY);
-        assertThat(savedPayment.getPlan()).isEqualTo(plan);
-        assertThat(savedPayment.getUser()).isEqualTo(user);
-
+        assertThat(result.paymentId()).isEqualTo(11L);
         assertThat(result.orderId()).isEqualTo("ORDER-20260408-NEW12345");
         assertThat(result.planId()).isEqualTo(1L);
         assertThat(result.planName()).isEqualTo("월간 이용권");
@@ -210,42 +208,86 @@ class PaymentServiceTest {
         assertThat(result.amount()).isEqualByComparingTo("9900");
         assertThat(result.provider()).isEqualTo("TOSS");
         assertThat(result.status()).isEqualTo("READY");
+        assertThat(result.requestedAt()).isEqualTo(requestedAt);
 
-        verify(paymentRepository).save(any(Payment.class));
+        verify(paymentWriter).saveReadyPayment(plan, user, PaymentProvider.TOSS);
     }
 
     @Test
-    @DisplayName("결제 저장 시 orderId unique 충돌이 발생하면 재시도 후 저장한다")
-    void createPayment_retries_whenOrderIdConflictOccurs() {
+    @DisplayName("결제 저장 시 unique 충돌이 발생하면 재조회 후 기존 READY 결제를 반환한다")
+    void createPayment_returnsConcurrentReady_whenDataIntegrityViolationOccurs() {
+        Payment concurrentReady = mock(Payment.class);
+        OffsetDateTime requestedAt = OffsetDateTime.now();
+
         given(subscriptionPlanRepository.findById(command.planId()))
                 .willReturn(Optional.of(plan));
         given(plan.isAvailable()).willReturn(true);
         given(plan.getPlanId()).willReturn(1L);
         given(plan.getPlanName()).willReturn("월간 이용권");
         given(plan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
+
+        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(false);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(user.getUserId()).willReturn(userId);
+
+        given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY))
+                .willReturn(Optional.empty())
+                .willReturn(Optional.of(concurrentReady));
+
+        given(paymentWriter.saveReadyPayment(plan, user, PaymentProvider.TOSS))
+                .willThrow(new DataIntegrityViolationException("unique constraint violation"));
+
+        given(concurrentReady.getPaymentId()).willReturn(12L);
+        given(concurrentReady.getOrderId()).willReturn("ORDER-20260408-CONCURRENT");
+        given(concurrentReady.getPlan()).willReturn(plan);
+        given(concurrentReady.getAmount()).willReturn(new BigDecimal("9900"));
+        given(concurrentReady.getProvider()).willReturn(PaymentProvider.TOSS);
+        given(concurrentReady.getStatus()).willReturn(PaymentStatus.READY);
+        given(concurrentReady.getRequestedAt()).willReturn(requestedAt);
+
+        PaymentReadyInfo result = paymentService.createPayment(userId, command);
+
+        assertThat(result.paymentId()).isEqualTo(12L);
+        assertThat(result.orderId()).isEqualTo("ORDER-20260408-CONCURRENT");
+        assertThat(result.status()).isEqualTo("READY");
+
+        verify(paymentWriter, times(1)).saveReadyPayment(plan, user, PaymentProvider.TOSS);
+        verify(paymentRepository, times(2))
+                .findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                        userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY);
+    }
+
+    @Test
+    @DisplayName("결제 저장 충돌이 반복되고 기존 READY도 없으면 최대 3번 재시도 후 INTERNAL_SERVER_ERROR 예외가 발생한다")
+    void createPayment_fail_whenSaveConflictRepeatsWithoutConcurrentReady() {
+        given(subscriptionPlanRepository.findById(command.planId()))
+                .willReturn(Optional.of(plan));
+        given(plan.isAvailable()).willReturn(true);
+        given(plan.getPlanId()).willReturn(1L);
         given(plan.getPrice()).willReturn(new BigDecimal("9900"));
 
         given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
                 .willReturn(false);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(user.getUserId()).willReturn(userId);
+
         given(paymentRepository.findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
                 userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY))
                 .willReturn(Optional.empty());
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        given(orderIdGenerator.generate())
-                .willReturn("ORDER-20260408-CONFLICT1")
-                .willReturn("ORDER-20260408-SUCCESS2");
+        given(paymentWriter.saveReadyPayment(plan, user, PaymentProvider.TOSS))
+                .willThrow(new DataIntegrityViolationException("unique constraint violation"));
 
-        given(paymentRepository.save(any(Payment.class)))
-                .willThrow(new DataIntegrityViolationException("unique constraint violation"))
-                .willAnswer(invocation -> invocation.getArgument(0));
+        assertThatThrownBy(() -> paymentService.createPayment(userId, command))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
 
-        PaymentReadyInfo result = paymentService.createPayment(userId, command);
-
-        assertThat(result.orderId()).isEqualTo("ORDER-20260408-SUCCESS2");
-        assertThat(result.status()).isEqualTo("READY");
-
-        verify(orderIdGenerator, times(2)).generate();
-        verify(paymentRepository, times(2)).save(any(Payment.class));
+        verify(paymentWriter, times(3)).saveReadyPayment(plan, user, PaymentProvider.TOSS);
+        verify(paymentRepository, times(4))
+                .findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
+                        userId, 1L, PaymentProvider.TOSS, PaymentStatus.READY);
     }
 }

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentWriterTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentWriterTest.java
@@ -1,0 +1,69 @@
+package com.solv.wefin.domain.payment;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.payment.entity.Payment;
+import com.solv.wefin.domain.payment.entity.PaymentProvider;
+import com.solv.wefin.domain.payment.entity.PaymentStatus;
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import com.solv.wefin.domain.payment.service.OrderIdGenerator;
+import com.solv.wefin.domain.payment.service.PaymentWriter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentWriterTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private OrderIdGenerator orderIdGenerator;
+
+    @Mock
+    private SubscriptionPlan plan;
+
+    @Mock
+    private User user;
+
+    @InjectMocks
+    private PaymentWriter paymentWriter;
+
+    @Test
+    @DisplayName("READY 결제를 생성해서 saveAndFlush 한다")
+    void saveReadyPayment_success() {
+        given(orderIdGenerator.generate()).willReturn("ORDER-20260409-TEST123");
+        given(plan.getPrice()).willReturn(new BigDecimal("9900"));
+
+        ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+        given(paymentRepository.saveAndFlush(paymentCaptor.capture()))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        Payment result = paymentWriter.saveReadyPayment(plan, user, PaymentProvider.TOSS);
+
+        Payment savedPayment = paymentCaptor.getValue();
+
+        assertThat(savedPayment.getOrderId()).isEqualTo("ORDER-20260409-TEST123");
+        assertThat(savedPayment.getPlan()).isEqualTo(plan);
+        assertThat(savedPayment.getUser()).isEqualTo(user);
+        assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.TOSS);
+        assertThat(savedPayment.getAmount()).isEqualByComparingTo("9900");
+        assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.READY);
+
+        assertThat(result).isSameAs(savedPayment);
+
+        verify(orderIdGenerator).generate();
+        verify(paymentRepository).saveAndFlush(savedPayment);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/user/UserServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/user/UserServiceTest.java
@@ -1,8 +1,9 @@
-package com.solv.wefin.domain.user.service;
+package com.solv.wefin.domain.user;
 
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.user.dto.MyPageInfo;
+import com.solv.wefin.domain.user.service.UserService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/solv/wefin/web/payment/PaymentControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/payment/PaymentControllerTest.java
@@ -1,0 +1,148 @@
+package com.solv.wefin.web.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
+import com.solv.wefin.domain.payment.service.PaymentService;
+import com.solv.wefin.global.config.SecurityConfig;
+import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
+import com.solv.wefin.global.config.security.JwtAuthenticationFilter;
+import com.solv.wefin.global.config.security.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PaymentController.class)
+@Import({
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        JwtAuthenticationEntryPoint.class
+})
+class PaymentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private PaymentService paymentService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("결제 준비 생성 요청에 성공한다")
+    void createPayment_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        PaymentReadyInfo info = new PaymentReadyInfo(
+                1L,
+                "ORDER-20260408-AB12CD34",
+                1L,
+                "프리미엄 월간 이용권",
+                "MONTHLY",
+                new BigDecimal("9900"),
+                "TOSS",
+                "READY",
+                OffsetDateTime.parse("2026-04-08T21:30:00+09:00")
+        );
+
+        given(paymentService.createPayment(eq(userId), any()))
+                .willReturn(info);
+
+        String requestBody = """
+                {
+                  "planId": 1,
+                  "provider": "TOSS"
+                }
+                """;
+
+        mockMvc.perform(post("/api/payments")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        userId,
+                                        null,
+                                        java.util.List.of()
+                                )
+                        ))
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.paymentId").value(1))
+                .andExpect(jsonPath("$.data.orderId").value("ORDER-20260408-AB12CD34"))
+                .andExpect(jsonPath("$.data.planId").value(1))
+                .andExpect(jsonPath("$.data.planName").value("프리미엄 월간 이용권"))
+                .andExpect(jsonPath("$.data.billingCycle").value("MONTHLY"))
+                .andExpect(jsonPath("$.data.amount").value(9900))
+                .andExpect(jsonPath("$.data.provider").value("TOSS"))
+                .andExpect(jsonPath("$.data.status").value("READY"))
+                .andExpect(jsonPath("$.data.requestedAt").exists());
+    }
+
+    @Test
+    @DisplayName("planId가 없으면 400을 반환한다")
+    void createPayment_fail_whenPlanIdIsNull() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        String requestBody = """
+                {
+                  "provider": "TOSS"
+                }
+                """;
+
+        mockMvc.perform(post("/api/payments")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        userId,
+                                        null,
+                                        java.util.List.of()
+                                )
+                        ))
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("provider가 비어 있으면 400을 반환한다")
+    void createPayment_fail_whenProviderIsBlank() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        String requestBody = """
+                {
+                  "planId": 1,
+                  "provider": ""
+                }
+                """;
+
+        mockMvc.perform(post("/api/payments")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        userId,
+                                        null,
+                                        java.util.List.of()
+                                )
+                        ))
+                        .contentType(APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
결제 요청을 생성하는 결제 준비 단계 API를 구현.

사용자가 선택한 구독 상품을 기준으로 결제 가능 여부를 검증하고 결제 요청 데이터를 생성하여 결제사(Toss) 연동에 필요한 정보를 반환.

실제 결제 승인 이전 단계로 주문 생성 및 상태 관리에 중점을 둔 API.
<br>

## ✅ 완료한 기능 명세

- [x] 결제 요청 생성 API 구현
- [x] 구독 상품 조회 및 활성 여부 검증
- [x] 활성 구독 존재 여부 검증
- [x] 기존 READY 결제 재사용 로직 구현
- [x] 주문번호 생성 로직 구현
- [x] 결제 준비 상태(READY) 생성 및 저장
- [x] Payment / Subscription / Plan 도메인 설계 및 구현
- [x] PaymentService 비즈니스 로직 구현
- [x] Controller / Request / Response DTO 구현
- [x] 결제 관련 ErrorCode 추가
- [x] 테스트 코드 작성 (PaymentServiceTest / PaymentControllerTest)

- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정

- 결제 준비 단계에서 결제 요청 중복 처리 방식을 고민했으나 매번 새로운 결제를 생성하는 대신, 동일 사용자와 동일 플랜에 대해 READY 상태 결제가 존재할 경우 이를 재사용하도록 설계하여 불필요한 결제 데이터 생성을 방지하도록 처리함

- 결제 생성 로직에서 불필요한 DB 접근을 줄이기 위해 provider 검증 → plan 조회 → plan 상태 검증 → 구독 여부 검증 → 기존 결제 확인 순으로 처리하여 빠르게 실패할 수 있도록 fail-fast 구조로 설계함

<br>

### 🔗 관련 이슈
Closes #167 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 API (POST /api/payments) 추가 — 구독 상품 선택 후 결제 준비 생성/조회
  * 결제·구독 도메인 전반 추가 — 플랜, 구독, 결제, 상태 및 결제사 모델 포함
  * 주문 ID 생성기 및 중복 충돌 재시도 로직 도입
* **검증/오류**
  * 요청 파라미터 검증 강화 및 신규 오류 코드(플랜/공급자/활성구독 관련) 추가
* **테스트**
  * 서비스·컨트롤러 단위 테스트 추가 (성공·실패·재시도 시나리오)
* **데이터베이스**
  * READY 상태에 대한 부분적 유니크 인덱스 마이그레이션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->