### PR TITLE
[WEF-557] 그룹 설계 변경 리팩토링

### DIFF
--- a/src/main/java/com/solv/wefin/domain/group/entity/Group.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/Group.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.OffsetDateTime;
+
 @Entity
 @Table(name = "groups")
 @Getter
@@ -24,6 +26,9 @@ public class Group {
     @Column(name = "group_type", nullable = false, length = 20)
     private GroupType groupType;
 
+    @Column(name = "created_at", nullable = false, updatable = false, insertable = false)
+    private OffsetDateTime createdAt;
+
     @Builder
     private Group(String name, GroupType groupType) {
         this.name = name;
@@ -31,11 +36,17 @@ public class Group {
     }
 
     public static Group createHomeGroup(String name) {
-        return new Group(name, GroupType.HOME);
+        return Group.builder()
+                .name(name)
+                .groupType(GroupType.HOME)
+                .build();
     }
 
     public static Group createSharedGroup(String name) {
-        return new Group(name, GroupType.SHARED);
+        return Group.builder()
+                .name(name)
+                .groupType(GroupType.SHARED)
+                .build();
     }
 
     public boolean isHomeGroup() {

--- a/src/main/java/com/solv/wefin/domain/group/entity/Group.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/Group.java
@@ -1,8 +1,8 @@
 package com.solv.wefin.domain.group.entity;
 
-import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "groups")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Group extends BaseEntity {
+public class Group {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,9 +24,10 @@ public class Group extends BaseEntity {
     @Column(name = "group_type", nullable = false, length = 20)
     private GroupType groupType;
 
+    @Builder
     private Group(String name, GroupType groupType) {
         this.name = name;
-        this.groupType = groupType;
+        this.groupType = groupType != null ? groupType : GroupType.SHARED;
     }
 
     public static Group createHomeGroup(String name) {

--- a/src/main/java/com/solv/wefin/domain/group/entity/Group.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/Group.java
@@ -1,18 +1,16 @@
 package com.solv.wefin.domain.group.entity;
 
+import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "groups")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Group {
+public class Group extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,16 +20,28 @@ public class Group {
     @Column(name = "group_name", nullable = false, length = 100)
     private String name;
 
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "group_type", nullable = false, length = 20)
+    private GroupType groupType;
 
-    @Builder
-    private Group(String name) {
+    private Group(String name, GroupType groupType) {
         this.name = name;
+        this.groupType = groupType;
     }
 
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = OffsetDateTime.now();
+    public static Group createHomeGroup(String name) {
+        return new Group(name, GroupType.HOME);
+    }
+
+    public static Group createSharedGroup(String name) {
+        return new Group(name, GroupType.SHARED);
+    }
+
+    public boolean isHomeGroup() {
+        return this.groupType == GroupType.HOME;
+    }
+
+    public boolean isSharedGroup() {
+        return this.groupType == GroupType.SHARED;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -3,7 +3,6 @@ package com.solv.wefin.domain.group.entity;
 import com.solv.wefin.domain.auth.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -42,12 +41,19 @@ public class GroupMember {
     @Column(name = "left_at")
     private OffsetDateTime leftAt;
 
-    @Builder
     private GroupMember(User user, Group group, GroupMemberRole role, GroupMemberStatus status) {
         this.user = user;
         this.group = group;
         this.role = role;
         this.status = status;
+    }
+
+    public static GroupMember createLeader(User user, Group group, GroupMemberStatus status) {
+        return new GroupMember(user, group, GroupMemberRole.LEADER, status);
+    }
+
+    public static GroupMember createMember(User user, Group group, GroupMemberStatus status) {
+        return new GroupMember(user, group, GroupMemberRole.MEMBER, status);
     }
 
     @PrePersist
@@ -57,9 +63,25 @@ public class GroupMember {
         }
     }
 
-    public void leave() {
-        this.status = GroupMemberStatus.LEFT;
-        this.leftAt = OffsetDateTime.now();
+    public void activate() {
+        this.status = GroupMemberStatus.ACTIVE;
+        this.leftAt = null;
+    }
+
+    public void deactivate() {
+        this.status = GroupMemberStatus.INACTIVE;
+    }
+
+    public boolean isActive() {
+        return this.status == GroupMemberStatus.ACTIVE;
+    }
+
+    public boolean isLeader() {
+        return this.role == GroupMemberRole.LEADER;
+    }
+
+    public boolean isHomeGroupMember() {
+        return this.group.isHomeGroup();
     }
 
     public enum GroupMemberRole {
@@ -69,6 +91,6 @@ public class GroupMember {
 
     public enum GroupMemberStatus {
         ACTIVE,
-        LEFT
+        INACTIVE
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -50,12 +50,22 @@ public class GroupMember {
         this.status = status;
     }
 
-    public static GroupMember createLeader(User user, Group group, GroupMemberStatus status) {
-        return new GroupMember(user, group, GroupMemberRole.LEADER, status);
+    public static GroupMember createLeader(User user, Group group) {
+        return GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMemberRole.LEADER)
+                .status(GroupMemberStatus.ACTIVE)
+                .build();
     }
 
-    public static GroupMember createMember(User user, Group group, GroupMemberStatus status) {
-        return new GroupMember(user, group, GroupMemberRole.MEMBER, status);
+    public static GroupMember createMember(User user, Group group) {
+        return GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMemberRole.MEMBER)
+                .status(GroupMemberStatus.ACTIVE)
+                .build();
     }
 
     @PrePersist

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -72,6 +72,7 @@ public class GroupMember {
 
     public void deactivate() {
         this.status = GroupMemberStatus.INACTIVE;
+        this.leftAt = OffsetDateTime.now();
     }
 
     public boolean isActive() {

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.group.entity;
 import com.solv.wefin.domain.auth.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -41,6 +42,7 @@ public class GroupMember {
     @Column(name = "left_at")
     private OffsetDateTime leftAt;
 
+    @Builder
     private GroupMember(User user, Group group, GroupMemberRole role, GroupMemberStatus status) {
         this.user = user;
         this.group = group;

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupType.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupType.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.group.entity;
+
+public enum GroupType {
+    HOME,
+    SHARED
+}

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.group.repository;
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.entity.GroupType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,6 +21,13 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             GroupMember.GroupMemberStatus status
     );
 
+    Optional<GroupMember> findByUser_UserIdAndGroup_Id(UUID userId, Long groupId);
+
+    Optional<GroupMember> findByUser_UserIdAndGroup_GroupType(
+            UUID userId,
+            GroupType groupType
+    );
+
     boolean existsByUser_UserIdAndGroupAndStatus(
             UUID userId,
             Group group,
@@ -33,8 +41,10 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             where gm.group = :group
               and gm.status = :status
             """)
-    List<GroupMember> findByGroupAndStatusWithUser(@Param("group") Group group,
-                                                   @Param("status") GroupMember.GroupMemberStatus status);
+    List<GroupMember> findByGroupAndStatusWithUser(
+            @Param("group") Group group,
+            @Param("status") GroupMember.GroupMemberStatus status
+    );
 
     long countByGroupAndStatus(Group group, GroupMember.GroupMemberStatus status);
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -23,6 +24,9 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GroupService {
+
+    private static final long MAX_GROUP_MEMBER_COUNT = 6L;
+
     private final GroupRepository groupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final GroupInviteRepository groupInviteRepository;
@@ -30,17 +34,14 @@ public class GroupService {
 
     @Transactional
     public Group createDefaultGroup(User user) {
-        Group group = Group.builder()
-                .name(user.getNickname() + "의 그룹")
-                .build();
+        Group group = Group.createHomeGroup(user.getNickname() + "의 그룹");
         Group savedGroup = groupRepository.save(group);
 
-        GroupMember groupMember = GroupMember.builder()
-                .user(user)
-                .group(savedGroup)
-                .role(GroupMember.GroupMemberRole.LEADER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
+        GroupMember groupMember = GroupMember.createLeader(
+                user,
+                savedGroup,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
 
         groupMemberRepository.save(groupMember);
         return savedGroup;
@@ -62,6 +63,10 @@ public class GroupService {
     public GroupInviteInfo createInviteCode(Long groupId, UUID userId) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        if (group.isHomeGroup()) {
+            throw new BusinessException(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
+        }
 
         boolean isMember = groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                 userId,
@@ -87,7 +92,9 @@ public class GroupService {
         GroupInvite invite = groupInviteRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_INVITE_NOT_FOUND));
 
-        if (invite.getExpiredAt().isBefore(java.time.OffsetDateTime.now())) {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        if (invite.getExpiredAt().isBefore(now)) {
             throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
         }
 
@@ -101,6 +108,10 @@ public class GroupService {
 
         Group targetGroup = groupRepository.findByIdForUpdate(invite.getGroup().getId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        if (targetGroup.isHomeGroup()) {
+            throw new BusinessException(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -119,20 +130,29 @@ public class GroupService {
                 GroupMember.GroupMemberStatus.ACTIVE
         );
 
-        if (activeMemberCount >= 6) {
+        if (activeMemberCount >= MAX_GROUP_MEMBER_COUNT) {
             throw new BusinessException(ErrorCode.GROUP_FULL);
         }
 
         if (currentActiveMember != null) {
-            currentActiveMember.leave();
+            currentActiveMember.deactivate();
         }
 
-        GroupMember newMember = GroupMember.builder()
-                .user(user)
-                .group(targetGroup)
-                .role(GroupMember.GroupMemberRole.MEMBER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
+        GroupMember targetMembership = groupMemberRepository
+                .findByUser_UserIdAndGroup_Id(userId, targetGroup.getId())
+                .orElse(null);
+
+        if (targetMembership != null) {
+            targetMembership.activate();
+            invite.markAccepted();
+            return GroupMemberInfo.from(targetMembership);
+        }
+
+        GroupMember newMember = GroupMember.createMember(
+                user,
+                targetGroup,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
 
         groupMemberRepository.save(newMember);
         invite.markAccepted();

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -39,8 +39,7 @@ public class GroupService {
 
         GroupMember groupMember = GroupMember.createLeader(
                 user,
-                savedGroup,
-                GroupMember.GroupMemberStatus.ACTIVE
+                savedGroup
         );
 
         groupMemberRepository.save(groupMember);
@@ -150,8 +149,7 @@ public class GroupService {
 
         GroupMember newMember = GroupMember.createMember(
                 user,
-                targetGroup,
-                GroupMember.GroupMemberStatus.ACTIVE
+                targetGroup
         );
 
         groupMemberRepository.save(newMember);

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -110,7 +110,7 @@ public class GroupService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
 
         if (targetGroup.isHomeGroup()) {
-            throw new BusinessException(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
+            throw new BusinessException(ErrorCode.GROUP_HOME_JOIN_NOT_ALLOWED);
         }
 
         User user = userRepository.findById(userId)

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     GROUP_FULL(400, "그룹 인원이 가득 찼습니다."),
     ALREADY_JOINED_GROUP(409, "이미 참여한 그룹입니다."),
     GROUP_HOME_INVITE_NOT_ALLOWED(400, "홈 그룹에는 초대 코드를 생성할 수 없습니다."),
+    GROUP_HOME_JOIN_NOT_ALLOWED(400, "홈 그룹에는 참여할 수 없습니다."),
     GROUP_HOME_LEAVE_NOT_ALLOWED(400, "홈 그룹은 탈퇴할 수 없습니다."),
     GROUP_HOME_GROUP_NOT_FOUND(404, "홈 그룹을 찾을 수 없습니다."),
 

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
     GROUP_INVITE_ALREADY_USED(400, "이미 사용된 초대 코드입니다."),
     GROUP_FULL(400, "그룹 인원이 가득 찼습니다."),
     ALREADY_JOINED_GROUP(409, "이미 참여한 그룹입니다."),
+    GROUP_HOME_INVITE_NOT_ALLOWED(400, "홈 그룹에는 초대 코드를 생성할 수 없습니다."),
+    GROUP_HOME_LEAVE_NOT_ALLOWED(400, "홈 그룹은 탈퇴할 수 없습니다."),
+    GROUP_HOME_GROUP_NOT_FOUND(404, "홈 그룹을 찾을 수 없습니다."),
 
     // Chat
     CHAT_MESSAGE_EMPTY(400, "메시지 내용은 비어 있을 수 없습니다."),

--- a/src/main/resources/db/migration/V22__add_unique_constraint_payment_ready.sql
+++ b/src/main/resources/db/migration/V22__add_unique_constraint_payment_ready.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX uk_payment_ready_unique
+    ON payment (user_id, plan_id, provider)
+    WHERE status = 'READY';

--- a/src/main/resources/db/migration/V22__add_unique_constraint_payment_ready.sql
+++ b/src/main/resources/db/migration/V22__add_unique_constraint_payment_ready.sql
@@ -1,3 +1,0 @@
-CREATE UNIQUE INDEX uk_payment_ready_unique
-    ON payment (user_id, plan_id, provider)
-    WHERE status = 'READY';

--- a/src/main/resources/db/migration/V23__add_home_group_policy_and_chat_news_share.sql
+++ b/src/main/resources/db/migration/V23__add_home_group_policy_and_chat_news_share.sql
@@ -1,0 +1,69 @@
+-- 1) groups 테이블에 group_type 추가
+ALTER TABLE "groups"
+    ADD COLUMN "group_type" VARCHAR(20) NOT NULL DEFAULT 'SHARED';
+
+ALTER TABLE "groups"
+    ADD CONSTRAINT "chk_groups_group_type"
+        CHECK ("group_type" IN ('HOME', 'SHARED'));
+
+
+-- 2) group_member status 제약 변경
+ALTER TABLE "group_member"
+DROP CONSTRAINT IF EXISTS "chk_group_member_status";
+
+UPDATE "group_member"
+SET "status" = 'INACTIVE'
+WHERE "status" = 'LEFT';
+
+ALTER TABLE "group_member"
+    ADD CONSTRAINT "chk_group_member_status"
+        CHECK ("status" IN ('ACTIVE', 'INACTIVE'));
+
+
+-- 3) role 제약 재확인
+ALTER TABLE "group_member"
+DROP CONSTRAINT IF EXISTS "chk_group_member_role";
+
+ALTER TABLE "group_member"
+    ADD CONSTRAINT "chk_group_member_role"
+        CHECK ("role" IN ('LEADER', 'MEMBER'));
+
+
+-- 4) 동일 사용자-동일 그룹 중복 가입 방지 제약 재확인
+ALTER TABLE "group_member"
+DROP CONSTRAINT IF EXISTS "uk_group_member_user_group";
+
+ALTER TABLE "group_member"
+    ADD CONSTRAINT "uk_group_member_user_group"
+        UNIQUE ("user_id", "group_id");
+
+
+-- 5) 유저당 ACTIVE 그룹 1개만 허용
+CREATE UNIQUE INDEX IF NOT EXISTS "uk_group_member_user_active"
+    ON "group_member" ("user_id")
+    WHERE "status" = 'ACTIVE';
+
+
+-- 6) 채팅 뉴스 공유 테이블 추가
+CREATE TABLE chat_message_news_share (
+                                         chat_message_id BIGINT PRIMARY KEY,
+                                         news_cluster_id BIGINT NOT NULL,
+                                         shared_title VARCHAR(255) NOT NULL,
+                                         shared_summary TEXT,
+                                         shared_thumbnail_url TEXT,
+                                         CONSTRAINT fk_chat_message_news_share_chat_message
+                                             FOREIGN KEY (chat_message_id) REFERENCES chat_message (message_id) ON DELETE CASCADE,
+                                         CONSTRAINT fk_chat_message_news_share_news_cluster
+                                             FOREIGN KEY (news_cluster_id) REFERENCES news_cluster (news_cluster_id)
+);
+
+CREATE INDEX idx_chat_message_news_share_news_cluster_id
+    ON chat_message_news_share (news_cluster_id);
+
+
+-- 7) user_interest NOT NULL 제약 추가
+ALTER TABLE "user_interest"
+    ALTER COLUMN "interest_type" SET NOT NULL;
+
+ALTER TABLE "user_interest"
+    ALTER COLUMN "interest_value" SET NOT NULL;

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -240,6 +240,52 @@ class GroupServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("joinGroup")
+    class JoinGroupTest {
+
+        @Test
+        @DisplayName("홈 그룹에는 참여할 수 없다")
+        void joinGroup_fail_when_home_group() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+            UUID inviteCode = UUID.randomUUID();
+
+            Group homeGroup = createGroup(1L, "홈 그룹", GroupType.HOME);
+            User user = createUser(userId, "test@test.com", "유저", "pw");
+
+            GroupInvite invite = createGroupInvite(
+                    10L,
+                    homeGroup,
+                    user,
+                    inviteCode,
+                    GroupInvite.InviteStatus.PENDING
+            );
+
+            when(groupInviteRepository.findByInviteCode(inviteCode))
+                    .thenReturn(Optional.of(invite));
+
+            when(groupRepository.findByIdForUpdate(homeGroup.getId()))
+                    .thenReturn(Optional.of(homeGroup));
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.joinGroup(userId, inviteCode)
+            );
+
+            // then
+            assertThat(exception.getErrorCode())
+                    .isEqualTo(ErrorCode.GROUP_HOME_JOIN_NOT_ALLOWED);
+
+            verify(userRepository, never()).findById(any());
+            verify(groupMemberRepository, never()).findByUser_UserIdAndStatus(any(), any());
+            verify(groupMemberRepository, never()).countByGroupAndStatus(any(), any());
+            verify(groupMemberRepository, never()).findByUser_UserIdAndGroup_Id(any(), anyLong());
+            verify(groupMemberRepository, never()).save(any());
+        }
+    }
+
     private Group createGroup(Long id, String name, GroupType groupType) throws Exception {
         Constructor<Group> constructor = Group.class.getDeclaredConstructor(String.class, GroupType.class);
         constructor.setAccessible(true);

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupInvite;
 import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.entity.GroupType;
 import com.solv.wefin.domain.group.repository.GroupInviteRepository;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
@@ -22,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -57,7 +59,7 @@ class GroupServiceTest {
         @DisplayName("그룹이 존재하면 ACTIVE 멤버 목록을 반환한다")
         void getActiveMembers_success() throws Exception {
             // given
-            Group group = createGroup(1L, "테스트 그룹");
+            Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
 
             User leaderUser = createUser(
                     UUID.randomUUID(),
@@ -137,12 +139,12 @@ class GroupServiceTest {
     class CreateInviteCodeTest {
 
         @Test
-        @DisplayName("그룹의 ACTIVE 멤버면 초대 코드를 생성한다")
+        @DisplayName("공유 그룹의 ACTIVE 멤버면 초대 코드를 생성한다")
         void createInviteCode_success() throws Exception {
             // given
             UUID userId = UUID.randomUUID();
 
-            Group group = createGroup(1L, "테스트 그룹");
+            Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
             User user = createUser(
                     userId,
                     "leader@test.com",
@@ -190,11 +192,33 @@ class GroupServiceTest {
         }
 
         @Test
-        @DisplayName("그룹의 멤버가 아니면 예외가 발생한다")
-        void createInviteCode_fail_when_not_member() {
+        @DisplayName("홈 그룹이면 초대 코드 생성이 불가하다")
+        void createInviteCode_fail_when_home_group() throws Exception {
             // given
             UUID userId = UUID.randomUUID();
-            Group group = mock(Group.class);
+            Group homeGroup = createGroup(1L, "리더의 그룹", GroupType.HOME);
+
+            when(groupRepository.findById(1L)).thenReturn(Optional.of(homeGroup));
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.createInviteCode(1L, userId)
+            );
+
+            // then
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
+            verify(groupMemberRepository, never()).existsByUser_UserIdAndGroupAndStatus(any(), any(), any());
+            verify(userRepository, never()).findById(any());
+            verify(groupInviteRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("공유 그룹의 ACTIVE 멤버가 아니면 예외가 발생한다")
+        void createInviteCode_fail_when_not_member() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+            Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
 
             when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
             when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
@@ -211,16 +235,15 @@ class GroupServiceTest {
 
             // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_FORBIDDEN);
-
             verify(userRepository, never()).findById(any());
             verify(groupInviteRepository, never()).save(any());
         }
     }
 
-    private Group createGroup(Long id, String name) throws Exception {
-        Constructor<Group> constructor = Group.class.getDeclaredConstructor(String.class);
+    private Group createGroup(Long id, String name, GroupType groupType) throws Exception {
+        Constructor<Group> constructor = Group.class.getDeclaredConstructor(String.class, GroupType.class);
         constructor.setAccessible(true);
-        Group group = constructor.newInstance(name);
+        Group group = constructor.newInstance(name, groupType);
 
         Field idField = Group.class.getDeclaredField("id");
         idField.setAccessible(true);
@@ -276,7 +299,7 @@ class GroupServiceTest {
                 User.class,
                 UUID.class,
                 GroupInvite.InviteStatus.class,
-                java.time.OffsetDateTime.class
+                OffsetDateTime.class
         );
         constructor.setAccessible(true);
 
@@ -285,7 +308,7 @@ class GroupServiceTest {
                 createdBy,
                 inviteCode,
                 status,
-                java.time.OffsetDateTime.now().plusHours(24)
+                OffsetDateTime.now().plusHours(24)
         );
 
         Field idField = GroupInvite.class.getDeclaredField("id");

--- a/src/test/java/com/solv/wefin/domain/trading/order/entity/OrderTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/entity/OrderTest.java
@@ -16,18 +16,18 @@ class OrderTest {
 
 	private Order createBuyOrder() {
 		return new Order(1L, 1L, OrderType.LIMIT, OrderSide.BUY, 10,
-			BigDecimal.valueOf(50000), Currency.KRW, null,
-			BigDecimal.valueOf(75), BigDecimal.ZERO);
+				BigDecimal.valueOf(50000), Currency.KRW, null,
+				BigDecimal.valueOf(75), BigDecimal.ZERO);
 	}
 
 	private Order createSellOrder() {
 		return new Order(1L, 1L, OrderType.LIMIT, OrderSide.SELL, 5,
-			BigDecimal.valueOf(120000), Currency.KRW, null,
-			BigDecimal.valueOf(75), BigDecimal.ZERO);
+				BigDecimal.valueOf(120000), Currency.KRW, null,
+				BigDecimal.valueOf(75), BigDecimal.ZERO);
 	}
 
 	@Nested
-	class 취소 {
+	class CancelTest {
 		@Test
 		void 취소_성공() {
 			Order order = createBuyOrder();
@@ -41,8 +41,8 @@ class OrderTest {
 			Order order = createBuyOrder();
 			order.fill(10);
 			assertThatThrownBy(() -> order.cancel())
-				.isInstanceOf(BusinessException.class)
-				.hasMessage(ErrorCode.ORDER_ALREADY_FILLED.getMessage());
+					.isInstanceOf(BusinessException.class)
+					.hasMessage(ErrorCode.ORDER_ALREADY_FILLED.getMessage());
 		}
 
 		@Test
@@ -50,24 +50,24 @@ class OrderTest {
 			Order order = createBuyOrder();
 			order.cancel();
 			assertThatThrownBy(() -> order.cancel())
-				.isInstanceOf(BusinessException.class)
+					.isInstanceOf(BusinessException.class)
 					.hasMessage(ErrorCode.ORDER_ALREADY_CANCELLED.getMessage());
 		}
 	}
 
 	@Nested
-	class 정정 {
+	class ModifyTest {
 		@Test
 		void 정정_성공_가격수량변경() {
 			Order order = createBuyOrder();
 			order.modify(new BigDecimal("12000"), 20);
 
 			assertThat(order.getQuantity()).isEqualTo(20);
-			assertThat(order.getRequestPrice()).
-				isEqualByComparingTo(new BigDecimal("12000"));
+			assertThat(order.getRequestPrice())
+					.isEqualByComparingTo(new BigDecimal("12000"));
 			BigDecimal newFee = BigDecimal.valueOf(12000)
-				.multiply(BigDecimal.valueOf(20))
-				.multiply(TradingConstants.FEE_RATE);
+					.multiply(BigDecimal.valueOf(20))
+					.multiply(TradingConstants.FEE_RATE);
 			assertThat(order.getFee()).isEqualByComparingTo(newFee);
 		}
 
@@ -76,8 +76,8 @@ class OrderTest {
 			Order order = createSellOrder();
 			order.modify(new BigDecimal("15000"), 10);
 			BigDecimal newTax = BigDecimal.valueOf(15000)
-				.multiply(BigDecimal.valueOf(10))
-				.multiply(TradingConstants.TAX_RATE);
+					.multiply(BigDecimal.valueOf(10))
+					.multiply(TradingConstants.TAX_RATE);
 			assertThat(order.getTax()).isEqualByComparingTo(newTax);
 		}
 
@@ -86,42 +86,42 @@ class OrderTest {
 			Order order = createBuyOrder();
 			order.fill(10);
 			assertThatThrownBy(() -> order.modify(new BigDecimal(120000), 20))
-				.isInstanceOf(BusinessException.class)
-				.hasMessage(ErrorCode.ORDER_ALREADY_FILLED.getMessage());
+					.isInstanceOf(BusinessException.class)
+					.hasMessage(ErrorCode.ORDER_ALREADY_FILLED.getMessage());
 		}
 
 		@Test
 		void 정정_실패_수량_0이하() {
 			Order order = createBuyOrder();
 			assertThatThrownBy(() -> order.modify(new BigDecimal(120000), 0))
-				.isInstanceOf(BusinessException.class)
-				.hasMessage(ErrorCode.ORDER_INVALID_QUANTITY.getMessage());
+					.isInstanceOf(BusinessException.class)
+					.hasMessage(ErrorCode.ORDER_INVALID_QUANTITY.getMessage());
 		}
 
 		@Test
 		void 정정_실패_가격_null() {
 			Order order = createBuyOrder();
 			assertThatThrownBy(() -> order.modify(null, 10))
-				.isInstanceOf(BusinessException.class)
-				.hasMessage(ErrorCode.ORDER_INVALID_AMOUNT.getMessage());
+					.isInstanceOf(BusinessException.class)
+					.hasMessage(ErrorCode.ORDER_INVALID_AMOUNT.getMessage());
 		}
 	}
 
 	@Nested
-	class 소유권검증 {
+	class OwnershipValidationTest {
 		@Test
 		void 소유권검증_성공() {
 			Order order = createBuyOrder();
 			assertThatCode(() -> order.validateOwnership(1L))
-				.doesNotThrowAnyException();
+					.doesNotThrowAnyException();
 		}
 
 		@Test
 		void 소유권검증_실패_불일치() {
 			Order order = createBuyOrder();
 			assertThatThrownBy(() -> order.validateOwnership(999L))
-				.isInstanceOf(BusinessException.class)
-				.hasMessage(ErrorCode.ORDER_OWNERSHIP_MISMATCH.getMessage());
+					.isInstanceOf(BusinessException.class)
+					.hasMessage(ErrorCode.ORDER_OWNERSHIP_MISMATCH.getMessage());
 		}
 	}
 }

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -174,7 +174,7 @@ class OrderServiceTest {
 	}
 
 	@Nested
-	class 주문취소_검증{
+	class CancelOrderTest{
 
 		@Test
 		void 취소_성공_매수주문() {
@@ -239,7 +239,7 @@ class OrderServiceTest {
 	}
 
 	@Nested
-	class 주문정정_검증{
+	class ModifyOrderTest{
 
 		@Test
 		void 정정_성공_매수_가격변경() {


### PR DESCRIPTION
## 📌 PR 설명
홈 그룹(HOME) / 단체 그룹(SHARED) 구조를 도입하고,
사용자는 항상 하나의 활성 그룹만 가지도록 그룹 정책을 개선했습니다.
<br>

## ✅ 완료한 기능 명세

- [x] 그룹 타입(HOME, SHARED) 추가
- [x] 회원가입 시 홈 그룹 자동 생성
- [x] status: ACTIVE / INACTIVE로 변경
- [x] partial unique index로 ACTIVE 그룹 1개 제한
- [x] 단체 그룹에서만 초대 가능하도록 제한
- [x] 사용자는 하나의 ACTIVE 그룹만 유지하도록 제한
- [x] 단체 그룹 참여 시 기존 그룹은 INACTIVE 처리
- [x] 단체 그룹 탈퇴 시 홈 그룹 ACTIVE 복구
- [x] 홈 그룹에서는 초대 코드 생성 불가
 
- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 기존에는 사용자가 여러 그룹을 동시에 활성 상태로 가질 수 있어 데이터 정합성 문제가 발생할 수 있었음
-> 유저당 ACTIVE 그룹 1개 정책을 DB 레벨에서 강제하도록 설계
- 홈 그룹을 별도로 정의하여 그룹 탈퇴 시에도 항상 기본 그룹으로 복귀할 수 있도록 구조를 개선
<br>

### 🔗 관련 이슈
Closes #180 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹 유형 도입: HOME / SHARED
  * 홈 그룹 전용 공통 규칙(초대·참여·탈퇴 제한)
  * 채팅 메시지 기반 뉴스 공유 기능 추가

* **개선 사항**
  * 그룹 멤버십 상태 및 생성 흐름 개선(활성/비활성 전환, 팩토리 메서드)
  * 데이터베이스 제약 강화 및 마이그레이션(그룹 타입, 멤버 상태, 유니크 인덱스 등)
  * 오류 코드에 홈 그룹 관련 항목 추가

* **테스트**
  * 서비스 로직 관련 단위 테스트 보강(홈 그룹 시나리오 추가)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->