### PR TITLE
[WEF-539] 포트폴리오 및 보유 종목 조회 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/batch/scheduler/StockCollectScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/game/batch/scheduler/StockCollectScheduler.java
@@ -23,31 +23,26 @@ public class StockCollectScheduler {
     }
 
     /**
-     * 하루 5회 × 320종목 = 1,600종목/일 → 2일이면 전 종목 완료
+     * 하루 4회 × 320종목 = 1,280종목/일 → 약 2일이면 전 종목 완료
      */
+    @Scheduled(cron = "0 42 1 * * *")
+    public void collectAt0142() {
+        runCollect("01:42");
+    }
+
+    @Scheduled(cron = "0 30 9 * * *")
+    public void collectAt0930() {
+        runCollect("09:30");
+    }
+
     @Scheduled(cron = "0 0 13 * * *")
     public void collectAt1300() {
         runCollect("13:00");
     }
 
-    @Scheduled(cron = "0 0 16 * * *")
-    public void collectAt1600() {
-        runCollect("16:00");
-    }
-
-    @Scheduled(cron = "0 0 20 * * *")
-    public void collectAt2000() {
-        runCollect("20:00");
-    }
-
-    @Scheduled(cron = "0 0 23 * * *")
-    public void collectAt2300() {
-        runCollect("23:00");
-    }
-
-    @Scheduled(cron = "0 30 2 * * *")
-    public void collectAt0230() {
-        runCollect("02:30");
+    @Scheduled(cron = "0 0 18 * * *")
+    public void collectAt1800() {
+        runCollect("18:00");
     }
 
     private void runCollect(String scheduleLabel) {

--- a/src/main/java/com/solv/wefin/domain/game/holding/repository/GameHoldingRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/holding/repository/GameHoldingRepository.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.stock.entity.StockInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +13,7 @@ public interface GameHoldingRepository extends JpaRepository<GameHolding, UUID> 
 
     /** 매수 시: 기존 보유 종목이 있는지 조회 (있으면 addQuantity, 없으면 create) */
     Optional<GameHolding> findByParticipantAndStockInfo(GameParticipant participant, StockInfo stockInfo);
+
+    /** 포트폴리오/보유종목 조회: 수량이 0보다 큰 보유종목만 조회 */
+    List<GameHolding> findAllByParticipantAndQuantityGreaterThan(GameParticipant participant, int quantity);
 }

--- a/src/main/java/com/solv/wefin/domain/game/news/service/NewsBatchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/service/NewsBatchService.java
@@ -18,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @RequiredArgsConstructor
 public class NewsBatchService {
 
-    private static final LocalDate COLLECT_START = LocalDate.of(2020, 1, 2);
+    private static final LocalDate COLLECT_START = LocalDate.of(2021, 1, 1);
     private static final LocalDate COLLECT_END = LocalDate.of(2024, 12, 31);
     private static final int BATCH_SIZE = 150;
     private static final long OPENAI_DELAY_MS = 1_000;

--- a/src/main/java/com/solv/wefin/domain/game/order/service/GameOrderService.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/service/GameOrderService.java
@@ -74,11 +74,11 @@ public class GameOrderService {
         StockInfo stockInfo = stockInfoRepository.findById(symbol)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_NOT_FOUND));
 
-        // 5. 턴 날짜의 시가 조회
+        // 5. 턴 날짜의 종가 조회
         StockDaily stockDaily = stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, currentTurn.getTurnDate())
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
 
-        BigDecimal price = stockDaily.getOpenPrice();
+        BigDecimal price = stockDaily.getClosePrice();
 
         // 6. 매수/매도 분기
         if (orderType == OrderType.BUY) {

--- a/src/main/java/com/solv/wefin/domain/game/participant/dto/HoldingInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/dto/HoldingInfo.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.game.participant.dto;
+
+import java.math.BigDecimal;
+
+public record HoldingInfo(
+        String symbol,
+        String stockName,
+        int quantity,
+        BigDecimal avgPrice,
+        BigDecimal currentPrice,
+        BigDecimal evalAmount,
+        BigDecimal profitRate
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/participant/dto/PortfolioInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/dto/PortfolioInfo.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.game.participant.dto;
+
+import java.math.BigDecimal;
+
+public record PortfolioInfo(
+        BigDecimal seedMoney,
+        BigDecimal cash,
+        BigDecimal stockValue,
+        BigDecimal totalAsset,
+        BigDecimal profitRate
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
@@ -68,9 +68,11 @@ public class GamePortfolioService {
         BigDecimal seedMoney = gameRoom.getSeed();
         BigDecimal cash = participant.getSeed();
         BigDecimal totalAsset = cash.add(stockValue).setScale(2, RoundingMode.HALF_UP);
-        BigDecimal profitRate = totalAsset.subtract(seedMoney)
-                .multiply(new BigDecimal("100"))
-                .divide(seedMoney, 2, RoundingMode.HALF_UP);
+        BigDecimal profitRate = seedMoney.compareTo(BigDecimal.ZERO) == 0
+                ? BigDecimal.ZERO
+                : totalAsset.subtract(seedMoney)
+                        .multiply(new BigDecimal("100"))
+                        .divide(seedMoney, 2, RoundingMode.HALF_UP);
 
         return new PortfolioInfo(seedMoney, cash, stockValue, totalAsset, profitRate);
     }
@@ -110,9 +112,12 @@ public class GamePortfolioService {
                     BigDecimal currentPrice = stockDaily.getClosePrice();
                     BigDecimal evalAmount = currentPrice.multiply(BigDecimal.valueOf(holding.getQuantity()))
                             .setScale(2, RoundingMode.HALF_UP);
-                    BigDecimal profitRate = currentPrice.subtract(holding.getAvgPrice())
-                            .multiply(new BigDecimal("100"))
-                            .divide(holding.getAvgPrice(), 2, RoundingMode.HALF_UP);
+                    BigDecimal avgPrice = holding.getAvgPrice();
+                    BigDecimal profitRate = avgPrice.compareTo(BigDecimal.ZERO) == 0
+                            ? BigDecimal.ZERO
+                            : currentPrice.subtract(avgPrice)
+                                    .multiply(new BigDecimal("100"))
+                                    .divide(avgPrice, 2, RoundingMode.HALF_UP);
 
                     return new HoldingInfo(
                             holding.getStockInfo().getSymbol(),

--- a/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
@@ -1,0 +1,148 @@
+package com.solv.wefin.domain.game.participant.service;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
+import com.solv.wefin.domain.game.participant.dto.HoldingInfo;
+import com.solv.wefin.domain.game.participant.dto.PortfolioInfo;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GamePortfolioService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final GameHoldingRepository gameHoldingRepository;
+    private final StockDailyRepository stockDailyRepository;
+
+    public PortfolioInfo getPortfolio(UUID roomId, UUID userId) {
+
+        // 1. 방 조회
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() != RoomStatus.IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
+        }
+
+        // 2. 참가자 조회
+        GameParticipant participant = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. 현재 턴 조회
+        GameTurn currentTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        LocalDate turnDate = currentTurn.getTurnDate();
+
+        // 4. 보유종목 평가금액 계산
+        BigDecimal stockValue = calculateStockValue(participant, turnDate)
+                .setScale(2, RoundingMode.HALF_UP);
+
+        // 5. 포트폴리오 조립
+        BigDecimal seedMoney = gameRoom.getSeed();
+        BigDecimal cash = participant.getSeed();
+        BigDecimal totalAsset = cash.add(stockValue).setScale(2, RoundingMode.HALF_UP);
+        BigDecimal profitRate = totalAsset.subtract(seedMoney)
+                .multiply(new BigDecimal("100"))
+                .divide(seedMoney, 2, RoundingMode.HALF_UP);
+
+        return new PortfolioInfo(seedMoney, cash, stockValue, totalAsset, profitRate);
+    }
+
+    public List<HoldingInfo> getHoldings(UUID roomId, UUID userId) {
+
+        // 1. 방 조회
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() != RoomStatus.IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
+        }
+
+        // 2. 참가자 조회
+        GameParticipant participant = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. 현재 턴 조회
+        GameTurn currentTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        LocalDate turnDate = currentTurn.getTurnDate();
+
+        // 4. 보유종목별 상세 정보 계산
+        List<GameHolding> holdings = gameHoldingRepository
+                .findAllByParticipantAndQuantityGreaterThan(participant, 0);
+
+        return holdings.stream()
+                .map(holding -> {
+                    StockDaily stockDaily = stockDailyRepository
+                            .findByStockInfoAndTradeDate(holding.getStockInfo(), turnDate)
+                            .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+
+                    BigDecimal currentPrice = stockDaily.getClosePrice();
+                    BigDecimal evalAmount = currentPrice.multiply(BigDecimal.valueOf(holding.getQuantity()))
+                            .setScale(2, RoundingMode.HALF_UP);
+                    BigDecimal profitRate = currentPrice.subtract(holding.getAvgPrice())
+                            .multiply(new BigDecimal("100"))
+                            .divide(holding.getAvgPrice(), 2, RoundingMode.HALF_UP);
+
+                    return new HoldingInfo(
+                            holding.getStockInfo().getSymbol(),
+                            holding.getStockName(),
+                            holding.getQuantity(),
+                            holding.getAvgPrice(),
+                            currentPrice,
+                            evalAmount,
+                            profitRate
+                    );
+                })
+                .toList();
+    }
+
+    private BigDecimal calculateStockValue(GameParticipant participant, LocalDate turnDate) {
+        List<GameHolding> holdings = gameHoldingRepository
+                .findAllByParticipantAndQuantityGreaterThan(participant, 0);
+
+        BigDecimal stockValue = BigDecimal.ZERO;
+
+        for (GameHolding holding : holdings) {
+            StockDaily stockDaily = stockDailyRepository
+                    .findByStockInfoAndTradeDate(holding.getStockInfo(), turnDate)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+
+            BigDecimal holdingValue = stockDaily.getClosePrice()
+                    .multiply(BigDecimal.valueOf(holding.getQuantity()));
+            stockValue = stockValue.add(holdingValue);
+        }
+
+        return stockValue;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
@@ -11,6 +11,7 @@ import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
 import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.entity.TurnStatus;
@@ -25,7 +26,10 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -103,11 +107,15 @@ public class GamePortfolioService {
         List<GameHolding> holdings = gameHoldingRepository
                 .findAllByParticipantAndQuantityGreaterThan(participant, 0);
 
+        // N+1 방지: 보유종목 전체의 주가를 한 번에 조회
+        Map<String, StockDaily> priceMap = buildPriceMap(holdings, turnDate);
+
         return holdings.stream()
                 .map(holding -> {
-                    StockDaily stockDaily = stockDailyRepository
-                            .findByStockInfoAndTradeDate(holding.getStockInfo(), turnDate)
-                            .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+                    StockDaily stockDaily = priceMap.get(holding.getStockInfo().getSymbol());
+                    if (stockDaily == null) {
+                        throw new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND);
+                    }
 
                     BigDecimal currentPrice = stockDaily.getClosePrice();
                     BigDecimal evalAmount = currentPrice.multiply(BigDecimal.valueOf(holding.getQuantity()))
@@ -136,12 +144,20 @@ public class GamePortfolioService {
         List<GameHolding> holdings = gameHoldingRepository
                 .findAllByParticipantAndQuantityGreaterThan(participant, 0);
 
+        if (holdings.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        // N+1 방지: 보유종목 전체의 주가를 한 번에 조회
+        Map<String, StockDaily> priceMap = buildPriceMap(holdings, turnDate);
+
         BigDecimal stockValue = BigDecimal.ZERO;
 
         for (GameHolding holding : holdings) {
-            StockDaily stockDaily = stockDailyRepository
-                    .findByStockInfoAndTradeDate(holding.getStockInfo(), turnDate)
-                    .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+            StockDaily stockDaily = priceMap.get(holding.getStockInfo().getSymbol());
+            if (stockDaily == null) {
+                throw new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND);
+            }
 
             BigDecimal holdingValue = stockDaily.getClosePrice()
                     .multiply(BigDecimal.valueOf(holding.getQuantity()));
@@ -149,5 +165,22 @@ public class GamePortfolioService {
         }
 
         return stockValue;
+    }
+
+    /**
+     * 보유종목 목록의 주가를 한 번의 쿼리로 일괄 조회하여 Map으로 반환한다.
+     * key: symbol (StockInfo PK), value: StockDaily
+     */
+    private Map<String, StockDaily> buildPriceMap(List<GameHolding> holdings, LocalDate turnDate) {
+        List<StockInfo> stockInfos = holdings.stream()
+                .map(GameHolding::getStockInfo)
+                .toList();
+
+        return stockDailyRepository.findAllByStockInfoInAndTradeDate(stockInfos, turnDate)
+                .stream()
+                .collect(Collectors.toMap(
+                        sd -> sd.getStockInfo().getSymbol(),
+                        Function.identity()
+                ));
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -36,6 +36,9 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     /** 특정 종목의 특정 날짜 주가 데이터 조회 (매수/매도 시 시가 조회용) */
     Optional<StockDaily> findByStockInfoAndTradeDate(StockInfo stockInfo, LocalDate tradeDate);
 
+    /** 여러 종목의 특정 날짜 주가 데이터 일괄 조회 (N+1 방지용) */
+    List<StockDaily> findAllByStockInfoInAndTradeDate(List<StockInfo> stockInfos, LocalDate tradeDate);
+
    //키워드 검색. 짧은 키워드 대량 조회 제한
     @Query("SELECT sd FROM StockDaily sd " +
             "JOIN FETCH sd.stockInfo si " +

--- a/src/main/java/com/solv/wefin/web/game/portfolio/GamePortfolioController.java
+++ b/src/main/java/com/solv/wefin/web/game/portfolio/GamePortfolioController.java
@@ -1,0 +1,49 @@
+package com.solv.wefin.web.game.portfolio;
+
+import com.solv.wefin.domain.game.participant.dto.HoldingInfo;
+import com.solv.wefin.domain.game.participant.dto.PortfolioInfo;
+import com.solv.wefin.domain.game.participant.service.GamePortfolioService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.portfolio.dto.response.HoldingResponse;
+import com.solv.wefin.web.game.portfolio.dto.response.PortfolioResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/rooms/{roomId}")
+@RequiredArgsConstructor
+public class GamePortfolioController {
+
+    private final GamePortfolioService portfolioService;
+
+    @GetMapping("/portfolio")
+    public ResponseEntity<ApiResponse<PortfolioResponse>> getPortfolio(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        PortfolioInfo info = portfolioService.getPortfolio(roomId, userId);
+        PortfolioResponse response = PortfolioResponse.from(info);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/holdings")
+    public ResponseEntity<ApiResponse<List<HoldingResponse>>> getHoldings(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        List<HoldingResponse> response = portfolioService.getHoldings(roomId, userId).stream()
+                .map(HoldingResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/portfolio/dto/response/HoldingResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/portfolio/dto/response/HoldingResponse.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.game.portfolio.dto.response;
+
+import com.solv.wefin.domain.game.participant.dto.HoldingInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class HoldingResponse {
+
+    private String symbol;
+    private String stockName;
+    private int quantity;
+    private BigDecimal avgPrice;
+    private BigDecimal currentPrice;
+    private BigDecimal evalAmount;
+    private BigDecimal profitRate;
+
+    public static HoldingResponse from(HoldingInfo info) {
+        return new HoldingResponse(
+                info.symbol(),
+                info.stockName(),
+                info.quantity(),
+                info.avgPrice(),
+                info.currentPrice(),
+                info.evalAmount(),
+                info.profitRate()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/portfolio/dto/response/PortfolioResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/portfolio/dto/response/PortfolioResponse.java
@@ -1,0 +1,28 @@
+package com.solv.wefin.web.game.portfolio.dto.response;
+
+import com.solv.wefin.domain.game.participant.dto.PortfolioInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class PortfolioResponse {
+
+    private BigDecimal seedMoney;
+    private BigDecimal cash;
+    private BigDecimal stockValue;
+    private BigDecimal totalAsset;
+    private BigDecimal profitRate;
+
+    public static PortfolioResponse from(PortfolioInfo info) {
+        return new PortfolioResponse(
+                info.seedMoney(),
+                info.cash(),
+                info.stockValue(),
+                info.totalAsset(),
+                info.profitRate()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/stock/dto/response/StockSearchResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/dto/response/StockSearchResponse.java
@@ -19,7 +19,7 @@ public class StockSearchResponse {
                 stockDaily.getStockInfo().getSymbol(),
                 stockDaily.getStockInfo().getStockName(),
                 stockDaily.getStockInfo().getMarket(),
-                stockDaily.getOpenPrice()
+                stockDaily.getClosePrice()
         );
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,10 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
 
+  jackson:
+    generator:
+      write-bigdecimal-as-plain: true
+
   flyway:
     enabled: true
     locations: classpath:db/migration

--- a/src/test/java/com/solv/wefin/domain/game/news/service/NewsBatchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/NewsBatchServiceTest.java
@@ -38,7 +38,7 @@ class NewsBatchServiceTest {
     @Mock
     private BriefingCacheRepository briefingCacheRepository;
 
-    private static final LocalDate COLLECT_START = LocalDate.of(2020, 1, 2);
+    private static final LocalDate COLLECT_START = LocalDate.of(2021, 1, 1);
     private static final LocalDate COLLECT_END = LocalDate.of(2024, 12, 31);
 
     // === 배치 수집 성공 테스트 ===
@@ -46,10 +46,10 @@ class NewsBatchServiceTest {
     @Test
     @DisplayName("배치 수집 성공 — 미처리 날짜만 처리한다")
     void collectBatch_success_processesUnprocessedDates() {
-        // Given — 1/2, 1/3은 이미 처리됨, 1/4, 1/5는 미처리
+        // Given — 1/1, 1/2는 이미 처리됨, 1/3, 1/4, 1/5는 미처리
         Set<LocalDate> existingDates = new HashSet<>();
-        existingDates.add(LocalDate.of(2020, 1, 2));
-        existingDates.add(LocalDate.of(2020, 1, 3));
+        existingDates.add(LocalDate.of(2021, 1, 1));
+        existingDates.add(LocalDate.of(2021, 1, 2));
 
         given(briefingCacheRepository.findExistingDatesBetween(COLLECT_START, COLLECT_END))
                 .willReturn(existingDates);
@@ -59,14 +59,14 @@ class NewsBatchServiceTest {
         // When — 3일치 배치 처리 요청
         int result = newsBatchService.collectBatch(3);
 
-        // Then — 미처리 3건 처리 (1/4, 1/5, 1/6)
+        // Then — 미처리 3건 처리 (1/3, 1/4, 1/5)
         assertThat(result).isEqualTo(3);
-        verify(briefingService).getBriefingForDate(LocalDate.of(2020, 1, 4));
-        verify(briefingService).getBriefingForDate(LocalDate.of(2020, 1, 5));
-        verify(briefingService).getBriefingForDate(LocalDate.of(2020, 1, 6));
+        verify(briefingService).getBriefingForDate(LocalDate.of(2021, 1, 3));
+        verify(briefingService).getBriefingForDate(LocalDate.of(2021, 1, 4));
+        verify(briefingService).getBriefingForDate(LocalDate.of(2021, 1, 5));
         // 이미 처리된 날짜는 호출되지 않음
-        verify(briefingService, never()).getBriefingForDate(LocalDate.of(2020, 1, 2));
-        verify(briefingService, never()).getBriefingForDate(LocalDate.of(2020, 1, 3));
+        verify(briefingService, never()).getBriefingForDate(LocalDate.of(2021, 1, 1));
+        verify(briefingService, never()).getBriefingForDate(LocalDate.of(2021, 1, 2));
     }
 
     // === 이미 처리된 날짜 스킵 테스트 ===
@@ -74,10 +74,10 @@ class NewsBatchServiceTest {
     @Test
     @DisplayName("이미 처리된 날짜 스킵 — 처리된 날짜 사이의 미처리만 처리")
     void collectBatch_skipsProcessedDates() {
-        // Given — 1/2는 처리됨, 1/3은 미처리, 1/4는 처리됨, 1/5는 미처리
+        // Given — 1/1은 처리됨, 1/2는 미처리, 1/3은 처리됨, 1/4는 미처리
         Set<LocalDate> existingDates = new HashSet<>();
-        existingDates.add(LocalDate.of(2020, 1, 2));
-        existingDates.add(LocalDate.of(2020, 1, 4));
+        existingDates.add(LocalDate.of(2021, 1, 1));
+        existingDates.add(LocalDate.of(2021, 1, 3));
 
         given(briefingCacheRepository.findExistingDatesBetween(COLLECT_START, COLLECT_END))
                 .willReturn(existingDates);
@@ -87,10 +87,10 @@ class NewsBatchServiceTest {
         // When — 2일치만 처리 요청
         int result = newsBatchService.collectBatch(2);
 
-        // Then — 미처리 2건 처리 (1/3, 1/5)
+        // Then — 미처리 2건 처리 (1/2, 1/4)
         assertThat(result).isEqualTo(2);
-        verify(briefingService).getBriefingForDate(LocalDate.of(2020, 1, 3));
-        verify(briefingService).getBriefingForDate(LocalDate.of(2020, 1, 5));
+        verify(briefingService).getBriefingForDate(LocalDate.of(2021, 1, 2));
+        verify(briefingService).getBriefingForDate(LocalDate.of(2021, 1, 4));
     }
 
     // === 모든 날짜 처리 완료 ===
@@ -180,9 +180,9 @@ class NewsBatchServiceTest {
         given(briefingCacheRepository.findExistingDatesBetween(COLLECT_START, COLLECT_END))
                 .willReturn(existingDates);
 
-        LocalDate day1 = LocalDate.of(2020, 1, 2);
-        LocalDate day2 = LocalDate.of(2020, 1, 3);
-        LocalDate day3 = LocalDate.of(2020, 1, 4);
+        LocalDate day1 = LocalDate.of(2021, 1, 1);
+        LocalDate day2 = LocalDate.of(2021, 1, 2);
+        LocalDate day3 = LocalDate.of(2021, 1, 3);
 
         given(briefingService.getBriefingForDate(day1)).willReturn("브리핑1");
         given(briefingService.getBriefingForDate(day2))

--- a/src/test/java/com/solv/wefin/domain/game/order/service/GameOrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/order/service/GameOrderServiceTest.java
@@ -408,9 +408,9 @@ class GameOrderServiceTest {
         return StockInfo.create(TEST_SYMBOL, "삼성전자", "KOSPI", "전기전자");
     }
 
-    private StockDaily createStockDaily(StockInfo stockInfo, BigDecimal openPrice) {
+    private StockDaily createStockDaily(StockInfo stockInfo, BigDecimal closePrice) {
         return StockDaily.create(stockInfo, TEST_TRADE_DATE,
-                openPrice, openPrice, openPrice, openPrice,
+                closePrice, closePrice, closePrice, closePrice,
                 BigDecimal.valueOf(1000000), BigDecimal.ZERO);
     }
 }

--- a/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
@@ -98,8 +98,8 @@ class GamePortfolioServiceTest {
             setupCommonMocks(room, participant, turn);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holding));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
-                    .willReturn(Optional.of(stockDaily));
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung), TEST_TRADE_DATE))
+                    .willReturn(List.of(stockDaily));
 
             PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
 
@@ -129,10 +129,8 @@ class GamePortfolioServiceTest {
             setupCommonMocks(room, participant, turn);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holdingSamsung, holdingSk));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
-                    .willReturn(Optional.of(samsungDaily));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(sk, TEST_TRADE_DATE))
-                    .willReturn(Optional.of(skDaily));
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung, sk), TEST_TRADE_DATE))
+                    .willReturn(List.of(samsungDaily, skDaily));
 
             PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
 
@@ -211,8 +209,8 @@ class GamePortfolioServiceTest {
             setupCommonMocks(room, participant, turn);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holding));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, TEST_TRADE_DATE))
-                    .willReturn(Optional.empty());
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(stockInfo), TEST_TRADE_DATE))
+                    .willReturn(List.of());
 
             assertThatThrownBy(() -> portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID))
                     .isInstanceOf(BusinessException.class)
@@ -255,8 +253,8 @@ class GamePortfolioServiceTest {
             setupCommonMocks(room, participant, turn);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holding));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
-                    .willReturn(Optional.of(stockDaily));
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung), TEST_TRADE_DATE))
+                    .willReturn(List.of(stockDaily));
 
             List<HoldingInfo> result = portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID);
 
@@ -288,10 +286,8 @@ class GamePortfolioServiceTest {
             setupCommonMocks(room, participant, turn);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holdingSamsung, holdingSk));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
-                    .willReturn(Optional.of(samsungDaily));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(sk, TEST_TRADE_DATE))
-                    .willReturn(Optional.of(skDaily));
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung, sk), TEST_TRADE_DATE))
+                    .willReturn(List.of(samsungDaily, skDaily));
 
             List<HoldingInfo> result = portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID);
 
@@ -374,8 +370,8 @@ class GamePortfolioServiceTest {
             setupCommonMocks(room, participant, turn);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holding));
-            given(stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, TEST_TRADE_DATE))
-                    .willReturn(Optional.empty());
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(stockInfo), TEST_TRADE_DATE))
+                    .willReturn(List.of());
 
             assertThatThrownBy(() -> portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID))
                     .isInstanceOf(BusinessException.class)

--- a/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
@@ -1,0 +1,427 @@
+package com.solv.wefin.domain.game.participant.service;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
+import com.solv.wefin.domain.game.participant.dto.HoldingInfo;
+import com.solv.wefin.domain.game.participant.dto.PortfolioInfo;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GamePortfolioServiceTest {
+
+    @InjectMocks
+    private GamePortfolioService portfolioService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+    @Mock
+    private GameHoldingRepository gameHoldingRepository;
+    @Mock
+    private StockDailyRepository stockDailyRepository;
+
+    private static final UUID TEST_ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final LocalDate TEST_TRADE_DATE = LocalDate.of(2022, 3, 2);
+
+    // === 포트폴리오 성공 테스트 ===
+
+    @Nested
+    @DisplayName("포트폴리오 조회 성공")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("보유종목 없음 — cash = seed, stockValue = 0")
+        void portfolio_noHoldings() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            GameTurn turn = createGameTurn(room);
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of());
+
+            PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
+
+            assertThat(result.seedMoney()).isEqualByComparingTo(new BigDecimal("10000000"));
+            assertThat(result.cash()).isEqualByComparingTo(new BigDecimal("10000000"));
+            assertThat(result.stockValue()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("10000000"));
+            assertThat(result.profitRate()).isEqualByComparingTo(new BigDecimal("0.00"));
+        }
+
+        @Test
+        @DisplayName("보유종목 1개 — 종가 기준 평가금액 계산")
+        void portfolio_oneHolding() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("5000000"));
+            GameTurn turn = createGameTurn(room);
+            StockInfo samsung = createStockInfo("005930", "삼성전자");
+            GameHolding holding = GameHolding.create(participant, samsung, 10, new BigDecimal("55000"));
+            StockDaily stockDaily = createStockDaily(samsung, new BigDecimal("60000"));
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holding));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
+                    .willReturn(Optional.of(stockDaily));
+
+            PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
+
+            assertThat(result.stockValue()).isEqualByComparingTo(new BigDecimal("600000"));
+            assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("5600000"));
+            BigDecimal expectedRate = new BigDecimal("5600000").subtract(new BigDecimal("10000000"))
+                    .multiply(new BigDecimal("100"))
+                    .divide(new BigDecimal("10000000"), 2, RoundingMode.HALF_UP);
+            assertThat(result.profitRate()).isEqualByComparingTo(expectedRate);
+        }
+
+        @Test
+        @DisplayName("보유종목 여러 개 — 전체 stockValue 합산")
+        void portfolio_multipleHoldings() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("3000000"));
+            GameTurn turn = createGameTurn(room);
+
+            StockInfo samsung = createStockInfo("005930", "삼성전자");
+            StockInfo sk = createStockInfo("000660", "SK하이닉스");
+            GameHolding holdingSamsung = GameHolding.create(participant, samsung, 10, new BigDecimal("55000"));
+            GameHolding holdingSk = GameHolding.create(participant, sk, 5, new BigDecimal("120000"));
+
+            StockDaily samsungDaily = createStockDaily(samsung, new BigDecimal("60000"));
+            StockDaily skDaily = createStockDaily(sk, new BigDecimal("130000"));
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holdingSamsung, holdingSk));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
+                    .willReturn(Optional.of(samsungDaily));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(sk, TEST_TRADE_DATE))
+                    .willReturn(Optional.of(skDaily));
+
+            PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
+
+            assertThat(result.stockValue()).isEqualByComparingTo(new BigDecimal("1250000"));
+            assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("4250000"));
+            assertThat(result.profitRate()).isEqualByComparingTo(new BigDecimal("-57.50"));
+        }
+    }
+
+    // === 포트폴리오 실패 테스트 ===
+
+    @Nested
+    @DisplayName("포트폴리오 조회 실패")
+    class FailTests {
+
+        @Test
+        @DisplayName("실패 — 방이 존재하지 않음")
+        void fail_roomNotFound() {
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 게임 미시작 (WAITING 상태)")
+        void fail_gameNotStarted() {
+            GameRoom room = createWaitingRoom();
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("실패 — 참가자가 아님")
+        void fail_notParticipant() {
+            GameRoom room = createGameRoom();
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("실패 — ACTIVE 턴 없음")
+        void fail_noActiveTurn() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("실패 — 보유종목의 주가 데이터 없음")
+        void fail_stockPriceNotFound() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            GameTurn turn = createGameTurn(room);
+            StockInfo stockInfo = createStockInfo("005930", "삼성전자");
+            GameHolding holding = GameHolding.create(participant, stockInfo, 10, new BigDecimal("55000"));
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holding));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, TEST_TRADE_DATE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_STOCK_PRICE_NOT_FOUND);
+        }
+    }
+
+    // === 보유종목 성공 테스트 ===
+
+    @Nested
+    @DisplayName("보유종목 조회 성공")
+    class HoldingsSuccessTests {
+
+        @Test
+        @DisplayName("보유종목 없음 — 빈 리스트 반환")
+        void holdings_noHoldings() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            GameTurn turn = createGameTurn(room);
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of());
+
+            List<HoldingInfo> result = portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("보유종목 1개 — 종가 기준 평가금액, 수익률 계산")
+        void holdings_oneHolding() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("5000000"));
+            GameTurn turn = createGameTurn(room);
+            StockInfo samsung = createStockInfo("005930", "삼성전자");
+            GameHolding holding = GameHolding.create(participant, samsung, 10, new BigDecimal("55000"));
+            StockDaily stockDaily = createStockDaily(samsung, new BigDecimal("60000"));
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holding));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
+                    .willReturn(Optional.of(stockDaily));
+
+            List<HoldingInfo> result = portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID);
+
+            assertThat(result).hasSize(1);
+            HoldingInfo info = result.get(0);
+            assertThat(info.symbol()).isEqualTo("005930");
+            assertThat(info.stockName()).isEqualTo("삼성전자");
+            assertThat(info.quantity()).isEqualTo(10);
+            assertThat(info.avgPrice()).isEqualByComparingTo(new BigDecimal("55000"));
+            assertThat(info.currentPrice()).isEqualByComparingTo(new BigDecimal("60000"));
+            assertThat(info.evalAmount()).isEqualByComparingTo(new BigDecimal("600000"));
+            assertThat(info.profitRate()).isEqualByComparingTo(new BigDecimal("9.09"));
+        }
+
+        @Test
+        @DisplayName("보유종목 여러 개 — 각 종목별 독립 계산")
+        void holdings_multipleHoldings() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("3000000"));
+            GameTurn turn = createGameTurn(room);
+
+            StockInfo samsung = createStockInfo("005930", "삼성전자");
+            StockInfo sk = createStockInfo("000660", "SK하이닉스");
+            GameHolding holdingSamsung = GameHolding.create(participant, samsung, 10, new BigDecimal("55000"));
+            GameHolding holdingSk = GameHolding.create(participant, sk, 5, new BigDecimal("120000"));
+            StockDaily samsungDaily = createStockDaily(samsung, new BigDecimal("60000"));
+            StockDaily skDaily = createStockDaily(sk, new BigDecimal("130000"));
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holdingSamsung, holdingSk));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(samsung, TEST_TRADE_DATE))
+                    .willReturn(Optional.of(samsungDaily));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(sk, TEST_TRADE_DATE))
+                    .willReturn(Optional.of(skDaily));
+
+            List<HoldingInfo> result = portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID);
+
+            assertThat(result).hasSize(2);
+
+            HoldingInfo skInfo = result.stream()
+                    .filter(h -> h.symbol().equals("000660"))
+                    .findFirst().orElseThrow();
+            assertThat(skInfo.evalAmount()).isEqualByComparingTo(new BigDecimal("650000"));
+            assertThat(skInfo.profitRate()).isEqualByComparingTo(new BigDecimal("8.33"));
+        }
+    }
+
+    // === 보유종목 실패 테스트 ===
+
+    @Nested
+    @DisplayName("보유종목 조회 실패")
+    class HoldingsFailTests {
+
+        @Test
+        @DisplayName("실패 — 방이 존재하지 않음")
+        void fail_roomNotFound() {
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 참가자가 아님")
+        void fail_notParticipant() {
+            GameRoom room = createGameRoom();
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("실패 — 게임 미시작 (WAITING 상태)")
+        void fail_gameNotStarted() {
+            GameRoom room = createWaitingRoom();
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("실패 — ACTIVE 턴 없음")
+        void fail_noActiveTurn() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("실패 — 보유종목의 주가 데이터 없음")
+        void fail_stockPriceNotFound() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
+            GameTurn turn = createGameTurn(room);
+            StockInfo stockInfo = createStockInfo("005930", "삼성전자");
+            GameHolding holding = GameHolding.create(participant, stockInfo, 10, new BigDecimal("55000"));
+
+            setupCommonMocks(room, participant, turn);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holding));
+            given(stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, TEST_TRADE_DATE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> portfolioService.getHoldings(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_STOCK_PRICE_NOT_FOUND);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private void setupCommonMocks(GameRoom room, GameParticipant participant, GameTurn turn) {
+        given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+        given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(turn));
+    }
+
+    private GameRoom createGameRoom() {
+        GameRoom room = GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
+                6, 7, TEST_TRADE_DATE, TEST_TRADE_DATE.plusMonths(6));
+        room.start();
+        return room;
+    }
+
+    private GameRoom createWaitingRoom() {
+        return GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
+                6, 7, TEST_TRADE_DATE, TEST_TRADE_DATE.plusMonths(6));
+    }
+
+    private GameTurn createGameTurn(GameRoom room) {
+        return GameTurn.createFirst(room);
+    }
+
+    private GameParticipant createParticipant(GameRoom room, BigDecimal cash) {
+        GameParticipant participant = GameParticipant.createLeader(room, TEST_USER_ID);
+        participant.assignSeed(cash);
+        return participant;
+    }
+
+    private StockInfo createStockInfo(String symbol, String name) {
+        return StockInfo.create(symbol, name, "KOSPI", "전기전자");
+    }
+
+    private StockDaily createStockDaily(StockInfo stockInfo, BigDecimal closePrice) {
+        return StockDaily.create(stockInfo, TEST_TRADE_DATE,
+                closePrice, closePrice, closePrice, closePrice,
+                BigDecimal.valueOf(1000000), BigDecimal.ZERO);
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
<br>포트폴리오 조회 + 보유종목 조회 API 구현 및 종가 통일

## ✅ 완료한 기능 명세

- [x] 참가자의 시드머니, 보유 현금, 주식 평가금액, 총자산, 수익률 조회
- [x] 보유종목의 평가금액 현재 턴의 종가 기준으로 산출
- [x] 참가자가 보유한 종목별 수량, 평균매입단가, 현재가(종가), 평가금액, 수익률조회
- [x] 차트 및 매수 매도 시 종가로 통일
- [x]  BigDecimal JSON 직렬화 설정
<br>

## 📸 스크린샷

<br>
<img width="2938" height="1646" alt="image" src="https://github.com/user-attachments/assets/37159c22-0c40-4135-baf5-05b92df36205" />
<img width="1430" height="1162" alt="image" src="https://github.com/user-attachments/assets/4c0be286-4585-4206-8b1b-da0c65a94664" />
<img width="1404" height="1160" alt="image" src="https://github.com/user-attachments/assets/09a6ade1-c08e-496c-9a22-7513ea8090f9" />


## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #90 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게임 포트폴리오 API 추가: 포트폴리오 요약(초기자본·현금·주식평가액·총자산·수익률) 및 보유종목 상세 조회 제공
* **버그 수정**
  * 주식 가격 기준을 시가에서 종가로 변경(검색/주문/응답 전반에 반영)
* **테스트**
  * GamePortfolioService 단위 테스트 추가(다양한 성공/실패 시나리오 포함)
* **설정/기타**
  * BigDecimal 직렬화 옵션 추가 및 일괄 주식 수집 스케줄 조정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->