### PR TITLE
[WEF-186] 뉴스 공유 기능 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/command/ShareNewsCommand.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/command/ShareNewsCommand.java
@@ -1,7 +1,6 @@
 package com.solv.wefin.domain.chat.groupChat.dto.command;
 
 public record ShareNewsCommand(
-        Long newsClusterId,
-        Long replyToMessageId
+        Long newsClusterId
 ) {
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/command/ShareNewsCommand.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/command/ShareNewsCommand.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.chat.groupChat.dto.command;
+
+public record ShareNewsCommand(
+        Long newsClusterId,
+        Long replyToMessageId
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/ChatMessageInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/ChatMessageInfo.java
@@ -11,6 +11,7 @@ public record ChatMessageInfo(
         String sender,
         String content,
         OffsetDateTime createdAt,
-        ReplyMessageInfo replyTo
+        ReplyMessageInfo replyTo,
+        NewsShareInfo newsShare
 ) {
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/NewsShareInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/NewsShareInfo.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.chat.groupChat.dto.info;
+
+public record NewsShareInfo(
+        Long newsClusterId,
+        String title,
+        String summary,
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
@@ -67,13 +67,13 @@ public class ChatMessage {
                 .build();
     }
 
-    public static ChatMessage createNewsMessage(User user, Group group, ChatMessage replyToMessage) {
+    public static ChatMessage createNewsMessage(User user, Group group, String title) {
         return ChatMessage.builder()
                 .user(user)
                 .group(group)
                 .messageType(MessageType.NEWS)
-                .content("")
-                .replyToMessage(replyToMessage)
+                .content(title)
+                .replyToMessage(null)
                 .createdAt(OffsetDateTime.now())
                 .build();
     }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
@@ -40,6 +40,9 @@ public class ChatMessage {
     @JoinColumn(name = "reply_to_message_id")
     private ChatMessage replyToMessage;
 
+    @OneToOne(mappedBy = "chatMessage", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private ChatMessageNewsShare newsShare;
+
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt;
 
@@ -62,6 +65,21 @@ public class ChatMessage {
                 .replyToMessage(replyToMessage)
                 .createdAt(OffsetDateTime.now())
                 .build();
+    }
+
+    public static ChatMessage createNewsMessage(User user, Group group, ChatMessage replyToMessage) {
+        return ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.NEWS)
+                .content("")
+                .replyToMessage(replyToMessage)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+
+    public void attachNewsShare(ChatMessageNewsShare newsShare) {
+        this.newsShare = newsShare;
     }
 }
 

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessageNewsShare.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessageNewsShare.java
@@ -1,0 +1,65 @@
+package com.solv.wefin.domain.chat.groupChat.entity;
+
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_message_news_share")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessageNewsShare {
+
+    @Id
+    @Column(name = "chat_message_id")
+    private Long chatMessageId;
+
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_message_id", nullable = false)
+    private ChatMessage chatMessage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_cluster_id", nullable = false)
+    private NewsCluster newsCluster;
+
+    @Column(name = "shared_title", nullable = false)
+    private String sharedTitle;
+
+    @Column(name = "shared_summary", columnDefinition = "TEXT")
+    private String sharedSummary;
+
+    @Column(name = "shared_thumbnail_url", columnDefinition = "TEXT")
+    private String sharedThumbnailUrl;
+
+    @Builder
+    private ChatMessageNewsShare(
+            ChatMessage chatMessage,
+            NewsCluster newsCluster,
+            String sharedTitle,
+            String sharedSummary,
+            String sharedThumbnailUrl
+    ) {
+        this.chatMessage = chatMessage;
+        this.newsCluster = newsCluster;
+        this.sharedTitle = sharedTitle;
+        this.sharedSummary = sharedSummary;
+        this.sharedThumbnailUrl = sharedThumbnailUrl;
+    }
+
+    public static ChatMessageNewsShare create(
+            ChatMessage chatMessage,
+            NewsCluster newsCluster
+    ) {
+        return ChatMessageNewsShare.builder()
+                .chatMessage(chatMessage)
+                .newsCluster(newsCluster)
+                .sharedTitle(newsCluster.getTitle())
+                .sharedSummary(newsCluster.getSummary())
+                .sharedThumbnailUrl(newsCluster.getThumbnailUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/MessageType.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/MessageType.java
@@ -1,5 +1,5 @@
 package com.solv.wefin.domain.chat.groupChat.entity;
 
 public enum MessageType {
-    MEMO, CHAT, SYSTEM
+    NEWS, CHAT, SYSTEM
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/event/ChatMessageCreatedEvent.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/event/ChatMessageCreatedEvent.java
@@ -1,21 +1,12 @@
 package com.solv.wefin.domain.chat.groupChat.event;
 
-import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.time.OffsetDateTime;
-import java.util.UUID;
 
 @Getter
 @RequiredArgsConstructor
 public class ChatMessageCreatedEvent {
-    private final Long messageId;
-    private final UUID userId;
     private final Long groupId;
-    private final String messageType;
-    private final String sender;
-    private final String content;
-    private final OffsetDateTime createdAt;
-    private final ReplyMessageInfo replyTo;
+    private final ChatMessageInfo message;
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageNewsShareRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageNewsShareRepository.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.chat.groupChat.repository;
+
+import com.solv.wefin.domain.chat.groupChat.entity.ChatMessageNewsShare;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ChatMessageNewsShareRepository  extends JpaRepository<ChatMessageNewsShare, Long> {
+    Optional<ChatMessageNewsShare> findByChatMessage_Id(Long messageId);
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
@@ -20,6 +20,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         left join fetch m.group
         left join fetch m.replyToMessage
         left join fetch m.replyToMessage.user
+        left join fetch m.newsShare
+        left join fetch m.newsShare.newsCluster
         where m.group.id = :groupId
         order by m.id desc
     """)
@@ -32,6 +34,8 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         left join fetch m.group
         left join fetch m.replyToMessage
         left join fetch m.replyToMessage.user
+        left join fetch m.newsShare
+        left join fetch m.newsShare.newsCluster
         where m.group.id = :groupId
             and m.id < :beforeMessageId
         order by m.id desc

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageNewsShareService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageNewsShareService.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.domain.chat.groupChat.service;
+
+import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
+import com.solv.wefin.domain.chat.groupChat.entity.ChatMessageNewsShare;
+import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageNewsShareRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageNewsShareService {
+
+    private final ChatMessageNewsShareRepository chatMessageNewsShareRepository;
+
+    public ChatMessageNewsShare save(ChatMessage chatMessage, NewsCluster newsCluster) {
+        ChatMessageNewsShare newsShare = ChatMessageNewsShare.create(chatMessage, newsCluster);
+        chatMessage.attachNewsShare(newsShare);
+        return chatMessageNewsShareRepository.save(newsShare);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -183,10 +183,16 @@ public class ChatMessageService {
             return null;
         }
 
+        String previewContent = replyMessage.getContent();
+
+        if (replyMessage.getMessageType() == MessageType.NEWS && replyMessage.getNewsShare() != null) {
+            previewContent = "[뉴스] " + replyMessage.getNewsShare().getSharedTitle();
+        }
+
         return new ReplyMessageInfo(
                 replyMessage.getId(),
                 resolveSender(replyMessage),
-                replyMessage.getContent()
+                previewContent
         );
     }
 

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -95,6 +95,10 @@ public class ChatMessageService {
 
     @Transactional
     public ChatMessageInfo shareNews(UUID userId, ShareNewsCommand command) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
         validateShareNewsCommand(command);
 
         User user = userRepository.findById(userId)

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -4,16 +4,21 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
+import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
+import com.solv.wefin.domain.chat.groupChat.entity.ChatMessageNewsShare;
 import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
 import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
 import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageRepository;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +52,8 @@ public class ChatMessageService {
     private static final int MAX_PAGE_SIZE = 100;
 
     private final Map<String, Object> chatLocks = new ConcurrentHashMap<>();
+    private final NewsClusterRepository newsClusterRepository;
+    private final ChatMessageNewsShareService chatMessageNewsShareService;
 
     @Transactional
     public void sendMessage(String content, UUID userId, Long replyToMessageId) {
@@ -86,6 +93,35 @@ public class ChatMessageService {
         }
     }
 
+    @Transactional
+    public ChatMessageInfo shareNews(UUID userId, ShareNewsCommand command) {
+        validateShareNewsCommand(command);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Group group = findActiveUserGroup(userId);
+        NewsCluster newsCluster = newsClusterRepository.findById(command.newsClusterId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.NEWS_CLUSTER_NOT_FOUND));
+
+        ChatMessage replyToMessage = null;
+        if (command.replyToMessageId() != null) {
+            replyToMessage = chatMessageRepository.findByIdAndGroup_Id(command.replyToMessageId(), group.getId())
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
+        }
+
+        ChatMessage chatMessage = chatMessageRepository.save(
+                ChatMessage.createNewsMessage(user, group, replyToMessage)
+        );
+
+        chatMessageNewsShareService.save(chatMessage, newsCluster);
+
+        ChatMessageInfo info = toInfo(chatMessage);
+
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(group.getId(), info));
+
+        return info;
+    }
 
     public ChatMessagesInfo getMessages(UUID userId, Long beforeMessageId, int size) {
 
@@ -117,6 +153,18 @@ public class ChatMessageService {
     }
 
     private ChatMessageInfo toInfo(ChatMessage message) {
+        NewsShareInfo newsShareInfo = null;
+
+        if (message.getNewsShare() != null) {
+            ChatMessageNewsShare newsShare = message.getNewsShare();
+            newsShareInfo = new NewsShareInfo(
+                    newsShare.getNewsCluster().getId(),
+                    newsShare.getSharedTitle(),
+                    newsShare.getSharedSummary(),
+                    newsShare.getSharedThumbnailUrl()
+            );
+        }
+
         return new ChatMessageInfo(
                 message.getId(),
                 extractUserId(message),
@@ -125,7 +173,8 @@ public class ChatMessageService {
                 resolveSender(message),
                 message.getContent(),
                 message.getCreatedAt(),
-                toReplyInfo(message.getReplyToMessage())
+                toReplyInfo(message.getReplyToMessage()),
+                newsShareInfo
         );
     }
 
@@ -143,15 +192,15 @@ public class ChatMessageService {
 
     private ChatMessageCreatedEvent toEvent(ChatMessage message) {
         return new ChatMessageCreatedEvent(
-                message.getId(),
-                extractUserId(message),
                 extractGroupId(message),
-                message.getMessageType().name(),
-                resolveSender(message),
-                message.getContent(),
-                message.getCreatedAt(),
-                toReplyInfo(message.getReplyToMessage())
+                toInfo(message)
         );
+    }
+
+    private void validateShareNewsCommand(ShareNewsCommand command) {
+        if(command == null || command.newsClusterId() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
     }
 
     private void validateMessage(String content) {

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -108,14 +108,8 @@ public class ChatMessageService {
         NewsCluster newsCluster = newsClusterRepository.findById(command.newsClusterId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.NEWS_CLUSTER_NOT_FOUND));
 
-        ChatMessage replyToMessage = null;
-        if (command.replyToMessageId() != null) {
-            replyToMessage = chatMessageRepository.findByIdAndGroup_Id(command.replyToMessageId(), group.getId())
-                    .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
-        }
-
         ChatMessage chatMessage = chatMessageRepository.save(
-                ChatMessage.createNewsMessage(user, group, replyToMessage)
+                ChatMessage.createNewsMessage(user, group, newsCluster.getTitle())
         );
 
         chatMessageNewsShareService.save(chatMessage, newsCluster);
@@ -187,16 +181,10 @@ public class ChatMessageService {
             return null;
         }
 
-        String previewContent = replyMessage.getContent();
-
-        if (replyMessage.getMessageType() == MessageType.NEWS && replyMessage.getNewsShare() != null) {
-            previewContent = "[뉴스] " + replyMessage.getNewsShare().getSharedTitle();
-        }
-
         return new ReplyMessageInfo(
                 replyMessage.getId(),
                 resolveSender(replyMessage),
-                previewContent
+                replyMessage.getContent()
         );
     }
 

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -28,6 +28,8 @@ public enum ErrorCode {
     CHAT_MESSAGE_NOT_FOUND(404, "채팅 메시지를 찾을 수 없습니다."),
     AI_CHAT_REQUEST_FAILED(503, "AI 응답 생성에 실패했습니다."),
     AI_CHAT_TIMEOUT(504, "AI 응답 시간이 초과되었습니다."),
+    NEWS_CLUSTER_NOT_FOUND(404, "뉴스 기사를 찾을 수 없습니다."),
+
 
     // Common
     INVALID_INPUT(400, "잘못된 입력입니다."),

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
@@ -1,11 +1,14 @@
 package com.solv.wefin.web.chat.groupChat;
 
+import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.chat.groupChat.dto.request.ShareNewsRequest;
 import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMessagesResponse;
 import com.solv.wefin.web.chat.groupChat.dto.response.GroupChatMetaResponse;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,19 @@ public class GroupChatController {
         ChatMessagesInfo info = chatMessageService.getMessages(userId, beforeMessageId, size);
 
         return ApiResponse.success(GroupChatMessagesResponse.from(info));
+    }
+
+    @PostMapping("/news-share")
+    public ApiResponse<Void> shareNews (
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody ShareNewsRequest request
+    ) {
+        chatMessageService.shareNews(
+                userId,
+                new ShareNewsCommand(request.newsClusterId(), request.replyToMessageId())
+        );
+
+        return ApiResponse.success(null);
     }
 
     @GetMapping("/me")

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
@@ -44,7 +44,7 @@ public class GroupChatController {
     ) {
         chatMessageService.shareNews(
                 userId,
-                new ShareNewsCommand(request.newsClusterId(), request.replyToMessageId())
+                new ShareNewsCommand(request.newsClusterId())
         );
 
         return ApiResponse.success(null);

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/request/ShareNewsRequest.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/request/ShareNewsRequest.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.web.chat.groupChat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ShareNewsRequest(
+        @NotNull
+        Long newsClusterId,
+        Long replyToMessageId
+) {
+}

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/request/ShareNewsRequest.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/request/ShareNewsRequest.java
@@ -4,7 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record ShareNewsRequest(
         @NotNull
-        Long newsClusterId,
-        Long replyToMessageId
+        Long newsClusterId
 ) {
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/ChatMessageResponse.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.web.chat.groupChat.dto.response;
 
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -23,6 +24,7 @@ public class ChatMessageResponse {
     private String content;
     private OffsetDateTime createdAt;
     private ReplyMessageInfo replyTo;
+    private NewsShareInfo newsShare;
 
     public static ChatMessageResponse from(ChatMessageInfo info) {
         return ChatMessageResponse.builder()
@@ -34,6 +36,7 @@ public class ChatMessageResponse {
                 .content(info.content())
                 .createdAt(info.createdAt())
                 .replyTo(info.replyTo())
+                .newsShare(info.newsShare())
                 .build();
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/listener/ChatMessageEventListener.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/listener/ChatMessageEventListener.java
@@ -17,16 +17,7 @@ public class ChatMessageEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(ChatMessageCreatedEvent event) {
 
-        ChatMessageResponse response = ChatMessageResponse.builder()
-                .messageId(event.getMessageId())
-                .userId(event.getUserId())
-                .groupId(event.getGroupId())
-                .messageType(event.getMessageType())
-                .sender(event.getSender())
-                .content(event.getContent())
-                .createdAt(event.getCreatedAt())
-                .replyTo(event.getReplyTo())
-                .build();
+        ChatMessageResponse response = ChatMessageResponse.from(event.getMessage());
 
         messagingTemplate.convertAndSend(
                 String.format("/topic/chat/group/%d", event.getGroupId()),

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -4,14 +4,18 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
+import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
+import com.solv.wefin.domain.chat.groupChat.entity.ChatMessageNewsShare;
 import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
 import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
 import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageRepository;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +32,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -44,6 +49,8 @@ class ChatMessageServiceTest {
     private GroupMemberRepository groupMemberRepository;
     private ChatSpamGuard chatSpamGuard;
     private ChatMessageService chatMessageService;
+    private NewsClusterRepository newsClusterRepository;
+    private ChatMessageNewsShareService chatMessageNewsShareService;
 
     @BeforeEach
     void setUp() {
@@ -52,13 +59,17 @@ class ChatMessageServiceTest {
         eventPublisher = mock(ApplicationEventPublisher.class);
         groupMemberRepository = mock(GroupMemberRepository.class);
         chatSpamGuard = mock(ChatSpamGuard.class);
+        newsClusterRepository = mock(NewsClusterRepository.class);
+        chatMessageNewsShareService = mock(ChatMessageNewsShareService.class);
 
         chatMessageService = new ChatMessageService(
                 chatMessageRepository,
                 userRepository,
                 eventPublisher,
                 groupMemberRepository,
-                chatSpamGuard
+                chatSpamGuard,
+                newsClusterRepository,
+                chatMessageNewsShareService
         );
     }
 
@@ -426,4 +437,124 @@ class ChatMessageServiceTest {
         assertEquals("세 번째 메시지", result.messages().get(1).content());
     }
 
+    @Test
+    @DisplayName("뉴스 공유 메시지를 저장하고 뉴스 공유 정보를 포함한 응답을 반환한다")
+    void shareNews_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("groupUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        Group group = Group.builder()
+                .name("group")
+                .build();
+        ReflectionTestUtils.setField(group, "id", 1L);
+
+        GroupMember groupMember = GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMember.GroupMemberRole.MEMBER)
+                .status(GroupMember.GroupMemberStatus.ACTIVE)
+                .build();
+
+        NewsCluster newsCluster = NewsCluster.createSingle(
+                new float[]{1.0f},
+                100L,
+                "https://image.test/thumb.png",
+                OffsetDateTime.now()
+        );
+        ReflectionTestUtils.setField(newsCluster, "id", 55L);
+        ReflectionTestUtils.setField(newsCluster, "title", "cluster title");
+        ReflectionTestUtils.setField(newsCluster, "summary", "cluster summary");
+        ReflectionTestUtils.setField(newsCluster, "thumbnailUrl", "https://image.test/thumb.png");
+
+        ChatMessage savedMessage = ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.NEWS)
+                .content("")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(savedMessage, "id", 10L);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(newsClusterRepository.findById(55L)).thenReturn(Optional.of(newsCluster));
+        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMessage);
+        when(chatMessageNewsShareService.save(savedMessage, newsCluster))
+                .thenAnswer(invocation -> {
+                    ChatMessageNewsShare newsShare = ChatMessageNewsShare.create(savedMessage, newsCluster);
+                    savedMessage.attachNewsShare(newsShare);
+                    return newsShare;
+                });
+
+        // when
+        var result = chatMessageService.shareNews(userId, new ShareNewsCommand(55L, null));
+
+        // then
+        verify(chatMessageRepository).save(argThat(message ->
+                message.getMessageType() == MessageType.NEWS
+                        && "".equals(message.getContent())
+                        && message.getReplyToMessage() == null
+        ));
+        verify(chatMessageNewsShareService).save(savedMessage, newsCluster);
+        verify(eventPublisher).publishEvent(any(ChatMessageCreatedEvent.class));
+
+        assertEquals(10L, result.messageId());
+        assertEquals("NEWS", result.messageType());
+        assertNotNull(result.newsShare());
+        assertEquals(55L, result.newsShare().newsClusterId());
+        assertEquals("cluster title", result.newsShare().title());
+        assertEquals("cluster summary", result.newsShare().summary());
+        assertEquals("https://image.test/thumb.png", result.newsShare().thumbnailUrl());
+    }
+
+    @Test
+    @DisplayName("공유할 뉴스 클러스터가 없으면 예외가 발생한다")
+    void shareNews_fail_when_news_cluster_not_found() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("groupUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        Group group = Group.builder()
+                .name("group")
+                .build();
+        ReflectionTestUtils.setField(group, "id", 1L);
+
+        GroupMember groupMember = GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMember.GroupMemberRole.MEMBER)
+                .status(GroupMember.GroupMemberStatus.ACTIVE)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(newsClusterRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> chatMessageService.shareNews(userId, new ShareNewsCommand(999L, null))
+        );
+
+        // then
+        assertEquals(ErrorCode.NEWS_CLUSTER_NOT_FOUND, exception.getErrorCode());
+        verify(chatMessageRepository, never()).save(any());
+        verify(chatMessageNewsShareService, never()).save(any(), any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
 }

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -477,7 +477,7 @@ class ChatMessageServiceTest {
                 .user(user)
                 .group(group)
                 .messageType(MessageType.NEWS)
-                .content("")
+                .content("cluster title")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(savedMessage, "id", 10L);
@@ -495,12 +495,12 @@ class ChatMessageServiceTest {
                 });
 
         // when
-        var result = chatMessageService.shareNews(userId, new ShareNewsCommand(55L, null));
+        var result = chatMessageService.shareNews(userId, new ShareNewsCommand(55L));
 
         // then
         verify(chatMessageRepository).save(argThat(message ->
                 message.getMessageType() == MessageType.NEWS
-                        && "".equals(message.getContent())
+                        && "cluster title".equals(message.getContent())
                         && message.getReplyToMessage() == null
         ));
         verify(chatMessageNewsShareService).save(savedMessage, newsCluster);
@@ -548,7 +548,7 @@ class ChatMessageServiceTest {
         // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
-                () -> chatMessageService.shareNews(userId, new ShareNewsCommand(999L, null))
+                () -> chatMessageService.shareNews(userId, new ShareNewsCommand(999L))
         );
 
         // then

--- a/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -58,6 +60,7 @@ class GroupChatControllerTest {
                 "groupUser",
                 "안녕하세요",
                 OffsetDateTime.now(),
+                null,
                 null
         );
 
@@ -133,5 +136,81 @@ class GroupChatControllerTest {
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.groupId").value(7))
                 .andExpect(jsonPath("$.data.groupName").value("우리 그룹"));
+    }
+
+    @Test
+    @DisplayName("뉴스 공유 요청을 받으면 성공 응답을 반환한다")
+    void shareNews_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        ChatMessageInfo info = new ChatMessageInfo(
+                10L,
+                userId,
+                3L,
+                "NEWS",
+                "groupUser",
+                "",
+                OffsetDateTime.now(),
+                null,
+                new com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo(
+                        55L,
+                        "cluster title",
+                        "cluster summary",
+                        "https://image.test/thumb.png"
+                )
+        );
+
+        when(chatMessageService.shareNews(
+                userId,
+                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(55L, null)
+        )).thenReturn(info);
+
+        // when // then
+        mockMvc.perform(post("/api/chat/group/news-share")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        )))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "newsClusterId": 55
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 뉴스 클러스터를 공유하면 404를 반환한다")
+    void shareNews_fail_when_news_cluster_not_found() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        when(chatMessageService.shareNews(
+                userId,
+                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(999L, null)
+        )).thenThrow(new BusinessException(ErrorCode.NEWS_CLUSTER_NOT_FOUND));
+
+        // when // then
+        mockMvc.perform(post("/api/chat/group/news-share")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        )))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "newsClusterId": 999
+                                }
+                                """))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("NEWS_CLUSTER_NOT_FOUND"));
     }
 }

--- a/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
@@ -163,7 +163,7 @@ class GroupChatControllerTest {
 
         when(chatMessageService.shareNews(
                 userId,
-                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(55L, null)
+                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(55L)
         )).thenReturn(info);
 
         // when // then
@@ -192,7 +192,7 @@ class GroupChatControllerTest {
 
         when(chatMessageService.shareNews(
                 userId,
-                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(999L, null)
+                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(999L)
         )).thenThrow(new BusinessException(ErrorCode.NEWS_CLUSTER_NOT_FOUND));
 
         // when // then


### PR DESCRIPTION
## 📌 PR 설명

그룹 채팅에서 뉴스 클러스터를 공유할 수 있는 기능을 추가했습니다.  
기존 그룹 채팅은 일반 텍스트 메시지 중심 구조였는데, 이번 작업에서는 뉴스 공유 메시지를 별도 타입으로 정의하고, 채팅방에서는 카드 형태로 보여줄 수 있도록 백엔드 구조를 확장했습니다.

이번 기능은 단순히 링크 문자열을 보내는 방식이 아니라, 그룹 채팅 메시지와 뉴스 공유 스냅샷을 분리해서 저장하도록 설계했습니다.  
채팅 메시지 본체는 `chat_message`가 유지하고, 뉴스 카드 렌더링에 필요한 제목/요약/썸네일 정보는 `chat_message_news_share`에 저장해 일반 텍스트 메시지와 뉴스 공유 메시지를 구분해서 다룰 수 있도록 했습니다.

또한 뉴스 공유 요청은 그룹 채팅의 일반 메시지 입력과는 성격이 다르다고 판단해, 기존 메시지 전송 WebSocket 흐름과 별도로 REST API를 통해 처리하고, 저장 이후에는 기존 그룹 채팅 이벤트/브로드캐스트 흐름을 그대로 재사용하도록 연결했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[WEF-182] 그룹 채팅 뉴스 공유 기능 구현**
- [x] 그룹 채팅 메시지 타입에 `NEWS` 추가
- [x] 뉴스 공유 스냅샷 저장용 `chat_message_news_share` 구조 추가
- [x] `NewsCluster` 기준 뉴스 공유 저장 로직 구현
- [x] 그룹 채팅 뉴스 공유 서비스 로직 구현
- [x] 그룹 채팅 뉴스 공유 REST API 추가
- [x] 그룹 채팅 WebSocket 브로드캐스트 응답에 뉴스 공유 payload 포함
- [x] 그룹 채팅 메시지 조회 응답에 뉴스 공유 정보 포함
- [x] 뉴스 공유 서비스 테스트 및 컨트롤러 테스트 추가

<br>

## 💭 고민과 해결과정

이번 작업에서 가장 먼저 고민한 부분은 **개인화 뉴스 화면에서 본 뉴스를 그룹 채팅에 무엇으로 공유할 것인가**였습니다.  
처음에는 개별 기사(`news_article`)를 공유 대상으로 볼지, 외부/내부 URL을 그대로 보내는 방식으로 갈지 고민했습니다. 하지만 실제로 서비스에서 사용자에게 보여주는 단위가 개별 기사보다 뉴스 클러스터(`news_cluster`)에 가까웠기 때문에, 최종적으로는 공유 대상도 `news_cluster` 기준으로 맞추는 쪽이 더 자연스럽다고 판단했습니다.

즉 사용자마다 개인화 추천 결과는 다를 수 있지만, 그룹 채팅에 공유되는 대상은 공통 식별 가능한 뉴스 클러스터로 보는 구조를 택했습니다.  
이렇게 하면 추천 결과와 공유 대상을 분리해서 볼 수 있고, 채팅에서 보여주는 카드와 상세 페이지 이동 흐름도 더 일관되게 가져갈 수 있다고 봤습니다.

두 번째 고민은 **뉴스 공유 정보를 어디에 저장할 것인가**였습니다.  
처음에는 `chat_message` 테이블에 뉴스 관련 컬럼을 직접 추가하는 방법도 생각할 수 있었지만, 이 경우 일반 텍스트 메시지와 뉴스 공유 메시지가 같은 테이블 안에서 계속 확장되면서 구조가 복잡해질 수 있다고 느꼈습니다. 그래서 `chat_message`는 공통 메시지 본체로 유지하고, 뉴스 공유 카드에 필요한 정보만 별도 `chat_message_news_share` 테이블에 저장하는 방향으로 설계했습니다.

여기서도 “무엇을 snapshot으로 남길 것인가”를 한 번 더 고민했습니다.  
외부 원문 URL이나 상세 페이지에 필요한 모든 정보를 다 저장할 수도 있었지만, 채팅방에서 실제로 필요한 건 카드에 보이는 정보뿐이라고 판단했습니다. 그래서 최종적으로는 `news_cluster_id`와 함께:

- `shared_title`
- `shared_summary`
- `shared_thumbnail_url`

만 snapshot으로 저장하고, 상세 페이지는 `newsClusterId`를 기준으로 현재 데이터를 다시 조회하는 구조로 정리했습니다.  
즉 채팅방 카드에 필요한 정보와, 상세 페이지에서 보여줄 본문 데이터의 책임을 분리한 셈입니다.

세 번째로는 **요청 경로를 REST로 할지 WebSocket으로 할지**를 고민했습니다.  
기존 그룹 채팅의 일반 메시지 입력은 WebSocket 기반이었지만, 뉴스 공유는 사용자가 직접 타이핑해서 보내는 자유 입력보다 “뉴스 카드에서 공유 버튼을 누르는 액션”에 더 가까웠습니다. 그래서 이 기능은 일반 채팅 입력과 동일한 WebSocket 요청으로 넣기보다, 별도 REST API로 처리하는 편이 더 자연스럽다고 판단했습니다.

대신 저장 이후의 흐름은 기존 그룹 채팅과 동일하게 유지했습니다.  
즉 REST API로 공유 요청을 받고, 서버에서 `ChatMessage`와 `ChatMessageNewsShare`를 저장한 뒤, 기존 `ChatMessageCreatedEvent`와 WebSocket 브로드캐스트를 그대로 재사용해서 그룹 채팅 구독자들에게 실시간으로 전달되도록 연결했습니다. 이렇게 하니 입력 방식은 기능 성격에 맞게 분리하면서도, 최종 반영 흐름은 기존 채팅 아키텍처와 자연스럽게 통합할 수 있었습니다.

마지막으로 응답 구조도 함께 정리했습니다.  
이미 그룹 채팅 메시지 응답은 `ChatMessageInfo`와 `ChatMessageResponse`를 중심으로 관리되고 있었기 때문에, 뉴스 공유 메시지도 별도 예외 구조를 만들기보다 `newsShare` 필드를 추가해 하나의 메시지 응답 구조 안에 담도록 맞췄습니다. 그 결과 일반 채팅 메시지와 뉴스 공유 메시지를 `messageType` 기준으로 프론트에서 분기 렌더링할 수 있는 기반이 생겼습니다.

<br>

### 🔗 관련 이슈
Closes #182

<br>

[WEF-182]: https://sol-v.atlassian.net/browse/WEF-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 그룹 채팅에서 뉴스 기사 공유 기능 추가(제목·요약·썸네일 메타데이터 포함)
  * 메시지에 뉴스 공유 첨부 및 답글 형태로 표시
  * 채팅 메시지 응답에 뉴스 공유 정보 포함 및 관련 이벤트 발행
  * 뉴스 공유 전송을 위한 새 POST API 엔드포인트 추가

* **Bug Fixes**
  * 뉴스 미존재 시 명확한 404 에러 코드 반환 및 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->