### PR TITLE
[WEF-92] 그룹 탈퇴 및 1인 그룹 전환

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/solv/wefin/domain/auth/repository/UserRepository.java
@@ -1,7 +1,11 @@
 package com.solv.wefin.domain.auth.repository;
 
 import com.solv.wefin.domain.auth.entity.User;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -11,4 +15,8 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select u from User u where u.userId = :userId")
+    Optional<User> findByIdForUpdate(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/solv/wefin/domain/group/dto/LeaveGroupInfo.java
+++ b/src/main/java/com/solv/wefin/domain/group/dto/LeaveGroupInfo.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.group.dto;
+
+public record LeaveGroupInfo (
+        Long leftGroupId,
+        Long currentGroupId
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -85,6 +85,10 @@ public class GroupMember {
         this.leftAt = OffsetDateTime.now();
     }
 
+    public void changeRoleToLeader() {
+        this.role = GroupMemberRole.LEADER;
+    }
+
     public boolean isActive() {
         return this.status == GroupMemberStatus.ACTIVE;
     }

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -89,6 +89,10 @@ public class GroupMember {
         this.role = GroupMemberRole.LEADER;
     }
 
+    public void changeRoleToMember() {
+        this.role = GroupMemberRole.MEMBER;
+    }
+
     public boolean isActive() {
         return this.status == GroupMemberStatus.ACTIVE;
     }

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
@@ -28,6 +28,12 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             GroupType groupType
     );
 
+    Optional<GroupMember> findFirstByGroupAndStatusAndUser_UserIdNotOrderByIdAsc(
+            Group group,
+            GroupMember.GroupMemberStatus status,
+            UUID userId
+    );
+
     boolean existsByUser_UserIdAndGroupAndStatus(
             UUID userId,
             Group group,

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -195,11 +195,7 @@ public class GroupService {
 
         GroupMember homeGroupMember = groupMemberRepository
                 .findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME)
-                .orElseGet(() -> {
-                    createDefaultGroup(user);
-                    return groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_HOME_MEMBERSHIP_NOT_FOUND));
-                });
+                .orElseGet(() -> createDefaultGroupAndGetMembership(user));
 
         homeGroupMember.activate();
 
@@ -207,5 +203,13 @@ public class GroupService {
                 group.getId(),
                 homeGroupMember.getGroup().getId()
         );
+    }
+
+    private GroupMember createDefaultGroupAndGetMembership(User user) {
+        Group group = Group.createHomeGroup(user.getNickname() + "의 그룹");
+        Group savedGroup = groupRepository.save(group);
+
+        GroupMember groupMember = GroupMember.createLeader(user, savedGroup);
+        return groupMemberRepository.save(groupMember);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -4,9 +4,11 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.dto.GroupInviteInfo;
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import com.solv.wefin.domain.group.dto.LeaveGroupInfo;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupInvite;
 import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.entity.GroupType;
 import com.solv.wefin.domain.group.repository.GroupInviteRepository;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
@@ -37,12 +39,9 @@ public class GroupService {
         Group group = Group.createHomeGroup(user.getNickname() + "의 그룹");
         Group savedGroup = groupRepository.save(group);
 
-        GroupMember groupMember = GroupMember.createLeader(
-                user,
-                savedGroup
-        );
-
+        GroupMember groupMember = GroupMember.createLeader(user, savedGroup);
         groupMemberRepository.save(groupMember);
+
         return savedGroup;
     }
 
@@ -121,7 +120,7 @@ public class GroupService {
 
         if (currentActiveMember != null
                 && currentActiveMember.getGroup().getId().equals(targetGroup.getId())) {
-            throw new BusinessException(ErrorCode.ALREADY_JOINED_GROUP);
+            throw new BusinessException(ErrorCode.GROUP_ALREADY_JOINED);
         }
 
         long activeMemberCount = groupMemberRepository.countByGroupAndStatus(
@@ -147,14 +146,66 @@ public class GroupService {
             return GroupMemberInfo.from(targetMembership);
         }
 
-        GroupMember newMember = GroupMember.createMember(
-                user,
-                targetGroup
+        GroupMember newMember = GroupMember.createMember(user, targetGroup);
+        groupMemberRepository.save(newMember);
+
+        invite.markAccepted();
+        return GroupMemberInfo.from(newMember);
+    }
+
+    @Transactional
+    public LeaveGroupInfo leaveGroup(Long groupId, UUID userId) {
+        Group group = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        if (group.isHomeGroup()) {
+            throw new BusinessException(ErrorCode.GROUP_HOME_LEAVE_NOT_ALLOWED);
+        }
+
+        GroupMember leavingMember = groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, groupId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_MEMBER_NOT_FOUND));
+
+        if (!leavingMember.isActive()) {
+            throw new BusinessException(ErrorCode.GROUP_MEMBER_ALREADY_INACTIVE);
+        }
+
+        boolean wasLeader = leavingMember.isLeader();
+
+        leavingMember.deactivate();
+
+        long remainingActiveMemberCount = groupMemberRepository.countByGroupAndStatus(
+                group,
+                GroupMember.GroupMemberStatus.ACTIVE
         );
 
-        groupMemberRepository.save(newMember);
-        invite.markAccepted();
+        if (wasLeader && remainingActiveMemberCount > 0) {
+            GroupMember nextLeader = groupMemberRepository
+                    .findFirstByGroupAndStatusAndUser_UserIdNotOrderByIdAsc(
+                            group,
+                            GroupMember.GroupMemberStatus.ACTIVE,
+                            userId
+                    )
+                    .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_LEADER_TRANSFER_FAILED));
 
-        return GroupMemberInfo.from(newMember);
+            nextLeader.changeRoleToLeader();
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember homeGroupMember = groupMemberRepository
+                .findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME)
+                .orElseGet(() -> {
+                    createDefaultGroup(user);
+                    return groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_HOME_MEMBERSHIP_NOT_FOUND));
+                });
+
+        homeGroupMember.activate();
+
+        return new LeaveGroupInfo(
+                group.getId(),
+                homeGroupMember.getGroup().getId()
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -194,12 +194,17 @@ public class GroupService {
             nextLeader.changeRoleToLeader();
         }
 
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdForUpdate(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
         GroupMember homeGroupMember = groupMemberRepository
                 .findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME)
-                .orElseGet(() -> createDefaultGroupAndGetMembership(user));
+                .orElseGet(() -> {
+                    GroupMember created = createDefaultGroupAndGetMembership(user);
+                    return groupMemberRepository
+                            .findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME)
+                            .orElse(created);
+                });
 
         homeGroupMember.activate();
 

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -171,6 +171,10 @@ public class GroupService {
 
         boolean wasLeader = leavingMember.isLeader();
 
+        if (wasLeader) {
+            leavingMember.changeRoleToMember();
+        }
+
         leavingMember.deactivate();
 
         long remainingActiveMemberCount = groupMemberRepository.countByGroupAndStatus(

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -13,16 +13,19 @@ public enum ErrorCode {
     // Group
     GROUP_NOT_FOUND(404, "그룹을 찾을 수 없습니다."),
     GROUP_MEMBER_FORBIDDEN(403, "해당 그룹의 멤버만 조회할 수 있습니다."),
+    GROUP_MEMBER_NOT_FOUND(404, "그룹 멤버를 찾을 수 없습니다."),
+    GROUP_MEMBER_ALREADY_INACTIVE(400, "이미 비활성화된 그룹 멤버입니다."),
     GROUP_INVITE_FORBIDDEN(403, "해당 그룹의 초대 코드를 생성할 권한이 없습니다."),
     GROUP_INVITE_NOT_FOUND(404, "초대 코드를 찾을 수 없습니다."),
     GROUP_INVITE_EXPIRED(400, "만료된 초대 코드입니다."),
     GROUP_INVITE_ALREADY_USED(400, "이미 사용된 초대 코드입니다."),
     GROUP_FULL(400, "그룹 인원이 가득 찼습니다."),
-    ALREADY_JOINED_GROUP(409, "이미 참여한 그룹입니다."),
+    GROUP_ALREADY_JOINED(409, "이미 참여한 그룹입니다."),
     GROUP_HOME_INVITE_NOT_ALLOWED(400, "홈 그룹에는 초대 코드를 생성할 수 없습니다."),
     GROUP_HOME_JOIN_NOT_ALLOWED(400, "홈 그룹에는 참여할 수 없습니다."),
     GROUP_HOME_LEAVE_NOT_ALLOWED(400, "홈 그룹은 탈퇴할 수 없습니다."),
-    GROUP_HOME_GROUP_NOT_FOUND(404, "홈 그룹을 찾을 수 없습니다."),
+    GROUP_HOME_MEMBERSHIP_NOT_FOUND(404, "홈 그룹 멤버십을 찾을 수 없습니다."),
+    GROUP_LEADER_TRANSFER_FAILED(500, "리더 권한 위임에 실패했습니다."),
 
     // Chat
     CHAT_MESSAGE_EMPTY(400, "메시지 내용은 비어 있을 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/group/GroupController.java
+++ b/src/main/java/com/solv/wefin/web/group/GroupController.java
@@ -4,10 +4,7 @@ import com.solv.wefin.domain.group.dto.GroupInviteInfo;
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.global.common.ApiResponse;
-import com.solv.wefin.web.group.dto.CreateGroupInviteResponse;
-import com.solv.wefin.web.group.dto.GroupMemberResponse;
-import com.solv.wefin.web.group.dto.JoinGroupRequest;
-import com.solv.wefin.web.group.dto.JoinGroupResponse;
+import com.solv.wefin.web.group.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -50,5 +47,17 @@ public class GroupController {
         return ApiResponse.success(
                 JoinGroupResponse.from(info)
         );
+    }
+
+    @DeleteMapping("/{groupId}/members/me")
+    public ApiResponse<LeaveGroupResponse> leaveGroup(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal UUID userId
+    ) {
+        LeaveGroupResponse response = LeaveGroupResponse.from(
+                groupService.leaveGroup(groupId, userId)
+        );
+
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/solv/wefin/web/group/dto/LeaveGroupResponse.java
+++ b/src/main/java/com/solv/wefin/web/group/dto/LeaveGroupResponse.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.group.dto;
+
+import com.solv.wefin.domain.group.dto.LeaveGroupInfo;
+
+public record LeaveGroupResponse(
+        Long leftGroupId,
+        Long currentGroupId
+) {
+    public static LeaveGroupResponse from(LeaveGroupInfo info) {
+        return new LeaveGroupResponse(
+                info.leftGroupId(),
+                info.currentGroupId()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.dto.GroupInviteInfo;
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import com.solv.wefin.domain.group.dto.LeaveGroupInfo;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupInvite;
 import com.solv.wefin.domain.group.entity.GroupMember;
@@ -283,6 +284,251 @@ class GroupServiceTest {
             verify(groupMemberRepository, never()).countByGroupAndStatus(any(), any());
             verify(groupMemberRepository, never()).findByUser_UserIdAndGroup_Id(any(), anyLong());
             verify(groupMemberRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("leaveGroup")
+    class LeaveGroupTest {
+
+        @Test
+        @DisplayName("단체 그룹 탈퇴 시 홈 그룹으로 전환된다")
+        void leaveGroup_success() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+
+            Group sharedGroup = createGroup(1L, "공유 그룹", GroupType.SHARED);
+            Group homeGroup = createGroup(100L, "홈 그룹", GroupType.HOME);
+
+            User user = createUser(userId, "test@test.com", "유저", "pw");
+
+            GroupMember leavingMember = createGroupMember(
+                    10L,
+                    user,
+                    sharedGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            GroupMember homeGroupMember = createGroupMember(
+                    20L,
+                    user,
+                    homeGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.INACTIVE
+            );
+
+            when(groupRepository.findByIdForUpdate(1L))
+                    .thenReturn(Optional.of(sharedGroup));
+            when(groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, 1L))
+                    .thenReturn(Optional.of(leavingMember));
+            when(groupMemberRepository.countByGroupAndStatus(
+                    sharedGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(0L);
+            when(userRepository.findById(userId))
+                    .thenReturn(Optional.of(user));
+            when(groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME))
+                    .thenReturn(Optional.of(homeGroupMember));
+
+            // when
+            LeaveGroupInfo result = groupService.leaveGroup(1L, userId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.leftGroupId()).isEqualTo(1L),
+                    () -> assertThat(result.currentGroupId()).isEqualTo(100L),
+                    () -> assertThat(leavingMember.isActive()).isFalse(),
+                    () -> assertThat(homeGroupMember.isActive()).isTrue()
+            );
+        }
+
+        @Test
+        @DisplayName("리더가 탈퇴하면 남은 ACTIVE 멤버에게 리더를 위임한다")
+        void leaveGroup_success_when_leader_transfers_leadership() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+            UUID memberUserId = UUID.randomUUID();
+
+            Group sharedGroup = createGroup(1L, "공유 그룹", GroupType.SHARED);
+            Group homeGroup = createGroup(100L, "홈 그룹", GroupType.HOME);
+
+            User leaderUser = createUser(userId, "leader@test.com", "리더", "pw");
+            User memberUser = createUser(memberUserId, "member@test.com", "멤버", "pw");
+
+            GroupMember leavingLeader = createGroupMember(
+                    10L,
+                    leaderUser,
+                    sharedGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            GroupMember remainingMember = createGroupMember(
+                    11L,
+                    memberUser,
+                    sharedGroup,
+                    GroupMember.GroupMemberRole.MEMBER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            GroupMember homeGroupMember = createGroupMember(
+                    20L,
+                    leaderUser,
+                    homeGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.INACTIVE
+            );
+
+            when(groupRepository.findByIdForUpdate(1L))
+                    .thenReturn(Optional.of(sharedGroup));
+            when(groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, 1L))
+                    .thenReturn(Optional.of(leavingLeader));
+            when(groupMemberRepository.countByGroupAndStatus(
+                    sharedGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(1L);
+            when(userRepository.findById(userId))
+                    .thenReturn(Optional.of(leaderUser));
+            when(groupMemberRepository.findFirstByGroupAndStatusAndUser_UserIdNotOrderByIdAsc(
+                    sharedGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE,
+                    userId
+            )).thenReturn(Optional.of(remainingMember));
+            when(groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME))
+                    .thenReturn(Optional.of(homeGroupMember));
+
+            // when
+            LeaveGroupInfo result = groupService.leaveGroup(1L, userId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.leftGroupId()).isEqualTo(1L),
+                    () -> assertThat(result.currentGroupId()).isEqualTo(100L),
+                    () -> assertThat(leavingLeader.isActive()).isFalse(),
+                    () -> assertThat(homeGroupMember.isActive()).isTrue(),
+                    () -> assertThat(remainingMember.isLeader()).isTrue()
+            );
+        }
+
+        @Test
+        @DisplayName("홈 그룹은 탈퇴할 수 없다")
+        void leaveGroup_fail_when_home_group() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+            Group homeGroup = createGroup(1L, "홈 그룹", GroupType.HOME);
+
+            when(groupRepository.findByIdForUpdate(1L))
+                    .thenReturn(Optional.of(homeGroup));
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.leaveGroup(1L, userId)
+            );
+
+            // then
+            assertThat(exception.getErrorCode())
+                    .isEqualTo(ErrorCode.GROUP_HOME_LEAVE_NOT_ALLOWED);
+
+            verify(groupMemberRepository, never()).findByUser_UserIdAndGroup_Id(any(), anyLong());
+            verify(groupMemberRepository, never()).findByUser_UserIdAndGroup_GroupType(any(), any());
+        }
+
+        @Test
+        @DisplayName("이미 비활성화된 그룹 멤버는 탈퇴할 수 없다")
+        void leaveGroup_fail_when_member_already_inactive() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+
+            Group sharedGroup = createGroup(1L, "공유 그룹", GroupType.SHARED);
+            User user = createUser(userId, "test@test.com", "유저", "pw");
+
+            GroupMember inactiveMember = createGroupMember(
+                    10L,
+                    user,
+                    sharedGroup,
+                    GroupMember.GroupMemberRole.MEMBER,
+                    GroupMember.GroupMemberStatus.INACTIVE
+            );
+
+            when(groupRepository.findByIdForUpdate(1L))
+                    .thenReturn(Optional.of(sharedGroup));
+            when(groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, 1L))
+                    .thenReturn(Optional.of(inactiveMember));
+
+            // when
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.leaveGroup(1L, userId)
+            );
+
+            // then
+            assertThat(exception.getErrorCode())
+                    .isEqualTo(ErrorCode.GROUP_MEMBER_ALREADY_INACTIVE);
+
+            verify(groupMemberRepository, never()).countByGroupAndStatus(any(), any());
+            verify(groupMemberRepository, never()).findByUser_UserIdAndGroup_GroupType(any(), any());
+        }
+
+        @Test
+        @DisplayName("홈 그룹 멤버십이 없으면 홈 그룹을 새로 생성한 뒤 전환한다")
+        void leaveGroup_success_when_home_membership_missing() throws Exception {
+            // given
+            UUID userId = UUID.randomUUID();
+
+            Group sharedGroup = createGroup(1L, "공유 그룹", GroupType.SHARED);
+            Group createdHomeGroup = createGroup(100L, "유저의 그룹", GroupType.HOME);
+
+            User user = createUser(userId, "test@test.com", "유저", "pw");
+
+            GroupMember leavingMember = createGroupMember(
+                    10L,
+                    user,
+                    sharedGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            GroupMember createdHomeGroupMember = createGroupMember(
+                    20L,
+                    user,
+                    createdHomeGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            when(groupRepository.findByIdForUpdate(1L))
+                    .thenReturn(Optional.of(sharedGroup));
+            when(groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, 1L))
+                    .thenReturn(Optional.of(leavingMember));
+            when(groupMemberRepository.countByGroupAndStatus(
+                    sharedGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(0L);
+            when(userRepository.findById(userId))
+                    .thenReturn(Optional.of(user));
+
+            when(groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME))
+                    .thenReturn(Optional.empty())
+                    .thenReturn(Optional.of(createdHomeGroupMember));
+
+            when(groupRepository.save(any(Group.class)))
+                    .thenReturn(createdHomeGroup);
+
+            // when
+            LeaveGroupInfo result = groupService.leaveGroup(1L, userId);
+
+            // then
+            assertAll(
+                    () -> assertThat(result.leftGroupId()).isEqualTo(1L),
+                    () -> assertThat(result.currentGroupId()).isEqualTo(100L),
+                    () -> assertThat(leavingMember.isActive()).isFalse(),
+                    () -> assertThat(createdHomeGroupMember.isActive()).isTrue()
+            );
+
+            verify(groupRepository).save(any(Group.class));
+            verify(groupMemberRepository).save(any(GroupMember.class));
         }
     }
 

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -167,7 +167,8 @@ class GroupServiceTest {
                     group,
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(true);
-            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(userRepository.findById(userId))
+                    .thenReturn(Optional.of(user));
             when(groupInviteRepository.save(any(GroupInvite.class))).thenReturn(invite);
 
             // when
@@ -326,7 +327,7 @@ class GroupServiceTest {
                     sharedGroup,
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(0L);
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdForUpdate(userId))
                     .thenReturn(Optional.of(user));
             when(groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME))
                     .thenReturn(Optional.of(homeGroupMember));
@@ -389,7 +390,7 @@ class GroupServiceTest {
                     sharedGroup,
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(1L);
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdForUpdate(userId))
                     .thenReturn(Optional.of(leaderUser));
             when(groupMemberRepository.findFirstByGroupAndStatusAndUser_UserIdNotOrderByIdAsc(
                     sharedGroup,
@@ -508,13 +509,11 @@ class GroupServiceTest {
                     sharedGroup,
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(0L);
-            when(userRepository.findById(userId))
+            when(userRepository.findByIdForUpdate(userId))
                     .thenReturn(Optional.of(user));
-
             when(groupMemberRepository.findByUser_UserIdAndGroup_GroupType(userId, GroupType.HOME))
                     .thenReturn(Optional.empty())
                     .thenReturn(Optional.of(createdHomeGroupMember));
-
             when(groupRepository.save(any(Group.class)))
                     .thenReturn(createdHomeGroup);
             when(groupMemberRepository.save(any(GroupMember.class)))

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -515,6 +515,8 @@ class GroupServiceTest {
 
             when(groupRepository.save(any(Group.class)))
                     .thenReturn(createdHomeGroup);
+            when(groupMemberRepository.save(any(GroupMember.class)))
+                    .thenReturn(createdHomeGroupMember);
 
             // when
             LeaveGroupInfo result = groupService.leaveGroup(1L, userId);

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupServiceTest.java
@@ -339,6 +339,7 @@ class GroupServiceTest {
                     () -> assertThat(result.leftGroupId()).isEqualTo(1L),
                     () -> assertThat(result.currentGroupId()).isEqualTo(100L),
                     () -> assertThat(leavingMember.isActive()).isFalse(),
+                    () -> assertThat(leavingMember.isLeader()).isFalse(),
                     () -> assertThat(homeGroupMember.isActive()).isTrue()
             );
         }
@@ -406,6 +407,7 @@ class GroupServiceTest {
                     () -> assertThat(result.leftGroupId()).isEqualTo(1L),
                     () -> assertThat(result.currentGroupId()).isEqualTo(100L),
                     () -> assertThat(leavingLeader.isActive()).isFalse(),
+                    () -> assertThat(leavingLeader.isLeader()).isFalse(),
                     () -> assertThat(homeGroupMember.isActive()).isTrue(),
                     () -> assertThat(remainingMember.isLeader()).isTrue()
             );
@@ -526,6 +528,7 @@ class GroupServiceTest {
                     () -> assertThat(result.leftGroupId()).isEqualTo(1L),
                     () -> assertThat(result.currentGroupId()).isEqualTo(100L),
                     () -> assertThat(leavingMember.isActive()).isFalse(),
+                    () -> assertThat(leavingMember.isLeader()).isFalse(),
                     () -> assertThat(createdHomeGroupMember.isActive()).isTrue()
             );
 

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -2,6 +2,7 @@ package com.solv.wefin.web.group;
 
 import com.solv.wefin.domain.group.dto.GroupInviteInfo;
 import com.solv.wefin.domain.group.dto.GroupMemberInfo;
+import com.solv.wefin.domain.group.dto.LeaveGroupInfo;
 import com.solv.wefin.domain.group.entity.GroupInvite;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.global.config.security.JwtProvider;
@@ -24,6 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
 @WebMvcTest(GroupController.class)
 class GroupControllerTest {
@@ -106,5 +108,27 @@ class GroupControllerTest {
                 .andExpect(jsonPath("$.data.inviteCode").value("550e8400-e29b-41d4-a716-446655440000"))
                 .andExpect(jsonPath("$.data.status").value("PENDING"))
                 .andExpect(jsonPath("$.data.expiredAt").exists());
+    }
+
+    @Test
+    @DisplayName("그룹 탈퇴에 성공한다")
+    void leaveGroup_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        given(groupService.leaveGroup(1L, userId))
+                .willReturn(new LeaveGroupInfo(1L, 100L));
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userId, null, List.of());
+
+        // when & then
+        mockMvc.perform(delete("/api/groups/{groupId}/members/me", 1L)
+                        .with(authentication(authentication))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.leftGroupId").value(1))
+                .andExpect(jsonPath("$.data.currentGroupId").value(100));
     }
 }


### PR DESCRIPTION
…test coverage (#185)

## 📌 PR 설명
그룹 탈퇴 기능을 구현하고 HOME 그룹 전환 정책 및 리더 위임 로직을 포함하여 그룹 상태 전환 흐름을 완성.

예외 케이스 및 fallback 시나리오를 포함한 서비스/컨트롤러 테스트를 보강.
<br>

## ✅ 완료한 기능 명세

- [x] 그룹 탈퇴 API 구현 (DELETE/api/groups/{groupId}/members/me)
- [x] 단체 그룹 탈퇴 시 HOME 그룹으로 전환 로직 구현
- [x] 리더 탈퇴 시 다음 멤버에게 리더 위임 처리
- [x] 이미 INACTIVE 상태 멤버 탈퇴 방지 처리
- [x] HOME 그룹 멤버십이 없는 경우 fallback 생성 로직 추가
- [x] GroupService 테스트 보강 (정상/예외/리더 위임/재생성 케이스)
- [x] GroupController 테스트 추가 (탈퇴 API)
- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 유저는 항상 ACTIVE 그룹을 하나만 가져야 하므로 탈퇴 시 SHARED → INACTIVE, HOME → ACTIVE 전환 구조로 설계
- 리더 탈퇴 시 그룹이 유지되도록 남은 ACTIVE 멤버 중 1명을 자동으로 리더 위임하도록 구현
- HOME 그룹 멤버십이 없는 경우 createDefaultGroup()을 통해 fallback 생성하도록 처리
- 성공 케이스뿐 아니라 리더 위임, HOME 그룹 탈퇴 방지, INACTIVE 탈퇴 방지, HOME fallback 생성 등 핵심 분기 로직을 모두 테스트로 검증
<br>

### 🔗 관련 이슈
Closes #185 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 탈퇴 API 추가: 사용자가 자신의 그룹을 탈퇴하고 탈퇴한 그룹 ID 및 현재 활성 홈 그룹 ID를 응답받음.
  * 홈 그룹이 없을 때 기본 홈 그룹/멤버십 생성 및 반환.

* **버그 수정**
  * 그룹 가입·상태 관련 오류 코드 정비 및 탈퇴 시 홈 멤버십 복구/보존 로직 개선.
  * 리더 탈퇴 시 리더 권한을 다른 활성 멤버로 적절히 이관하거나 미지정 처리.

* **테스트**
  * 그룹 탈퇴 성공/실패·리더 이관 등 단위 및 컨트롤러 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->