### PR TITLE
[WEF-529] 뉴스 클러스터 읽음 처리·피드백 및  단독 클러스터 AI 요약 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -62,12 +62,8 @@ public class ClusterInteractionService {
     public void submitFeedback(UUID userId, Long clusterId, FeedbackType feedbackType) {
         validateActiveCluster(clusterId);
 
-        if (feedbackRepository.existsByUserIdAndNewsClusterId(userId, clusterId)) {
-            throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
-        }
-
         try {
-            feedbackRepository.save(UserNewsClusterFeedback.create(userId, clusterId, feedbackType));
+            feedbackRepository.saveAndFlush(UserNewsClusterFeedback.create(userId, clusterId, feedbackType));
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
         }
@@ -75,8 +71,8 @@ public class ClusterInteractionService {
         try {
             interestWeightService.updateWeights(userId, clusterId, feedbackType);
         } catch (Exception e) {
-            log.warn("가중치 업데이트 실패 (피드백은 저장됨) — userId: {}, clusterId: {}, error: {}",
-                    userId, clusterId, e.getMessage());
+            log.warn("가중치 업데이트 실패 (피드백은 저장됨) — userId: {}, clusterId: {}",
+                    userId, clusterId, e);
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -1,19 +1,13 @@
 package com.solv.wefin.domain.news.cluster.service;
 
-import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
-import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
-import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
-import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
-import com.solv.wefin.domain.user.entity.UserInterest;
-import com.solv.wefin.domain.user.repository.UserInterestRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,34 +16,24 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 /**
  * 클러스터 읽음 처리 및 피드백 서비스
  *
  * 읽음: 중복 시 무시 (idempotent)
  * 피드백: 1회만 가능, 중복 시 409
- * 피드백 시 user_interest 가중치를 원자적 UPDATE로 업데이트 (HELPFUL +1, NOT_HELPFUL -1)
+ * 가중치 업데이트는 ClusterInterestWeightService에서 별도 트랜잭션으로 처리
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class ClusterInteractionService {
 
-    private static final BigDecimal HELPFUL_WEIGHT = BigDecimal.ONE;
-    private static final BigDecimal NOT_HELPFUL_WEIGHT = BigDecimal.ONE.negate();
-    private static final Set<TagType> WEIGHT_TARGET_TYPES = Set.of(TagType.SECTOR, TagType.STOCK);
-
     private final NewsClusterRepository newsClusterRepository;
     private final UserNewsClusterReadRepository readRepository;
     private final UserNewsClusterFeedbackRepository feedbackRepository;
-    private final NewsClusterArticleRepository clusterArticleRepository;
-    private final NewsArticleTagRepository articleTagRepository;
-    private final UserInterestRepository userInterestRepository;
+    private final ClusterInterestWeightService interestWeightService;
 
     /**
      * 클러스터 읽음을 기록한다.
@@ -73,8 +57,6 @@ public class ClusterInteractionService {
     /**
      * 클러스터에 피드백을 남긴다.
      * 1회만 가능하며, 이미 피드백한 경우 409를 반환한다.
-     * 피드백 저장 후 가중치 업데이트는 별도 트랜잭션으로 처리하여,
-     * 가중치 실패가 피드백 저장을 롤백하지 않도록 한다
      */
     @Transactional
     public void submitFeedback(UUID userId, Long clusterId, FeedbackType feedbackType) {
@@ -91,7 +73,7 @@ public class ClusterInteractionService {
         }
 
         try {
-            updateInterestWeights(userId, clusterId, feedbackType);
+            interestWeightService.updateWeights(userId, clusterId, feedbackType);
         } catch (Exception e) {
             log.warn("가중치 업데이트 실패 (피드백은 저장됨) — userId: {}, clusterId: {}, error: {}",
                     userId, clusterId, e.getMessage());
@@ -108,48 +90,5 @@ public class ClusterInteractionService {
         if (cluster.getStatus() != ClusterStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.CLUSTER_NOT_FOUND);
         }
-    }
-
-    /**
-     * 피드백에 따라 클러스터 소속 기사의 SECTOR/STOCK 태그에 대한 가중치를 원자적으로 업데이트한다.
-     * 해당 관심사가 없으면 새로 생성한다
-     */
-    private void updateInterestWeights(UUID userId, Long clusterId, FeedbackType feedbackType) {
-        BigDecimal delta = feedbackType == FeedbackType.HELPFUL ? HELPFUL_WEIGHT : NOT_HELPFUL_WEIGHT;
-
-        List<Long> articleIds = clusterArticleRepository.findByNewsClusterId(clusterId).stream()
-                .map(NewsClusterArticle::getNewsArticleId)
-                .toList();
-
-        if (articleIds.isEmpty()) {
-            return;
-        }
-
-        // SECTOR/STOCK 태그만 대상, (tagType, tagCode) 기준 중복 제거
-        record TagKey(String type, String code) {}
-        Set<TagKey> tagKeys = articleTagRepository.findByNewsArticleIdIn(articleIds).stream()
-                .filter(t -> WEIGHT_TARGET_TYPES.contains(t.getTagType()))
-                .map(t -> new TagKey(t.getTagType().name(), t.getTagCode()))
-                .collect(Collectors.toSet());
-
-        for (TagKey key : tagKeys) {
-            int updated = userInterestRepository.addWeightAtomically(
-                    userId, key.type(), key.code(), delta);
-
-            if (updated == 0) {
-                // 관심사가 없으면 새로 생성
-                try {
-                    userInterestRepository.saveAndFlush(
-                            UserInterest.create(userId, key.type(), key.code(), delta));
-                } catch (DataIntegrityViolationException e) {
-                    // 동시 생성 경쟁 — 이미 생성됐으므로 원자적 UPDATE 재시도
-                    userInterestRepository.addWeightAtomically(
-                            userId, key.type(), key.code(), delta);
-                }
-            }
-        }
-
-        log.info("피드백 가중치 업데이트 — userId: {}, clusterId: {}, type: {}, 태그 수: {}",
-                userId, clusterId, feedbackType, tagKeys.size());
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -1,0 +1,155 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 클러스터 읽음 처리 및 피드백 서비스
+ *
+ * 읽음: 중복 시 무시 (idempotent)
+ * 피드백: 1회만 가능, 중복 시 409
+ * 피드백 시 user_interest 가중치를 원자적 UPDATE로 업데이트 (HELPFUL +1, NOT_HELPFUL -1)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClusterInteractionService {
+
+    private static final BigDecimal HELPFUL_WEIGHT = BigDecimal.ONE;
+    private static final BigDecimal NOT_HELPFUL_WEIGHT = BigDecimal.ONE.negate();
+    private static final Set<TagType> WEIGHT_TARGET_TYPES = Set.of(TagType.SECTOR, TagType.STOCK);
+
+    private final NewsClusterRepository newsClusterRepository;
+    private final UserNewsClusterReadRepository readRepository;
+    private final UserNewsClusterFeedbackRepository feedbackRepository;
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleTagRepository articleTagRepository;
+    private final UserInterestRepository userInterestRepository;
+
+    /**
+     * 클러스터 읽음을 기록한다.
+     * 이미 읽은 경우 무시한다 (idempotent).
+     * 동시 요청 시 unique violation을 잡아 무시한다
+     */
+    @Transactional
+    public void markRead(UUID userId, Long clusterId) {
+        validateActiveCluster(clusterId);
+
+        if (readRepository.existsByUserIdAndNewsClusterId(userId, clusterId)) {
+            return;
+        }
+        try {
+            readRepository.save(UserNewsClusterRead.create(userId, clusterId));
+        } catch (DataIntegrityViolationException e) {
+            log.debug("읽음 중복 저장 무시 — userId: {}, clusterId: {}", userId, clusterId);
+        }
+    }
+
+    /**
+     * 클러스터에 피드백을 남긴다.
+     * 1회만 가능하며, 이미 피드백한 경우 409를 반환한다.
+     * 피드백 저장 후 가중치 업데이트는 별도 트랜잭션으로 처리하여,
+     * 가중치 실패가 피드백 저장을 롤백하지 않도록 한다
+     */
+    @Transactional
+    public void submitFeedback(UUID userId, Long clusterId, FeedbackType feedbackType) {
+        validateActiveCluster(clusterId);
+
+        if (feedbackRepository.existsByUserIdAndNewsClusterId(userId, clusterId)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
+        }
+
+        try {
+            feedbackRepository.save(UserNewsClusterFeedback.create(userId, clusterId, feedbackType));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
+        }
+
+        try {
+            updateInterestWeights(userId, clusterId, feedbackType);
+        } catch (Exception e) {
+            log.warn("가중치 업데이트 실패 (피드백은 저장됨) — userId: {}, clusterId: {}, error: {}",
+                    userId, clusterId, e.getMessage());
+        }
+    }
+
+    /**
+     * 클러스터가 존재하고 ACTIVE 상태인지 검증한다
+     */
+    private void validateActiveCluster(Long clusterId) {
+        NewsCluster cluster = newsClusterRepository.findById(clusterId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CLUSTER_NOT_FOUND));
+
+        if (cluster.getStatus() != ClusterStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.CLUSTER_NOT_FOUND);
+        }
+    }
+
+    /**
+     * 피드백에 따라 클러스터 소속 기사의 SECTOR/STOCK 태그에 대한 가중치를 원자적으로 업데이트한다.
+     * 해당 관심사가 없으면 새로 생성한다
+     */
+    private void updateInterestWeights(UUID userId, Long clusterId, FeedbackType feedbackType) {
+        BigDecimal delta = feedbackType == FeedbackType.HELPFUL ? HELPFUL_WEIGHT : NOT_HELPFUL_WEIGHT;
+
+        List<Long> articleIds = clusterArticleRepository.findByNewsClusterId(clusterId).stream()
+                .map(NewsClusterArticle::getNewsArticleId)
+                .toList();
+
+        if (articleIds.isEmpty()) {
+            return;
+        }
+
+        // SECTOR/STOCK 태그만 대상, (tagType, tagCode) 기준 중복 제거
+        record TagKey(String type, String code) {}
+        Set<TagKey> tagKeys = articleTagRepository.findByNewsArticleIdIn(articleIds).stream()
+                .filter(t -> WEIGHT_TARGET_TYPES.contains(t.getTagType()))
+                .map(t -> new TagKey(t.getTagType().name(), t.getTagCode()))
+                .collect(Collectors.toSet());
+
+        for (TagKey key : tagKeys) {
+            int updated = userInterestRepository.addWeightAtomically(
+                    userId, key.type(), key.code(), delta);
+
+            if (updated == 0) {
+                // 관심사가 없으면 새로 생성
+                try {
+                    userInterestRepository.saveAndFlush(
+                            UserInterest.create(userId, key.type(), key.code(), delta));
+                } catch (DataIntegrityViolationException e) {
+                    // 동시 생성 경쟁 — 이미 생성됐으므로 원자적 UPDATE 재시도
+                    userInterestRepository.addWeightAtomically(
+                            userId, key.type(), key.code(), delta);
+                }
+            }
+        }
+
+        log.info("피드백 가중치 업데이트 — userId: {}, clusterId: {}, type: {}, 태그 수: {}",
+                userId, clusterId, feedbackType, tagKeys.size());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInterestWeightService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInterestWeightService.java
@@ -5,11 +5,9 @@ import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
-import com.solv.wefin.domain.user.entity.UserInterest;
 import com.solv.wefin.domain.user.repository.UserInterestRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -61,18 +59,7 @@ public class ClusterInterestWeightService {
                 .collect(Collectors.toSet());
 
         for (TagKey key : tagKeys) {
-            int updated = userInterestRepository.addWeightAtomically(
-                    userId, key.type(), key.code(), delta);
-
-            if (updated == 0) {
-                try {
-                    userInterestRepository.saveAndFlush(
-                            UserInterest.create(userId, key.type(), key.code(), delta));
-                } catch (DataIntegrityViolationException e) {
-                    userInterestRepository.addWeightAtomically(
-                            userId, key.type(), key.code(), delta);
-                }
-            }
+            userInterestRepository.upsertWeight(userId, key.type(), key.code(), delta);
         }
 
         log.info("피드백 가중치 업데이트 — userId: {}, clusterId: {}, type: {}, 태그 수: {}",

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInterestWeightService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInterestWeightService.java
@@ -1,0 +1,81 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 피드백에 따른 user_interest 가중치 업데이트 서비스
+ *
+ * REQUIRES_NEW 트랜잭션으로 실행되어, 가중치 실패가 피드백 저장 트랜잭션에 영향을 주지 않는다
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ClusterInterestWeightService {
+
+    private static final BigDecimal HELPFUL_WEIGHT = BigDecimal.ONE;
+    private static final BigDecimal NOT_HELPFUL_WEIGHT = BigDecimal.ONE.negate();
+    private static final Set<TagType> WEIGHT_TARGET_TYPES = Set.of(TagType.SECTOR, TagType.STOCK);
+
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleTagRepository articleTagRepository;
+    private final UserInterestRepository userInterestRepository;
+
+    /**
+     * 클러스터 소속 기사의 SECTOR/STOCK 태그에 대한 가중치를 원자적으로 업데이트한다.
+     * 별도 트랜잭션으로 실행되어 실패 시 호출부 트랜잭션에 영향을 주지 않는다
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateWeights(UUID userId, Long clusterId, FeedbackType feedbackType) {
+        BigDecimal delta = feedbackType == FeedbackType.HELPFUL ? HELPFUL_WEIGHT : NOT_HELPFUL_WEIGHT;
+
+        List<Long> articleIds = clusterArticleRepository.findByNewsClusterId(clusterId).stream()
+                .map(NewsClusterArticle::getNewsArticleId)
+                .toList();
+
+        if (articleIds.isEmpty()) {
+            return;
+        }
+
+        record TagKey(String type, String code) {}
+        Set<TagKey> tagKeys = articleTagRepository.findByNewsArticleIdIn(articleIds).stream()
+                .filter(t -> WEIGHT_TARGET_TYPES.contains(t.getTagType()))
+                .map(t -> new TagKey(t.getTagType().name(), t.getTagCode()))
+                .collect(Collectors.toSet());
+
+        for (TagKey key : tagKeys) {
+            int updated = userInterestRepository.addWeightAtomically(
+                    userId, key.type(), key.code(), delta);
+
+            if (updated == 0) {
+                try {
+                    userInterestRepository.saveAndFlush(
+                            UserInterest.create(userId, key.type(), key.code(), delta));
+                } catch (DataIntegrityViolationException e) {
+                    userInterestRepository.addWeightAtomically(
+                            userId, key.type(), key.code(), delta);
+                }
+            }
+        }
+
+        log.info("피드백 가중치 업데이트 — userId: {}, clusterId: {}, type: {}, 태그 수: {}",
+                userId, clusterId, feedbackType, tagKeys.size());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInterestWeightService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInterestWeightService.java
@@ -42,6 +42,9 @@ public class ClusterInterestWeightService {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void updateWeights(UUID userId, Long clusterId, FeedbackType feedbackType) {
+        if (feedbackType == null) {
+            throw new IllegalArgumentException("feedbackType은 null일 수 없습니다");
+        }
         BigDecimal delta = feedbackType == FeedbackType.HELPFUL ? HELPFUL_WEIGHT : NOT_HELPFUL_WEIGHT;
 
         List<Long> articleIds = clusterArticleRepository.findByNewsClusterId(clusterId).stream()
@@ -62,7 +65,8 @@ public class ClusterInterestWeightService {
             userInterestRepository.upsertWeight(userId, key.type(), key.code(), delta);
         }
 
-        log.info("피드백 가중치 업데이트 — userId: {}, clusterId: {}, type: {}, 태그 수: {}",
-                userId, clusterId, feedbackType, tagKeys.size());
+        log.info("피드백 가중치 업데이트 — clusterId: {}, type: {}, 태그 수: {}",
+                clusterId, feedbackType, tagKeys.size());
+        log.debug("피드백 가중치 상세 — userId: {}, clusterId: {}", userId, clusterId);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -15,6 +15,7 @@ import com.solv.wefin.domain.news.cluster.repository.ClusterSummarySectionReposi
 import com.solv.wefin.domain.news.cluster.repository.ClusterSummarySectionSourceRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -51,6 +52,7 @@ public class NewsClusterQueryService {
     private final NewsArticleRepository newsArticleRepository;
     private final NewsArticleTagRepository articleTagRepository;
     private final UserNewsClusterReadRepository readRepository;
+    private final UserNewsClusterFeedbackRepository feedbackRepository;
     private final ClusterSummarySectionRepository sectionRepository;
     private final ClusterSummarySectionSourceRepository sectionSourceRepository;
 
@@ -347,6 +349,14 @@ public class NewsClusterQueryService {
         boolean isRead = userId != null
                 && readRepository.existsByUserIdAndNewsClusterId(userId, clusterId);
 
+        // 피드백 여부
+        String feedbackType = null;
+        if (userId != null) {
+            feedbackType = feedbackRepository.findByUserIdAndNewsClusterId(userId, clusterId)
+                    .map(fb -> fb.getFeedbackType().name())
+                    .orElse(null);
+        }
+
         // 단독 클러스터(기사 1건 + 섹션 없음)는 기사 전문을 내려준다
         String articleContent = null;
         if (articleIds.size() == 1 && sectionDetails.isEmpty()) {
@@ -359,7 +369,7 @@ public class NewsClusterQueryService {
                 cluster.getId(), cluster.getTitle(), cluster.getSummary(),
                 cluster.getThumbnailUrl(), cluster.getPublishedAt(),
                 cluster.getArticleCount(), sources, stocks, marketTags, isRead,
-                sectionDetails, articleContent
+                feedbackType, sectionDetails, articleContent
         );
     }
 
@@ -505,6 +515,7 @@ public class NewsClusterQueryService {
             List<StockInfo> relatedStocks,
             List<String> marketTags,
             boolean isRead,
+            String feedbackType,
             List<SectionDetail> sections,
             String articleContent
     ) {

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -305,7 +305,8 @@ public class OpenAiSummaryClient {
     public SummaryResult generateSingleArticleSummary(String title, String content) {
         String truncatedContent = content != null && content.length() > MAX_ARTICLE_LENGTH
                 ? content.substring(0, MAX_ARTICLE_LENGTH) : (content != null ? content : "");
-        String userMessage = "제목: " + title + "\n\n본문: " + truncatedContent;
+        String safeTitle = title != null ? title : "";
+        String userMessage = "제목: " + safeTitle + "\n\n본문: " + truncatedContent;
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -34,6 +34,26 @@ public class OpenAiSummaryClient {
     // 클러스터당 프롬프트에 포함할 최대 기사 수
     private static final int MAX_ARTICLES_PER_CLUSTER = 10;
 
+    private static final String SINGLE_ARTICLE_SUMMARY_PROMPT = """
+            당신은 금융 뉴스 전문 에디터입니다.
+            기사 한 건의 본문을 읽고 핵심 내용을 요약하세요.
+
+            규칙:
+            1. title: 핵심 이슈를 한 줄로 요약 (50자 이내, 한글)
+            2. leadSummary: 기사 핵심 요약 (200~400자, 한글)
+               - 팩트, 원인/배경, 전망/영향을 포함하되 기사에 있는 내용만 작성
+               - 구체적 수치, 기업명, 날짜를 포함할 것
+               - 광고, 기자 서명, 언론사 홍보 문구 등은 제외
+            3. sections: 없음 (빈 배열)
+
+            반드시 아래 JSON 형식으로만 응답하세요:
+            {
+              "title": "요약 제목",
+              "leadSummary": "핵심 내용 요약...",
+              "sections": []
+            }
+            """;
+
     private static final String SINGLE_TITLE_PROMPT = """
             당신은 금융 뉴스 전문 에디터입니다.
             기사 한 건의 제목을 깔끔하게 다듬어주세요.
@@ -270,6 +290,59 @@ public class OpenAiSummaryClient {
             log.warn("단독 title AI 재생성 실패: {}", e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * 단독 클러스터용 — 기사 한 건의 본문을 AI로 요약한다.
+     *
+     * 크롤링된 원문에는 광고, 기자 서명 등 노이즈가 포함되어 있으므로
+     * AI가 핵심 내용만 추출하여 title + leadSummary를 생성한다
+     *
+     * @param title 기사 제목
+     * @param content 기사 본문
+     * @return title + leadSummary (sections는 빈 배열)
+     */
+    public SummaryResult generateSingleArticleSummary(String title, String content) {
+        String truncatedContent = content != null && content.length() > MAX_ARTICLE_LENGTH
+                ? content.substring(0, MAX_ARTICLE_LENGTH) : (content != null ? content : "");
+        String userMessage = "제목: " + title + "\n\n본문: " + truncatedContent;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        Map<String, Object> body = Map.of(
+                "model", model,
+                "response_format", Map.of("type", "json_object"),
+                "messages", List.of(
+                        Map.of("role", "system", "content", SINGLE_ARTICLE_SUMMARY_PROMPT),
+                        Map.of("role", "user", "content", userMessage)
+                )
+        );
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(body, headers);
+
+        OpenAiChatApiResponse response;
+        try {
+            response = restTemplate.postForObject(OPENAI_CHAT_URL, request, OpenAiChatApiResponse.class);
+        } catch (HttpStatusCodeException e) {
+            throw new OpenAiClientException(
+                    "OpenAI Single Summary API HTTP 오류: " + e.getStatusCode(), e.getStatusCode(), e);
+        } catch (RestClientException e) {
+            throw new OpenAiClientException(
+                    "OpenAI Single Summary API 호출 실패: " + e.getMessage(), null, e);
+        }
+
+        if (response == null || response.getChoices() == null || response.getChoices().isEmpty()) {
+            throw new IllegalStateException("OpenAI Single Summary API 응답이 비어있습니다");
+        }
+
+        OpenAiChatApiResponse.Choice firstChoice = response.getChoices().get(0);
+        if (firstChoice == null || firstChoice.getMessage() == null || firstChoice.getMessage().getContent() == null) {
+            throw new IllegalStateException("OpenAI Single Summary API 응답 메시지가 비어있습니다");
+        }
+
+        return parseSummaryResult(firstChoice.getMessage().getContent());
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -49,6 +49,10 @@ public class SummaryService {
 
     /**
      * 요약 생성이 필요한 클러스터를 조회하여 AI 요약을 생성한다.
+     *
+     * 주의: 이 메서드에 @Transactional을 붙이면 안 된다.
+     * AI 외부 API 호출이 트랜잭션 안에서 실행되어 DB 커넥션이 장시간 점유된다.
+     * 저장은 persistenceService의 개별 @Transactional 메서드가 처리한다
      */
     public void generatePendingSummaries() {
         // 대상 조회: ACTIVE 상태 + 요약이 필요한 상태(PENDING/STALE/FAILED).
@@ -85,7 +89,7 @@ public class SummaryService {
                     continue;
                 }
 
-                // 3) 단독 클러스터 최적화 — AI 호출 없이 기사 제목/요약을 그대로 사용
+                // 3) 단독 클러스터 — AI로 본문 요약 (실패 시 fallback)
                 if (articleIds.size() == 1) {
                     if (handleSingleArticleCluster(cluster, articleIds)) {
                         successCount++;
@@ -144,7 +148,11 @@ public class SummaryService {
     }
 
     /**
-     * 단독 클러스터(기사 1건)는 AI 호출 없이 기사 제목/요약을 그대로 사용한다
+     * 단독 클러스터(기사 1건)는 AI로 본문을 요약한다.
+     *
+     * 크롤링된 원문에는 광고, 기자 서명 등 노이즈가 포함되어 있으므로
+     * AI가 핵심 내용만 추출하여 title + summary를 생성한다.
+     * AI 호출 실패 시 기존 fallback(제목 클렌징 + 기사 요약 그대로 사용)으로 처리한다
      *
      * @param cluster 요약 대상 클러스터
      * @param expectedArticleIds 조회 시점의 기사 ID 목록 (기사 집합 변경 감지용)
@@ -159,8 +167,31 @@ public class SummaryService {
         }
 
         var article = articleOpt.get();
-        String title = resolveTitle(article);
-        String summary = article.getSummary() != null ? article.getSummary() : title;
+        String title;
+        String summary;
+
+        // 본문이 있으면 AI 요약, 없으면 기존 fallback
+        if (article.getContent() != null && !article.getContent().isBlank()) {
+            try {
+                SummaryResult result = openAiSummaryClient.generateSingleArticleSummary(
+                        article.getTitle(), article.getContent());
+                title = result.getTitle() != null && !result.getTitle().isBlank()
+                        ? result.getTitle() : resolveTitle(article);
+                summary = result.getLeadSummary() != null && !result.getLeadSummary().isBlank()
+                        ? result.getLeadSummary() : (article.getSummary() != null ? article.getSummary() : title);
+                log.info("단독 클러스터 AI 요약 성공 — clusterId: {}, articleId: {}",
+                        cluster.getId(), articleId);
+            } catch (Exception e) {
+                log.warn("단독 클러스터 AI 요약 실패, fallback 사용 — clusterId: {}, error: {}",
+                        cluster.getId(), e.getMessage());
+                title = resolveTitle(article);
+                summary = article.getSummary() != null ? article.getSummary() : title;
+            }
+        } else {
+            title = resolveTitle(article);
+            summary = article.getSummary() != null ? article.getSummary() : title;
+        }
+
         persistenceService.markGeneratedSingle(cluster.getId(), title, summary, expectedArticleIds);
         return true;
     }

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -182,8 +182,8 @@ public class SummaryService {
                 log.info("단독 클러스터 AI 요약 성공 — clusterId: {}, articleId: {}",
                         cluster.getId(), articleId);
             } catch (Exception e) {
-                log.warn("단독 클러스터 AI 요약 실패, fallback 사용 — clusterId: {}, error: {}",
-                        cluster.getId(), e.getMessage());
+                log.warn("단독 클러스터 AI 요약 실패, fallback 사용 — clusterId: {}",
+                        cluster.getId(), e);
                 title = resolveTitle(article);
                 summary = resolveSummaryFallback(article, title);
             }

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -178,22 +178,30 @@ public class SummaryService {
                 title = result.getTitle() != null && !result.getTitle().isBlank()
                         ? result.getTitle() : resolveTitle(article);
                 summary = result.getLeadSummary() != null && !result.getLeadSummary().isBlank()
-                        ? result.getLeadSummary() : (article.getSummary() != null ? article.getSummary() : title);
+                        ? result.getLeadSummary() : resolveSummaryFallback(article, title);
                 log.info("단독 클러스터 AI 요약 성공 — clusterId: {}, articleId: {}",
                         cluster.getId(), articleId);
             } catch (Exception e) {
                 log.warn("단독 클러스터 AI 요약 실패, fallback 사용 — clusterId: {}, error: {}",
                         cluster.getId(), e.getMessage());
                 title = resolveTitle(article);
-                summary = article.getSummary() != null ? article.getSummary() : title;
+                summary = resolveSummaryFallback(article, title);
             }
         } else {
             title = resolveTitle(article);
-            summary = article.getSummary() != null ? article.getSummary() : title;
+            summary = resolveSummaryFallback(article, title);
         }
 
         persistenceService.markGeneratedSingle(cluster.getId(), title, summary, expectedArticleIds);
         return true;
+    }
+
+    /**
+     * 기사의 summary를 반환한다. null이거나 blank이면 title을 fallback으로 사용한다
+     */
+    private String resolveSummaryFallback(com.solv.wefin.domain.news.article.entity.NewsArticle article, String title) {
+        String summary = article.getSummary();
+        return summary != null && !summary.isBlank() ? summary : title;
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/user/entity/UserInterest.java
+++ b/src/main/java/com/solv/wefin/domain/user/entity/UserInterest.java
@@ -1,0 +1,69 @@
+package com.solv.wefin.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 사용자 관심사 (분야/종목/주제)
+ *
+ * 뉴스 피드백 등의 행동으로 가중치가 누적되며, 개인화 추천에 활용된다
+ */
+@Entity
+@Table(name = "user_interest",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_interest_user_type_value",
+                columnNames = {"user_id", "interest_type", "interest_value"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInterest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_interest_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "interest_type", nullable = false, length = 30)
+    private String interestType;
+
+    @Column(name = "interest_value", nullable = false, length = 100)
+    private String interestValue;
+
+    @Column(name = "weight", precision = 5, scale = 2)
+    private BigDecimal weight;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    /**
+     * 피드백 등에 의해 가중치를 증감한다
+     */
+    public void addWeight(BigDecimal delta) {
+        this.weight = (this.weight != null ? this.weight : BigDecimal.ZERO).add(delta);
+    }
+
+    /**
+     * 새 관심사를 생성한다 (피드백에 의한 자동 생성)
+     */
+    public static UserInterest create(UUID userId, String interestType, String interestValue, BigDecimal weight) {
+        UserInterest interest = new UserInterest();
+        interest.userId = userId;
+        interest.interestType = interestType;
+        interest.interestValue = interestValue;
+        interest.weight = weight;
+        return interest;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
@@ -21,7 +21,7 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
      * @return 업데이트된 행 수 (0이면 해당 관심사가 없음)
      */
     @Modifying
-    @Query("UPDATE UserInterest u SET u.weight = u.weight + :delta " +
+    @Query("UPDATE UserInterest u SET u.weight = COALESCE(u.weight, 0) + :delta " +
             "WHERE u.userId = :userId AND u.interestType = :type AND u.interestValue = :value")
     int addWeightAtomically(@Param("userId") UUID userId,
                             @Param("type") String type,

--- a/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.domain.user.repository;
+
+import com.solv.wefin.domain.user.entity.UserInterest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserInterestRepository extends JpaRepository<UserInterest, Long> {
+
+    Optional<UserInterest> findByUserIdAndInterestTypeAndInterestValue(
+            UUID userId, String interestType, String interestValue);
+
+    /**
+     * 가중치를 원자적으로 증감한다. Lost Update 방지
+     *
+     * @return 업데이트된 행 수 (0이면 해당 관심사가 없음)
+     */
+    @Modifying
+    @Query("UPDATE UserInterest u SET u.weight = u.weight + :delta " +
+            "WHERE u.userId = :userId AND u.interestType = :type AND u.interestValue = :value")
+    int addWeightAtomically(@Param("userId") UUID userId,
+                            @Param("type") String type,
+                            @Param("value") String value,
+                            @Param("delta") BigDecimal delta);
+}

--- a/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
@@ -16,15 +16,18 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
             UUID userId, String interestType, String interestValue);
 
     /**
-     * 가중치를 원자적으로 증감한다. Lost Update 방지
-     *
-     * @return 업데이트된 행 수 (0이면 해당 관심사가 없음)
+     * 가중치를 원자적으로 upsert한다.
+     * 존재하면 weight를 증감하고, 없으면 새로 생성한다.
+     * PostgreSQL INSERT ON CONFLICT DO UPDATE로 단일 쿼리 실행
      */
     @Modifying
-    @Query("UPDATE UserInterest u SET u.weight = COALESCE(u.weight, 0) + :delta " +
-            "WHERE u.userId = :userId AND u.interestType = :type AND u.interestValue = :value")
-    int addWeightAtomically(@Param("userId") UUID userId,
-                            @Param("type") String type,
-                            @Param("value") String value,
-                            @Param("delta") BigDecimal delta);
+    @Query(value = "INSERT INTO user_interest (user_id, interest_type, interest_value, weight, created_at) " +
+            "VALUES (:userId, :type, :value, :delta, NOW()) " +
+            "ON CONFLICT (user_id, interest_type, interest_value) " +
+            "DO UPDATE SET weight = COALESCE(user_interest.weight, 0) + :delta",
+            nativeQuery = true)
+    void upsertWeight(@Param("userId") UUID userId,
+                      @Param("type") String type,
+                      @Param("value") String value,
+                      @Param("delta") BigDecimal delta);
 }

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -1,13 +1,16 @@
 package com.solv.wefin.web.news.controller;
 
+import com.solv.wefin.domain.news.cluster.service.ClusterInteractionService;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterDetailResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.news.dto.request.FeedbackRequest;
 import com.solv.wefin.web.news.dto.response.ClusterDetailResponse;
 import com.solv.wefin.web.news.dto.response.ClusterFeedResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -31,6 +34,7 @@ public class NewsClusterController {
     private static final Set<String> VALID_SORT_VALUES = Set.of("publishedAt", "updatedAt");
 
     private final NewsClusterQueryService newsClusterQueryService;
+    private final ClusterInteractionService clusterInteractionService;
 
     /**
      * 뉴스 클러스터 피드 목록을 조회한다.
@@ -92,5 +96,45 @@ public class NewsClusterController {
     ) {
         ClusterDetailResult result = newsClusterQueryService.getDetail(clusterId, userId);
         return ApiResponse.success(ClusterDetailResponse.from(result));
+    }
+
+    /**
+     * 클러스터 읽음을 기록한다.
+     * 비회원(userId=null)은 무시한다
+     *
+     * @param clusterId 클러스터 ID
+     * @param userId 사용자 ID (비인증 시 null)
+     */
+    @PostMapping("/{clusterId}/read")
+    public ApiResponse<Void> markRead(
+            @PathVariable Long clusterId,
+            @AuthenticationPrincipal UUID userId
+    ) {
+        if (userId != null) {
+            clusterInteractionService.markRead(userId, clusterId);
+        }
+        return ApiResponse.success(null);
+    }
+
+    /**
+     * 클러스터에 피드백을 남긴다.
+     * 1회만 가능하며, 이미 피드백한 경우 409를 반환한다.
+     * 인증 필수
+     *
+     * @param clusterId 클러스터 ID
+     * @param request 피드백 유형 (HELPFUL / NOT_HELPFUL)
+     * @param userId 사용자 ID
+     */
+    @PostMapping("/{clusterId}/feedback")
+    public ApiResponse<Void> submitFeedback(
+            @PathVariable Long clusterId,
+            @Valid @RequestBody FeedbackRequest request,
+            @AuthenticationPrincipal UUID userId
+    ) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+        clusterInteractionService.submitFeedback(userId, clusterId, request.type());
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/solv/wefin/web/news/dto/request/FeedbackRequest.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/request/FeedbackRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotNull;
 /**
  * 클러스터 피드백 요청 DTO
  *
- * @param type 피드백 유형 (HELPFUL 또는 NOT_HELPFUL). Jackson이 역직렬화 시 검증한다
+ * @param type 피드백 유형 (HELPFUL 또는 NOT_HELPFUL). @Valid에 의한 Bean Validation으로 검증된다
  */
 public record FeedbackRequest(
         @NotNull(message = "type은 필수입니다")

--- a/src/main/java/com/solv/wefin/web/news/dto/request/FeedbackRequest.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/request/FeedbackRequest.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.news.dto.request;
+
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 클러스터 피드백 요청 DTO
+ *
+ * @param type 피드백 유형 (HELPFUL 또는 NOT_HELPFUL). Jackson이 역직렬화 시 검증한다
+ */
+public record FeedbackRequest(
+        @NotNull(message = "type은 필수입니다")
+        FeedbackType type
+) {
+}

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterDetailResponse.java
@@ -24,6 +24,7 @@ public record ClusterDetailResponse(
         List<StockResponse> relatedStocks,
         List<String> marketTags,
         boolean isRead,
+        String feedbackType,
         List<SectionResponse> sections,
         String articleContent
 ) {
@@ -48,7 +49,7 @@ public record ClusterDetailResponse(
                 result.clusterId(), result.title(), result.summary(),
                 result.thumbnailUrl(), result.publishedAt(),
                 result.sourceCount(), sources, stocks, result.marketTags(),
-                result.isRead(), sections, result.articleContent()
+                result.isRead(), result.feedbackType(), sections, result.articleContent()
         );
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.OffsetDateTime;
@@ -85,11 +86,10 @@ class ClusterInteractionServiceTest {
     @DisplayName("submitFeedback — 정상 저장 + 가중치 업데이트 호출")
     void submitFeedback_success() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
-        given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
 
         service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
 
-        verify(feedbackRepository).save(any());
+        verify(feedbackRepository).saveAndFlush(any());
         verify(interestWeightService).updateWeights(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
     }
 
@@ -97,7 +97,8 @@ class ClusterInteractionServiceTest {
     @DisplayName("submitFeedback — 중복 시 DUPLICATE_RESOURCE")
     void submitFeedback_duplicate() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
-        given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(true);
+        given(feedbackRepository.saveAndFlush(any()))
+                .willThrow(new DataIntegrityViolationException("unique constraint"));
 
         assertThatThrownBy(() -> service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL))
                 .isInstanceOf(BusinessException.class)
@@ -108,13 +109,12 @@ class ClusterInteractionServiceTest {
     @DisplayName("submitFeedback — 가중치 실패해도 피드백은 저장됨")
     void submitFeedback_weightFailure_feedbackSaved() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
-        given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
         doThrow(new RuntimeException("가중치 오류"))
                 .when(interestWeightService).updateWeights(any(), any(), any());
 
         service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
 
-        verify(feedbackRepository).save(any());
+        verify(feedbackRepository).saveAndFlush(any());
     }
 
     private NewsCluster activeCluster() {

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
@@ -1,16 +1,11 @@
 package com.solv.wefin.domain.news.cluster.service;
 
-import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
-import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
-import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
-import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
-import com.solv.wefin.domain.user.repository.UserInterestRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -21,9 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,9 +31,7 @@ class ClusterInteractionServiceTest {
     @Mock private NewsClusterRepository newsClusterRepository;
     @Mock private UserNewsClusterReadRepository readRepository;
     @Mock private UserNewsClusterFeedbackRepository feedbackRepository;
-    @Mock private NewsClusterArticleRepository clusterArticleRepository;
-    @Mock private NewsArticleTagRepository articleTagRepository;
-    @Mock private UserInterestRepository userInterestRepository;
+    @Mock private ClusterInterestWeightService interestWeightService;
 
     @InjectMocks
     private ClusterInteractionService service;
@@ -91,21 +82,15 @@ class ClusterInteractionServiceTest {
     }
 
     @Test
-    @DisplayName("submitFeedback — 정상 저장 + 가중치 업데이트")
+    @DisplayName("submitFeedback — 정상 저장 + 가중치 업데이트 호출")
     void submitFeedback_success() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
         given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
-        given(clusterArticleRepository.findByNewsClusterId(CLUSTER_ID))
-                .willReturn(List.of(NewsClusterArticle.create(CLUSTER_ID, 100L, 0, false)));
-        given(articleTagRepository.findByNewsArticleIdIn(List.of(100L)))
-                .willReturn(List.of(stockTag(100L, "005930")));
-        given(userInterestRepository.addWeightAtomically(eq(USER_ID), eq("STOCK"), eq("005930"), any()))
-                .willReturn(1);
 
         service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
 
         verify(feedbackRepository).save(any());
-        verify(userInterestRepository).addWeightAtomically(USER_ID, "STOCK", "005930", BigDecimal.ONE);
+        verify(interestWeightService).updateWeights(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
     }
 
     @Test
@@ -124,8 +109,8 @@ class ClusterInteractionServiceTest {
     void submitFeedback_weightFailure_feedbackSaved() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
         given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
-        given(clusterArticleRepository.findByNewsClusterId(CLUSTER_ID))
-                .willThrow(new RuntimeException("DB 오류"));
+        doThrow(new RuntimeException("가중치 오류"))
+                .when(interestWeightService).updateWeights(any(), any(), any());
 
         service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
 
@@ -144,14 +129,5 @@ class ClusterInteractionServiceTest {
         NewsCluster cluster = activeCluster();
         cluster.deactivate();
         return cluster;
-    }
-
-    private NewsArticleTag stockTag(Long articleId, String code) {
-        return NewsArticleTag.builder()
-                .newsArticleId(articleId)
-                .tagType(NewsArticleTag.TagType.STOCK)
-                .tagCode(code)
-                .tagName("삼성전자")
-                .build();
     }
 }

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
@@ -1,0 +1,157 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterInteractionServiceTest {
+
+    @Mock private NewsClusterRepository newsClusterRepository;
+    @Mock private UserNewsClusterReadRepository readRepository;
+    @Mock private UserNewsClusterFeedbackRepository feedbackRepository;
+    @Mock private NewsClusterArticleRepository clusterArticleRepository;
+    @Mock private NewsArticleTagRepository articleTagRepository;
+    @Mock private UserInterestRepository userInterestRepository;
+
+    @InjectMocks
+    private ClusterInteractionService service;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final Long CLUSTER_ID = 1L;
+
+    @Test
+    @DisplayName("markRead — 정상 저장")
+    void markRead_success() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(readRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
+
+        service.markRead(USER_ID, CLUSTER_ID);
+
+        verify(readRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("markRead — 중복 호출 시 idempotent")
+    void markRead_duplicate_ignored() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(readRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(true);
+
+        service.markRead(USER_ID, CLUSTER_ID);
+
+        verify(readRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("markRead — 존재하지 않는 클러스터 시 CLUSTER_NOT_FOUND")
+    void markRead_clusterNotFound() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.markRead(USER_ID, CLUSTER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CLUSTER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("markRead — INACTIVE 클러스터 시 CLUSTER_NOT_FOUND")
+    void markRead_inactiveCluster() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(inactiveCluster()));
+
+        assertThatThrownBy(() -> service.markRead(USER_ID, CLUSTER_ID))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.CLUSTER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("submitFeedback — 정상 저장 + 가중치 업데이트")
+    void submitFeedback_success() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
+        given(clusterArticleRepository.findByNewsClusterId(CLUSTER_ID))
+                .willReturn(List.of(NewsClusterArticle.create(CLUSTER_ID, 100L, 0, false)));
+        given(articleTagRepository.findByNewsArticleIdIn(List.of(100L)))
+                .willReturn(List.of(stockTag(100L, "005930")));
+        given(userInterestRepository.addWeightAtomically(eq(USER_ID), eq("STOCK"), eq("005930"), any()))
+                .willReturn(1);
+
+        service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
+
+        verify(feedbackRepository).save(any());
+        verify(userInterestRepository).addWeightAtomically(USER_ID, "STOCK", "005930", BigDecimal.ONE);
+    }
+
+    @Test
+    @DisplayName("submitFeedback — 중복 시 DUPLICATE_RESOURCE")
+    void submitFeedback_duplicate() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(true);
+
+        assertThatThrownBy(() -> service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode").isEqualTo(ErrorCode.DUPLICATE_RESOURCE);
+    }
+
+    @Test
+    @DisplayName("submitFeedback — 가중치 실패해도 피드백은 저장됨")
+    void submitFeedback_weightFailure_feedbackSaved() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(feedbackRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
+        given(clusterArticleRepository.findByNewsClusterId(CLUSTER_ID))
+                .willThrow(new RuntimeException("DB 오류"));
+
+        service.submitFeedback(USER_ID, CLUSTER_ID, FeedbackType.HELPFUL);
+
+        verify(feedbackRepository).save(any());
+    }
+
+    private NewsCluster activeCluster() {
+        NewsCluster cluster = NewsCluster.createSingle(
+                new float[]{0.1f}, 100L, null, OffsetDateTime.now());
+        ReflectionTestUtils.setField(cluster, "id", CLUSTER_ID);
+        ReflectionTestUtils.setField(cluster, "status", ClusterStatus.ACTIVE);
+        return cluster;
+    }
+
+    private NewsCluster inactiveCluster() {
+        NewsCluster cluster = activeCluster();
+        cluster.deactivate();
+        return cluster;
+    }
+
+    private NewsArticleTag stockTag(Long articleId, String code) {
+        return NewsArticleTag.builder()
+                .newsArticleId(articleId)
+                .tagType(NewsArticleTag.TagType.STOCK)
+                .tagCode(code)
+                .tagName("삼성전자")
+                .build();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -17,6 +17,7 @@ import com.solv.wefin.domain.news.cluster.repository.ClusterSummarySectionReposi
 import com.solv.wefin.domain.news.cluster.repository.ClusterSummarySectionSourceRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterDetailResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
@@ -49,6 +50,7 @@ class NewsClusterQueryServiceTest {
     @Mock private NewsArticleRepository newsArticleRepository;
     @Mock private NewsArticleTagRepository articleTagRepository;
     @Mock private UserNewsClusterReadRepository readRepository;
+    @Mock private UserNewsClusterFeedbackRepository feedbackRepository;
     @Mock private ClusterSummarySectionRepository sectionRepository;
     @Mock private ClusterSummarySectionSourceRepository sectionSourceRepository;
 
@@ -59,7 +61,7 @@ class NewsClusterQueryServiceTest {
         queryService = new NewsClusterQueryService(
                 newsClusterRepository, clusterArticleRepository,
                 newsArticleRepository, articleTagRepository, readRepository,
-                sectionRepository, sectionSourceRepository);
+                feedbackRepository, sectionRepository, sectionSourceRepository);
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
@@ -106,8 +106,8 @@ class SummaryServiceTest {
     }
 
     @Test
-    @DisplayName("단독 클러스터 — AI 호출 없이 기사 제목/요약 사용")
-    void generatePendingSummaries_singleArticle_noApiCall() {
+    @DisplayName("단독 클러스터 — AI 본문 요약 성공 시 AI 결과 사용")
+    void generatePendingSummaries_singleArticle_aiSuccess() {
         // given
         NewsCluster cluster = createCluster(10L, 1, SummaryStatus.PENDING);
         NewsArticle article = createArticle(1L);
@@ -119,11 +119,41 @@ class SummaryServiceTest {
         given(newsArticleRepository.findById(1L))
                 .willReturn(Optional.of(article));
 
+        SummaryResult aiResult = mock(SummaryResult.class);
+        given(aiResult.getTitle()).willReturn("AI 생성 제목");
+        given(aiResult.getLeadSummary()).willReturn("AI 생성 요약");
+        given(openAiSummaryClient.generateSingleArticleSummary(any(), any()))
+                .willReturn(aiResult);
+
         // when
         summaryService.generatePendingSummaries();
 
         // then
+        verify(openAiSummaryClient).generateSingleArticleSummary(any(), any());
         verify(openAiSummaryClient, never()).generateSummary(any());
+        verify(persistenceService).markGeneratedSingle(eq(10L), eq("AI 생성 제목"), eq("AI 생성 요약"), any());
+    }
+
+    @Test
+    @DisplayName("단독 클러스터 — AI 실패 시 기사 제목/요약 fallback")
+    void generatePendingSummaries_singleArticle_aiFail_fallback() {
+        // given
+        NewsCluster cluster = createCluster(10L, 1, SummaryStatus.PENDING);
+        NewsArticle article = createArticle(1L);
+
+        given(newsClusterRepository.findByStatusAndSummaryStatusIn(any(), any(), any()))
+                .willReturn(List.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterId(10L))
+                .willReturn(List.of(NewsClusterArticle.create(10L, 1L, 1, false)));
+        given(newsArticleRepository.findById(1L))
+                .willReturn(Optional.of(article));
+        given(openAiSummaryClient.generateSingleArticleSummary(any(), any()))
+                .willThrow(new RuntimeException("AI 호출 실패"));
+
+        // when
+        summaryService.generatePendingSummaries();
+
+        // then
         verify(persistenceService).markGeneratedSingle(eq(10L), eq("테스트 기사 1"), any(), any());
     }
 


### PR DESCRIPTION
## 📌 PR 설명
클러스터 상세 페이지의 핵심 기능인 읽음 처리, 피드백, 단독 클러스터 AI 요약을 구현했습니다. 피드백 시 사용자 관심사 가중치를 원자적으로 업데이트하여 개인화 추천의 기반을 마련했습니다.

1. **읽음 처리 API**
   `POST /api/news/clusters/{id}/read` 엔드포인트를 추가했습니다. 상세 페이지 진입 시 자동으로 호출됩니다. 비회원은 무시하고 중복 요청은 여러 번 요청하더라도 한 번만 처리되도록 처리합니다.

2. **피드백 API + 개인화 가중치**
   `POST /api/news/clusters/{id}/feedback` 엔드포인트를 추가했습니다. HELPFUL/NOT_HELPFUL 1회만 가능하며 중복 시 409를 반환합니다. 피드백 시 클러스터에 속한 SECTOR/STOCK 태그에 대한 `user_interest.weight`를 원자적 UPDATE(`SET weight = weight + :delta`)로 증감합니다. 가중치 업데이트 실패가 피드백 저장을 롤백하지 않도록 분리했습니다.

3. **상세 API feedbackType 필드 추가**
   `ClusterDetailResult`와 `ClusterDetailResponse`에 `feedbackType` 필드(null/HELPFUL/NOT_HELPFUL)를 추가하여, FE에서 이미 피드백한 경우 버튼을 숨길 수 있도록 했습니다.

4. **단독 클러스터 본문 AI 요약**
   기존에는 단독 클러스터(기사 1건)의 크롤링 원문을 그대로 노출했으나 불필요한 광고가 포함되는 문제가 있었습니다. `generateSingleArticleSummary()` 전용 프롬프트를 추가하여 AI가 핵심 내용만 추출한 title + leadSummary를 생성합니다. AI 실패 시 기존 fallback(제목 클렌징 + 기사 요약)으로 처리합니다.

<br>

## ✅ 수정 파일

### 신규
1. `ClusterInteractionService.java` — 읽음/피드백 서비스 + 원자적 가중치 업데이트 (new)
2. `UserInterest.java` — 사용자 관심사 Entity (new)
3. `UserInterestRepository.java` — 관심사 Repository + `addWeightAtomically` 쿼리 (new)
4. `FeedbackRequest.java` — 피드백 요청 DTO, FeedbackType enum 직접 바인딩 (new)
5. `ClusterInteractionServiceTest.java` — 테스트 7건 (new)

### 수정
6. `NewsClusterController.java` — `/read`, `/feedback` 엔드포인트 추가 (modified)
7. `NewsClusterQueryService.java` — `feedbackRepository` 의존성 추가, 상세 응답에 `feedbackType` 포함 (modified)
8. `ClusterDetailResponse.java` — `feedbackType` 필드 추가 (modified)
9. `OpenAiSummaryClient.java` — `generateSingleArticleSummary()` + 전용 프롬프트 추가 (modified)
10. `SummaryService.java` — `handleSingleArticleCluster` AI 요약 호출로 변경, `@Transactional` 금지 주석 추가 (modified)
11. `NewsClusterQueryServiceTest.java` — `feedbackRepository` mock 추가 (modified)
12. `SummaryServiceTest.java` — AI 성공/실패 fallback 테스트 분리 (modified)

<br>

## 💭 고민과 해결과정

### 1. 가중치 업데이트의 Lost Update 방지

초기에는 `findByUserIdAndInterestTypeAndInterestValue()`로 엔티티를 조회한 뒤 `interest.addWeight(delta)`로 in-memory 덧셈을 했습니다. 그러나 두 트랜잭션이 같은 관심사에 동시에 접근하면 한쪽의 덧셈이 유실되는 Lost Update 문제가 발생하여 `UPDATE UserInterest SET weight = weight + :delta WHERE ...` 원자적 쿼리로 변경하여 DB 레벨에서 동시성을 보장하도록 했습니다.

### 2. DataIntegrityViolationException 후 같은 트랜잭션에서 재조회 문제

초기에는 `save()` 시 unique violation이 발생하면 같은 트랜잭션 내에서 재조회 후 업데이트했습니다. 그러나 JPA에서 DataIntegrityViolationException 발생 시 트랜잭션이 rollback-only로 마킹되어, 재조회가 성공해도 최종 커밋 시 `UnexpectedRollbackException`이 발생합니다. 원자적 UPDATE + INSERT 패턴으로 변경하여, UPDATE 결과가 0행이면 INSERT하고 경쟁 시 UPDATE를 재시도하는 방식으로 해결했습니다.

### 3. 피드백 저장과 가중치 업데이트의 트랜잭션 분리

가중치 실패가 피드백 저장을 롤백시키면 안 되므로, `updateInterestWeights()`를 try-catch로 감싸 실패해도 피드백은 유지되도록 했습니다.

### 4. FeedbackRequest의 타입 안전성

초기에는 `@Pattern(regexp = "HELPFUL|NOT_HELPFUL") String type`으로 받았으나, `@Pattern`은 null을 통과시키고, 잘못된 값이 `valueOf()`에서 500으로 터질 수 있었습니다. `FeedbackType` enum으로 직접 바인딩하도록 변경하여,Jackson 역직렬화 시점에 유효하지 않은 값은 400으로 거부하도록 하였습니다.

<br>

### 🔗 관련 이슈
Closes #133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 클러스터 읽기표시·피드백 제출 API 추가(비인증 읽기 호출은 부작용 없이 성공).
  * 클러스터 상세 응답에 사용자의 feedbackType 포함.
  * 싱글 아티클용 AI 요약 생성 기능 추가(내용 있을 시 AI 호출, 실패 시 기존 폴백).
  * 사용자 관심(UserInterest) 엔티티 및 가중치 업서트 저장소와 가중치 갱신 서비스 추가.

* **버그 수정/내결함성**
  * 읽기 기록의 멱등성 보장 및 동시성 충돌 무해화.
  * 중복 피드백 차단 및 동시성 제약을 적절히 매핑.
  * 가중치 갱신 실패 시 피드백 저장은 롤백되지 않음.

* **테스트**
  * 읽기·피드백 흐름, 가중치 갱신 내결함성 및 AI 요약 성공/실패 경로 단위테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->