### PR TITLE
[WEF-275] 게임 종목 검색 구현 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/news/scheduler/NewsBatchScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/scheduler/NewsBatchScheduler.java
@@ -16,18 +16,37 @@ public class NewsBatchScheduler {
     private final NewsBatchService newsBatchService;
 
     /**
-     * 매일 04:00에 150일치 뉴스 크롤링 + AI 브리핑 생성.
-     * 약 20분 소요 (크롤링 10분 + OpenAI 10분).
-     * 9일이면 전체 기간(2020~2024) 완료.
+     * 하루 4회 뉴스 크롤링 + AI 브리핑 생성 (150일치 × 4 = 600일/day).
+     * 약 3일이면 전체 기간(2020~2024, 1,825일) 완료.
+     * 수집 완료 후에는 이미 처리된 날짜를 건너뛰므로 추가 부하 없음.
      */
     @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
-    public void collectDaily() {
-        log.info("[뉴스 배치 시작] 스케줄=04:00");
+    public void collectMorning() {
+        runBatch("04:00");
+    }
+
+    @Scheduled(cron = "0 0 12 * * *", zone = "Asia/Seoul")
+    public void collectNoon() {
+        runBatch("12:00");
+    }
+
+    @Scheduled(cron = "0 0 19 * * *", zone = "Asia/Seoul")
+    public void collectEvening() {
+        runBatch("19:00");
+    }
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void collectMidnight() {
+        runBatch("00:00");
+    }
+
+    private void runBatch(String schedule) {
+        log.info("[뉴스 배치 시작] 스케줄={}", schedule);
         try {
             int count = newsBatchService.collectBatch(150);
-            log.info("[뉴스 배치 종료] 스케줄=04:00, 처리={}건", count);
+            log.info("[뉴스 배치 종료] 스케줄={}, 처리={}건", schedule, count);
         } catch (Exception e) {
-            log.error("[뉴스 배치 에러] 스케줄=04:00", e);
+            log.error("[뉴스 배치 에러] 스케줄={}", schedule, e);
         }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 

--- a/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -15,7 +15,6 @@ import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
-import com.solv.wefin.web.game.room.dto.response.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -65,7 +64,7 @@ public class GameRoomService {
         }
 
         //endDate 계산
-        LocalDate rangeStart = LocalDate.of(2020, 1, 1);
+        LocalDate rangeStart = LocalDate.of(2021, 1, 1);
         LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(command.periodMonths());
         long daysBetween = ChronoUnit.DAYS.between(rangeStart, rangeEnd);
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
@@ -319,7 +318,5 @@ gameParticipant.builder()
 
 
  */
-
-
 
 

--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -17,7 +17,18 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     List<StockDaily> findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(
             StockInfo stockInfo, LocalDate startDate, LocalDate endDate);
 
-    @Query("SELECT sd.tradeDate FROM StockDaily sd WHERE sd.stockInfo = :stockInfo AND sd.tradeDate IN :dates")
+    @Query("SELECT sd.tradeDate " +
+            "FROM StockDaily sd " +
+            "WHERE sd.stockInfo = :stockInfo " +
+            "AND sd.tradeDate IN :dates ")
     Set<LocalDate> findExistingDates(@Param("stockInfo") StockInfo stockInfo,
                                      @Param("dates") List<LocalDate> dates);
+
+    @Query("SELECT sd FROM StockDaily sd " +
+            "JOIN FETCH sd.stockInfo si " +
+            "WHERE sd.tradeDate = :tradeDate " +
+            "AND (si.stockName LIKE :keyword ESCAPE '\\' OR si.symbol LIKE :keyword ESCAPE '\\') " +
+            "ORDER BY si.stockName ASC")
+    List<StockDaily> searchByKeywordAndTradeDate(@Param("keyword") String keyword,
+                                                 @Param("tradeDate") LocalDate tradeDate);
 }

--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.game.stock.repository;
 
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
 import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import org.springframework.data.jpa.repository.Query;
@@ -24,11 +25,16 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     Set<LocalDate> findExistingDates(@Param("stockInfo") StockInfo stockInfo,
                                      @Param("dates") List<LocalDate> dates);
 
+    /**
+     * 키워드 검색. 짧은 키워드에서 대량 조회가 발생하지 않도록
+     * 호출측에서 Pageable로 결과 개수를 반드시 제한한다.
+     */
     @Query("SELECT sd FROM StockDaily sd " +
             "JOIN FETCH sd.stockInfo si " +
             "WHERE sd.tradeDate = :tradeDate " +
             "AND (si.stockName LIKE :keyword ESCAPE '\\' OR si.symbol LIKE :keyword ESCAPE '\\') " +
             "ORDER BY si.stockName ASC")
     List<StockDaily> searchByKeywordAndTradeDate(@Param("keyword") String keyword,
-                                                 @Param("tradeDate") LocalDate tradeDate);
+                                                 @Param("tradeDate") LocalDate tradeDate,
+                                                 Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockChartService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockChartService.java
@@ -1,0 +1,51 @@
+package com.solv.wefin.domain.game.stock.service;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockChartService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final StockInfoRepository stockInfoRepository;
+    private final StockDailyRepository stockDailyRepository;
+
+    public List<StockDaily> getChart(String symbol, UUID roomId) {
+        // 1. 게임방 확인
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2. ACTIVE 턴 → 턴 날짜
+        GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        // 3. 종목 존재 확인
+        StockInfo stockInfo = stockInfoRepository.findById(symbol)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_NOT_FOUND));
+
+        // 4. 턴 날짜 기준 2년치 일봉 조회
+        LocalDate turnDate = activeTurn.getTurnDate();
+        LocalDate twoYearsAgo = turnDate.minusYears(2);
+        return stockDailyRepository.findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(
+                stockInfo, twoYearsAgo, turnDate);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockChartService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockChartService.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.game.stock.service;
 
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
@@ -25,24 +27,30 @@ import java.util.UUID;
 public class StockChartService {
 
     private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
     private final StockInfoRepository stockInfoRepository;
     private final StockDailyRepository stockDailyRepository;
 
-    public List<StockDaily> getChart(String symbol, UUID roomId) {
+    public List<StockDaily> getChart(String symbol, UUID roomId, UUID userId) {
         // 1. 게임방 확인
         GameRoom gameRoom = gameRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
-        // 2. ACTIVE 턴 → 턴 날짜
+        // 2. 참가자 확인
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. ACTIVE 턴 → 턴 날짜
         GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
-        // 3. 종목 존재 확인
+        // 4. 종목 존재 확인
         StockInfo stockInfo = stockInfoRepository.findById(symbol)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_NOT_FOUND));
 
-        // 4. 턴 날짜 기준 2년치 일봉 조회
+        // 5. 턴 날짜 기준 2년치 일봉 조회
         LocalDate turnDate = activeTurn.getTurnDate();
         LocalDate twoYearsAgo = turnDate.minusYears(2);
         return stockDailyRepository.findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.game.stock.service;
 
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
@@ -22,17 +24,22 @@ import java.util.UUID;
 public class StockSearchService {
 
     private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
     private final StockDailyRepository stockDailyRepository;
 
-    public List<StockDaily> searchStocks(UUID roomId, String keyword) {
+    public List<StockDaily> searchStocks(UUID roomId, UUID userId, String keyword) {
         GameRoom gameRoom = gameRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
 
         GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
-        String escaped = keyword.replace("%", "\\%").replace("_", "\\_");
+        String escaped = keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
         String likeKeyword = "%" + escaped + "%";
         return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate());
 

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -1,0 +1,48 @@
+package com.solv.wefin.domain.game.stock.service;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StockSearchService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final StockDailyRepository stockDailyRepository;
+
+    public List<StockDaily> searchStocks(UUID roomId, String keyword) {
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        String escaped = keyword.replace("%", "\\%").replace("_", "\\_");
+        String likeKeyword = "%" + escaped + "%";
+        return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate());
+
+    }
+}
+
+/**
+ 종목 검색 : 날짜 필요 -> 게임룸 검색 -> 턴 조회 -> 날짜 획득
+
+ 1. 게임방 확인
+ 2. 턴조회 (ACITVE)
+ 3. 종목 검색 = keyword로 ** 턴 날짜에 거래 데이터 없으면 제외
+ */

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -12,6 +12,8 @@ import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,26 +25,44 @@ import java.util.UUID;
 @Transactional(readOnly = true)
 public class StockSearchService {
 
+    /**
+     * 키워드 검색 결과 개수 상한.
+     * 짧은 키워드(1~2자)에서 수천 건이 반환되어 네트워크/응답 시간이 폭주하는 걸 방지.
+     * 50개면 자동완성/드롭다운 용도로 충분.
+     */
+    private static final int MAX_SEARCH_RESULTS = 50;
+
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
     private final StockDailyRepository stockDailyRepository;
 
     public List<StockDaily> searchStocks(UUID roomId, UUID userId, String keyword) {
+        // 공백/빈 문자열 조기 반환.
+        // 그대로 LIKE 쿼리에 넣으면 "%   %"나 "%%"가 되어 거의 전체 종목이 매칭됨.
+        String trimmed = keyword == null ? "" : keyword.trim();
+        if (trimmed.isEmpty()) {
+            return List.of();
+        }
+
+        // 1. 게임방 존재 확인
         GameRoom gameRoom = gameRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
 
+        // 2. 참가자 검증
         gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
                 .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
 
+        // 3. ACTIVE 턴 조회 → 턴 날짜 획득
         GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
-        String escaped = keyword.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        // 4. keyword로 종목 검색 (턴 날짜에 거래 데이터 있는 것만, 최대 MAX_SEARCH_RESULTS건)
+        String escaped = trimmed.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
         String likeKeyword = "%" + escaped + "%";
-        return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate());
-
+        Pageable pageable = PageRequest.of(0, MAX_SEARCH_RESULTS);
+        return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate(), pageable);
     }
 }
 

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -1,11 +1,16 @@
 package com.solv.wefin.domain.game.turn.repository;
 
+import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
+
+    Optional<GameTurn> findByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
 
 
 }

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -36,7 +36,6 @@ public class SecurityConfig {
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**").permitAll()
                         .requestMatchers("/api/admin/**").permitAll() // 임시
-                        .requestMatchers("/api/rooms/**").permitAll() // 임시
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -101,9 +101,13 @@ public enum ErrorCode {
     ROOM_NOT_PARTICIPANT(404, "참가자가 아닙니다."),
     ROOM_NOT_HOST(403,"방장만 게임을 시작할 수 있습니다."),
     ROOM_MIN_PLAYERS(400, "2명 이상의 참가자가 필요합니다."),
-    ROOM_NOT_WAITING(400, "대기 상태가 아닙니다");
+    ROOM_NOT_WAITING(400, "대기 상태가 아닙니다."),
 
     // GameTurn
+    GAME_NOT_STARTED(400, "게임이 시작되지 않았습니다."),
+
+    // GameStock
+    GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -6,8 +6,14 @@ import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
 import com.solv.wefin.domain.game.room.dto.RoomListInfo;
 import com.solv.wefin.domain.game.room.dto.StartRoomInfo;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.game.room.service.GameRoomService;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.LeaveRoomResponse;
 import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.*;
@@ -15,30 +21,32 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/rooms")
 @RequiredArgsConstructor
-public class GameRoomController {
+public class
+GameRoomController {
 
     private final GameRoomService gameRoomService;
-
-    //로그인 구현 전 묵데이터
-    //private static final UUID TEMP_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
-    private static final Long TEMP_GROUP_ID = 1L;
+    private final GroupMemberRepository groupMemberRepository;
+    private final UserRepository userRepository;
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateRoomResponse>> createRoom(
-            @RequestHeader("X-User-Id") UUID userId, @Valid @RequestBody CreateRoomRequest request) {
+            @AuthenticationPrincipal UUID userId, @Valid @RequestBody CreateRoomRequest request) {
 
+        Long groupId = getActiveGroupId(userId);
         CreateRoomCommand command = new CreateRoomCommand(
                 request.getSeedMoney(), request.getPeriodMonths(), request.getMoveDays());
-        GameRoom gameRoom = gameRoomService.createRoom(userId, TEMP_GROUP_ID, command);
+        GameRoom gameRoom = gameRoomService.createRoom(userId, groupId, command);
         CreateRoomResponse response = CreateRoomResponse.from(gameRoom);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, response));
@@ -50,8 +58,9 @@ public class GameRoomController {
      get /api/rooms
      */
     @GetMapping
-    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms(@RequestHeader("X-User-Id") UUID userId) {
-        List<RoomListInfo> rooms = gameRoomService.getRooms(TEMP_GROUP_ID, userId);
+    public ResponseEntity<ApiResponse<List<RoomListResponse>>> getRooms(@AuthenticationPrincipal UUID userId) {
+        Long groupId = getActiveGroupId(userId);
+        List<RoomListInfo> rooms = gameRoomService.getRooms(groupId, userId);
         List<RoomListResponse> response = rooms.stream().map(
                 r -> RoomListResponse.from(r.room(), r.playerCount())).collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -62,8 +71,13 @@ public class GameRoomController {
 
         RoomDetailInfo detail = gameRoomService.getRoomDetail(roomId);
 
+        List<UUID> userIds = detail.participants().stream()
+                .map(GameParticipant::getUserId).toList();
+        Map<UUID, String> nicknameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, User::getNickname));
+
         List<ParticipantDetailDto> participantDtos = detail.participants().stream().map(
-                p -> ParticipantDetailDto.from(p, "묵데이터유저")
+                p -> ParticipantDetailDto.from(p, nicknameMap.getOrDefault(p.getUserId(), "알 수 없음"))
         ).collect(Collectors.toList());
 
         RoomDetailResponse response = RoomDetailResponse.from(detail.room(), participantDtos);
@@ -72,7 +86,7 @@ public class GameRoomController {
 
     // 게임방 입장
     @PostMapping("/{roomId}/join")
-    public ResponseEntity<ApiResponse<JoinRoomResponse>> joinRoom(@PathVariable UUID roomId, @RequestHeader("X-User-Id") UUID userId) {
+    public ResponseEntity<ApiResponse<JoinRoomResponse>> joinRoom(@PathVariable UUID roomId, @AuthenticationPrincipal UUID userId) {
 
         GameParticipant participant = gameRoomService.joinRoom(roomId, userId);
         JoinRoomResponse response = JoinRoomResponse.from(participant);
@@ -82,7 +96,7 @@ public class GameRoomController {
 
     //게임방 퇴장
     @DeleteMapping("/{roomId}/leave")
-    public ResponseEntity<ApiResponse<LeaveRoomResponse>> leaveRoom(@PathVariable UUID roomId, @RequestHeader("X-User-Id") UUID userId) {
+    public ResponseEntity<ApiResponse<LeaveRoomResponse>> leaveRoom(@PathVariable UUID roomId, @AuthenticationPrincipal UUID userId) {
 
         gameRoomService.leaveRoom(roomId, userId);
         LeaveRoomResponse response = LeaveRoomResponse.success();
@@ -93,16 +107,20 @@ public class GameRoomController {
     //게임 시작
     @PostMapping("/{roomId}/start")
     public ResponseEntity<ApiResponse<StartRoomResponse>> startRoom(
-            @PathVariable UUID roomId, @RequestHeader("X-User-Id") UUID userId) {
+            @PathVariable UUID roomId, @AuthenticationPrincipal UUID userId) {
 
         StartRoomInfo info = gameRoomService.startRoom(roomId, userId);
-
-        TurnDetailDto turnDto = TurnDetailDto.from(info.firstTurn());
         StartRoomResponse response = StartRoomResponse.from(info);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    private Long getActiveGroupId(UUID userId) {
+        return groupMemberRepository
+                .findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND))
+                .getGroup().getId();
+    }
 }
 
 /**

--- a/src/main/java/com/solv/wefin/web/game/room/dto/LeaveRoomResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/LeaveRoomResponse.java
@@ -1,6 +1,5 @@
 package com.solv.wefin.web.game.room.dto;
 
-import com.solv.wefin.domain.game.room.entity.GameRoom;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/solv/wefin/web/game/room/dto/request/CreateRoomRequest.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/request/CreateRoomRequest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.web.game.room.dto.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -17,6 +18,7 @@ public class CreateRoomRequest {
 
     @NotNull(message="기간 설정 오류")
     @Min(value = 1, message = "게임 기간은 0보다 커야 합니다.")
+    @Max(value = 47, message = "게임 기간은 47개월을 초과할 수 없습니다.")
     private Integer periodMonths;
 
     @NotNull(message = "턴당 이동 오류")

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/ParticipantDetailDto.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/ParticipantDetailDto.java
@@ -6,7 +6,6 @@ import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigInteger;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
@@ -5,7 +5,6 @@ import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 

--- a/src/main/java/com/solv/wefin/web/game/stock/StockChartController.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/StockChartController.java
@@ -1,0 +1,36 @@
+package com.solv.wefin.web.game.stock;
+
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.service.StockChartService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.stock.dto.response.ChartResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/stocks/{symbol}")
+public class StockChartController {
+
+    private final StockChartService stockChartService;
+
+    @GetMapping("/chart")
+    public ResponseEntity<ApiResponse<List<ChartResponse>>> getChart(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable String symbol,
+            @RequestParam UUID roomId) {
+
+        List<StockDaily> dailyData = stockChartService.getChart(symbol, roomId);
+
+        List<ChartResponse> response = dailyData.stream()
+                .map(ChartResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/stock/StockChartController.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/StockChartController.java
@@ -25,7 +25,7 @@ public class StockChartController {
             @PathVariable String symbol,
             @RequestParam UUID roomId) {
 
-        List<StockDaily> dailyData = stockChartService.getChart(symbol, roomId);
+        List<StockDaily> dailyData = stockChartService.getChart(symbol, roomId, userId);
 
         List<ChartResponse> response = dailyData.stream()
                 .map(ChartResponse::from)

--- a/src/main/java/com/solv/wefin/web/game/stock/StockSearchController.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/StockSearchController.java
@@ -1,0 +1,36 @@
+package com.solv.wefin.web.game.stock;
+
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.service.StockSearchService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.stock.dto.response.StockSearchResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rooms/{roomId}/stocks")
+public class StockSearchController {
+
+    private final StockSearchService stockSearchService;
+
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<List<StockSearchResponse>>> searchStocks(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID roomId,
+            @RequestParam String keyword) {
+
+        List<StockDaily> stocks = stockSearchService.searchStocks(roomId, keyword);
+
+        List<StockSearchResponse> response = stocks.stream()
+                .map(StockSearchResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/stock/StockSearchController.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/StockSearchController.java
@@ -25,7 +25,7 @@ public class StockSearchController {
             @PathVariable UUID roomId,
             @RequestParam String keyword) {
 
-        List<StockDaily> stocks = stockSearchService.searchStocks(roomId, keyword);
+        List<StockDaily> stocks = stockSearchService.searchStocks(roomId, userId, keyword);
 
         List<StockSearchResponse> response = stocks.stream()
                 .map(StockSearchResponse::from)

--- a/src/main/java/com/solv/wefin/web/game/stock/dto/response/ChartResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/dto/response/ChartResponse.java
@@ -1,0 +1,33 @@
+package com.solv.wefin.web.game.stock.dto.response;
+
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class ChartResponse {
+
+    private LocalDate tradeDate;
+    private BigDecimal openPrice;
+    private BigDecimal highPrice;
+    private BigDecimal lowPrice;
+    private BigDecimal closePrice;
+    private BigDecimal volume;
+    private BigDecimal changeRate;
+
+    public static ChartResponse from(StockDaily stockDaily) {
+        return new ChartResponse(
+                stockDaily.getTradeDate(),
+                stockDaily.getOpenPrice(),
+                stockDaily.getHighPrice(),
+                stockDaily.getLowPrice(),
+                stockDaily.getClosePrice(),
+                stockDaily.getVolume(),
+                stockDaily.getChangeRate()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/stock/dto/response/StockSearchResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/dto/response/StockSearchResponse.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.web.game.stock.dto.response;
+
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class StockSearchResponse {
+
+    private String symbol;
+    private String stockName;
+    private String market;
+    private BigDecimal price;
+
+    public static StockSearchResponse from(StockDaily stockDaily) {
+        return new StockSearchResponse(
+                stockDaily.getStockInfo().getSymbol(),
+                stockDaily.getStockInfo().getStockName(),
+                stockDaily.getStockInfo().getMarket(),
+                stockDaily.getOpenPrice()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockChartServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockChartServiceTest.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.game.stock.service;
 
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
@@ -46,6 +48,9 @@ class StockChartServiceTest {
     private GameTurnRepository gameTurnRepository;
 
     @Mock
+    private GameParticipantRepository gameParticipantRepository;
+
+    @Mock
     private StockInfoRepository stockInfoRepository;
 
     @Mock
@@ -62,10 +67,11 @@ class StockChartServiceTest {
     @Test
     @DisplayName("차트 조회 성공 — 2년치 일봉 데이터 반환")
     void getChart_success() {
-        // Given — 방 존재, ACTIVE 턴 존재, 종목 존재, 일봉 3건
+        // Given — 방 존재, 참가자 확인, ACTIVE 턴 존재, 종목 존재, 일봉 3건
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
         GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
         StockInfo stockInfo = StockInfo.create(SYMBOL, "삼성전자", "KOSPI", "전기전자");
 
         StockDaily daily1 = createStockDaily(stockInfo, LocalDate.of(2020, 1, 3), new BigDecimal("55000"));
@@ -74,6 +80,8 @@ class StockChartServiceTest {
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
         given(stockInfoRepository.findById(SYMBOL))
@@ -83,7 +91,7 @@ class StockChartServiceTest {
                 .willReturn(List.of(daily1, daily2, daily3));
 
         // When
-        List<StockDaily> result = stockChartService.getChart(SYMBOL, roomId);
+        List<StockDaily> result = stockChartService.getChart(SYMBOL, roomId, TEST_USER_ID);
 
         // Then — 3건 반환, 날짜 오름차순
         assertThat(result).hasSize(3);
@@ -98,14 +106,17 @@ class StockChartServiceTest {
     @Test
     @DisplayName("차트 조회 성공 — 데이터 없으면 빈 리스트 반환")
     void getChart_emptyResult() {
-        // Given — 방, 턴, 종목 존재하지만 일봉 데이터 없음
+        // Given — 방, 참가자, 턴, 종목 존재하지만 일봉 데이터 없음
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
         GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
         StockInfo stockInfo = StockInfo.create(SYMBOL, "삼성전자", "KOSPI", "전기전자");
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
         given(stockInfoRepository.findById(SYMBOL))
@@ -115,7 +126,7 @@ class StockChartServiceTest {
                 .willReturn(Collections.emptyList());
 
         // When
-        List<StockDaily> result = stockChartService.getChart(SYMBOL, roomId);
+        List<StockDaily> result = stockChartService.getChart(SYMBOL, roomId, TEST_USER_ID);
 
         // Then — 빈 리스트 (에러 아님)
         assertThat(result).isEmpty();
@@ -130,7 +141,7 @@ class StockChartServiceTest {
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, fakeRoomId))
+        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, fakeRoomId, TEST_USER_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> {
                     BusinessException be = (BusinessException) ex;
@@ -149,14 +160,17 @@ class StockChartServiceTest {
         // Given
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, roomId))
+        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, roomId, TEST_USER_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> {
                     BusinessException be = (BusinessException) ex;
@@ -171,26 +185,56 @@ class StockChartServiceTest {
     @Test
     @DisplayName("차트 조회 실패 — 존재하지 않는 종목이면 GAME_STOCK_NOT_FOUND")
     void getChart_stockNotFound() {
-        // Given — 방, 턴은 존재하지만 종목 없음
+        // Given — 방, 참가자, 턴은 존재하지만 종목 없음
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
         GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
         given(stockInfoRepository.findById("999999"))
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> stockChartService.getChart("999999", roomId))
+        assertThatThrownBy(() -> stockChartService.getChart("999999", roomId, TEST_USER_ID))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> {
                     BusinessException be = (BusinessException) ex;
                     assertThat(be.getErrorCode()).isEqualTo(ErrorCode.GAME_STOCK_NOT_FOUND);
                 });
 
+        verify(stockDailyRepository, never())
+                .findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("차트 조회 실패 — 참가자가 아니면 ROOM_NOT_PARTICIPANT")
+    void getChart_notParticipant() {
+        // Given — 방은 존재하지만 해당 유저는 참가자가 아님
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        UUID outsiderUserId = UUID.fromString("00000000-0000-4000-a000-000000000099");
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, outsiderUserId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, roomId, outsiderUserId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(stockInfoRepository, never()).findById(any());
         verify(stockDailyRepository, never())
                 .findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(any(), any(), any());
     }

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockChartServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockChartServiceTest.java
@@ -1,0 +1,214 @@
+package com.solv.wefin.domain.game.stock.service;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StockChartServiceTest {
+
+    @InjectMocks
+    private StockChartService stockChartService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+
+    @Mock
+    private StockInfoRepository stockInfoRepository;
+
+    @Mock
+    private StockDailyRepository stockDailyRepository;
+
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final String SYMBOL = "005930";
+    private static final LocalDate TURN_DATE = LocalDate.of(2022, 1, 3);
+    private static final LocalDate TWO_YEARS_AGO = TURN_DATE.minusYears(2);
+
+    // === 차트 조회 테스트 ===
+
+    @Test
+    @DisplayName("차트 조회 성공 — 2년치 일봉 데이터 반환")
+    void getChart_success() {
+        // Given — 방 존재, ACTIVE 턴 존재, 종목 존재, 일봉 3건
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        StockInfo stockInfo = StockInfo.create(SYMBOL, "삼성전자", "KOSPI", "전기전자");
+
+        StockDaily daily1 = createStockDaily(stockInfo, LocalDate.of(2020, 1, 3), new BigDecimal("55000"));
+        StockDaily daily2 = createStockDaily(stockInfo, LocalDate.of(2020, 6, 15), new BigDecimal("60000"));
+        StockDaily daily3 = createStockDaily(stockInfo, TURN_DATE, new BigDecimal("71000"));
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockInfoRepository.findById(SYMBOL))
+                .willReturn(Optional.of(stockInfo));
+        given(stockDailyRepository.findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(
+                stockInfo, TWO_YEARS_AGO, TURN_DATE))
+                .willReturn(List.of(daily1, daily2, daily3));
+
+        // When
+        List<StockDaily> result = stockChartService.getChart(SYMBOL, roomId);
+
+        // Then — 3건 반환, 날짜 오름차순
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getTradeDate()).isEqualTo(LocalDate.of(2020, 1, 3));
+        assertThat(result.get(2).getTradeDate()).isEqualTo(TURN_DATE);
+        assertThat(result.get(2).getOpenPrice()).isEqualTo(new BigDecimal("71000"));
+
+        verify(stockDailyRepository).findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(
+                stockInfo, TWO_YEARS_AGO, TURN_DATE);
+    }
+
+    @Test
+    @DisplayName("차트 조회 성공 — 데이터 없으면 빈 리스트 반환")
+    void getChart_emptyResult() {
+        // Given — 방, 턴, 종목 존재하지만 일봉 데이터 없음
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        StockInfo stockInfo = StockInfo.create(SYMBOL, "삼성전자", "KOSPI", "전기전자");
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockInfoRepository.findById(SYMBOL))
+                .willReturn(Optional.of(stockInfo));
+        given(stockDailyRepository.findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(
+                stockInfo, TWO_YEARS_AGO, TURN_DATE))
+                .willReturn(Collections.emptyList());
+
+        // When
+        List<StockDaily> result = stockChartService.getChart(SYMBOL, roomId);
+
+        // Then — 빈 리스트 (에러 아님)
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("차트 조회 실패 — 존재하지 않는 방이면 ROOM_NOT_FOUND")
+    void getChart_roomNotFound() {
+        // Given
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findById(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, fakeRoomId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(stockInfoRepository, never()).findById(any());
+        verify(stockDailyRepository, never())
+                .findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("차트 조회 실패 — ACTIVE 턴 없으면 GAME_NOT_STARTED")
+    void getChart_gameNotStarted() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockChartService.getChart(SYMBOL, roomId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.GAME_NOT_STARTED);
+                });
+
+        verify(stockInfoRepository, never()).findById(any());
+        verify(stockDailyRepository, never())
+                .findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("차트 조회 실패 — 존재하지 않는 종목이면 GAME_STOCK_NOT_FOUND")
+    void getChart_stockNotFound() {
+        // Given — 방, 턴은 존재하지만 종목 없음
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockInfoRepository.findById("999999"))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockChartService.getChart("999999", roomId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.GAME_STOCK_NOT_FOUND);
+                });
+
+        verify(stockDailyRepository, never())
+                .findByStockInfoAndTradeDateBetweenOrderByTradeDateAsc(any(), any(), any());
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createGameRoom() {
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,
+                6, 7, LocalDate.of(2022, 1, 3), LocalDate.of(2022, 7, 3));
+    }
+
+    private StockDaily createStockDaily(StockInfo stockInfo, LocalDate tradeDate, BigDecimal openPrice) {
+        return StockDaily.create(stockInfo, tradeDate,
+                openPrice,
+                openPrice.add(new BigDecimal("1000")),
+                openPrice.subtract(new BigDecimal("1000")),
+                openPrice.add(new BigDecimal("500")),
+                new BigDecimal("1000000"),
+                new BigDecimal("1.5"));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.domain.game.stock.service;
 
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
@@ -45,6 +47,9 @@ class StockSearchServiceTest {
     private GameTurnRepository gameTurnRepository;
 
     @Mock
+    private GameParticipantRepository gameParticipantRepository;
+
+    @Mock
     private StockDailyRepository stockDailyRepository;
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
@@ -56,10 +61,11 @@ class StockSearchServiceTest {
     @Test
     @DisplayName("종목 검색 성공 — 키워드에 매칭되는 종목 2개 반환")
     void searchStocks_success() {
-        // Given — 방 존재, ACTIVE 턴 존재, 키워드 "삼성"에 2개 매칭
+        // Given — 방 존재, 참가자 확인, ACTIVE 턴 존재, 키워드 "삼성"에 2개 매칭
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
         GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
 
         StockInfo samsung = StockInfo.create("005930", "삼성전자", "KOSPI", "전기전자");
         StockInfo samsungSDI = StockInfo.create("006400", "삼성SDI", "KOSPI", "전기전자");
@@ -68,13 +74,15 @@ class StockSearchServiceTest {
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
         given(stockDailyRepository.searchByKeywordAndTradeDate("%삼성%", TURN_DATE))
                 .willReturn(List.of(daily1, daily2));
 
         // When
-        List<StockDaily> result = stockSearchService.searchStocks(roomId, "삼성");
+        List<StockDaily> result = stockSearchService.searchStocks(roomId, TEST_USER_ID, "삼성");
 
         // Then — 2개 반환, 각각 StockInfo 접근 가능
         assertThat(result).hasSize(2);
@@ -88,20 +96,23 @@ class StockSearchServiceTest {
     @Test
     @DisplayName("종목 검색 성공 — 결과 없으면 빈 리스트 반환")
     void searchStocks_emptyResult() {
-        // Given — 방 존재, ACTIVE 턴 존재, 매칭 결과 없음
+        // Given — 방 존재, 참가자 확인, ACTIVE 턴 존재, 매칭 결과 없음
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
         GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
         given(stockDailyRepository.searchByKeywordAndTradeDate("%없는종목%", TURN_DATE))
                 .willReturn(Collections.emptyList());
 
         // When
-        List<StockDaily> result = stockSearchService.searchStocks(roomId, "없는종목");
+        List<StockDaily> result = stockSearchService.searchStocks(roomId, TEST_USER_ID, "없는종목");
 
         // Then — 빈 리스트 (에러 아님)
         assertThat(result).isEmpty();
@@ -116,7 +127,7 @@ class StockSearchServiceTest {
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> stockSearchService.searchStocks(fakeRoomId, "삼성"))
+        assertThatThrownBy(() -> stockSearchService.searchStocks(fakeRoomId, TEST_USER_ID, "삼성"))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> {
                     BusinessException be = (BusinessException) ex;
@@ -134,14 +145,17 @@ class StockSearchServiceTest {
         // Given — 방은 존재하지만 ACTIVE 턴이 없음 (게임 미시작)
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
 
         given(gameRoomRepository.findById(roomId))
                 .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> stockSearchService.searchStocks(roomId, "삼성"))
+        assertThatThrownBy(() -> stockSearchService.searchStocks(roomId, TEST_USER_ID, "삼성"))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(ex -> {
                     BusinessException be = (BusinessException) ex;
@@ -149,6 +163,31 @@ class StockSearchServiceTest {
                 });
 
         // 턴이 없으니 종목 검색은 호출되면 안 된다
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
+    }
+
+    @Test
+    @DisplayName("종목 검색 실패 — 참가자가 아니면 ROOM_NOT_PARTICIPANT")
+    void searchStocks_notParticipant() {
+        // Given — 방은 존재하지만 해당 유저는 참가자가 아님
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        UUID outsiderUserId = UUID.fromString("00000000-0000-4000-a000-000000000099");
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, outsiderUserId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockSearchService.searchStocks(roomId, outsiderUserId, "삼성"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
         verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
     }
 

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
@@ -1,0 +1,171 @@
+package com.solv.wefin.domain.game.stock.service;
+
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class StockSearchServiceTest {
+
+    @InjectMocks
+    private StockSearchService stockSearchService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+
+    @Mock
+    private StockDailyRepository stockDailyRepository;
+
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final LocalDate TURN_DATE = LocalDate.of(2020, 1, 2);
+
+    // === 종목 검색 테스트 ===
+
+    @Test
+    @DisplayName("종목 검색 성공 — 키워드에 매칭되는 종목 2개 반환")
+    void searchStocks_success() {
+        // Given — 방 존재, ACTIVE 턴 존재, 키워드 "삼성"에 2개 매칭
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+
+        StockInfo samsung = StockInfo.create("005930", "삼성전자", "KOSPI", "전기전자");
+        StockInfo samsungSDI = StockInfo.create("006400", "삼성SDI", "KOSPI", "전기전자");
+        StockDaily daily1 = createStockDaily(samsung, TURN_DATE, new BigDecimal("71000"));
+        StockDaily daily2 = createStockDaily(samsungSDI, TURN_DATE, new BigDecimal("450000"));
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockDailyRepository.searchByKeywordAndTradeDate("%삼성%", TURN_DATE))
+                .willReturn(List.of(daily1, daily2));
+
+        // When
+        List<StockDaily> result = stockSearchService.searchStocks(roomId, "삼성");
+
+        // Then — 2개 반환, 각각 StockInfo 접근 가능
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getStockInfo().getStockName()).isEqualTo("삼성전자");
+        assertThat(result.get(0).getOpenPrice()).isEqualTo(new BigDecimal("71000"));
+        assertThat(result.get(1).getStockInfo().getStockName()).isEqualTo("삼성SDI");
+
+        verify(stockDailyRepository).searchByKeywordAndTradeDate("%삼성%", TURN_DATE);
+    }
+
+    @Test
+    @DisplayName("종목 검색 성공 — 결과 없으면 빈 리스트 반환")
+    void searchStocks_emptyResult() {
+        // Given — 방 존재, ACTIVE 턴 존재, 매칭 결과 없음
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockDailyRepository.searchByKeywordAndTradeDate("%없는종목%", TURN_DATE))
+                .willReturn(Collections.emptyList());
+
+        // When
+        List<StockDaily> result = stockSearchService.searchStocks(roomId, "없는종목");
+
+        // Then — 빈 리스트 (에러 아님)
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("종목 검색 실패 — 존재하지 않는 방이면 ROOM_NOT_FOUND")
+    void searchStocks_roomNotFound() {
+        // Given — 존재하지 않는 roomId
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findById(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockSearchService.searchStocks(fakeRoomId, "삼성"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        // 방을 못 찾았으니 턴 조회, 종목 검색은 호출되면 안 된다
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
+    }
+
+    @Test
+    @DisplayName("종목 검색 실패 — ACTIVE 턴 없으면 GAME_NOT_STARTED")
+    void searchStocks_gameNotStarted() {
+        // Given — 방은 존재하지만 ACTIVE 턴이 없음 (게임 미시작)
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockSearchService.searchStocks(roomId, "삼성"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.GAME_NOT_STARTED);
+                });
+
+        // 턴이 없으니 종목 검색은 호출되면 안 된다
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createGameRoom() {
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,
+                6, 7, LocalDate.of(2020, 1, 2), LocalDate.of(2020, 7, 2));
+    }
+
+    private StockDaily createStockDaily(StockInfo stockInfo, LocalDate tradeDate, BigDecimal openPrice) {
+        return StockDaily.create(stockInfo, tradeDate,
+                openPrice,
+                openPrice.add(new BigDecimal("1000")),
+                openPrice.subtract(new BigDecimal("1000")),
+                openPrice.add(new BigDecimal("500")),
+                new BigDecimal("1000000"),
+                new BigDecimal("1.5"));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -78,7 +79,7 @@ class StockSearchServiceTest {
                 .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
-        given(stockDailyRepository.searchByKeywordAndTradeDate("%삼성%", TURN_DATE))
+        given(stockDailyRepository.searchByKeywordAndTradeDate(eq("%삼성%"), eq(TURN_DATE), any(Pageable.class)))
                 .willReturn(List.of(daily1, daily2));
 
         // When
@@ -90,7 +91,7 @@ class StockSearchServiceTest {
         assertThat(result.get(0).getOpenPrice()).isEqualTo(new BigDecimal("71000"));
         assertThat(result.get(1).getStockInfo().getStockName()).isEqualTo("삼성SDI");
 
-        verify(stockDailyRepository).searchByKeywordAndTradeDate("%삼성%", TURN_DATE);
+        verify(stockDailyRepository).searchByKeywordAndTradeDate(eq("%삼성%"), eq(TURN_DATE), any(Pageable.class));
     }
 
     @Test
@@ -108,7 +109,7 @@ class StockSearchServiceTest {
                 .willReturn(Optional.of(participant));
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
-        given(stockDailyRepository.searchByKeywordAndTradeDate("%없는종목%", TURN_DATE))
+        given(stockDailyRepository.searchByKeywordAndTradeDate(eq("%없는종목%"), eq(TURN_DATE), any(Pageable.class)))
                 .willReturn(Collections.emptyList());
 
         // When
@@ -136,7 +137,7 @@ class StockSearchServiceTest {
 
         // 방을 못 찾았으니 턴 조회, 종목 검색은 호출되면 안 된다
         verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
-        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any(), any());
     }
 
     @Test
@@ -163,7 +164,7 @@ class StockSearchServiceTest {
                 });
 
         // 턴이 없으니 종목 검색은 호출되면 안 된다
-        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any(), any());
     }
 
     @Test
@@ -188,7 +189,39 @@ class StockSearchServiceTest {
                 });
 
         verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
-        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any());
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("종목 검색 — 공백만 있는 keyword는 빈 리스트 반환, Repository 호출 안 함")
+    void searchStocks_blankKeyword() {
+        // Given — keyword가 공백 문자열
+        UUID roomId = UUID.fromString("00000000-0000-4000-a000-000000000010");
+
+        // When
+        List<StockDaily> result = stockSearchService.searchStocks(roomId, TEST_USER_ID, "   ");
+
+        // Then — 빈 리스트 반환, 그리고 그 어떤 Repository도 호출되지 않음
+        // (방/참가자/턴 조회조차 없이 즉시 종료되어야 함)
+        assertThat(result).isEmpty();
+        verify(gameRoomRepository, never()).findById(any());
+        verify(gameParticipantRepository, never()).findByGameRoomAndUserId(any(), any());
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("종목 검색 — null keyword도 빈 리스트 반환")
+    void searchStocks_nullKeyword() {
+        // Given — keyword가 null
+        UUID roomId = UUID.fromString("00000000-0000-4000-a000-000000000010");
+
+        // When
+        List<StockDaily> result = stockSearchService.searchStocks(roomId, TEST_USER_ID, null);
+
+        // Then
+        assertThat(result).isEmpty();
+        verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any(), any());
     }
 
     // === 헬퍼 메서드 ===


### PR DESCRIPTION
## 📌 PR 설명
<br> 게임 페이지 종목 검색 구현 ( 배치 스케줄러로 저장한 db에서 검색) 

## ✅ 완료한 기능 명세

- [x] 종목 검색 기능
- [x] 차트 조회
- [x] 뉴스 조회 api
- [x] 게임 시작일 범위 변경


<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
종목 검색에서 사용자 입력을 JPQL LIKE 절에 바로 넣으면, %나 _ 같은 와일드카드 문자가 의도치 않은 패턴 매칭을 일으킬 수 있습니다. 서비스 계층에서  % → \%, _ → \_로 이스케이프 처리하고, JPQL에 ESCAPE '\' 절을 추가했습니다. 

검색 결과에서 보여주는 가격과 실제 주문 체결 가격이 다르면 사용자 혼란이 생길 수 있습니다. 주문은 시가(openPrice) 기준으로 체결되므로, 검색 결과의 현재가도 종가(closePrice)에서 시가(openPrice)로 통일했습니다.
<br>

### 🔗 관련 이슈
Closes #87 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * 뉴스 배치 스케줄러가 하루 4회(아침/정오/저녁/자정)로 확대됩니다.
  * 주식 차트 조회 API와 주식 검색 API 및 관련 응답 DTO가 추가됩니다.
  * 게임 턴 기반 주식 데이터 조회가 지원됩니다.

* **Security**
  * 방 관련 API 경로에 인증이 필수로 적용됩니다.
  * 컨트롤러에서 헤더 기반 식별 대신 인증 주체(Principal)를 사용합니다.

* **Bug Fixes / Validation**
  * 방 생성 요청의 기간 검증이 최대 47개월로 제한됩니다.

* **UI / Responses**
  * 방 상세에서 참가자 닉네임이 실제 닉네임으로 표시되며, 미확인 시 "알 수 없음"으로 표시됩니다.

* **Tests**
  * 주식 차트·검색 서비스에 대한 단위 테스트가 추가되었습니다.

* **Chores**
  * 불필요한 임포트 정리 및 에러 코드/메시지 일부 수정이 이루어졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->