### PR TITLE
[WEF-482] 게임 매수/매도 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/holding/entity/GameHolding.java
+++ b/src/main/java/com/solv/wefin/domain/game/holding/entity/GameHolding.java
@@ -1,0 +1,89 @@
+package com.solv.wefin.domain.game.holding.entity;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.UUID;
+
+@Entity
+@Table(name = "game_holding",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"participant_id", "symbol"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameHolding {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "holding_id")
+    private UUID holdingId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    private GameParticipant participant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "symbol", nullable = false)
+    private StockInfo stockInfo;
+
+    @Column(name = "stock_name", nullable = false)
+    private String stockName;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "avg_price", nullable = false, precision = 18, scale = 2)
+    private BigDecimal avgPrice;
+
+    @Builder
+    private GameHolding(GameParticipant participant, StockInfo stockInfo,
+                        String stockName, Integer quantity, BigDecimal avgPrice) {
+        this.participant = participant;
+        this.stockInfo = stockInfo;
+        this.stockName = stockName;
+        this.quantity = quantity;
+        this.avgPrice = avgPrice;
+    }
+
+    public static GameHolding create(GameParticipant participant, StockInfo stockInfo,
+                                     Integer quantity, BigDecimal avgPrice) {
+        return GameHolding.builder()
+                .participant(participant)
+                .stockInfo(stockInfo)
+                .stockName(stockInfo.getStockName())
+                .quantity(quantity)
+                .avgPrice(avgPrice)
+                .build();
+    }
+
+    /**
+     * 추가 매수 시 수량 증가 + 평균 매수가 가중평균 재계산
+     * 새 평균가 = (기존수량 × 기존평균가 + 추가수량 × 매수가) / 전체수량
+     */
+    public void addQuantity(Integer buyQuantity, BigDecimal buyPrice) {
+        BigDecimal totalCost = this.avgPrice.multiply(BigDecimal.valueOf(this.quantity))
+                .add(buyPrice.multiply(BigDecimal.valueOf(buyQuantity)));
+        this.quantity += buyQuantity;
+        this.avgPrice = totalCost.divide(BigDecimal.valueOf(this.quantity), 2, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * 매도 시 수량 감소. 평균 매수가는 변하지 않음.
+     * 전량 매도 시에는 이 메서드를 호출하지 말고 Service에서 바로 delete 해야 한다 (CHECK > 0 제약조건).
+     */
+    public void reduceQuantity(Integer sellQuantity) {
+        if (sellQuantity <= 0) {
+            throw new IllegalArgumentException("매도 수량은 0보다 커야 합니다.");
+        }
+        if (sellQuantity >= this.quantity) {
+            throw new IllegalStateException("전량 매도는 reduceQuantity가 아닌 delete로 처리해야 합니다.");
+        }
+        this.quantity -= sellQuantity;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/holding/repository/GameHoldingRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/holding/repository/GameHoldingRepository.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.game.holding.repository;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GameHoldingRepository extends JpaRepository<GameHolding, UUID> {
+
+    /** 매수 시: 기존 보유 종목이 있는지 조회 (있으면 addQuantity, 없으면 create) */
+    Optional<GameHolding> findByParticipantAndStockInfo(GameParticipant participant, StockInfo stockInfo);
+}

--- a/src/main/java/com/solv/wefin/domain/game/news/dto/BriefingInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/dto/BriefingInfo.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.game.news.dto;
+
+import java.time.LocalDate;
+
+/**
+ * 게임 컨텍스트의 AI 브리핑 조회 결과.
+ *
+ * @param targetDate   브리핑 대상 날짜 (활성 턴의 날짜)
+ * @param briefingText 캐시 또는 OpenAI 생성 결과 텍스트
+ */
+public record BriefingInfo(LocalDate targetDate, String briefingText) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/news/service/BriefingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/service/BriefingService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -23,62 +24,68 @@ public class BriefingService {
     private final OpenAiBriefingClient openAiBriefingClient;
     private final BriefingCacheRepository briefingCacheRepository;
 
-    /**
-     * 특정 날짜의 AI 브리핑을 조회하거나 생성한다.
-     * 1. briefing_cache에서 캐시 조회
-     * 2. 캐시 미스 → 뉴스 크롤링 + OpenAI 브리핑 생성 → 캐시 저장
-     *
-     * @return 브리핑 텍스트
-     */
+    /** 날짜별 in-process 락 — 같은 날짜 동시 요청의 크롤링/OpenAI 중복 호출을 직렬화한다. */
+    private final ConcurrentHashMap<LocalDate, Object> dateLocks = new ConcurrentHashMap<>();
+
+    /** 특정 날짜의 AI 브리핑을 briefing_cache에서 조회하거나, 없으면 크롤링 + OpenAI로 생성해 저장한다. */
     public String getBriefingForDate(LocalDate date) {
-        // 1. 캐시 조회
         Optional<BriefingCache> cached = briefingCacheRepository.findByTargetDate(date);
         if (cached.isPresent()) {
-            log.debug("[브리핑] 캐시 히트: date={}", date);
             return cached.get().getBriefingText();
         }
 
-        log.info("[브리핑] 생성 시작: date={}", date);
+        Object lock = dateLocks.computeIfAbsent(date, k -> new Object());
+        synchronized (lock) {
+            try {
+                Optional<BriefingCache> rechecked = briefingCacheRepository.findByTargetDate(date);
+                if (rechecked.isPresent()) {
+                    return rechecked.get().getBriefingText();
+                }
 
-        // 2. 뉴스 크롤링 + DB 저장
-        List<GameNewsArchive> news = newsCrawlService.crawlAndSave(date);
-        log.info("[브리핑] 수집된 뉴스: {}건 (date={})", news.size(), date);
+                log.info("[브리핑] 생성 시작: date={}", date);
 
-        // 3. OpenAI 브리핑 생성
-        String briefingText = generateBriefing(date, news);
+                List<GameNewsArchive> news = newsCrawlService.crawlAndSave(date);
+                log.info("[브리핑] 수집된 뉴스: {}건 (date={})", news.size(), date);
 
-        // 4. 캐시 저장 (동시 요청 시 UNIQUE 위반 → 이미 저장된 데이터 반환)
-        try {
-            BriefingCache cache = BriefingCache.create(date, briefingText);
-            briefingCacheRepository.save(cache);
-        } catch (DataIntegrityViolationException e) {
-            log.info("[브리핑] 동시 생성 감지, 기존 캐시 사용: date={}", date);
-            return briefingCacheRepository.findByTargetDate(date)
-                    .map(BriefingCache::getBriefingText)
-                    .orElse(briefingText);
+                if (news.isEmpty()) {
+                    log.warn("[브리핑] 뉴스 없음 → 폴백 반환, briefing_cache 미저장: date={}", date);
+                    return buildDefaultBriefing(date);
+                }
+
+                String briefingText;
+                try {
+                    briefingText = generateBriefingViaOpenAi(date, news);
+                } catch (Exception e) {
+                    log.error("[브리핑] OpenAI 호출 실패 → 폴백 반환, briefing_cache 미저장: date={}, error={}",
+                            date, e.getMessage());
+                    return buildDefaultBriefing(date, news);
+                }
+
+                try {
+                    BriefingCache cache = BriefingCache.create(date, briefingText);
+                    briefingCacheRepository.save(cache);
+                } catch (DataIntegrityViolationException e) {
+                    log.info("[브리핑] 동시 생성 감지, 기존 캐시 사용: date={}", date);
+                    return briefingCacheRepository.findByTargetDate(date)
+                            .map(BriefingCache::getBriefingText)
+                            .orElse(briefingText);
+                }
+
+                return briefingText;
+            } finally {
+                dateLocks.remove(date);
+            }
         }
-
-        return briefingText;
     }
 
-    private String generateBriefing(LocalDate date, List<GameNewsArchive> news) {
-        if (news.isEmpty()) {
-            return buildDefaultBriefing(date);
-        }
+    private String generateBriefingViaOpenAi(LocalDate date, List<GameNewsArchive> news) {
+        List<ArticleSummary> summaries = news.stream()
+                .map(n -> new ArticleSummary(
+                        n.getTitle(), n.getSummary(),
+                        n.getOriginalUrl(), n.getCategory()))
+                .toList();
 
-        try {
-            // Entity → ArticleSummary 변환 (openai 패키지가 news Entity에 의존하지 않도록)
-            List<ArticleSummary> summaries = news.stream()
-                    .map(n -> new ArticleSummary(
-                            n.getTitle(), n.getSummary(),
-                            n.getOriginalUrl(), n.getCategory()))
-                    .toList();
-
-            return openAiBriefingClient.generateBriefing(date, summaries);
-        } catch (Exception e) {
-            log.error("[브리핑] OpenAI 호출 실패: date={}, error={}", date, e.getMessage());
-            return buildDefaultBriefing(date, news);
-        }
+        return openAiBriefingClient.generateBriefing(date, summaries);
     }
 
     private String buildDefaultBriefing(LocalDate date) {

--- a/src/main/java/com/solv/wefin/domain/game/news/service/GameBriefingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/service/GameBriefingService.java
@@ -1,0 +1,54 @@
+package com.solv.wefin.domain.game.news.service;
+
+import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * 게임 컨텍스트의 AI 브리핑 조회 서비스.
+ * 방/참가자/활성 턴 검증 후 {@link BriefingService}에 위임한다.
+ *
+ * <p>{@code @Transactional} 미부착: 내부 BriefingService가 캐시 미스 시 DB write +
+ * 외부 API 호출(~30초)을 수행하므로, 상위에서 트랜잭션으로 감싸면 long-running tx 위험.
+ * 검증 쿼리 3건은 각 auto-tx로 충분.
+ */
+@Service
+@RequiredArgsConstructor
+public class GameBriefingService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final BriefingService briefingService;
+
+    public BriefingInfo getBriefingForRoom(UUID roomId, UUID userId) {
+        // 1. 게임방 확인
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2. 참가자 검증
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. ACTIVE 턴 → 턴 날짜
+        GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        // 4. 기존 BriefingService에 위임 (캐시 히트/미스 처리)
+        String briefingText = briefingService.getBriefingForDate(activeTurn.getTurnDate());
+
+        return new BriefingInfo(activeTurn.getTurnDate(), briefingText);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/order/dto/OrderCommand.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/dto/OrderCommand.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.game.order.dto;
+
+import com.solv.wefin.domain.game.order.entity.OrderType;
+
+public record OrderCommand(String symbol, OrderType orderType, Integer quantity) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/order/entity/GameOrder.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/entity/GameOrder.java
@@ -1,0 +1,103 @@
+package com.solv.wefin.domain.game.order.entity;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "game_order")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameOrder {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "order_id")
+    private UUID orderId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    private GameParticipant participant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "turn_id", nullable = false)
+    private GameTurn turn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "symbol", nullable = false)
+    private StockInfo stockInfo;
+
+    @Column(name = "stock_name", nullable = false)
+    private String stockName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "order_type", nullable = false)
+    private OrderType orderType;
+
+    @Column(name = "order_price", nullable = false, precision = 18, scale = 2)
+    private BigDecimal orderPrice;
+
+    @Column(name = "quantity", nullable = false)
+    private Integer quantity;
+
+    @Column(name = "fee", nullable = false, precision = 18, scale = 2)
+    private BigDecimal fee;
+
+    @Column(name = "tax", nullable = false, precision = 18, scale = 2)
+    private BigDecimal tax;
+
+    @Builder
+    private GameOrder(GameParticipant participant, GameTurn turn, StockInfo stockInfo,
+                      String stockName, OrderType orderType, BigDecimal orderPrice,
+                      Integer quantity, BigDecimal fee, BigDecimal tax) {
+        this.participant = participant;
+        this.turn = turn;
+        this.stockInfo = stockInfo;
+        this.stockName = stockName;
+        this.orderType = orderType;
+        this.orderPrice = orderPrice;
+        this.quantity = quantity;
+        this.fee = fee;
+        this.tax = tax;
+    }
+
+    public static GameOrder createBuy(GameParticipant participant, GameTurn turn,
+                                      StockInfo stockInfo, BigDecimal orderPrice,
+                                      Integer quantity, BigDecimal fee) {
+        return GameOrder.builder()
+                .participant(participant)
+                .turn(turn)
+                .stockInfo(stockInfo)
+                .stockName(stockInfo.getStockName())
+                .orderType(OrderType.BUY)
+                .orderPrice(orderPrice)
+                .quantity(quantity)
+                .fee(fee)
+                .tax(BigDecimal.ZERO)
+                .build();
+    }
+
+    public static GameOrder createSell(GameParticipant participant, GameTurn turn,
+                                       StockInfo stockInfo, BigDecimal orderPrice,
+                                       Integer quantity, BigDecimal fee, BigDecimal tax) {
+        return GameOrder.builder()
+                .participant(participant)
+                .turn(turn)
+                .stockInfo(stockInfo)
+                .stockName(stockInfo.getStockName())
+                .orderType(OrderType.SELL)
+                .orderPrice(orderPrice)
+                .quantity(quantity)
+                .fee(fee)
+                .tax(tax)
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/order/entity/OrderType.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/entity/OrderType.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.game.order.entity;
+
+public enum OrderType {
+    BUY,  // 매수
+    SELL  // 매도
+}

--- a/src/main/java/com/solv/wefin/domain/game/order/repository/GameOrderRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/repository/GameOrderRepository.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.game.order.repository;
+
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GameOrderRepository extends JpaRepository<GameOrder, UUID> {
+}

--- a/src/main/java/com/solv/wefin/domain/game/order/service/GameOrderService.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/service/GameOrderService.java
@@ -1,0 +1,153 @@
+package com.solv.wefin.domain.game.order.service;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
+import com.solv.wefin.domain.game.order.dto.OrderCommand;
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GameOrderService {
+
+    private static final BigDecimal FEE_RATE = new BigDecimal("0.00015");   // 0.015%
+    private static final BigDecimal TAX_RATE = new BigDecimal("0.0018");    // 0.18%
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final StockInfoRepository stockInfoRepository;
+    private final StockDailyRepository stockDailyRepository;
+    private final GameOrderRepository gameOrderRepository;
+    private final GameHoldingRepository gameHoldingRepository;
+
+    @Transactional
+    public GameOrder placeOrder(UUID roomId, UUID userId, OrderCommand command) {
+
+        String symbol = command.symbol();
+        OrderType orderType = command.orderType();
+        Integer quantity = command.quantity();
+
+        // 1. 방 조회 + 상태 확인
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() != RoomStatus.IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
+        }
+
+        // 2. 현재 턴 조회 (ACTIVE 턴)
+        GameTurn currentTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        // 3. 참가자 조회 + 비관적 락 (잔액 동시성 제어)
+        GameParticipant participant = gameParticipantRepository
+                .findByGameRoomAndUserIdForUpdate(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 4. 종목 조회
+        StockInfo stockInfo = stockInfoRepository.findById(symbol)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_NOT_FOUND));
+
+        // 5. 턴 날짜의 시가 조회
+        StockDaily stockDaily = stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, currentTurn.getTurnDate())
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+
+        BigDecimal price = stockDaily.getOpenPrice();
+
+        // 6. 매수/매도 분기
+        if (orderType == OrderType.BUY) {
+            return executeBuy(participant, currentTurn, stockInfo, price, quantity);
+        } else {
+            return executeSell(participant, currentTurn, stockInfo, price, quantity);
+        }
+    }
+
+    private GameOrder executeBuy(GameParticipant participant, GameTurn turn,
+                                 StockInfo stockInfo, BigDecimal price, Integer quantity) {
+
+        BigDecimal totalPrice = price.multiply(BigDecimal.valueOf(quantity));
+        BigDecimal fee = totalPrice.multiply(FEE_RATE).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal totalCost = totalPrice.add(fee);
+
+        // 잔고 확인
+        if (participant.getSeed().compareTo(totalCost) < 0) {
+            throw new BusinessException(ErrorCode.ORDER_INSUFFICIENT_BALANCE);
+        }
+
+        // 잔고 차감
+        participant.deductCash(totalCost);
+
+        // 보유종목 갱신 (있으면 가중평균, 없으면 생성)
+        Optional<GameHolding> existingHolding = gameHoldingRepository
+                .findByParticipantAndStockInfo(participant, stockInfo);
+
+        if (existingHolding.isPresent()) {
+            existingHolding.get().addQuantity(quantity, price);
+        } else {
+            GameHolding newHolding = GameHolding.create(participant, stockInfo, quantity, price);
+            gameHoldingRepository.save(newHolding);
+        }
+
+        // 주문 저장
+        GameOrder order = GameOrder.createBuy(participant, turn, stockInfo, price, quantity, fee);
+        return gameOrderRepository.save(order);
+    }
+
+    private GameOrder executeSell(GameParticipant participant, GameTurn turn,
+                                  StockInfo stockInfo, BigDecimal price, Integer quantity) {
+
+        // 보유종목 확인
+        GameHolding holding = gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_STOCK_NOT_HELD));
+
+        // 보유 수량 확인
+        if (holding.getQuantity() < quantity) {
+            throw new BusinessException(ErrorCode.ORDER_INSUFFICIENT_HOLDINGS);
+        }
+
+        BigDecimal totalPrice = price.multiply(BigDecimal.valueOf(quantity));
+        BigDecimal fee = totalPrice.multiply(FEE_RATE).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal tax = totalPrice.multiply(TAX_RATE).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal netProceeds = totalPrice.subtract(fee).subtract(tax);
+
+        // 잔고 증가
+        participant.addCash(netProceeds);
+
+        // 보유종목: 전량 매도면 삭제, 일부면 수량 감소
+        if (holding.getQuantity().equals(quantity)) {
+            gameHoldingRepository.delete(holding);
+        } else {
+            holding.reduceQuantity(quantity);
+        }
+
+        // 주문 저장
+        GameOrder order = GameOrder.createSell(participant, turn, stockInfo, price, quantity, fee, tax);
+        return gameOrderRepository.save(order);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -34,8 +35,8 @@ public class GameParticipant {
     @Column(name = "is_leader", nullable = false)
     private Boolean isLeader;
 
-    @Column(name = "seed")
-    private Long seed;
+    @Column(name = "seed", precision = 18, scale = 2)
+    private BigDecimal seed;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -79,9 +80,28 @@ public class GameParticipant {
                 .build();
     }
 
-    public void assignSeed(Long seed) {
+    public void assignSeed(BigDecimal seed) {
 
         this.seed = seed;
+    }
+
+    /** 매수 시 잔액 차감 (총 매수금 + 수수료) */
+    public void deductCash(BigDecimal amount) {
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("차감 금액은 0보다 커야 합니다.");
+        }
+        if (this.seed.compareTo(amount) < 0) {
+            throw new IllegalStateException("잔액이 부족합니다.");
+        }
+        this.seed = this.seed.subtract(amount);
+    }
+
+    /** 매도 시 잔액 증가 (총 매도금 - 수수료 - 세금) */
+    public void addCash(BigDecimal amount) {
+        if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("증가 금액은 0보다 커야 합니다.");
+        }
+        this.seed = this.seed.add(amount);
     }
 
     public void leave() {

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -81,7 +81,9 @@ public class GameParticipant {
     }
 
     public void assignSeed(BigDecimal seed) {
-
+        if (seed == null || seed.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("시드머니는 null이거나 음수일 수 없습니다.");
+        }
         this.seed = seed;
     }
 

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -3,7 +3,10 @@ package com.solv.wefin.domain.game.participant.repository;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,4 +28,8 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
     //방장 위임 - 참가자 중 랜덤 선택
     List<GameParticipant> findByGameRoomAndStatus(GameRoom gameRoom, ParticipantStatus status);
 
+    // 매수/매도 시 참가자 잔액 비관적 락 (SELECT FOR UPDATE)
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM GameParticipant p WHERE p.gameRoom = :gameRoom AND p.userId = :userId")
+    Optional<GameParticipant> findByGameRoomAndUserIdForUpdate(GameRoom gameRoom, UUID userId);
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/dto/CreateRoomCommand.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/dto/CreateRoomCommand.java
@@ -1,4 +1,6 @@
 package com.solv.wefin.domain.game.room.dto;
 
-public record CreateRoomCommand(Long seedMoney, Integer periodMonths, Integer moveDays) {
+import java.math.BigDecimal;
+
+public record CreateRoomCommand(BigDecimal seedMoney, Integer periodMonths, Integer moveDays) {
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/entity/GameRoom.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/entity/GameRoom.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -28,8 +29,8 @@ public class GameRoom {
     @Column(name = "user_id", nullable = false)
     private UUID  userId;
 
-    @Column(name = "seed", nullable = false)
-    private Long  seed;
+    @Column(name = "seed", nullable = false, precision = 18, scale = 2)
+    private BigDecimal seed;
 
     @Column(name ="period_month", nullable = false)
     private Integer  periodMonth;
@@ -62,7 +63,7 @@ public class GameRoom {
     }
 
     @Builder
-    public GameRoom (Long groupId, UUID userId, Long seed, Integer periodMonth, Integer moveDays, LocalDate startDate, LocalDate endDate) {
+    public GameRoom (Long groupId, UUID userId, BigDecimal seed, Integer periodMonth, Integer moveDays, LocalDate startDate, LocalDate endDate) {
       this.groupId = groupId;
       this.userId = userId;
       this.seed = seed;
@@ -73,7 +74,7 @@ public class GameRoom {
       this.status = WAITING;
     }
 
-    public static GameRoom create(Long groupId, UUID userId, Long seed, Integer periodMonth, Integer moveDays, LocalDate startDate, LocalDate endDate) {
+    public static GameRoom create(Long groupId, UUID userId, BigDecimal seed, Integer periodMonth, Integer moveDays, LocalDate startDate, LocalDate endDate) {
         return GameRoom.builder()
                 .groupId(groupId)
                 .userId(userId)

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.game.room.service;
 
+import java.math.BigDecimal;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
@@ -11,6 +12,7 @@ import com.solv.wefin.domain.game.participant.repository.GameParticipantReposito
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.event.GameRoomEvent;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
@@ -39,6 +41,7 @@ public class GameRoomService {
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
+    private final StockDailyRepository stockDailyRepository;
     private final ApplicationEventPublisher eventPublisher;
 
 
@@ -63,12 +66,16 @@ public class GameRoomService {
             throw new BusinessException(ErrorCode.ROOM_HOST_DAILY_LIMIT);
         }
 
-        //endDate 계산
+        // start_date 랜덤 추출 + 거래일 보정
         LocalDate rangeStart = LocalDate.of(2021, 1, 1);
         LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(command.periodMonths());
         long daysBetween = ChronoUnit.DAYS.between(rangeStart, rangeEnd);
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);
-        LocalDate startDate = rangeStart.plusDays(randomDays);
+        LocalDate rawStartDate = rangeStart.plusDays(randomDays);
+
+        LocalDate startDate = stockDailyRepository.findLatestTradeDateOnOrBefore(rawStartDate)
+                .orElseThrow(() -> new IllegalStateException(
+                        "거래일 데이터가 없습니다. rawStartDate=" + rawStartDate));
         LocalDate endDate = startDate.plusMonths(command.periodMonths());
 
         //게임룸 저장
@@ -250,7 +257,7 @@ public class GameRoomService {
         }
 
         // 5. 참가자 전원에게 시드머니 지급
-        Long seedMoney = gameRoom.getSeed();
+        BigDecimal seedMoney = gameRoom.getSeed();
         for (GameParticipant participant : activeParticipants) {
             participant.assignSeed(seedMoney);
         }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -67,7 +67,8 @@ public class GameRoomService {
         }
 
         // start_date 랜덤 추출 + 거래일 보정
-        LocalDate rangeStart = LocalDate.of(2021, 1, 1);
+        LocalDate rangeStart = stockDailyRepository.findEarliestTradeDate()
+                .orElseThrow(() -> new IllegalStateException("주가 데이터가 없습니다. 데이터 수집이 필요합니다."));
         LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(command.periodMonths());
         long daysBetween = ChronoUnit.DAYS.between(rangeStart, rangeEnd);
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);

--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -29,6 +29,10 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     @Query("SELECT MAX(sd.tradeDate) FROM StockDaily sd WHERE sd.tradeDate <= :date")
     Optional<LocalDate> findLatestTradeDateOnOrBefore(@Param("date") LocalDate date);
 
+    /** 수집된 주가 데이터의 최초 거래일 (방 생성 시 시작일 범위 하한용) */
+    @Query("SELECT MIN(sd.tradeDate) FROM StockDaily sd")
+    Optional<LocalDate> findEarliestTradeDate();
+
     /** 특정 종목의 특정 날짜 주가 데이터 조회 (매수/매도 시 시가 조회용) */
     Optional<StockDaily> findByStockInfoAndTradeDate(StockInfo stockInfo, LocalDate tradeDate);
 

--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -25,10 +26,13 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     Set<LocalDate> findExistingDates(@Param("stockInfo") StockInfo stockInfo,
                                      @Param("dates") List<LocalDate> dates);
 
-    /**
-     * 키워드 검색. 짧은 키워드에서 대량 조회가 발생하지 않도록
-     * 호출측에서 Pageable로 결과 개수를 반드시 제한한다.
-     */
+    @Query("SELECT MAX(sd.tradeDate) FROM StockDaily sd WHERE sd.tradeDate <= :date")
+    Optional<LocalDate> findLatestTradeDateOnOrBefore(@Param("date") LocalDate date);
+
+    /** 특정 종목의 특정 날짜 주가 데이터 조회 (매수/매도 시 시가 조회용) */
+    Optional<StockDaily> findByStockInfoAndTradeDate(StockInfo stockInfo, LocalDate tradeDate);
+
+   //키워드 검색. 짧은 키워드 대량 조회 제한
     @Query("SELECT sd FROM StockDaily sd " +
             "JOIN FETCH sd.stockInfo si " +
             "WHERE sd.tradeDate = :tradeDate " +

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -129,7 +129,8 @@ public enum ErrorCode {
     GAME_NOT_STARTED(400, "게임이 시작되지 않았습니다."),
 
     // GameStock
-    GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다.");
+    GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다."),
+    GAME_STOCK_PRICE_NOT_FOUND(404, "해당 날짜의 주가 데이터가 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/game/briefing/BriefingController.java
+++ b/src/main/java/com/solv/wefin/web/game/briefing/BriefingController.java
@@ -1,0 +1,34 @@
+package com.solv.wefin.web.game.briefing;
+
+import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import com.solv.wefin.domain.game.news.service.GameBriefingService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.briefing.dto.response.BriefingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rooms/{roomId}/briefing")
+public class BriefingController {
+
+    private final GameBriefingService gameBriefingService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<BriefingResponse>> getBriefing(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID roomId) {
+
+        BriefingInfo info = gameBriefingService.getBriefingForRoom(roomId, userId);
+        BriefingResponse response = BriefingResponse.from(info);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/briefing/dto/response/BriefingResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/briefing/dto/response/BriefingResponse.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.web.game.briefing.dto.response;
+
+import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class BriefingResponse {
+
+    private LocalDate targetDate;
+    private String briefingText;
+
+    public static BriefingResponse from(BriefingInfo info) {
+        return new BriefingResponse(
+                info.targetDate(),
+                info.briefingText()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/order/GameOrderController.java
+++ b/src/main/java/com/solv/wefin/web/game/order/GameOrderController.java
@@ -1,0 +1,39 @@
+package com.solv.wefin.web.game.order;
+
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.dto.OrderCommand;
+import com.solv.wefin.domain.game.order.service.GameOrderService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.order.dto.request.OrderRequest;
+import com.solv.wefin.web.game.order.dto.response.OrderResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/rooms/{roomId}/orders")
+@RequiredArgsConstructor
+public class GameOrderController {
+
+    private final GameOrderService orderService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<OrderResponse>> placeOrder(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody OrderRequest request) {
+
+        OrderCommand command = new OrderCommand(
+                request.getSymbol(), request.getOrderType(), request.getQuantity());
+
+        GameOrder order = orderService.placeOrder(roomId, userId, command);
+
+        OrderResponse response = OrderResponse.from(order);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(201, response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/order/dto/request/OrderRequest.java
+++ b/src/main/java/com/solv/wefin/web/game/order/dto/request/OrderRequest.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.web.game.order.dto.request;
+
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderRequest {
+
+    @NotBlank(message = "종목 코드는 필수입니다")
+    private String symbol;
+
+    @NotNull(message = "주문 유형은 필수입니다")
+    private OrderType orderType;
+
+    @NotNull(message = "수량은 필수입니다")
+    @Min(value = 1, message = "수량은 1 이상이어야 합니다")
+    private Integer quantity;
+}

--- a/src/main/java/com/solv/wefin/web/game/order/dto/response/OrderResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/order/dto/response/OrderResponse.java
@@ -1,0 +1,36 @@
+package com.solv.wefin.web.game.order.dto.response;
+
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class OrderResponse {
+
+    private UUID orderId;
+    private String symbol;
+    private String stockName;
+    private OrderType orderType;
+    private Integer quantity;
+    private BigDecimal price;
+    private BigDecimal fee;
+    private BigDecimal tax;
+
+    public static OrderResponse from(GameOrder order) {
+        return new OrderResponse(
+                order.getOrderId(),
+                order.getStockInfo().getSymbol(),
+                order.getStockName(),
+                order.getOrderType(),
+                order.getQuantity(),
+                order.getOrderPrice(),
+                order.getFee(),
+                order.getTax()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/room/dto/request/CreateRoomRequest.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/request/CreateRoomRequest.java
@@ -1,5 +1,7 @@
 package com.solv.wefin.web.game.room.dto.request;
 
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -7,14 +9,17 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CreateRoomRequest {
 
     @NotNull(message="시드머니 오류")
-    @Min(value = 1, message = "시드머니는 0보다 커야합니다")
-    private Long seedMoney;
+    @DecimalMin(value = "1", message = "시드머니는 0보다 커야합니다")
+    @Digits(integer = 16, fraction = 2, message = "시드머니는 정수 16자리, 소수 2자리 이내여야 합니다")
+    private BigDecimal seedMoney;
 
     @NotNull(message="기간 설정 오류")
     @Min(value = 1, message = "게임 기간은 0보다 커야 합니다.")

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -16,7 +17,7 @@ public class RoomDetailResponse {
 
     private UUID roomId;
     private UUID hostId;
-    private Long seed;
+    private BigDecimal seed;
     private Integer periodMonths;
     private Integer moveDays;
     private LocalDate startDate;

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomListResponse.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -15,7 +16,7 @@ public class RoomListResponse {
 
     private UUID roomId;
     private UUID hostUserId;
-    private Long seedMoney;
+    private BigDecimal seedMoney;
     private Integer periodMonths;
     private Integer moveDays;
     private LocalDate startDate;

--- a/src/main/resources/db/migration/V26__update_game_decimal_and_add_daily_quest.sql
+++ b/src/main/resources/db/migration/V26__update_game_decimal_and_add_daily_quest.sql
@@ -1,0 +1,91 @@
+-- game_room의 seed 금액 컬럼을 소수점 2자리까지 저장할 수 있도록 변경
+ALTER TABLE game_room
+ALTER COLUMN seed TYPE DECIMAL(18,2) USING seed::DECIMAL(18,2);
+
+-- game_participant의 seed 금액 컬럼을 소수점 2자리까지 저장할 수 있도록 변경
+ALTER TABLE game_participant
+ALTER COLUMN seed TYPE DECIMAL(18,2) USING seed::DECIMAL(18,2);
+
+-- game_order 금액 관련 컬럼을 소수점 2자리까지 저장할 수 있도록 변경
+ALTER TABLE game_order
+ALTER COLUMN order_price TYPE DECIMAL(18,2) USING order_price::DECIMAL(18,2),
+    ALTER COLUMN fee TYPE DECIMAL(18,2) USING fee::DECIMAL(18,2),
+    ALTER COLUMN tax TYPE DECIMAL(18,2) USING tax::DECIMAL(18,2);
+
+-- game_order 필수 컬럼에 NOT NULL 및 기본값 제약 추가
+ALTER TABLE game_order
+    ALTER COLUMN stock_name SET NOT NULL,
+    ALTER COLUMN order_type SET NOT NULL,
+    ALTER COLUMN order_price SET NOT NULL,
+    ALTER COLUMN quantity SET NOT NULL,
+    ALTER COLUMN fee SET NOT NULL,
+    ALTER COLUMN tax SET NOT NULL,
+    ALTER COLUMN tax SET DEFAULT 0;
+
+-- game_holding의 평균 단가 컬럼을 소수점 2자리까지 저장할 수 있도록 변경
+ALTER TABLE game_holding
+    ALTER COLUMN avg_price TYPE DECIMAL(18,2) USING avg_price::DECIMAL(18,2);
+
+-- game_holding의 quantity 기본값 제거
+ALTER TABLE game_holding
+    ALTER COLUMN quantity DROP DEFAULT;
+
+-- game_portfolio_snapshot 금액 컬럼을 소수점 2자리까지 저장할 수 있도록 변경
+ALTER TABLE game_portfolio_snapshot
+ALTER COLUMN total_asset TYPE DECIMAL(18,2) USING total_asset::DECIMAL(18,2),
+    ALTER COLUMN cash TYPE DECIMAL(18,2) USING cash::DECIMAL(18,2),
+    ALTER COLUMN stock_value TYPE DECIMAL(18,2) USING stock_value::DECIMAL(18,2);
+
+-- quest_template에 퀘스트 식별용 code 컬럼 추가
+ALTER TABLE quest_template
+    ADD COLUMN code VARCHAR(50);
+
+-- code를 필수값으로 설정
+ALTER TABLE quest_template
+    ALTER COLUMN code SET NOT NULL;
+
+-- code 중복 방지를 위한 유니크 제약 추가
+ALTER TABLE quest_template
+    ADD CONSTRAINT uq_quest_template_code UNIQUE (code);
+
+-- 하루 공통 퀘스트를 저장할 daily_quest 테이블 생성
+CREATE TABLE daily_quest (
+                             daily_quest_id BIGSERIAL PRIMARY KEY,
+                             template_id BIGINT NOT NULL,
+                             quest_date DATE NOT NULL,
+                             target_value INTEGER NOT NULL,
+                             reward INTEGER NOT NULL,
+                             created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                             updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                             CONSTRAINT fk_daily_quest_template
+                                 FOREIGN KEY (template_id) REFERENCES quest_template(template_id),
+                             CONSTRAINT uq_daily_quest_date_template
+                                 UNIQUE (quest_date, template_id)
+);
+
+-- user_quest가 daily_quest를 참조할 수 있도록 컬럼 추가
+ALTER TABLE user_quest
+    ADD COLUMN daily_quest_id BIGINT;
+
+-- 기존 user_quest -> quest_template 외래키 제거
+ALTER TABLE user_quest
+DROP CONSTRAINT "FK_quest_template_TO_user_quest_1";
+
+-- user_quest와 daily_quest 연결용 외래키 제약 추가
+ALTER TABLE user_quest
+    ADD CONSTRAINT fk_user_quest_daily_quest
+        FOREIGN KEY (daily_quest_id) REFERENCES daily_quest(daily_quest_id);
+
+-- 같은 유저에게 같은 daily_quest가 중복 발급되지 않도록 유니크 제약 추가
+ALTER TABLE user_quest
+    ADD CONSTRAINT uq_user_quest_user_daily_quest UNIQUE (user_id, daily_quest_id);
+
+ALTER TABLE user_quest
+    ALTER COLUMN daily_quest_id SET NOT NULL;
+
+-- user_quest에서 공통 퀘스트 정보 컬럼 제거
+-- template/target/reward는 이제 daily_quest가 관리
+ALTER TABLE user_quest
+DROP COLUMN template_id,
+DROP COLUMN target_value,
+DROP COLUMN reward;

--- a/src/test/java/com/solv/wefin/domain/game/news/service/BriefingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/BriefingServiceTest.java
@@ -3,8 +3,6 @@ package com.solv.wefin.domain.game.news.service;
 import com.solv.wefin.domain.game.news.entity.BriefingCache;
 import com.solv.wefin.domain.game.news.entity.GameNewsArchive;
 import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
-import com.solv.wefin.domain.game.news.service.BriefingService;
-import com.solv.wefin.domain.game.news.service.NewsCrawlService;
 import com.solv.wefin.domain.game.openai.OpenAiBriefingClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,13 +13,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -117,7 +118,8 @@ class BriefingServiceTest {
         assertThat(result).contains(TEST_DATE.toString());
         assertThat(result).contains("뉴스 데이터가 없습니다");
         verify(openAiBriefingClient, never()).generateBriefing(any(), anyList());
-        verify(briefingCacheRepository).save(any(BriefingCache.class));
+        // 폴백은 briefing_cache에 저장하지 않음
+        verify(briefingCacheRepository, never()).save(any(BriefingCache.class));
     }
 
     // === OpenAI 호출 실패 시 폴백 ===
@@ -144,19 +146,29 @@ class BriefingServiceTest {
         assertThat(result).contains(TEST_DATE.toString());
         assertThat(result).contains("삼성전자 실적 발표");
         assertThat(result).contains("코스피 상승세 지속");
-        // 폴백이어도 캐시에 저장됨
-        verify(briefingCacheRepository).save(any(BriefingCache.class));
+        // 폴백은 briefing_cache에 저장하지 않음
+        verify(briefingCacheRepository, never()).save(any(BriefingCache.class));
     }
 
-    // === 동시 요청 시 DataIntegrityViolationException 처리 ===
+    // === 2차 방어선: 멀티 JVM 시나리오 (DataIntegrityViolationException) ===
 
     @Test
-    @DisplayName("동시 요청 시 UNIQUE 위반 — 기존 캐시 데이터 반환")
-    void getBriefingForDate_concurrentSave_returnsExistingCache() {
-        // Given — 캐시 없음 → 브리핑 생성 → 캐시 저장 시 UNIQUE 위반
+    @DisplayName("[2차 방어선] 다른 JVM이 먼저 저장한 경우 — UNIQUE 위반 후 기존 캐시 반환")
+    void getBriefingForDate_multiJvmConcurrentSave_returnsExistingCache() {
+        // Given — 단일 JVM에선 in-process 락이 막아주지만,
+        //         멀티 JVM 확장 시에는 save() 시점에 UNIQUE 위반이 발생할 수 있다.
+        //         이 테스트는 그 2차 방어선이 동작하는지 검증한다.
+        //
+        // 호출 순서:
+        //   1) fast-path findByTargetDate → empty (우리 JVM 캐시 없음)
+        //   2) 락 획득 후 re-check findByTargetDate → empty (아직 다른 JVM도 저장 전)
+        //   3) 크롤링 + OpenAI 진행 중 다른 JVM이 먼저 save 완료
+        //   4) 우리 JVM이 save → UNIQUE 위반 → catch 진입
+        //   5) catch 내부 findByTargetDate → Optional.of(다른 JVM이 저장한 캐시)
         given(briefingCacheRepository.findByTargetDate(TEST_DATE))
-                .willReturn(Optional.empty())  // 첫 조회: 없음
-                .willReturn(Optional.of(BriefingCache.create(TEST_DATE, "다른 스레드가 먼저 저장한 브리핑")));  // 예외 후 재조회
+                .willReturn(Optional.empty())                                                      // (1) fast-path
+                .willReturn(Optional.empty())                                                      // (2) re-check (DCL)
+                .willReturn(Optional.of(BriefingCache.create(TEST_DATE, "다른 JVM이 먼저 저장한 브리핑"))); // (5) catch 내부
 
         List<GameNewsArchive> news = List.of(createNewsArchive("뉴스"));
         given(newsCrawlService.crawlAndSave(TEST_DATE)).willReturn(news);
@@ -167,11 +179,92 @@ class BriefingServiceTest {
         given(briefingCacheRepository.save(any(BriefingCache.class)))
                 .willThrow(new DataIntegrityViolationException("Unique constraint violation"));
 
-        // When — 동시 저장 예외 발생
+        // When
         String result = briefingService.getBriefingForDate(TEST_DATE);
 
-        // Then — 다른 스레드가 먼저 저장한 캐시 반환
-        assertThat(result).isEqualTo("다른 스레드가 먼저 저장한 브리핑");
+        // Then — 다른 JVM이 저장한 캐시 반환
+        assertThat(result).isEqualTo("다른 JVM이 먼저 저장한 브리핑");
+    }
+
+    // === 1차 방어선: 단일 JVM in-process 락 동시성 검증 ===
+
+    @Test
+    @DisplayName("[1차 방어선] 같은 날짜 동시 요청 — 크롤링/OpenAI는 1번만 호출")
+    void getBriefingForDate_concurrentSameDate_onlyOneGeneration() throws Exception {
+        // Given — 2개 스레드가 동시에 같은 날짜를 요청한다.
+        //         첫 스레드가 크롤링 중일 때 두 번째 스레드가 진입하도록
+        //         CountDownLatch로 타이밍을 정렬한다.
+        final int threadCount = 2;
+        final java.util.concurrent.CountDownLatch startGate = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.CountDownLatch insideCrawl = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.atomic.AtomicInteger crawlCallCount = new java.util.concurrent.atomic.AtomicInteger(0);
+
+        // 캐시는 항상 empty (어떤 호출이 와도 미스)
+        // → DCL 없으면 2번의 crawl/openai가 발생해야 맞지만, 락 덕분에 1번만 발생해야 한다.
+        //
+        // 단, 저장 이후 들어오는 재조회는 save된 것처럼 보여야 하므로
+        //   - 처음 2번 (fast-path, re-check): empty
+        //   - 이후: Optional.of(저장된 캐시)
+        BriefingCache savedCache = BriefingCache.create(TEST_DATE, "락으로 직렬화된 브리핑");
+        given(briefingCacheRepository.findByTargetDate(TEST_DATE))
+                .willReturn(Optional.empty())      // thread1 fast-path
+                .willReturn(Optional.empty())      // thread1 re-check
+                .willReturn(Optional.empty())      // thread2 fast-path (아직 저장 전이므로 empty)
+                .willReturn(Optional.of(savedCache)); // thread2 re-check — thread1이 save 완료한 시점
+
+        // crawl 호출 시: 카운트 + 두 번째 스레드가 fast-path에 진입할 수 있도록 대기
+        given(newsCrawlService.crawlAndSave(TEST_DATE)).willAnswer(inv -> {
+            crawlCallCount.incrementAndGet();
+            insideCrawl.countDown();                  // thread2를 깨움
+            Thread.sleep(200);                         // thread2가 fast-path + 락 대기에 진입할 시간을 벌어줌
+            return List.of(createNewsArchive("뉴스"));
+        });
+
+        given(openAiBriefingClient.generateBriefing(eq(TEST_DATE), anyList()))
+                .willReturn("락으로 직렬화된 브리핑");
+
+        // When — 2 스레드 동시 실행
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(threadCount);
+        java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(threadCount);
+        java.util.List<String> results = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+
+        // thread1: 먼저 진입해서 락을 잡고 crawl로 들어감
+        pool.submit(() -> {
+            try {
+                startGate.await();
+                results.add(briefingService.getBriefingForDate(TEST_DATE));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                done.countDown();
+            }
+        });
+
+        // thread2: thread1이 crawl에 진입한 이후에 시작 → 락 대기
+        pool.submit(() -> {
+            try {
+                startGate.await();
+                insideCrawl.await();   // thread1이 crawl 내부에 들어갈 때까지 대기
+                results.add(briefingService.getBriefingForDate(TEST_DATE));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                done.countDown();
+            }
+        });
+
+        startGate.countDown();
+        done.await(5, java.util.concurrent.TimeUnit.SECONDS);
+        pool.shutdown();
+
+        // Then — crawl/OpenAI는 **1번만** 호출되어야 한다
+        assertThat(crawlCallCount.get()).isEqualTo(1);
+        verify(newsCrawlService).crawlAndSave(TEST_DATE);
+        verify(openAiBriefingClient).generateBriefing(eq(TEST_DATE), anyList());
+        verify(briefingCacheRepository).save(any(BriefingCache.class));
+        // 두 스레드 모두 같은 브리핑 결과를 받아야 한다
+        assertThat(results).hasSize(2);
+        assertThat(results).allMatch(s -> s.equals("락으로 직렬화된 브리핑"));
     }
 
     // === 헬퍼 메서드 ===

--- a/src/test/java/com/solv/wefin/domain/game/news/service/GameBriefingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/GameBriefingServiceTest.java
@@ -1,0 +1,194 @@
+package com.solv.wefin.domain.game.news.service;
+
+import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameBriefingServiceTest {
+
+    @InjectMocks
+    private GameBriefingService gameBriefingService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+
+    @Mock
+    private BriefingService briefingService;
+
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final String BRIEFING_TEXT = "2022-01-03 시장 브리핑: 코스피 상승 마감.";
+
+    // === 성공 케이스 ===
+
+    @Test
+    @DisplayName("브리핑 조회 성공 — 활성 턴의 날짜로 브리핑 반환")
+    void getBriefingForRoom_success() {
+        // Given — 방 존재, ACTIVE 참가자, ACTIVE 턴, 브리핑 텍스트
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        LocalDate turnDate = activeTurn.getTurnDate();
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(briefingService.getBriefingForDate(turnDate))
+                .willReturn(BRIEFING_TEXT);
+
+        // When
+        BriefingInfo result = gameBriefingService.getBriefingForRoom(roomId, TEST_USER_ID);
+
+        // Then — 활성 턴의 날짜와 브리핑 텍스트가 묶여서 반환
+        assertThat(result).isNotNull();
+        assertThat(result.targetDate()).isEqualTo(turnDate);
+        assertThat(result.briefingText()).isEqualTo(BRIEFING_TEXT);
+
+        verify(briefingService).getBriefingForDate(turnDate);
+    }
+
+    // === 실패 케이스 ===
+
+    @Test
+    @DisplayName("브리핑 조회 실패 — 존재하지 않는 방이면 ROOM_NOT_FOUND")
+    void getBriefingForRoom_roomNotFound() {
+        // Given
+        UUID fakeRoomId = UUID.fromString("00000000-0000-4000-a000-999999999999");
+        given(gameRoomRepository.findById(fakeRoomId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameBriefingService.getBriefingForRoom(fakeRoomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        // 방이 없으면 이후 단계는 호출되지 않아야 한다
+        verify(gameParticipantRepository, never()).findByGameRoomAndUserId(any(), any());
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(briefingService, never()).getBriefingForDate(any());
+    }
+
+    @Test
+    @DisplayName("브리핑 조회 실패 — 참가자가 아니면 ROOM_NOT_PARTICIPANT")
+    void getBriefingForRoom_notParticipant() {
+        // Given — 방은 존재하지만 해당 유저는 참가자가 아님
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        UUID outsiderUserId = UUID.fromString("00000000-0000-4000-a000-000000000099");
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, outsiderUserId))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameBriefingService.getBriefingForRoom(roomId, outsiderUserId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(briefingService, never()).getBriefingForDate(any());
+    }
+
+    @Test
+    @DisplayName("브리핑 조회 실패 — 이미 퇴장(LEFT)한 참가자면 ROOM_NOT_PARTICIPANT")
+    void getBriefingForRoom_participantLeft() {
+        // Given — 참가자 row는 있지만 status가 LEFT
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant leftParticipant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        leftParticipant.leave(); // status → LEFT
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(leftParticipant));
+
+        // When & Then
+        assertThatThrownBy(() -> gameBriefingService.getBriefingForRoom(roomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT);
+                });
+
+        verify(gameTurnRepository, never()).findByGameRoomAndStatus(any(), any());
+        verify(briefingService, never()).getBriefingForDate(any());
+    }
+
+    @Test
+    @DisplayName("브리핑 조회 실패 — ACTIVE 턴이 없으면 GAME_NOT_STARTED")
+    void getBriefingForRoom_gameNotStarted() {
+        // Given — 방, 참가자는 정상이지만 ACTIVE 턴이 없음 (게임 아직 시작 전 or 이미 종료)
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> gameBriefingService.getBriefingForRoom(roomId, TEST_USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.GAME_NOT_STARTED);
+                });
+
+        // ACTIVE 턴이 없으면 하위 BriefingService는 호출되지 않아야 한다
+        verify(briefingService, never()).getBriefingForDate(any());
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createGameRoom() {
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
+                6, 7, LocalDate.of(2022, 1, 3), LocalDate.of(2022, 7, 3));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/order/service/GameOrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/order/service/GameOrderServiceTest.java
@@ -1,0 +1,416 @@
+package com.solv.wefin.domain.game.order.service;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
+import com.solv.wefin.domain.game.order.dto.OrderCommand;
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameOrderServiceTest {
+
+    @InjectMocks
+    private GameOrderService orderService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private StockInfoRepository stockInfoRepository;
+    @Mock
+    private StockDailyRepository stockDailyRepository;
+    @Mock
+    private GameOrderRepository gameOrderRepository;
+    @Mock
+    private GameHoldingRepository gameHoldingRepository;
+
+    private static final UUID TEST_ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final String TEST_SYMBOL = "005930";
+    private static final LocalDate TEST_TRADE_DATE = LocalDate.of(2022, 3, 2);
+
+    // === 매수 테스트 ===
+
+    @Nested
+    @DisplayName("매수 (BUY)")
+    class BuyTests {
+
+        @Test
+        @DisplayName("매수 성공 — 신규 종목, 주문 저장 + 보유종목 생성 + 잔고 차감")
+        void buy_success_newHolding() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("55500"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+            given(gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo))
+                    .willReturn(Optional.empty());
+            given(gameOrderRepository.save(any(GameOrder.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            GameOrder result = orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 10));
+
+            // Then
+            // 주문 검증
+            assertThat(result.getOrderType()).isEqualTo(OrderType.BUY);
+            assertThat(result.getQuantity()).isEqualTo(10);
+            assertThat(result.getOrderPrice()).isEqualByComparingTo(new BigDecimal("55500"));
+            assertThat(result.getTax()).isEqualByComparingTo(BigDecimal.ZERO);
+
+            // 수수료: 55500 × 10 × 0.00015 = 83.25
+            BigDecimal expectedFee = new BigDecimal("55500").multiply(BigDecimal.TEN)
+                    .multiply(new BigDecimal("0.00015")).setScale(2, RoundingMode.HALF_UP);
+            assertThat(result.getFee()).isEqualByComparingTo(expectedFee);
+
+            // 잔고 차감: 555000 + 83.25 = 555083.25
+            BigDecimal expectedCash = new BigDecimal("10000000")
+                    .subtract(new BigDecimal("555000").add(expectedFee));
+            assertThat(participant.getSeed()).isEqualByComparingTo(expectedCash);
+
+            // 보유종목 신규 생성 확인
+            verify(gameHoldingRepository).save(any(GameHolding.class));
+        }
+
+        @Test
+        @DisplayName("매수 성공 — 기존 보유 종목, 가중평균 재계산")
+        void buy_success_existingHolding() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("72000"));
+
+            // 기존 보유: 10주 @ 70000
+            GameHolding existing = GameHolding.create(participant, stockInfo, 10, new BigDecimal("70000"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+            given(gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo))
+                    .willReturn(Optional.of(existing));
+            given(gameOrderRepository.save(any(GameOrder.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When — 5주 추가 매수 @ 72000
+            orderService.placeOrder(TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 5));
+
+            // Then — 가중평균: (10×70000 + 5×72000) / 15 = 70666.67
+            assertThat(existing.getQuantity()).isEqualTo(15);
+            BigDecimal expectedAvg = new BigDecimal("70000").multiply(BigDecimal.TEN)
+                    .add(new BigDecimal("72000").multiply(BigDecimal.valueOf(5)))
+                    .divide(BigDecimal.valueOf(15), 2, RoundingMode.HALF_UP);
+            assertThat(existing.getAvgPrice()).isEqualByComparingTo(expectedAvg);
+
+            // 신규 save 호출 없음 (기존 엔티티 dirty checking)
+            verify(gameHoldingRepository, never()).save(any(GameHolding.class));
+        }
+
+        @Test
+        @DisplayName("매수 실패 — 잔고 부족")
+        void buy_fail_insufficientBalance() {
+            // Given — 잔고 1000원, 55500원짜리 10주 매수 시도
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("1000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("55500"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+
+            // When & Then
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_INSUFFICIENT_BALANCE);
+
+            verify(gameOrderRepository, never()).save(any());
+        }
+    }
+
+    // === 매도 테스트 ===
+
+    @Nested
+    @DisplayName("매도 (SELL)")
+    class SellTests {
+
+        @Test
+        @DisplayName("매도 성공 — 일부 매도, 잔고 증가 + 수량 감소")
+        void sell_success_partial() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("5000000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("60000"));
+
+            // 보유: 20주
+            GameHolding holding = GameHolding.create(participant, stockInfo, 20, new BigDecimal("55000"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+            given(gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo))
+                    .willReturn(Optional.of(holding));
+            given(gameOrderRepository.save(any(GameOrder.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When — 10주 매도 @ 60000
+            GameOrder result = orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.SELL, 10));
+
+            // Then
+            assertThat(result.getOrderType()).isEqualTo(OrderType.SELL);
+            assertThat(result.getQuantity()).isEqualTo(10);
+
+            // 수수료: 600000 × 0.00015 = 90.00
+            BigDecimal expectedFee = new BigDecimal("600000")
+                    .multiply(new BigDecimal("0.00015")).setScale(2, RoundingMode.HALF_UP);
+            // 세금: 600000 × 0.0018 = 1080.00
+            BigDecimal expectedTax = new BigDecimal("600000")
+                    .multiply(new BigDecimal("0.0018")).setScale(2, RoundingMode.HALF_UP);
+            assertThat(result.getFee()).isEqualByComparingTo(expectedFee);
+            assertThat(result.getTax()).isEqualByComparingTo(expectedTax);
+
+            // 잔고: 5000000 + (600000 - 90 - 1080) = 5598830
+            BigDecimal netProceeds = new BigDecimal("600000").subtract(expectedFee).subtract(expectedTax);
+            BigDecimal expectedCash = new BigDecimal("5000000").add(netProceeds);
+            assertThat(participant.getSeed()).isEqualByComparingTo(expectedCash);
+
+            // 보유 수량 감소 (삭제 아님)
+            assertThat(holding.getQuantity()).isEqualTo(10);
+            verify(gameHoldingRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("��도 성공 — 전량 매도, 보유종목 삭제")
+        void sell_success_allQuantity_holdingDeleted() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("5000000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("60000"));
+
+            // 보유: 10주
+            GameHolding holding = GameHolding.create(participant, stockInfo, 10, new BigDecimal("55000"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+            given(gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo))
+                    .willReturn(Optional.of(holding));
+            given(gameOrderRepository.save(any(GameOrder.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When — 전량 10주 매도
+            orderService.placeOrder(TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.SELL, 10));
+
+            // Then — 전량 매도 → 바로 삭제 (reduceQuantity 호출 없이)
+            verify(gameHoldingRepository).delete(holding);
+        }
+
+        @Test
+        @DisplayName("매도 실패 — 보유 종목 없음")
+        void sell_fail_notHeld() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("55500"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+            given(gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo))
+                    .willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.SELL, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_STOCK_NOT_HELD);
+        }
+
+        @Test
+        @DisplayName("매도 실패 — 보유 수량 부족")
+        void sell_fail_insufficientHoldings() {
+            // Given — 5주 보유, 10주 매도 시도
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            StockInfo stockInfo = createStockInfo();
+            StockDaily stockDaily = createStockDaily(stockInfo, new BigDecimal("55500"));
+
+            GameHolding holding = GameHolding.create(participant, stockInfo, 5, new BigDecimal("55000"));
+
+            setupCommonMocks(room, turn, participant, stockInfo, stockDaily);
+            given(gameHoldingRepository.findByParticipantAndStockInfo(participant, stockInfo))
+                    .willReturn(Optional.of(holding));
+
+            // When & Then
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.SELL, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ORDER_INSUFFICIENT_HOLDINGS);
+        }
+    }
+
+    // === 공통 검증 테스트 ===
+
+    @Nested
+    @DisplayName("공통 검증")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("실패 — 방이 존재하지 않음")
+        void fail_roomNotFound() {
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 게임 미시작 (WAITING 상태)")
+        void fail_gameNotStarted() {
+            GameRoom room = createWaitingRoom();
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("실패 — 종목을 찾을 수 없음")
+        void fail_stockNotFound() {
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.of(turn));
+            given(gameParticipantRepository.findByGameRoomAndUserIdForUpdate(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(stockInfoRepository.findById(TEST_SYMBOL)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_STOCK_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 해당 날짜 주가 데이터 없음")
+        void fail_stockPriceNotFound() {
+            GameRoom room = createGameRoom();
+            GameTurn turn = createGameTurn(room);
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            StockInfo stockInfo = createStockInfo();
+
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.of(turn));
+            given(gameParticipantRepository.findByGameRoomAndUserIdForUpdate(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(stockInfoRepository.findById(TEST_SYMBOL)).willReturn(Optional.of(stockInfo));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, TEST_TRADE_DATE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> orderService.placeOrder(
+                    TEST_ROOM_ID, TEST_USER_ID, new OrderCommand(TEST_SYMBOL, OrderType.BUY, 10)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_STOCK_PRICE_NOT_FOUND);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private void setupCommonMocks(GameRoom room, GameTurn turn,
+                                   GameParticipant participant, StockInfo stockInfo, StockDaily stockDaily) {
+        given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+        given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(turn));
+        given(gameParticipantRepository.findByGameRoomAndUserIdForUpdate(room, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(stockInfoRepository.findById(TEST_SYMBOL)).willReturn(Optional.of(stockInfo));
+        given(stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, TEST_TRADE_DATE))
+                .willReturn(Optional.of(stockDaily));
+    }
+
+    private GameRoom createGameRoom() {
+        GameRoom room = GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
+                6, 7, TEST_TRADE_DATE, TEST_TRADE_DATE.plusMonths(6));
+        room.start();
+        return room;
+    }
+
+    private GameRoom createWaitingRoom() {
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
+                6, 7, TEST_TRADE_DATE, TEST_TRADE_DATE.plusMonths(6));
+    }
+
+    private GameTurn createGameTurn(GameRoom room) {
+        return GameTurn.createFirst(room);
+    }
+
+    private GameParticipant createParticipant(GameRoom room, BigDecimal seed) {
+        GameParticipant participant = GameParticipant.createLeader(room, TEST_USER_ID);
+        participant.assignSeed(seed);
+        return participant;
+    }
+
+    private StockInfo createStockInfo() {
+        return StockInfo.create(TEST_SYMBOL, "삼성전자", "KOSPI", "전기전자");
+    }
+
+    private StockDaily createStockDaily(StockInfo stockInfo, BigDecimal openPrice) {
+        return StockDaily.create(stockInfo, TEST_TRADE_DATE,
+                openPrice, openPrice, openPrice, openPrice,
+                BigDecimal.valueOf(1000000), BigDecimal.ZERO);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -10,6 +10,7 @@ import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.event.GameRoomEvent;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
@@ -23,6 +24,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.Collections;
@@ -55,6 +57,9 @@ class GameRoomServiceTest {
     private GameTurnRepository gameTurnRepository;
 
     @Mock
+    private StockDailyRepository stockDailyRepository;
+
+    @Mock
     private ApplicationEventPublisher eventPublisher;
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
@@ -73,6 +78,9 @@ class GameRoomServiceTest {
         given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(false);
+        // 랜덤으로 뽑힌 날짜는 이하에서 가장 가까운 거래일로 보정
+        given(stockDailyRepository.findLatestTradeDateOnOrBefore(any(LocalDate.class)))
+                .willReturn(Optional.of(LocalDate.of(2022, 1, 3)));
 
         CreateRoomCommand request = createCommand();
 
@@ -181,7 +189,7 @@ class GameRoomServiceTest {
         // Then — 방 정보 검증
         assertThat(result.room().getRoomId()).isEqualTo(roomId);
         assertThat(result.room().getStatus()).isEqualTo(RoomStatus.WAITING);
-        assertThat(result.room().getSeed()).isEqualTo(10000000L);
+        assertThat(result.room().getSeed()).isEqualByComparingTo(new BigDecimal("10000000"));
 
         // Then — 참가자 목록 검증
         assertThat(result.participants()).hasSize(1);
@@ -577,8 +585,8 @@ class GameRoomServiceTest {
         verify(gameTurnRepository).save(any(GameTurn.class));
 
         // Then — 시드머니 지급
-        assertThat(leader.getSeed()).isEqualTo(10000000L);
-        assertThat(member.getSeed()).isEqualTo(10000000L);
+        assertThat(leader.getSeed()).isEqualByComparingTo(new BigDecimal("10000000"));
+        assertThat(member.getSeed()).isEqualByComparingTo(new BigDecimal("10000000"));
         verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.GAME_STARTED));
     }
 
@@ -692,12 +700,12 @@ class GameRoomServiceTest {
     // === 헬퍼 메서드 ===
 
     private CreateRoomCommand createCommand() {
-        return new CreateRoomCommand(10000000L, 6, 7);
+        return new CreateRoomCommand(new BigDecimal("10000000"), 6, 7);
     }
 
 
     private GameRoom createGameRoom() {
-        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
                 6, 7, LocalDate.of(2020, 1, 2), LocalDate.of(2020, 7, 2));
     }
 }

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -78,6 +78,9 @@ class GameRoomServiceTest {
         given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(false);
+        // DB 최초 거래일 — 방 생성 시 시작일 범위 하한
+        given(stockDailyRepository.findEarliestTradeDate())
+                .willReturn(Optional.of(LocalDate.of(2021, 1, 4)));
         // 랜덤으로 뽑힌 날짜는 이하에서 가장 가까운 거래일로 보정
         given(stockDailyRepository.findLatestTradeDateOnOrBefore(any(LocalDate.class)))
                 .willReturn(Optional.of(LocalDate.of(2022, 1, 3)));

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -101,6 +101,33 @@ class GameRoomServiceTest {
     }
 
     @Test
+    @DisplayName("게임방 생성 성공 — 주말/공휴일이 뽑혀도 거래일로 보정된 start_date가 반영된다")
+    void createRoom_startDateAdjustedToTradeDay() {
+        // Given — 정상 조건 + 거래일 보정 스텁 (임의 날짜 → 2022-01-03 월요일)
+        given(gameRoomRepository.existsByGroupIdAndStatusIn(any(Long.class), any(List.class)))
+                .willReturn(false);
+        given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
+                .willReturn(false);
+        given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
+                any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
+                .willReturn(false);
+        given(stockDailyRepository.findEarliestTradeDate())
+                .willReturn(Optional.of(LocalDate.of(2021, 1, 4)));
+        LocalDate adjustedTradeDate = LocalDate.of(2022, 1, 3);
+        given(stockDailyRepository.findLatestTradeDateOnOrBefore(any(LocalDate.class)))
+                .willReturn(Optional.of(adjustedTradeDate));
+
+        CreateRoomCommand request = createCommand();
+
+        // When
+        GameRoom result = gameRoomService.createRoom(TEST_USER_ID, TEST_GROUP_ID, request);
+
+        // Then — 보정된 거래일이 start_date로 반영되고, end_date는 + periodMonths
+        assertThat(result.getStartDate()).isEqualTo(adjustedTradeDate);
+        assertThat(result.getEndDate()).isEqualTo(adjustedTradeDate.plusMonths(request.periodMonths()));
+    }
+
+    @Test
     @DisplayName("게임방 생성 실패 — 방장 1일 1회 제한 위반 시 예외 발생")
     void createRoom_dailyLimitExceeded() {
         // Given — 그룹/방장 활성 방 없음, 오늘 이미 게임 시작 이력 있음

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockChartServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockChartServiceTest.java
@@ -242,7 +242,7 @@ class StockChartServiceTest {
     // === 헬퍼 메서드 ===
 
     private GameRoom createGameRoom() {
-        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
                 6, 7, LocalDate.of(2022, 1, 3), LocalDate.of(2022, 7, 3));
     }
 

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
@@ -227,7 +227,7 @@ class StockSearchServiceTest {
     // === 헬퍼 메서드 ===
 
     private GameRoom createGameRoom() {
-        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, 10000000L,
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
                 6, 7, LocalDate.of(2020, 1, 2), LocalDate.of(2020, 7, 2));
     }
 


### PR DESCRIPTION
## 📌 PR 설명
<br> 게임 플레이 중 종목을 매수/매도할 수 있는 주문 API를 구현했습니다. 매수 시 수수료(0.015%), 매도 시 수수료 + 세금(0.18%)이 적용되며,                                                                                              
 잔고/보유수량 검증 및 비관적 락을 통한 동시성 제어를 포함합니다.       
db의 금액 컬럼을 Long → BigDecimal(18,2)로 전환하고, 팀원 코드와의 Bean 이름 충돌을 해결했습니다.                        

## ✅ 완료한 기능 명세

- [x] 매수: 잔고 확인 ->  수수료 계산 -> 잔고 차감 -> 보유종목 생성 -> 주문 저장
- [x] 매도: 보유종목 확인 -> 수수료+세금 계산 -> 잔고 증가 ->  보유종목 수량 감소/삭제 -> 주문 저장
- [x] 전량 매도 시 holding 삭제 
- [x] db변경 관련 DTO, Command, Service, Test 수정
- [x] 테스트코드


<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
1. 전량 매도 시 holding 처리
 - game_holding 테이블에 CHECK(quantity > 0) 제약이 있어서, reduceQuantity()로 0까지 줄이면 DB 에러가 발생 했습니다. 전량 매도 시(holding.quantity == sellQuantity)면 reduceQuantity() 대신 gameHoldingRepository.delete(holding) 호출로  보유 종목에서 삭제로 변경해 해결했습니다.

2. BigDecimal 적용 범위
 - seed 컬럼이 Long이면 수수료/세금 계산 시 소수점 제외 ->  금액 정밀도 손실 발생 -> DB를 DECIMAL(18,2)로 변경하고, Java 엔티티/DTO를 BigDecimal로 전환 했습니다.

3. 동시성 제어 — 비관적 락 선택
 - 같은 참가자가 동시에 여러 주문을 보내면 잔고가 음수가 될 수 있습니다. findByGameRoomAndUserIdForUpdate 에 @Lock(PESSIMISTIC_WRITE) 적용해  트랜잭션이 끝날 때까지 해당 참가자 row를 잠궜습니다.

<br>

### 🔗 관련 이슈
Closes #90 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 룸별 시황 브리핑 조회 API 추가
  * 매수/매도 주문 API 및 주문 응답 추가
  * 주식 보유(홀딩) 관리 기능 추가

* **개선 사항**
  * 금전 관련 필드를 소수점 2자리(BigDecimal)로 전환해 정밀도 향상
  * 주문 처리 시 수수료·세금 계산 및 잔액·보유 업데이트 강화
  * 동일 날짜 브리핑 요청에 대한 동기화(동시성) 보완 및 캐싱 동작 개선

* **테스트**
  * 브리핑·주문 관련 단위 테스트 및 동시성 테스트 추가

* **기타(데이터베이스)**
  * 스키마 마이그레이션으로 금액/퀘스트 테이블 변경 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->