### PR TITLE
[WEF-445] 퀘스트 랜덤 생성

### DIFF
--- a/src/main/java/com/solv/wefin/domain/quest/entity/DailyQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/DailyQuest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.quest.entity;
 
+import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,7 +20,7 @@ import java.time.OffsetDateTime;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class DailyQuest {
+public class DailyQuest extends BaseEntity {
 
         @Id
         @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -38,12 +39,6 @@ public class DailyQuest {
 
         @Column(name = "reward", nullable = false)
         private Integer reward;
-
-        @Column(name = "created_at", nullable = false)
-        private OffsetDateTime createdAt;
-
-        @Column(name = "updated_at", nullable = false)
-        private OffsetDateTime updatedAt;
 
         @Builder
         private DailyQuest(
@@ -70,17 +65,5 @@ public class DailyQuest {
                         .targetValue(targetValue)
                         .reward(reward)
                         .build();
-        }
-
-        @PrePersist
-        protected void onCreate() {
-                OffsetDateTime now = OffsetDateTime.now();
-                this.createdAt = now;
-                this.updatedAt = now;
-        }
-
-        @PreUpdate
-        protected void onUpdate() {
-                this.updatedAt = OffsetDateTime.now();
         }
 }

--- a/src/main/java/com/solv/wefin/domain/quest/entity/DailyQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/DailyQuest.java
@@ -1,0 +1,86 @@
+package com.solv.wefin.domain.quest.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "daily_quest",
+        uniqueConstraints  = @UniqueConstraint(
+                name = "uq_daily_quest_date_template",
+                columnNames = {"quest_date", "template_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyQuest {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        @Column(name = "daily_quest_id")
+        private Long id;
+
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "template_id", nullable = false)
+        private QuestTemplate questTemplate;
+
+        @Column(name = "quest_date", nullable = false)
+        private LocalDate questDate;
+
+        @Column(name = "target_value", nullable = false)
+        private Integer targetValue;
+
+        @Column(name = "reward", nullable = false)
+        private Integer reward;
+
+        @Column(name = "created_at", nullable = false)
+        private OffsetDateTime createdAt;
+
+        @Column(name = "updated_at", nullable = false)
+        private OffsetDateTime updatedAt;
+
+        @Builder
+        private DailyQuest(
+                QuestTemplate questTemplate,
+                LocalDate questDate,
+                Integer targetValue,
+                Integer reward
+        ) {
+                this.questTemplate = questTemplate;
+                this.questDate = questDate;
+                this.targetValue = targetValue;
+                this.reward = reward;
+        }
+
+        public static DailyQuest create(
+                QuestTemplate questTemplate,
+                LocalDate questDate,
+                Integer targetValue,
+                Integer reward
+        ) {
+                return DailyQuest.builder()
+                        .questTemplate(questTemplate)
+                        .questDate(questDate)
+                        .targetValue(targetValue)
+                        .reward(reward)
+                        .build();
+        }
+
+        @PrePersist
+        protected void onCreate() {
+                OffsetDateTime now = OffsetDateTime.now();
+                this.createdAt = now;
+                this.updatedAt = now;
+        }
+
+        @PreUpdate
+        protected void onUpdate() {
+                this.updatedAt = OffsetDateTime.now();
+        }
+}

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestCompleteType.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestCompleteType.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.quest.entity;
+
+public enum QuestCompleteType {
+    COUNT,
+    PERCENT
+}

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestEventType.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestEventType.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.quest.entity;
+
+public enum QuestEventType {
+    LOGIN,
+    BUY_STOCK,
+    SEND_GROUP_CHAT,
+    SHARE_NEWS,
+    USE_AI_CHAT,
+    JOIN_GAME_ROOM,
+    CREATE_GAME_ROOM,
+    CREATE_ACCOUNT
+}

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestStatus.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestStatus.java
@@ -1,0 +1,8 @@
+package com.solv.wefin.domain.quest.entity;
+
+public enum QuestStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED,
+    REWARDED
+}

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestTemplate.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestTemplate.java
@@ -1,14 +1,14 @@
 package com.solv.wefin.domain.quest.entity;
 
 import com.solv.wefin.global.common.BaseEntity;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
-
-import java.time.OffsetDateTime;
 
 @Entity
 @Table(name = "quest_template")
@@ -56,11 +56,28 @@ public class QuestTemplate extends BaseEntity {
 
     @PrePersist
     protected void onCreate() {
+        validateInvariant();
+
         if (this.repeatable == null) {
             this.repeatable = false;
         }
         if (this.active == null) {
             this.active = true;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        validateInvariant();
+    }
+
+    private void validateInvariant() {
+        if (this.targetValue == null || this.targetValue <= 0) {
+            throw new BusinessException(ErrorCode.QUEST_TARGET_VALUE_INVALID);
+        }
+
+        if (this.reward == null || this.reward < 0) {
+            throw new BusinessException(ErrorCode.QUEST_REWARD_INVALID);
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestTemplate.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestTemplate.java
@@ -1,0 +1,88 @@
+package com.solv.wefin.domain.quest.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "quest_template")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestTemplate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "template_id")
+    private Long id;
+
+    @Column(name = "code", nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(name = "title", nullable = false, length = 100)
+    private String title;
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "complete_type", nullable = false, length = 30)
+    private QuestCompleteType completeType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type", nullable = false, length = 30)
+    private QuestEventType eventType;
+
+    @Column(name = "target_value", nullable = false)
+    private Integer targetValue;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "condition_json", columnDefinition = "jsonb")
+    private String conditionJson;
+
+    @Column(name = "reward", nullable = false)
+    private Integer reward;
+
+    @Column(name = "is_repeatable", nullable = false)
+    private Boolean repeatable;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean active;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+
+        if (this.repeatable == null) {
+            this.repeatable = false;
+        }
+        if (this.active == null) {
+            this.active = true;
+        }
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public void deactivate() {
+        this.active = false;
+    }
+
+    public void activate() {
+        this.active = true;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestTemplate.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestTemplate.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.quest.entity;
 
+import com.solv.wefin.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import java.time.OffsetDateTime;
 @Table(name = "quest_template")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class QuestTemplate {
+public class QuestTemplate extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -53,29 +54,14 @@ public class QuestTemplate {
     @Column(name = "is_active", nullable = false)
     private Boolean active;
 
-    @Column(name = "created_at", nullable = false)
-    private OffsetDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private OffsetDateTime updatedAt;
-
     @PrePersist
     protected void onCreate() {
-        OffsetDateTime now = OffsetDateTime.now();
-        this.createdAt = now;
-        this.updatedAt = now;
-
         if (this.repeatable == null) {
             this.repeatable = false;
         }
         if (this.active == null) {
             this.active = true;
         }
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = OffsetDateTime.now();
     }
 
     public void deactivate() {

--- a/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
@@ -1,6 +1,8 @@
 package com.solv.wefin.domain.quest.entity;
 
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -103,6 +105,15 @@ public class UserQuest {
     }
 
     public void updateProgress(int progress) {
+
+        if (progress < 0) {
+            throw new BusinessException(ErrorCode.QUEST_PROGRESS_INVALID);
+        }
+
+        if (this.status == QuestStatus.COMPLETED || this.status == QuestStatus.REWARDED) {
+            return;
+        }
+
         this.progress = progress;
 
         if (progress > 0 && this.status == QuestStatus.NOT_STARTED) {
@@ -117,6 +128,10 @@ public class UserQuest {
     }
 
     public void complete() {
+
+        if (this.status == QuestStatus.COMPLETED || this.status == QuestStatus.REWARDED) {
+            return;
+        }
         this.status = QuestStatus.COMPLETED;
         this.completedAt = OffsetDateTime.now();
 
@@ -126,6 +141,11 @@ public class UserQuest {
     }
 
     public void markRewarded() {
+
+        if (this.status != QuestStatus.COMPLETED) {
+            throw new BusinessException(ErrorCode.QUEST_REWARD_NOT_ALLOWED);
+        }
+
         this.status = QuestStatus.REWARDED;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.quest.entity;
 
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.global.common.BaseEntity;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import jakarta.persistence.*;
@@ -21,7 +22,7 @@ import java.time.OffsetDateTime;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserQuest {
+public class UserQuest extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,12 +49,6 @@ public class UserQuest {
 
     @Column(name = "completed_at")
     private OffsetDateTime completedAt;
-
-    @Column(name = "created_at", nullable = false)
-    private OffsetDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private OffsetDateTime updatedAt;
 
     @Builder
     private UserQuest (
@@ -87,14 +82,6 @@ public class UserQuest {
         if (this.progress == null) {
             this.progress = 0;
         }
-
-        this.createdAt = now;
-        this.updatedAt = now;
-    }
-
-    @PreUpdate
-    protected void onUpdate() {
-        this.updatedAt = OffsetDateTime.now();
     }
 
     public void start() {
@@ -114,20 +101,20 @@ public class UserQuest {
             return;
         }
 
-        this.progress = progress;
+        Integer targetValue = this.dailyQuest.getTargetValue();
+        this.progress = targetValue != null ? Math.min(progress, targetValue) : progress;
 
         if (progress > 0 && this.status == QuestStatus.NOT_STARTED) {
             this.status = QuestStatus.IN_PROGRESS;
             this.startedAt = OffsetDateTime.now();
         }
 
-        Integer targetValue = this.dailyQuest.getTargetValue();
         if (targetValue != null && progress >= targetValue) {
             complete();
         }
     }
 
-    public void complete() {
+    private void complete() {
 
         if (this.status == QuestStatus.COMPLETED || this.status == QuestStatus.REWARDED) {
             return;

--- a/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
@@ -1,0 +1,132 @@
+package com.solv.wefin.domain.quest.entity;
+
+import com.solv.wefin.domain.auth.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "user_quest",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_user_quest_user_daily_quest",
+                columnNames = {"user_id", "daily_quest_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserQuest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "quest_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "daily_quest_id", nullable = false)
+    private DailyQuest dailyQuest;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private QuestStatus status;
+
+    @Column(name = "progress", nullable = false)
+    private Integer progress;
+
+    @Column(name = "started_at")
+    private OffsetDateTime startedAt;
+
+    @Column(name = "completed_at")
+    private OffsetDateTime completedAt;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Builder
+    private UserQuest (
+            DailyQuest dailyQuest,
+            User user,
+            QuestStatus status,
+            Integer progress
+    ) {
+        this.dailyQuest = dailyQuest;
+        this.user = user;
+        this.status = status;
+        this.progress = progress;
+    }
+
+    public static UserQuest assign(User user, DailyQuest dailyQuest) {
+        return UserQuest.builder()
+                .user(user)
+                .dailyQuest(dailyQuest)
+                .status(QuestStatus.NOT_STARTED)
+                .progress(0)
+                .build();
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        if (this.status == null) {
+            this.status = QuestStatus.NOT_STARTED;
+        }
+        if (this.progress == null) {
+            this.progress = 0;
+        }
+
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    public void start() {
+        if (this.status == QuestStatus.NOT_STARTED) {
+            this.status = QuestStatus.IN_PROGRESS;
+            this.startedAt = OffsetDateTime.now();
+        }
+    }
+
+    public void updateProgress(int progress) {
+        this.progress = progress;
+
+        if (progress > 0 && this.status == QuestStatus.NOT_STARTED) {
+            this.status = QuestStatus.IN_PROGRESS;
+            this.startedAt = OffsetDateTime.now();
+        }
+
+        Integer targetValue = this.dailyQuest.getTargetValue();
+        if (targetValue != null && progress >= targetValue) {
+            complete();
+        }
+    }
+
+    public void complete() {
+        this.status = QuestStatus.COMPLETED;
+        this.completedAt = OffsetDateTime.now();
+
+        if (this.startedAt == null) {
+            this.startedAt = this.completedAt;
+        }
+    }
+
+    public void markRewarded() {
+        this.status = QuestStatus.REWARDED;
+    }
+}
+

--- a/src/main/java/com/solv/wefin/domain/quest/repository/DailyQuestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/DailyQuestRepository.java
@@ -1,0 +1,17 @@
+package com.solv.wefin.domain.quest.repository;
+
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DailyQuestRepository extends JpaRepository<DailyQuest, Long> {
+
+    List<DailyQuest> findAllByQuestDate(LocalDate questDate);
+
+    boolean existsByQuestDate(LocalDate questDate);
+
+    Optional<DailyQuest> findByQuestDateAndQuestTemplate_Id(LocalDate questDate, Long templateId);
+}

--- a/src/main/java/com/solv/wefin/domain/quest/repository/DailyQuestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/DailyQuestRepository.java
@@ -5,13 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 public interface DailyQuestRepository extends JpaRepository<DailyQuest, Long> {
 
     List<DailyQuest> findAllByQuestDate(LocalDate questDate);
-
-    boolean existsByQuestDate(LocalDate questDate);
-
-    Optional<DailyQuest> findByQuestDateAndQuestTemplate_Id(LocalDate questDate, Long templateId);
 }

--- a/src/main/java/com/solv/wefin/domain/quest/repository/QuestTemplateRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/QuestTemplateRepository.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.quest.repository;
+
+import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestTemplateRepository extends JpaRepository<QuestTemplate, Long> {
+
+    List<QuestTemplate> findByActiveTrue();
+}

--- a/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.domain.quest.repository;
+
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
+
+    boolean existsByUser_UserIdAndDailyQuest_QuestDate(UUID userId, LocalDate questDate);
+
+    @Query("""
+    select uq
+    from UserQuest uq
+    join fetch uq.dailyQuest dq
+    join fetch dq.questTemplate qt
+    join fetch uq.user u
+    where u.userId = :userId
+      and dq.questDate = :questDate
+    order by uq.id asc
+    """)
+    List<UserQuest> findAllByUser_UserIdAndDailyQuest_QuestDateOrderByIdAsc(UUID userId, LocalDate questDate);
+
+    List<UserQuest> findAllByUser_UserIdOrderByIdDesc(UUID userId);
+
+    @Query("""
+    select uq
+    from UserQuest uq
+    join fetch uq.dailyQuest dq
+    join fetch dq.questTemplate qt
+    where uq.user.userId = :userId
+      and dq.questDate = :questDate
+    order by uq.id asc
+    """)
+    List<UserQuest> findTodayUserQuests(UUID userId, LocalDate questDate);
+
+}

--- a/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
@@ -10,22 +10,6 @@ import java.util.UUID;
 
 public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
 
-    boolean existsByUser_UserIdAndDailyQuest_QuestDate(UUID userId, LocalDate questDate);
-
-    @Query("""
-    select uq
-    from UserQuest uq
-    join fetch uq.dailyQuest dq
-    join fetch dq.questTemplate qt
-    join fetch uq.user u
-    where u.userId = :userId
-      and dq.questDate = :questDate
-    order by uq.id asc
-    """)
-    List<UserQuest> findAllByUser_UserIdAndDailyQuest_QuestDateOrderByIdAsc(UUID userId, LocalDate questDate);
-
-    List<UserQuest> findAllByUser_UserIdOrderByIdDesc(UUID userId);
-
     @Query("""
     select uq
     from UserQuest uq

--- a/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
@@ -54,7 +54,7 @@ public class DailyQuestService {
                 .toList();
 
         try {
-            return dailyQuestRepository.saveAll(dailyQuests);
+            return dailyQuestRepository.saveAllAndFlush(dailyQuests);
         } catch (DataIntegrityViolationException e) {
             return dailyQuestRepository.findAllByQuestDate(today);
         }

--- a/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
@@ -1,0 +1,71 @@
+package com.solv.wefin.domain.quest.service;
+
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import com.solv.wefin.domain.quest.repository.DailyQuestRepository;
+import com.solv.wefin.domain.quest.repository.QuestTemplateRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyQuestService {
+
+    private static final int DAILY_QUEST_COUNT = 3;
+
+    private final DailyQuestRepository dailyQuestRepository;
+    private final QuestTemplateRepository questTemplateRepository;
+
+    public List<DailyQuest> getOrCreateTodayDailyQuests() {
+        LocalDate today = LocalDate.now();
+
+        List<DailyQuest> todayQuests = dailyQuestRepository.findAllByQuestDate(today);
+        if (!todayQuests.isEmpty()) {
+            return todayQuests;
+        }
+
+        List<QuestTemplate> templates = new ArrayList<>(questTemplateRepository.findByActiveTrue());
+        if (templates.size() < DAILY_QUEST_COUNT) {
+            throw new BusinessException(ErrorCode.QUEST_TEMPLATE_NOT_ENOUGH);
+        }
+
+        Collections.shuffle(templates);
+
+        List<QuestTemplate> selectedTemplates = templates.subList(0, DAILY_QUEST_COUNT);
+
+        List<DailyQuest> dailyQuests = selectedTemplates.stream()
+                .map(template -> DailyQuest.create(
+                        template,
+                        today,
+                        resolveRandomTargetValue(template),
+                        template.getReward()
+                ))
+                .toList();
+
+        return dailyQuestRepository.saveAll(dailyQuests);
+    }
+
+    @Transactional(readOnly = true)
+    public List<DailyQuest> getTodayDailyQuests() {
+        return dailyQuestRepository.findAllByQuestDate(LocalDate.now());
+    }
+
+    private int resolveRandomTargetValue(QuestTemplate template) {
+        int baseTargetValue = template.getTargetValue() != null ? template.getTargetValue() : 1;
+
+        int min = Math.max(1, baseTargetValue - 1);
+        int max = baseTargetValue + 1;
+
+        return ThreadLocalRandom.current().nextInt(min, max + 1);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.quest.repository.QuestTemplateRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,7 +53,11 @@ public class DailyQuestService {
                 ))
                 .toList();
 
-        return dailyQuestRepository.saveAll(dailyQuests);
+        try {
+            return dailyQuestRepository.saveAll(dailyQuests);
+        } catch (DataIntegrityViolationException e) {
+            return dailyQuestRepository.findAllByQuestDate(today);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
@@ -1,0 +1,55 @@
+package com.solv.wefin.domain.quest.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import com.solv.wefin.domain.quest.repository.UserQuestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserQuestService {
+
+    private final UserRepository userRepository;
+    private final UserQuestRepository userQuestRepository;
+    private final DailyQuestService dailyQuestService;
+
+    public List<UserQuest> getOrIssueTodayUserQuests(UUID userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        List<UserQuest> todayUserQuests =
+                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+
+        if (!todayUserQuests.isEmpty()) {
+            return todayUserQuests;
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        List<DailyQuest> todayDailyQuests = dailyQuestService.getOrCreateTodayDailyQuests();
+
+        List<UserQuest> userQuests = todayDailyQuests.stream()
+                .map(dailyQuest -> UserQuest.assign(user, dailyQuest))
+                .toList();
+
+        return userQuestRepository.saveAll(userQuests);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserQuest> getTodayUserQuests(UUID userId) {
+        return userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.quest.repository.UserQuestRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,8 +30,10 @@ public class UserQuestService {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND);
         }
 
+        LocalDate today = LocalDate.now();
+
         List<UserQuest> todayUserQuests =
-                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+                userQuestRepository.findTodayUserQuests(userId, today);
 
         if (!todayUserQuests.isEmpty()) {
             return todayUserQuests;
@@ -45,7 +48,11 @@ public class UserQuestService {
                 .map(dailyQuest -> UserQuest.assign(user, dailyQuest))
                 .toList();
 
-        return userQuestRepository.saveAll(userQuests);
+        try {
+            return userQuestRepository.saveAll(userQuests);
+        } catch (DataIntegrityViolationException e) {
+            return userQuestRepository.findTodayUserQuests(userId, today);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
@@ -49,7 +49,7 @@ public class UserQuestService {
                 .toList();
 
         try {
-            return userQuestRepository.saveAll(userQuests);
+            return userQuestRepository.saveAllAndFlush(userQuests);
         } catch (DataIntegrityViolationException e) {
             return userQuestRepository.findTodayUserQuests(userId, today);
         }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -37,6 +37,9 @@ public enum ErrorCode {
     AI_CHAT_TIMEOUT(504, "AI 응답 시간이 초과되었습니다."),
     NEWS_CLUSTER_NOT_FOUND(404, "뉴스 기사를 찾을 수 없습니다."),
 
+    // quest
+    QUEST_TEMPLATE_NOT_ENOUGH(500, "활성 퀘스트 템플릿 수가 부족합니다."),
+    DAILY_QUEST_NOT_FOUND(404, "오늘의 퀘스트를 찾을 수 없습니다."),
 
     // Common
     INVALID_INPUT(400, "잘못된 입력입니다."),

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -40,6 +40,8 @@ public enum ErrorCode {
     // quest
     QUEST_TEMPLATE_NOT_ENOUGH(500, "활성 퀘스트 템플릿 수가 부족합니다."),
     DAILY_QUEST_NOT_FOUND(404, "오늘의 퀘스트를 찾을 수 없습니다."),
+    QUEST_PROGRESS_INVALID(400, "퀘스트 진행도는 0 이상이어야 합니다."),
+    QUEST_REWARD_NOT_ALLOWED(400, "완료된 퀘스트만 보상 처리할 수 있습니다."),
 
     // Common
     INVALID_INPUT(400, "잘못된 입력입니다."),

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
     DAILY_QUEST_NOT_FOUND(404, "오늘의 퀘스트를 찾을 수 없습니다."),
     QUEST_PROGRESS_INVALID(400, "퀘스트 진행도는 0 이상이어야 합니다."),
     QUEST_REWARD_NOT_ALLOWED(400, "완료된 퀘스트만 보상 처리할 수 있습니다."),
+    QUEST_TARGET_VALUE_INVALID(400, "퀘스트 목표치는 1 이상이어야 합니다."),
+    QUEST_REWARD_INVALID(400, "퀘스트 보상은 0 이상이어야 합니다."),
 
     // Common
     INVALID_INPUT(400, "잘못된 입력입니다."),

--- a/src/main/java/com/solv/wefin/web/quest/QuestController.java
+++ b/src/main/java/com/solv/wefin/web/quest/QuestController.java
@@ -1,0 +1,31 @@
+package com.solv.wefin.web.quest;
+
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import com.solv.wefin.domain.quest.service.UserQuestService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.quest.dto.response.TodayQuestListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/quests")
+public class QuestController {
+
+    private final UserQuestService userQuestService;
+
+    @GetMapping("/today")
+    public ApiResponse<TodayQuestListResponse> getTodayQuests(
+            @AuthenticationPrincipal UUID userId
+    ) {
+        List<UserQuest> userQuests = userQuestService.getOrIssueTodayUserQuests(userId);
+
+        return ApiResponse.success(TodayQuestListResponse.from(userQuests));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/quest/dto/response/QuestResponse.java
+++ b/src/main/java/com/solv/wefin/web/quest/dto/response/QuestResponse.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.web.quest.dto.response;
+
+import com.solv.wefin.domain.quest.entity.UserQuest;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+public record QuestResponse(
+        Long questId,
+        Long dailyQuestId,
+        Long templateId,
+        String code,
+        String title,
+        String description,
+        String status,
+        Integer progress,
+        Integer targetValue,
+        Integer reward,
+        LocalDate questDate,
+        OffsetDateTime startedAt,
+        OffsetDateTime completedAt
+) {
+    public static QuestResponse from(UserQuest userQuest) {
+        return new QuestResponse(
+                userQuest.getId(),
+                userQuest.getDailyQuest().getId(),
+                userQuest.getDailyQuest().getQuestTemplate().getId(),
+                userQuest.getDailyQuest().getQuestTemplate().getCode(),
+                userQuest.getDailyQuest().getQuestTemplate().getTitle(),
+                userQuest.getDailyQuest().getQuestTemplate().getDescription(),
+                userQuest.getStatus().name(),
+                userQuest.getProgress(),
+                userQuest.getDailyQuest().getTargetValue(),
+                userQuest.getDailyQuest().getReward(),
+                userQuest.getDailyQuest().getQuestDate(),
+                userQuest.getStartedAt(),
+                userQuest.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/quest/dto/response/TodayQuestListResponse.java
+++ b/src/main/java/com/solv/wefin/web/quest/dto/response/TodayQuestListResponse.java
@@ -1,0 +1,24 @@
+package com.solv.wefin.web.quest.dto.response;
+
+import com.solv.wefin.domain.quest.entity.UserQuest;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record TodayQuestListResponse(
+        LocalDate questDate,
+        List<QuestResponse> quests
+) {
+    public static TodayQuestListResponse from(List<UserQuest> userQuests) {
+        LocalDate questDate = userQuests.isEmpty()
+                ? LocalDate.now()
+                : userQuests.get(0).getDailyQuest().getQuestDate();
+
+        return new TodayQuestListResponse(
+                questDate,
+                userQuests.stream()
+                        .map(QuestResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
@@ -1,0 +1,109 @@
+package com.solv.wefin.domain.quest.service;
+
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import com.solv.wefin.domain.quest.repository.DailyQuestRepository;
+import com.solv.wefin.domain.quest.repository.QuestTemplateRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+class DailyQuestServiceTest {
+
+    private DailyQuestRepository dailyQuestRepository;
+    private QuestTemplateRepository questTemplateRepository;
+    private DailyQuestService dailyQuestService;
+
+    @BeforeEach
+    void setUp() {
+        dailyQuestRepository = mock(DailyQuestRepository.class);
+        questTemplateRepository = mock(QuestTemplateRepository.class);
+        dailyQuestService = new DailyQuestService(dailyQuestRepository, questTemplateRepository);
+    }
+
+    @Test
+    @DisplayName("오늘의 퀘스트가 이미 있으면 기존 퀘스트를 반환한다")
+    void getOrCreateTodayDailyQuests_returns_existing() {
+        // given
+        LocalDate today = LocalDate.now();
+
+        QuestTemplate template = mock(QuestTemplate.class);
+        DailyQuest dailyQuest = DailyQuest.create(template, today, 3, 100);
+        ReflectionTestUtils.setField(dailyQuest, "id", 1L);
+
+        when(dailyQuestRepository.findAllByQuestDate(today)).thenReturn(List.of(dailyQuest));
+
+        // when
+        List<DailyQuest> result = dailyQuestService.getOrCreateTodayDailyQuests();
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getId());
+        verify(questTemplateRepository, never()).findByActiveTrue();
+        verify(dailyQuestRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("오늘의 퀘스트가 없으면 활성 템플릿 3개로 새로 생성한다")
+    void getOrCreateTodayDailyQuests_creates_new() {
+        // given
+        LocalDate today = LocalDate.now();
+
+        QuestTemplate t1 = mockTemplate(1L, 3, 100);
+        QuestTemplate t2 = mockTemplate(2L, 2, 80);
+        QuestTemplate t3 = mockTemplate(3L, 1, 50);
+
+        when(dailyQuestRepository.findAllByQuestDate(today)).thenReturn(List.of());
+        when(questTemplateRepository.findByActiveTrue()).thenReturn(List.of(t1, t2, t3));
+        when(dailyQuestRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        List<DailyQuest> result = dailyQuestService.getOrCreateTodayDailyQuests();
+
+        // then
+        assertEquals(3, result.size());
+        assertTrue(result.stream().allMatch(q -> q.getQuestDate().equals(today)));
+        verify(dailyQuestRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("활성 템플릿이 3개보다 적으면 예외가 발생한다")
+    void getOrCreateTodayDailyQuests_fail_when_templates_not_enough() {
+        // given
+        LocalDate today = LocalDate.now();
+
+        QuestTemplate t1 = mockTemplate(1L, 3, 100);
+        QuestTemplate t2 = mockTemplate(2L, 2, 80);
+
+        when(dailyQuestRepository.findAllByQuestDate(today)).thenReturn(List.of());
+        when(questTemplateRepository.findByActiveTrue()).thenReturn(List.of(t1, t2));
+
+        // when
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> dailyQuestService.getOrCreateTodayDailyQuests()
+        );
+
+        // then
+        assertEquals(ErrorCode.QUEST_TEMPLATE_NOT_ENOUGH, exception.getErrorCode());
+        verify(dailyQuestRepository, never()).saveAll(anyList());
+    }
+
+    private QuestTemplate mockTemplate(Long id, Integer targetValue, Integer reward) {
+        QuestTemplate template = mock(QuestTemplate.class);
+        when(template.getId()).thenReturn(id);
+        when(template.getTargetValue()).thenReturn(targetValue);
+        when(template.getReward()).thenReturn(reward);
+        return template;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
@@ -50,7 +50,7 @@ class DailyQuestServiceTest {
         assertEquals(1, result.size());
         assertEquals(1L, result.get(0).getId());
         verify(questTemplateRepository, never()).findByActiveTrue();
-        verify(dailyQuestRepository, never()).saveAll(anyList());
+        verify(dailyQuestRepository, never()).saveAllAndFlush(anyList());
     }
 
     @Test
@@ -65,7 +65,7 @@ class DailyQuestServiceTest {
 
         when(dailyQuestRepository.findAllByQuestDate(today)).thenReturn(List.of());
         when(questTemplateRepository.findByActiveTrue()).thenReturn(List.of(t1, t2, t3));
-        when(dailyQuestRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(dailyQuestRepository.saveAllAndFlush(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
         List<DailyQuest> result = dailyQuestService.getOrCreateTodayDailyQuests();
@@ -73,7 +73,7 @@ class DailyQuestServiceTest {
         // then
         assertEquals(3, result.size());
         assertTrue(result.stream().allMatch(q -> q.getQuestDate().equals(today)));
-        verify(dailyQuestRepository).saveAll(anyList());
+        verify(dailyQuestRepository).saveAllAndFlush(anyList());
     }
 
     @Test
@@ -96,7 +96,7 @@ class DailyQuestServiceTest {
 
         // then
         assertEquals(ErrorCode.QUEST_TEMPLATE_NOT_ENOUGH, exception.getErrorCode());
-        verify(dailyQuestRepository, never()).saveAll(anyList());
+        verify(dailyQuestRepository, never()).saveAllAndFlush(anyList());
     }
 
     private QuestTemplate mockTemplate(Long id, Integer targetValue, Integer reward) {

--- a/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
@@ -19,7 +19,9 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class UserQuestServiceTest {
@@ -42,11 +44,11 @@ class UserQuestServiceTest {
     void getOrIssueTodayUserQuests_returns_existing() {
         // given
         UUID userId = UUID.randomUUID();
-        LocalDate today = LocalDate.now();
 
         UserQuest userQuest = mock(UserQuest.class);
 
-        when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of(userQuest));
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of(userQuest));
 
         // when
         List<UserQuest> result = userQuestService.getOrIssueTodayUserQuests(userId);
@@ -76,7 +78,8 @@ class UserQuestServiceTest {
         DailyQuest dailyQuest2 = DailyQuest.create(mock(QuestTemplate.class), today, 2, 80);
         DailyQuest dailyQuest3 = DailyQuest.create(mock(QuestTemplate.class), today, 1, 50);
 
-        when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of());
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of());
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(dailyQuestService.getOrCreateTodayDailyQuests()).thenReturn(List.of(dailyQuest1, dailyQuest2, dailyQuest3));
         when(userQuestRepository.saveAllAndFlush(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -115,9 +118,9 @@ class UserQuestServiceTest {
     void getOrIssueTodayUserQuests_fail_when_user_not_found() {
         // given
         UUID userId = UUID.randomUUID();
-        LocalDate today = LocalDate.now();
 
-        when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of());
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of());
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
         // when

--- a/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
@@ -1,0 +1,124 @@
+package com.solv.wefin.domain.quest.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import com.solv.wefin.domain.quest.repository.UserQuestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+class UserQuestServiceTest {
+
+    private UserRepository userRepository;
+    private UserQuestRepository userQuestRepository;
+    private DailyQuestService dailyQuestService;
+    private UserQuestService userQuestService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        userQuestRepository = mock(UserQuestRepository.class);
+        dailyQuestService = mock(DailyQuestService.class);
+        userQuestService = new UserQuestService(userRepository, userQuestRepository, dailyQuestService);
+    }
+
+    @Test
+    @DisplayName("오늘 유저 퀘스트가 이미 있으면 기존 퀘스트를 반환한다")
+    void getOrIssueTodayUserQuests_returns_existing() {
+        // given
+        UUID userId = UUID.randomUUID();
+        LocalDate today = LocalDate.now();
+
+        UserQuest userQuest = mock(UserQuest.class);
+
+        when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of(userQuest));
+
+        // when
+        List<UserQuest> result = userQuestService.getOrIssueTodayUserQuests(userId);
+
+        // then
+        assertEquals(1, result.size());
+        verify(userRepository, never()).findById(any());
+        verify(dailyQuestService, never()).getOrCreateTodayDailyQuests();
+        verify(userQuestRepository, never()).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("오늘 유저 퀘스트가 없으면 오늘의 공통 퀘스트를 발급한다")
+    void getOrIssueTodayUserQuests_issues_new() {
+        // given
+        UUID userId = UUID.randomUUID();
+        LocalDate today = LocalDate.now();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("questUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        DailyQuest dailyQuest1 = DailyQuest.create(mock(QuestTemplate.class), today, 3, 100);
+        DailyQuest dailyQuest2 = DailyQuest.create(mock(QuestTemplate.class), today, 2, 80);
+        DailyQuest dailyQuest3 = DailyQuest.create(mock(QuestTemplate.class), today, 1, 50);
+
+        when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of());
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(dailyQuestService.getOrCreateTodayDailyQuests()).thenReturn(List.of(dailyQuest1, dailyQuest2, dailyQuest3));
+        when(userQuestRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        List<UserQuest> result = userQuestService.getOrIssueTodayUserQuests(userId);
+
+        // then
+        assertEquals(3, result.size());
+        verify(userQuestRepository).saveAll(anyList());
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 예외가 발생한다")
+    void getOrIssueTodayUserQuests_fail_when_user_id_null() {
+        // when
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userQuestService.getOrIssueTodayUserQuests(null)
+        );
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("유저가 없으면 예외가 발생한다")
+    void getOrIssueTodayUserQuests_fail_when_user_not_found() {
+        // given
+        UUID userId = UUID.randomUUID();
+        LocalDate today = LocalDate.now();
+
+        when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of());
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userQuestService.getOrIssueTodayUserQuests(userId)
+        );
+
+        // then
+        assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
@@ -55,7 +55,7 @@ class UserQuestServiceTest {
         assertEquals(1, result.size());
         verify(userRepository, never()).findById(any());
         verify(dailyQuestService, never()).getOrCreateTodayDailyQuests();
-        verify(userQuestRepository, never()).saveAll(anyList());
+        verify(userQuestRepository, never()).saveAllAndFlush(anyList());
     }
 
     @Test
@@ -79,14 +79,22 @@ class UserQuestServiceTest {
         when(userQuestRepository.findTodayUserQuests(userId, today)).thenReturn(List.of());
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(dailyQuestService.getOrCreateTodayDailyQuests()).thenReturn(List.of(dailyQuest1, dailyQuest2, dailyQuest3));
-        when(userQuestRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(userQuestRepository.saveAllAndFlush(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 
         // when
         List<UserQuest> result = userQuestService.getOrIssueTodayUserQuests(userId);
 
         // then
         assertEquals(3, result.size());
-        verify(userQuestRepository).saveAll(anyList());
+        assertAll(
+                () -> assertSame(user, result.get(0).getUser()),
+                () -> assertSame(user, result.get(1).getUser()),
+                () -> assertSame(user, result.get(2).getUser()),
+                () -> assertSame(dailyQuest1, result.get(0).getDailyQuest()),
+                () -> assertSame(dailyQuest2, result.get(1).getDailyQuest()),
+                () -> assertSame(dailyQuest3, result.get(2).getDailyQuest())
+        );
+        verify(userQuestRepository).saveAllAndFlush(anyList());
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/web/quest/QuestControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/quest/QuestControllerTest.java
@@ -1,0 +1,131 @@
+package com.solv.wefin.web.quest;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import com.solv.wefin.domain.quest.entity.QuestCompleteType;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.entity.QuestStatus;
+import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import com.solv.wefin.domain.quest.service.UserQuestService;
+import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.global.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(QuestController.class)
+@Import(GlobalExceptionHandler.class)
+class QuestControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UserQuestService userQuestService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("오늘의 퀘스트 목록을 반환한다")
+    void getTodayQuests_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        LocalDate today = LocalDate.now();
+
+        QuestTemplate template = buildTemplate();
+        DailyQuest dailyQuest = DailyQuest.create(template, today, 3, 100);
+        ReflectionTestUtils.setField(dailyQuest, "id", 11L);
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("questUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        UserQuest userQuest = UserQuest.assign(user, dailyQuest);
+        ReflectionTestUtils.setField(userQuest, "id", 21L);
+        ReflectionTestUtils.setField(userQuest, "status", QuestStatus.IN_PROGRESS);
+        ReflectionTestUtils.setField(userQuest, "progress", 1);
+
+        when(userQuestService.getOrIssueTodayUserQuests(userId)).thenReturn(List.of(userQuest));
+
+        // when // then
+        mockMvc.perform(get("/api/quests/today")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.questDate").value(today.toString()))
+                .andExpect(jsonPath("$.data.quests[0].questId").value(21))
+                .andExpect(jsonPath("$.data.quests[0].dailyQuestId").value(11))
+                .andExpect(jsonPath("$.data.quests[0].code").value("SEND_GROUP_CHAT"))
+                .andExpect(jsonPath("$.data.quests[0].status").value("IN_PROGRESS"))
+                .andExpect(jsonPath("$.data.quests[0].progress").value(1))
+                .andExpect(jsonPath("$.data.quests[0].targetValue").value(3))
+                .andExpect(jsonPath("$.data.quests[0].reward").value(100));
+    }
+
+    @Test
+    @DisplayName("활성 템플릿이 부족하면 500 에러를 반환한다")
+    void getTodayQuests_fail_when_template_not_enough() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        when(userQuestService.getOrIssueTodayUserQuests(userId))
+                .thenThrow(new BusinessException(ErrorCode.QUEST_TEMPLATE_NOT_ENOUGH));
+
+        // when // then
+        mockMvc.perform(get("/api/quests/today")
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.code").value("QUEST_TEMPLATE_NOT_ENOUGH"));
+    }
+
+    private QuestTemplate buildTemplate() {
+        QuestTemplate template = mock(QuestTemplate.class);
+
+        when(template.getId()).thenReturn(1L);
+        when(template.getCode()).thenReturn("SEND_GROUP_CHAT");
+        when(template.getTitle()).thenReturn("그룹 채팅 보내기");
+        when(template.getDescription()).thenReturn("그룹 채팅 메시지를 보내보세요.");
+        when(template.getCompleteType()).thenReturn(QuestCompleteType.COUNT);
+        when(template.getEventType()).thenReturn(QuestEventType.SEND_GROUP_CHAT);
+        when(template.getTargetValue()).thenReturn(3);
+        when(template.getReward()).thenReturn(100);
+        when(template.getRepeatable()).thenReturn(true);
+        when(template.getActive()).thenReturn(true);
+
+        return template;
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
"오늘의 공통 퀘스트 3개를 생성하고 사용자에게 발급하는 구조”를 구현하였습니다.

이를 위해 퀘스트의 원본 정의인 `quest_template`, 하루 공통 퀘스트 세트를 나타내는 `daily_quest`, 그리고 사용자별 상태를 관리하는 `user_quest`를 분리해서 설계했습니다.  
또한 오늘의 퀘스트가 아직 생성되지 않았다면 조회 시점에 생성하고, 이후에는 같은 값을 재사용하도록 해서 별도 스케줄러 없이도 오늘의 퀘스트를 안정적으로 제공할 수 있도록 했습니다.

추가로 퀘스트 조회 API와 서비스/컨트롤러 테스트까지 함께 정리해, 이후 프론트에서 오늘의 퀘스트 목록을 바로 붙일 수 있는 기반을 만들었습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[WEF-445] 퀘스트 생성 및 조회 기능 구현**
- [x] `quest_template`, `daily_quest`, `user_quest` 구조 기반 퀘스트 도메인 모델 설계
- [x] 퀘스트 상태/완료 방식/이벤트 타입 enum 정의
- [x] 하루 공통 퀘스트 3개 생성 로직 구현
- [x] 오늘의 퀘스트가 없을 때 lazy 생성하는 서비스 구현
- [x] 사용자별 오늘의 퀘스트 발급 로직 구현
- [x] 중복 발급 방지 제약 추가
- [x] 오늘의 퀘스트 목록 조회 API 구현
- [x] DailyQuest/UserQuest 서비스 테스트 및 Quest 컨트롤러 테스트 추가

<br>

## 💭 고민과 해결과정

이번 작업에서 가장 먼저 고민한 부분은 “퀘스트 생성”을 어떻게 해석할 것인가였습니다.  
처음에는 사용자 활동, 상태, 선호를 바탕으로 사용자마다 다른 퀘스트를 만들어내는 방식도 생각할 수 있었지만, 현재 단계에서는 개인화 추천 로직까지 함께 가져가면 구현 범위가 너무 커질 수 있다고 판단했습니다. 그래서 이번 1차 구현에서는 “개인화 퀘스트 생성”이 아니라 **미리 정의된 퀘스트 템플릿 중에서 오늘 제공할 퀘스트를 선정하고, 이를 사용자에게 발급하는 구조**로 문제를 다시 정의했습니다.

즉 퀘스트 생성이라는 말을 실제 구현에서는 세 단계로 나눠서 보게 되었습니다.

- `quest_template`: 퀘스트의 원본 정의
- `daily_quest`: 하루 동안 모든 사용자에게 공통으로 제공되는 퀘스트 세트
- `user_quest`: 각 사용자가 받은 퀘스트의 상태와 진행도

처음에는 `quest_template`와 `user_quest` 두 테이블만으로도 갈 수 있지 않을까 생각했지만, 하루 단위로 공통 퀘스트 3개를 뽑고 모든 유저에게 같은 목표치를 보여주려면 그날의 공통 퀘스트 자체를 따로 저장하는 단위가 필요하다고 봤습니다. 그래서 최종적으로 `daily_quest`를 중간에 두는 구조로 정리했습니다.

만약 `daily_quest` 없이 `user_quest`에만 바로 복사해 넣으면 “오늘 어떤 3개의 퀘스트가 선택되었는가”라는 공통 기준이 사용자 데이터에 흩어지게 됩니다. 반면 `daily_quest`가 있으면 오늘의 퀘스트 세트를 먼저 고정해두고, 그걸 각 사용자에게 발급하는 식으로 책임을 분리할 수 있습니다. 결과적으로 하루 공통 퀘스트의 원본과 사용자별 진행 상태를 분리할 수 있었고, 이후 운영이나 디버깅 시에도 훨씬 명확한 구조가 되었습니다.

퀘스트 종류가 아직 많지 않다 보니, 같은 퀘스트가 여러 날 반복되면 지루하게 느껴질 수 있다는 점이 걸렸습니다. 그래서 퀘스트 종류는 하루 단위로 공통으로 고정하되, 목표치는 그날의 공통 퀘스트를 생성할 때 랜덤하게 정하는 방향을 택했습니다. 다만 이 랜덤 값 역시 사용자마다 다르게 주는 것이 아니라, **그날 선택된 퀘스트의 목표치는 모든 유저가 동일하게 보도록** 설계했습니다. 이렇게 하면 공정성은 유지하면서도 반복 퀘스트에 어느 정도 변주를 줄 수 있다고 판단했습니다.

퀘스트를 언제 생성할지도 고민 포인트였습니다.  
처음에는 스케줄러로 매일 자정에 미리 생성하는 방법도 생각할 수 있었지만, 1차 구현에서는 배치 운영 복잡도를 줄이기 위해 **조회 시점 lazy 생성 방식**을 선택했습니다. 즉 사용자가 오늘의 퀘스트를 처음 요청했을 때 아직 `daily_quest`가 없으면 그때 생성하고, 이후에는 같은 날짜의 퀘스트를 재사용하도록 했습니다. 이렇게 하면 별도의 스케줄러 없이도 오늘의 퀘스트를 안정적으로 제공할 수 있고, 지금 단계에서 구현과 운영을 모두 단순하게 가져갈 수 있습니다.

마지막으로 `user_quest`는 최대한 “사용자별 상태”만 들고 있도록 정리했습니다.  
초기 구조에서는 템플릿 정보와 보상, 목표값까지 `user_quest`가 직접 갖도록 설계했지만, `daily_quest`가 생긴 이후에는 그 역할이 겹치게 되었습니다. 그래서 공통 퀘스트 정보는 `daily_quest`가 갖고, `user_quest`는 상태(`NOT_STARTED`, `IN_PROGRESS`, `COMPLETED`, `REWARDED`)와 진행도, 시작/완료 시점만 관리하도록 단순화했습니다. 이 덕분에 퀘스트 원본 정의, 하루 공통 퀘스트, 사용자별 상태가 각자 명확한 책임을 가지는 구조가 되었습니다.

정리하면 이번 작업은 “퀘스트를 어떻게 생성할 것인가”라는 질문에 대해,  
**개인화 엔진이 아니라 공통 퀘스트 세트 + 사용자별 발급 구조로 먼저 구현한다**는 방향을 선택한 과정이었습니다.  
그 결과 1차 버전에서는 복잡한 추천 로직 없이도 퀘스트 생성, 발급, 조회까지 이어지는 기본 틀을 만들 수 있었습니다.

<br>

### 🔗 관련 이슈
Closes #83

<br>


[WEF-445]: https://sol-v.atlassian.net/browse/WEF-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 일일 퀘스트 시스템 도입 — 템플릿 기반 일일 퀘스트 생성 및 사용자별 발행/조회 지원
  * 퀘스트 상태 전환(시작/진행/완료/보상) 및 일괄 발행 흐름 제공
  * 퀘스트 조회 API: GET /api/quests/today

* **Enhancements**
  * 퀘스트 유형·이벤트·완료 기준 및 활성화/비활성화 기능 추가
  * 중복 방지 제약과 자동 생성 규칙(일별 고정 개수, 목표치 산정) 도입

* **Tests**
  * 서비스 및 컨트롤러 단위 테스트 추가 (정상/오류/경계 시나리오)

* **Chores**
  * 관련 오류 코드(템플릿 부족, 진행/보상 검증 등) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->