### PR TITLE
[WEF-600] 실시간 분봉 차트 WebSocket 연동

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -1,9 +1,6 @@
 package com.solv.wefin.domain.trading.market.client;
 
-import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
-import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
-import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
-import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -108,5 +105,29 @@ public class HantuMarketClient {
                 .header("tr_id", "FHKST01010300")
                 .header("custtype", "P")
                 .retrieve().body(HantuRecentTradeApiResponse.class);
+    }
+
+    /**
+     * 국내 주식 당일 분봉 시세를 조회합니다.
+     * @param stockCode 종목코드
+     * @param inputHour 조회 시작 시간 (HHMMSS, ex: "153000")
+     * @return 분봉 시세 응답 (1분 단위 OHLCV)
+     */
+    public HantuMinuteCandleApiResponse fetchMinutePrice(String stockCode, String inputHour) {
+        return hantuRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-time-itemchartprice")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .queryParam("FID_INPUT_HOUR_1", inputHour)
+                        .queryParam("FID_ETC_CLS_CODE", "")
+                        .queryParam("FID_PW_DATA_INCU_YN", "N")
+                        .build())
+                .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST03010200")
+                .header("custtype", "P")
+                .retrieve().body(HantuMinuteCandleApiResponse.class);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuMinuteCandleApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuMinuteCandleApiResponse.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import java.util.List;
+
+public record HantuMinuteCandleApiResponse(
+        Output1 output1,
+        List<Output2> output2
+) {
+    public record Output1(String rt_cd, String msg_cd, String msg1) {}
+
+    public record Output2(
+            String stck_bsop_date,  // 영업일자 (YYYYMMDD)
+            String stck_cntg_hour,  // 체결시간 (HHMMSS)
+            String stck_prpr,       // 현재가(종가)
+            String stck_oprc,       // 시가
+            String stck_hgpr,       // 고가
+            String stck_lwpr,       // 저가
+            String cntg_vol         // 체결 거래량
+    ) {}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/CandleResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/CandleResponse.java
@@ -1,28 +1,50 @@
 package com.solv.wefin.domain.trading.market.dto;
 
 import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuMinuteCandleApiResponse;
 import com.solv.wefin.global.util.ParseUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 public record CandleResponse(
-        LocalDate date,
+        LocalDateTime date,
         BigDecimal openPrice,
         BigDecimal highPrice,
         BigDecimal lowPrice,
         BigDecimal closePrice,
         long volume
 ) {
+    // 일봉/주봉/월봉용
     public static CandleResponse from(HantuCandleApiResponse.Output2 output2) {
         return new CandleResponse(
-                LocalDate.parse(output2.stck_bsop_date(), DateTimeFormatter.ofPattern("yyyyMMdd")),
+                LocalDate.parse(output2.stck_bsop_date(), DateTimeFormatter.ofPattern("yyyyMMdd"))
+                        .atStartOfDay(),
                 ParseUtils.parseBigDecimal(output2.stck_oprc()),
                 ParseUtils.parseBigDecimal(output2.stck_hgpr()),
                 ParseUtils.parseBigDecimal(output2.stck_lwpr()),
                 ParseUtils.parseBigDecimal(output2.stck_clpr()),
                 ParseUtils.parseLong(output2.acml_vol())
+        );
+    }
+
+    // 분봉용
+    public static CandleResponse fromMinute(HantuMinuteCandleApiResponse.Output2 output2) {
+        // "20260413" + "093000" → LocalDateTime
+        LocalDate date = LocalDate.parse(output2.stck_bsop_date(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+        int hour = Integer.parseInt(output2.stck_cntg_hour().substring(0, 2));
+        int minute = Integer.parseInt(output2.stck_cntg_hour().substring(2, 4));
+        LocalDateTime dateTime = date.atTime(hour, minute);
+
+        return new CandleResponse(
+                dateTime,
+                ParseUtils.parseBigDecimal(output2.stck_oprc()),
+                ParseUtils.parseBigDecimal(output2.stck_hgpr()),
+                ParseUtils.parseBigDecimal(output2.stck_lwpr()),
+                ParseUtils.parseBigDecimal(output2.stck_prpr()),
+                ParseUtils.parseLong(output2.cntg_vol())
         );
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/MinuteCandleResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/MinuteCandleResponse.java
@@ -11,5 +11,6 @@ public record MinuteCandleResponse(
         BigDecimal highPrice,
         BigDecimal lowPrice,
         BigDecimal closePrice,
-        long volume
+        long volume,
+        String periodCode
 ) {}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -41,7 +41,7 @@ public class CandleGenerator {
         for (int period : PERIODS) {
             int floored = (minute / period) * period;
             String timeKey = String.format("%02d%02d", hour, floored);
-            String mapKey = stockCode + ":" + period + ":" + timeKey;
+            String mapKey = stockCode + ":" + period;
 
             final AtomicReference<CandleData> toPush = new AtomicReference<>();
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/CandleGenerator.java
@@ -22,8 +22,11 @@ public class CandleGenerator {
 
     private final SimpMessagingTemplate messagingTemplate;
 
+    // period 목록
+    private static final int[] PERIODS = {1, 5, 15, 30, 60};
+
     // 종목별 현재 생성중인 분봉
-    private final ConcurrentHashMap<String, MinuteCandleData> currentCandles = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CandleData> currentCandles = new ConcurrentHashMap<>();
 
     // 체결가 수신 시 호출
     public void onTrade(String stockCode, BigDecimal price, long volume, String tradeTime) {
@@ -31,59 +34,64 @@ public class CandleGenerator {
             log.warn("유효하지 않은 tradeTime: stockCode={}, tradeTime={}", stockCode, tradeTime);
             return;
         }
-        // tradeTime "112654" → 분 키 "1126" 추출
-        String minuteKey = tradeTime.substring(0, 4);
 
-        // onTrade 시작: 체결 수신 확인
-        // log.debug("캔들 체결 수신: {} price={} minute={}", stockCode, price, minuteKey);
+        int hour = Integer.parseInt(tradeTime.substring(0, 2));
+        int minute = Integer.parseInt(tradeTime.substring(2, 4));
 
-        final AtomicReference<MinuteCandleData> toPush = new AtomicReference<>();
+        for (int period : PERIODS) {
+            int floored = (minute / period) * period;
+            String timeKey = String.format("%02d%02d", hour, floored);
+            String mapKey = stockCode + ":" + period + ":" + timeKey;
 
-        currentCandles.compute(stockCode, (key, existing) -> {
-            if (existing == null || !existing.minuteKey.equals(minuteKey)) {
-                if (existing != null) {
-                    toPush.set(existing);
+            final AtomicReference<CandleData> toPush = new AtomicReference<>();
+
+            currentCandles.compute(mapKey, (key, existing) -> {
+                if (existing == null || !existing.timeKey.equals(timeKey)) {
+                    if (existing != null) {
+                        toPush.set(existing);
+                    }
+                    return new CandleData(timeKey, period, price, price, price, price, volume);
                 }
-                return new MinuteCandleData(minuteKey, price, price, price, price, volume);
-            }
-            existing.update(price, volume);
-            return existing;
-        });
+                existing.update(price, volume);
+                return existing;
+            });
 
-        if (toPush.get() != null) {
-            pushCandle(stockCode, toPush.get());
+            if (toPush.get() != null) {
+                pushCandle(stockCode, toPush.get());
+            }
         }
     }
 
-    private void pushCandle(String stockCode, MinuteCandleData data) {
-        // pushCandle: 분봉 확정 push
-        log.info("분봉 확정 push: {} time={} O={} H={} L={} C={} V={}",
-                stockCode, data.minuteKey, data.open, data.high, data.low, data.close, data.volume);
+    private void pushCandle(String stockCode, CandleData data) {
+        log.info("분봉 확정 push: {} period={}m time={} O={} H={} L={} C={} V={}",
+                stockCode, data.period, data.timeKey,
+                data.open, data.high, data.low, data.close, data.volume);
 
-        // "1126" → 오늘 날짜 11:26:00
         LocalDateTime time = LocalDate.now(ZoneId.of("Asia/Seoul"))
-                .atTime(Integer.parseInt(data.minuteKey.substring(0, 2)),
-                        Integer.parseInt(data.minuteKey.substring(2, 4)));
+                .atTime(Integer.parseInt(data.timeKey.substring(0, 2)),
+                        Integer.parseInt(data.timeKey.substring(2, 4)));
 
         MinuteCandleResponse response = new MinuteCandleResponse(
                 WebSocketMessageType.CANDLE,
                 stockCode,
                 time,
                 data.open, data.high, data.low, data.close,
-                data.volume
+                data.volume,
+                String.valueOf(data.period)
         );
         messagingTemplate.convertAndSend("/topic/stocks/" + stockCode + "/candle", response);
     }
 
-    // 분봉 데이터를 담는 내부 클래스
-    private static class MinuteCandleData {
-        String minuteKey;  // "1126"
+    private static class CandleData {
+        String timeKey;    // "1125"
+        int period;        // 5
         BigDecimal open, high, low, close;
         long volume;
 
-        MinuteCandleData(String minuteKey, BigDecimal open, BigDecimal high, BigDecimal low,
-                         BigDecimal close, long volume) {
-            this.minuteKey = minuteKey;
+        CandleData(String timeKey, int period, BigDecimal open, BigDecimal high,
+                   BigDecimal low, BigDecimal close, long volume) {
+            this.timeKey = timeKey;
+            this.period = period;
             this.open = open;
             this.high = high;
             this.low = low;
@@ -102,7 +110,9 @@ public class CandleGenerator {
     @Scheduled(cron = "0 30 15 * * MON-FRI", zone = "Asia/Seoul")
     public void flushAll() {
         log.info("장 마감 분봉 flush 시작");
-        currentCandles.forEach((stockCode, data) -> {
+        currentCandles.forEach((mapKey, data) -> {
+            // mapKey: "005930:5:1125" → stockCode 추출
+            String stockCode = mapKey.substring(0, mapKey.indexOf(':'));
             pushCandle(stockCode, data);
         });
         currentCandles.clear();

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
@@ -201,8 +202,10 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             return List.of();
         }
 
+        // 한투 API가 내림차순(최신→과거)으로 반환하므로 오름차순 정렬
         List<CandleResponse> oneMinuteCandles = response.output2().stream()
                 .map(CandleResponse::fromMinute)
+                .sorted(Comparator.comparing(CandleResponse::date))
                 .toList();
 
         // 1분봉이면 그대로 반환

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.trading.market.service;
 import com.solv.wefin.domain.trading.common.ExchangeRateProvider;
 import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
 import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuMinuteCandleApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
@@ -37,6 +38,7 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private final ConcurrentHashMap<String, Long> priceCacheTimestamp = new ConcurrentHashMap<>();
     private static final long CACHE_TTL_MS = 5000; // 5초
     private static final Set<String> VALID_PERIOD_CODES = Set.of("D", "W", "M", "Y");
+    private static final Set<String> MINUTE_PERIOD_CODES = Set.of("1", "5", "15", "30", "60");
 
     public PriceResponse getPrice(String stockCode) {
         validateStockCode(stockCode);
@@ -145,6 +147,13 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         }
 
         periodCode = periodCode.toUpperCase();
+
+        // 분봉 조회
+        if (MINUTE_PERIOD_CODES.contains(periodCode)) {
+            return getMinuteCandles(stockCode);
+        }
+
+        // 일봉/주봉/월봉 조회
         if (!VALID_PERIOD_CODES.contains(periodCode)) {
             throw new BusinessException(ErrorCode.MARKET_INVALID_PERIOD_CODE);
         }
@@ -156,7 +165,6 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             return List.of();
         }
 
-        // 한투 API 응답 코드 검증 (rt_cd "0"이면 정상)
         if (response.output1() != null) {
             validateRtCode(response.output1().rt_cd());
         }
@@ -168,7 +176,28 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         return response.output2().stream()
                     .map(CandleResponse::from)
                     .toList();
+    }
 
+    private List<CandleResponse> getMinuteCandles(String stockCode) {
+        // 장 마감 시간(153000)부터 역순으로 조회하면 당일 전체 분봉을 가져옴
+        HantuMinuteCandleApiResponse response = hantuMarketClient.fetchMinutePrice(stockCode, "153000");
+        log.info("분봉 API 응답: {}", response);
+
+        if (response == null) {
+            return List.of();
+        }
+
+        if (response.output1() != null) {
+            validateRtCode(response.output1().rt_cd());
+        }
+
+        if (response.output2() == null) {
+            return List.of();
+        }
+
+        return response.output2().stream()
+                    .map(CandleResponse::fromMinute)
+                    .toList();
     }
 
     public List<RecentTradeResponse> getRecentTrades(String stockCode) {

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -21,6 +21,9 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
@@ -150,7 +153,7 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
 
         // 분봉 조회
         if (MINUTE_PERIOD_CODES.contains(periodCode)) {
-            return getMinuteCandles(stockCode);
+            return getMinuteCandles(stockCode, Integer.parseInt(periodCode));
         }
 
         // 일봉/주봉/월봉 조회
@@ -178,7 +181,7 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
                     .toList();
     }
 
-    private List<CandleResponse> getMinuteCandles(String stockCode) {
+    private List<CandleResponse> getMinuteCandles(String stockCode, int periodMinutes) {
         // 장 마감 시간(153000)부터 역순으로 조회하면 당일 전체 분봉을 가져옴
         HantuMinuteCandleApiResponse response = hantuMarketClient.fetchMinutePrice(stockCode, "153000");
         log.info("분봉 API 응답: {}", response);
@@ -195,9 +198,54 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             return List.of();
         }
 
-        return response.output2().stream()
-                    .map(CandleResponse::fromMinute)
-                    .toList();
+        List<CandleResponse> oneMinuteCandles = response.output2().stream()
+                .map(CandleResponse::fromMinute)
+                .toList();
+
+        // 1분봉이면 그대로 반환
+        if (periodMinutes == 1) {
+            return oneMinuteCandles;
+        }
+
+        // N분봉 집계
+        return aggregateCandles(oneMinuteCandles, periodMinutes);
+    }
+
+    // date의 분을 period 단위로 내림한 값을 키로 그룹핑
+    // 예: 09:33 → 09:30 (5분봉), 09:47 → 09:45 (15분봉)
+    private List<CandleResponse> aggregateCandles(List<CandleResponse> candles, int periodMinutes) {
+        LinkedHashMap<LocalDateTime, List<CandleResponse>> groups = new LinkedHashMap<>();
+
+        for (CandleResponse candle : candles) {
+            int minute = candle.date().getMinute();
+            int floored = (minute / periodMinutes) * periodMinutes;
+            LocalDateTime groupKey = candle.date().withMinute(floored).withSecond(0);
+
+            groups.computeIfAbsent(groupKey, k -> new ArrayList<>()).add(candle);
+        }
+
+        // 각 그룹을 하나의 캔들로 합침
+        return groups.entrySet().stream()
+                .map(entry -> {
+                    LocalDateTime time = entry.getKey();
+                    List<CandleResponse> group = entry.getValue();
+
+                    BigDecimal open = group.get(0).openPrice();
+                    BigDecimal close = group.get(group.size()-1).closePrice();
+
+                    BigDecimal high = group.get(0).highPrice();
+                    BigDecimal low = group.get(0).lowPrice();
+                    long volume = 0L;
+
+                    for (CandleResponse candle : group) {
+                        if (candle.highPrice().compareTo(high) > 0) high = candle.highPrice();
+                        if (candle.lowPrice().compareTo(low) < 0) low = candle.lowPrice();
+                        volume += candle.volume();
+                    }
+
+                    return new CandleResponse(time, open, high, low, close, volume);
+                })
+                .toList();
     }
 
     public List<RecentTradeResponse> getRecentTrades(String stockCode) {

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -22,6 +22,8 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -182,8 +184,9 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     }
 
     private List<CandleResponse> getMinuteCandles(String stockCode, int periodMinutes) {
-        // 장 마감 시간(153000)부터 역순으로 조회하면 당일 전체 분봉을 가져옴
-        HantuMinuteCandleApiResponse response = hantuMarketClient.fetchMinutePrice(stockCode, "153000");
+        // 현재 KST 시간 기준으로 분봉 조회 (역순으로 반환됨)
+        String inputHour = LocalDateTime.now(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ofPattern("HHmmss"));
+        HantuMinuteCandleApiResponse response = hantuMarketClient.fetchMinutePrice(stockCode, inputHour);
         log.info("분봉 API 응답: {}", response);
 
         if (response == null) {


### PR DESCRIPTION
## 📌 PR 설명
CandleGenerator를 확장하여 1분봉뿐 아니라 5분/15분/30분/60분봉을 동시에 집계하고 CANDLE 타입 WebSocket으로 push합니다. 
프론트에서 payload의 periodCode로 필요한 분봉만 필터링하여 차트에 반영할 수 있습니다.
<br>

## ✅ 완료한 기능 명세
- [x] CandleGenerator: period별(1/5/15/30/60) 캔들 동시 집계
- [x] 분봉 확정 시 periodCode 포함하여 `/topic/stocks/{code}/candle`로 push
- [x] MinuteCandleResponse에 periodCode 필드 추가
- [x] 장 마감 시 전체 period 분봉 flush
- [x] 분봉 REST API: 한투 `inquire-time-itemchartprice` (FHKST03010200) 연동
- [x] HantuMinuteCandleApiResponse DTO 추가
- [x] HantuMarketClient.fetchMinutePrice() 추가
- [x] MarketService: periodCode 1/5/15/30/60이면 분봉 API로 분기
- [x] CandleResponse: LocalDate → LocalDateTime 통일 (일봉/분봉 호환)

<br>

## 📸 스크린샷
<img width="1028" height="910" alt="image" src="https://github.com/user-attachments/assets/1608ba22-b97b-481e-bec0-722c51bd62a0" />

### 🧪 테스트
 mock pusher(`CandleMockPusher`)로 5초마다 가짜 CANDLE 메시지를 push하여 장외시간에 테스트 완료 후 삭제.
 - [x] 1분봉 탭: 실시간 캔들 생성 및 업데이트 확인
  - [x] 5분봉 탭: periodCode 필터링 정상 동작 확인
  - [x] 탭 전환 시 해당 period 캔들만 표시 확인
  - [x] CANDLE WS 메시지 파싱 정상 (Zod schema 검증 통과)
  - [x] 일봉/주봉/월봉 탭: 기존 REST + price 실시간 업데이트 정상 유지

### 미확인 (장중 테스트 필요)
- [x] 한투 분봉 REST API 응답 파싱 정상 여부
- [x] 분봉 탭에서 REST 초기 데이터 + WS 실시간 캔들 동시 동작
- [x] 5분/15분/30분/1시간 탭별 데이터 정확성

<br>

## 💭 고민과 해결과정
### **토픽 분리 vs payload 구분**
period별 토픽 분리(`/candle/5`)는 탭 전환 시 재구독 딜레이가 발생하므로, 단일 토픽 + payload의 periodCode로 구분하는 방식 채택

### **Map 키 설계**
`종목:period:시간키` 복합키로 하나의 ConcurrentHashMap에서 전체 period를 관리. period별 Map을 따로 두는 것보다 코드가 단순
<br>

### 🔗 관련 이슈
Closes #208 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 1/5/15/30/60분 단위 분봉 조회 및 캔들 생성 지원 추가
  * 외부 분봉 API 연동으로 분단위 시세 수집 기능 추가
  * 캔들 응답에 기간 식별자(period) 포함으로 기간별 구분 가능

* **Refactor**
  * 캔들 집계 로직을 다중 기간 동시 처리하도록 개선(주기별 개별 집계·플러시)
  * 캔들 날짜 표현을 날짜→날짜·시간으로 변경해 분단위 정밀도 보장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->