### PR TITLE
[WEF-579] 뉴스 기사 AI 종목 태깅 검증

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
@@ -16,7 +16,13 @@ public interface NewsArticleTagRepository extends JpaRepository<NewsArticleTag, 
      * 피드에 노출 가능한 클러스터에 속한 기사의 인기 태그를 조회한다.
      * 클러스터 수 기준 내림차순 정렬. Pageable로 limit 제어
      */
-    @Query("SELECT t.tagCode AS tagCode, t.tagName AS tagName, COUNT(DISTINCT nc.id) AS clusterCount " +
+    /**
+     * tagName이 아닌 tagCode만으로 그룹핑한다.
+     * SECTOR/TOPIC은 마스터 테이블이 없어 AI가 같은 코드에 다른 이름("기술"/"테크")을 붙이면
+     * (tagCode, tagName) 그룹이 쪼개져 집계가 왜곡된다. tagCode를 SoT로 삼고,
+     * 표시명은 MIN(tagName)으로 결정적으로 고정하여 쪼개짐을 원천 차단한다
+     */
+    @Query("SELECT t.tagCode AS tagCode, MIN(t.tagName) AS tagName, COUNT(DISTINCT nc.id) AS clusterCount " +
             "FROM NewsArticleTag t " +
             "JOIN NewsClusterArticle nca ON nca.newsArticleId = t.newsArticleId " +
             "JOIN NewsCluster nc ON nc.id = nca.newsClusterId " +
@@ -24,7 +30,7 @@ public interface NewsArticleTagRepository extends JpaRepository<NewsArticleTag, 
             "AND nc.status = :status " +
             "AND nc.summaryStatus IN :summaryStatuses " +
             "AND nc.title IS NOT NULL " +
-            "GROUP BY t.tagCode, t.tagName " +
+            "GROUP BY t.tagCode " +
             "ORDER BY COUNT(DISTINCT nc.id) DESC")
     List<PopularTagProjection> findPopularTags(
             @Param("tagType") NewsArticleTag.TagType tagType,

--- a/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
@@ -30,7 +30,7 @@ public class OpenAiTaggingClient {
             당신은 금융 뉴스 기사를 분석하여 태그를 추출하고 한 줄 요약을 작성하는 전문가입니다.
             기사를 읽고 다음을 추출하세요.
 
-            1. stocks: 기사에서 언급된 개별 종목 (코드와 한글 이름)
+            1. stocks: 기사에서 언급된 개별 종목 (한국 상장 종목만, 6자리 숫자 코드)
             2. sectors: 기사와 관련된 산업/섹터 (영문 코드와 한글 이름)
             3. topics: 기사의 주제/테마 (영문 코드와 한글 이름)
             4. summary: 기사 핵심 내용을 한 문장(50자 이내)으로 요약
@@ -39,7 +39,9 @@ public class OpenAiTaggingClient {
             규칙:
             - 각 카테고리는 최대 5개까지
             - 확실한 것만 포함 (추측 금지)
-            - 종목 코드는 한국 종목이면 6자리 숫자, 미국 종목이면 티커 심볼
+            - stocks는 한국 상장 종목의 6자리 숫자 코드만 사용한다
+              · 미국 티커(NVDA, TSLA 등), 지수(코스피, S&P500), 암호화폐는 stocks에 넣지 않음
+              · 미국 빅테크 뉴스는 sectors의 TECH로, 지수/시장 뉴스는 FINANCE로 분류
             - topic 코드는 대문자 영문 (예: EARNINGS, AI, REGULATION, IPO)
             - summary는 한글로 작성, 50자 이내
 

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/StockCodeValidator.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/StockCodeValidator.java
@@ -1,0 +1,45 @@
+package com.solv.wefin.domain.news.tagging.service;
+
+import com.solv.wefin.domain.trading.stock.repository.StockRepository;
+import com.solv.wefin.domain.trading.stock.repository.StockRepository.StockCodeNameProjection;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * AI가 생성한 종목 코드를 실제 마스터 테이블과 대조하여 검증/정규화한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockCodeValidator {
+
+    private final StockRepository stockRepository;
+
+    /**
+     * 현재 저장된 모든 종목의 `code → canonical name` 스냅샷을 반환한다.
+     *
+     * @return 종목 코드를 key, 정식 종목명을 value로 갖는 불변 Map
+     */
+    public Map<String, String> loadStockMap() {
+        Map<String, String> map = new HashMap<>();
+        int skipped = 0;
+        for (StockCodeNameProjection row : stockRepository.findAllStockCodeNamePairs()) {
+            String code = row.getCode();
+            String name = row.getName();
+            if (code == null || name == null) {
+                skipped++;
+                continue;
+            }
+            map.put(code, name);
+        }
+        if (skipped > 0) {
+            log.warn("종목 마스터 로드 중 null 포함 row 스킵 - count: {}", skipped);
+        }
+        return Collections.unmodifiableMap(map);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/StockCodeValidator.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/StockCodeValidator.java
@@ -12,6 +12,13 @@ import java.util.Map;
 
 /**
  * AI가 생성한 종목 코드를 실제 마스터 테이블과 대조하여 검증/정규화한다.
+ *
+ * 수명 주기: 이 클래스는 상태(캐시)를 보유하지 않는다. @Component 싱글톤이지만
+ * 내부 필드 캐싱이나 @PostConstruct 로드를 사용하지 않으므로, 호출자가
+ * {@link #loadStockMap()}을 부를 때마다 DB에서 최신 스냅샷을 새로 생성한다.
+ * 이 스냅샷의 유효 범위는 "호출자의 배치 1회(예: TaggingService#tagPendingArticles)"로
+ * 한정되며, 다음 배치에서는 다시 로드된다. 배치 실행 중 마스터가 갱신되어도
+ * 이미 로드된 스냅샷은 갱신되지 않는다
  */
 @Slf4j
 @Component
@@ -22,6 +29,10 @@ public class StockCodeValidator {
 
     /**
      * 현재 저장된 모든 종목의 `code → canonical name` 스냅샷을 반환한다.
+     *
+     * 호출 시점마다 DB를 새로 조회하여 불변 Map을 생성한다. 반환된 Map은
+     * 호출자의 배치 범위에서만 의미가 있으며, 장시간 재사용하면 최신 마스터와
+     * 어긋날 수 있으므로 배치 단위로 재호출해야 한다
      *
      * @return 종목 코드를 key, 정식 종목명을 value로 갖는 불변 Map
      */

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
@@ -16,7 +16,11 @@ import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * 태깅 생성 전체 흐름을 관리하는 서비스.
@@ -36,6 +40,7 @@ public class TaggingService {
     private final NewsArticleRepository newsArticleRepository;
     private final OpenAiTaggingClient openAiTaggingClient;
     private final TaggingPersistenceService persistenceService;
+    private final StockCodeValidator stockCodeValidator;
 
     /**
      * 크롤링 완료 + 태깅 미완료 기사를 조회하여 태그를 생성한다.
@@ -48,6 +53,10 @@ public class TaggingService {
             return;
         }
 
+        // 종목 마스터 스냅샷을 markProcessing 전에 로드한다.
+        Map<String, String> stockMap = stockCodeValidator.loadStockMap();
+        log.debug("종목 마스터 스냅샷 로드 완료 - 코드 수: {}", stockMap.size());
+
         persistenceService.markProcessing(targets);
 
         int successCount = 0;
@@ -55,7 +64,7 @@ public class TaggingService {
 
         for (int i = 0; i < targets.size(); i += PROCESS_CHUNK_SIZE) {
             List<NewsArticle> chunk = targets.subList(i, Math.min(i + PROCESS_CHUNK_SIZE, targets.size()));
-            int[] result = processChunk(chunk);
+            int[] result = processChunk(chunk, stockMap);
             successCount += result[0];
             failCount += result[1];
         }
@@ -74,15 +83,27 @@ public class TaggingService {
                 PageRequest.of(0, BATCH_SIZE));
     }
 
-    private int[] processChunk(List<NewsArticle> articles) {
+    private int[] processChunk(List<NewsArticle> articles, Map<String, String> stockMap) {
         List<NewsArticleTag> allTags = new ArrayList<>();
         List<NewsArticle> successArticles = new ArrayList<>();
         int failCount = 0;
 
         for (NewsArticle article : articles) {
             try {
-                List<NewsArticleTag> tags = generateTagsForArticle(article);
-                allTags.addAll(tags);
+                TagExtraction extracted = extractTags(article, stockMap);
+
+                // 필터링 후 유효 태그가 0개면 FAILED로 전환
+                if (extracted.tags().isEmpty()) {
+                    log.warn("유효 태그 0개 - articleId: {}", article.getId());
+                    persistenceService.markFailed(article.getId(), "유효 태그 0개 (AI 응답 품질)");
+                    failCount++;
+                    continue;
+                }
+
+                article.updateSummary(extracted.summary());
+                article.updateRelevance(extracted.relevance());
+
+                allTags.addAll(extracted.tags());
                 successArticles.add(article);
             } catch (Exception e) {
                 log.warn("태깅 실패 - articleId: {}", article.getId(), e);
@@ -104,52 +125,89 @@ public class TaggingService {
         return new int[]{successArticles.size(), failCount};
     }
 
-    private List<NewsArticleTag> generateTagsForArticle(NewsArticle article) {
+    /**
+     * AI 응답을 태그 목록 + 요약 + 관련성으로 추출한다. 엔티티 부작용 없음(pure)
+     *
+     * <p>STOCK: 마스터에 없는 코드는 스킵, 정상 코드는 마스터의 canonical name으로 강제.
+     * SECTOR/TOPIC: 대소문자/공백 정규화 + 중복 제거. 3종 태그 모두 (type+code) 기준 dedup</p>
+     */
+    private TagExtraction extractTags(NewsArticle article, Map<String, String> stockMap) {
         TaggingResult result = openAiTaggingClient.analyzeTags(article.getTitle(), article.getContent());
 
         if (result.isEmpty()) {
             throw new IllegalStateException("태깅 결과가 비어있습니다");
         }
 
-        article.updateSummary(result.getSummary());
-        article.updateRelevance(RelevanceStatus.from(result.getRelevance()));
-
         List<NewsArticleTag> tags = new ArrayList<>();
 
         if (result.getStocks() != null) {
+            Set<String> seenStockCodes = new HashSet<>();
             for (TaggingResult.TagItem item : result.getStocks()) {
+                String rawCode = item.getCode();
+                String code = rawCode == null ? null : rawCode.trim();
+                if (code == null || code.isEmpty() || !stockMap.containsKey(code)) {
+                    log.warn("마스터에 없는 STOCK 코드 스킵 - articleId: {}, rejectedCode: {}, tagName: {}",
+                            article.getId(), rawCode, item.getName());
+                    continue;
+                }
+                if (!seenStockCodes.add(code)) {
+                    continue; // AI가 같은 종목을 2번 반환한 경우 dedup
+                }
+                // 종목명은 AI 응답 대신 마스터의 canonical name으로 강제한다
+                // (code/name 불일치로 인기 태그 집계가 쪼개지는 문제를 방지)
                 tags.add(NewsArticleTag.builder()
                         .newsArticleId(article.getId())
                         .tagType(TagType.STOCK)
-                        .tagCode(item.getCode())
-                        .tagName(item.getName())
+                        .tagCode(code)
+                        .tagName(stockMap.get(code))
                         .build());
             }
         }
 
         if (result.getSectors() != null) {
-            for (TaggingResult.TagItem item : result.getSectors()) {
-                tags.add(NewsArticleTag.builder()
-                        .newsArticleId(article.getId())
-                        .tagType(TagType.SECTOR)
-                        .tagCode(item.getCode())
-                        .tagName(item.getName())
-                        .build());
-            }
+            addNormalizedTags(tags, result.getSectors(), TagType.SECTOR, article.getId());
         }
-
         if (result.getTopics() != null) {
-            for (TaggingResult.TagItem item : result.getTopics()) {
-                tags.add(NewsArticleTag.builder()
-                        .newsArticleId(article.getId())
-                        .tagType(TagType.TOPIC)
-                        .tagCode(item.getCode())
-                        .tagName(item.getName())
-                        .build());
-            }
+            addNormalizedTags(tags, result.getTopics(), TagType.TOPIC, article.getId());
         }
 
-        return tags;
+        return new TagExtraction(
+                tags,
+                result.getSummary(),
+                RelevanceStatus.from(result.getRelevance())
+        );
+    }
+
+    /**
+     * SECTOR/TOPIC 태그를 정규화(대문자/trim)하여 중복 제거 후 추가한다.
+     *
+     * LLM이 같은 코드를 "TECH" / "Tech" / "  TECH " 같이 다양하게 반환할 수 있어
+     * 인기 태그 집계에서 그룹이 쪼개지는 것을 방지한다. 이름은 AI 응답 그대로 사용
+     * (SECTOR/TOPIC는 마스터 테이블이 없음)
+     */
+    private void addNormalizedTags(List<NewsArticleTag> tags, List<TaggingResult.TagItem> items,
+                                   TagType type, Long articleId) {
+        Set<String> seen = new HashSet<>();
+        for (TaggingResult.TagItem item : items) {
+            String rawCode = item.getCode();
+            if (rawCode == null) continue;
+            String code = rawCode.trim().toUpperCase(Locale.ROOT);
+            if (code.isEmpty()) continue;
+            if (!seen.add(code)) continue;
+
+            tags.add(NewsArticleTag.builder()
+                    .newsArticleId(articleId)
+                    .tagType(type)
+                    .tagCode(code)
+                    .tagName(item.getName())
+                    .build());
+        }
+    }
+
+    /**
+     * 태그 추출 결과 (엔티티 부작용 없이 순수 값으로 전달)
+     */
+    private record TagExtraction(List<NewsArticleTag> tags, String summary, RelevanceStatus relevance) {
     }
 
     private int handleBatchSaveFailure(List<NewsArticle> articles, String errorMessage) {

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
@@ -143,6 +143,10 @@ public class TaggingService {
         if (result.getStocks() != null) {
             Set<String> seenStockCodes = new HashSet<>();
             for (TaggingResult.TagItem item : result.getStocks()) {
+                if (item == null) {
+                    log.warn("STOCK 배열 내 null 원소 스킵 - articleId: {}", article.getId());
+                    continue;
+                }
                 String rawCode = item.getCode();
                 String code = rawCode == null ? null : rawCode.trim();
                 if (code == null || code.isEmpty() || !stockMap.containsKey(code)) {
@@ -189,6 +193,10 @@ public class TaggingService {
                                    TagType type, Long articleId) {
         Set<String> seen = new HashSet<>();
         for (TaggingResult.TagItem item : items) {
+            if (item == null) {
+                log.warn("{} 배열 내 null 원소 스킵 - articleId: {}", type, articleId);
+                continue;
+            }
             String rawCode = item.getCode();
             if (rawCode == null) continue;
             String code = rawCode.trim().toUpperCase(Locale.ROOT);

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
@@ -53,7 +53,7 @@ public class TaggingService {
             return;
         }
 
-        // 종목 마스터 스냅샷을 markProcessing 전에 로드한다.
+        // 종목 마스터 스냅샷을 markProcessing 전에 로드한다 (배치 1회 로드, 배치 종료 시 GC).
         Map<String, String> stockMap = stockCodeValidator.loadStockMap();
         log.debug("종목 마스터 스냅샷 로드 완료 - 코드 수: {}", stockMap.size());
 

--- a/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepository.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/repository/StockRepository.java
@@ -2,10 +2,24 @@ package com.solv.wefin.domain.trading.stock.repository;
 
 import com.solv.wefin.domain.trading.stock.entity.Stock;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StockRepository extends JpaRepository<Stock, Long>, StockRepositoryCustom {
     boolean existsByStockCode(String stockCode);
     Optional<Stock> findByStockCode(String stockCode);
+
+    /**
+     * 모든 종목의 코드와 정식 이름을 반환한다.
+     * AI 태깅 검증 시 코드 비교 및 종목명 정규화(canonicalize)에 사용된다.
+     */
+    @Query("SELECT s.stockCode AS code, s.stockName AS name FROM Stock s")
+    List<StockCodeNameProjection> findAllStockCodeNamePairs();
+
+    interface StockCodeNameProjection {
+        String getCode();
+        String getName();
+    }
 }

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -25,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.lenient;
 
 @ExtendWith(MockitoExtension.class)
 class TaggingServiceTest {
@@ -35,6 +37,8 @@ class TaggingServiceTest {
     private OpenAiTaggingClient openAiTaggingClient;
     @Mock
     private TaggingPersistenceService persistenceService;
+    @Mock
+    private StockCodeValidator stockCodeValidator;
     @Captor
     private ArgumentCaptor<List<NewsArticleTag>> tagsCaptor;
     @Captor
@@ -45,7 +49,13 @@ class TaggingServiceTest {
 
     @BeforeEach
     void setUp() {
-        taggingService = new TaggingService(newsArticleRepository, openAiTaggingClient, persistenceService);
+        taggingService = new TaggingService(newsArticleRepository, openAiTaggingClient,
+                persistenceService, stockCodeValidator);
+        lenient().when(stockCodeValidator.loadStockMap())
+                .thenReturn(java.util.Map.of(
+                        "005930", "삼성전자",
+                        "000660", "SK하이닉스",
+                        "035720", "카카오"));
     }
 
     @Test
@@ -144,6 +154,337 @@ class TaggingServiceTest {
                         NewsArticleTag.TagType.STOCK,
                         NewsArticleTag.TagType.SECTOR,
                         NewsArticleTag.TagType.TOPIC);
+    }
+
+    @Test
+    @DisplayName("마스터에 없는 STOCK 코드는 스킵되고 SECTOR/TOPIC은 그대로 저장된다")
+    void tagPendingArticles_invalidStockCode_skippedButOthersKept() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        // stocks 중 마스터에 없는 코드(357600) 포함
+        String json = """
+                {
+                  "stocks": [
+                    {"code": "005930", "name": "삼성전자"},
+                    {"code": "357600", "name": "쿠팡"}
+                  ],
+                  "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then — 유효한 STOCK 1개 + SECTOR 1개 + TOPIC 1개만 저장
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        List<NewsArticleTag> savedTags = tagsCaptor.getValue();
+        assertThat(savedTags).hasSize(3);
+        assertThat(savedTags).extracting(NewsArticleTag::getTagCode)
+                .doesNotContain("357600")
+                .contains("005930", "SEMICONDUCTOR", "EARNINGS");
+    }
+
+    @Test
+    @DisplayName("STOCK 코드가 null이면 스킵한다")
+    void tagPendingArticles_nullStockCode_skipped() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": null, "name": "코드없음"}],
+                  "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then — STOCK 없이 SECTOR/TOPIC만 저장
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        List<NewsArticleTag> savedTags = tagsCaptor.getValue();
+        assertThat(savedTags).extracting(NewsArticleTag::getTagType)
+                .doesNotContain(NewsArticleTag.TagType.STOCK);
+    }
+
+    @Test
+    @DisplayName("모든 STOCK 코드가 마스터에 없어도 SECTOR/TOPIC이 있으면 그 기사는 성공 처리")
+    void tagPendingArticles_allStockCodesInvalid_butOtherTagsExist_succeeds() throws Exception {
+        // given
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [
+                    {"code": "999999", "name": "없는종목"},
+                    {"code": "888888", "name": "또없는종목"}
+                  ],
+                  "sectors": [{"code": "SEMICONDUCTOR", "name": "반도체"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then — SECTOR/TOPIC 2개만 저장, 기사는 성공
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), articlesCaptor.capture());
+        assertThat(tagsCaptor.getValue()).hasSize(2);
+        assertThat(tagsCaptor.getValue()).extracting(NewsArticleTag::getTagType)
+                .doesNotContain(NewsArticleTag.TagType.STOCK);
+        assertThat(articlesCaptor.getValue()).hasSize(1);
+        verify(persistenceService, never()).markFailed(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("필터링 후 유효 태그가 0개면 기사를 FAILED로 마킹한다 (PROCESSING 잔류 방지)")
+    void tagPendingArticles_zeroValidTags_marksFailed() throws Exception {
+        // given: stocks만 모두 invalid, sectors/topics 비어있음
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": "999999", "name": "없는종목"}],
+                  "sectors": [],
+                  "topics": []
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then — saveTagsBatch 호출 안 됨, markFailed로 PROCESSING 해소
+        verify(persistenceService, never()).saveTagsBatch(anyList(), anyList());
+        verify(persistenceService).markFailed(eq(1L), contains("유효 태그 0개"));
+    }
+
+    @Test
+    @DisplayName("STOCK 코드가 유효하면 tagName은 마스터의 canonical name으로 강제된다")
+    void tagPendingArticles_stockTagName_usesMasterCanonicalName() throws Exception {
+        // given: AI가 올바른 코드에 잘못된 이름 ("삼전")을 붙인 케이스
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": "005930", "name": "삼전"}],
+                  "sectors": [{"code": "TECH", "name": "기술"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then — tagName은 AI가 보낸 "삼전"이 아니라 마스터의 "삼성전자"
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        NewsArticleTag stockTag = tagsCaptor.getValue().stream()
+                .filter(t -> t.getTagType() == NewsArticleTag.TagType.STOCK)
+                .findFirst().orElseThrow();
+        assertThat(stockTag.getTagCode()).isEqualTo("005930");
+        assertThat(stockTag.getTagName()).isEqualTo("삼성전자");
+    }
+
+    @Test
+    @DisplayName("유효 태그 0개일 때 summary/relevance는 persist되지 않는다 (부작용 분리)")
+    void tagPendingArticles_zeroValidTags_doesNotMutateArticle() throws Exception {
+        // given: 유효 태그 0개 AI 응답
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": "999999", "name": "없는종목"}],
+                  "sectors": [],
+                  "topics": [],
+                  "summary": "무시되어야 할 요약",
+                  "relevance": "IRRELEVANT"
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        // when
+        taggingService.tagPendingArticles();
+
+        // then — markFailed 호출되고, article 엔티티의 summary/relevance는 변경 없음
+        verify(persistenceService).markFailed(eq(1L), contains("유효 태그 0개"));
+        verify(persistenceService, never()).saveTagsBatch(anyList(), anyList());
+        NewsArticle original = articles.get(0);
+        assertThat(original.getSummary()).isNull();
+        assertThat(original.getRelevance()).isEqualTo(NewsArticle.RelevanceStatus.PENDING); // default 유지
+    }
+
+    @Test
+    @DisplayName("유효 태그가 있을 때만 summary/relevance가 엔티티에 반영된다")
+    void tagPendingArticles_hasValidTags_mutatesArticle() throws Exception {
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": "005930", "name": "삼성전자"}],
+                  "sectors": [{"code": "TECH", "name": "기술"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}],
+                  "summary": "삼성전자 실적 호조",
+                  "relevance": "FINANCIAL"
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        taggingService.tagPendingArticles();
+
+        NewsArticle article = articles.get(0);
+        assertThat(article.getSummary()).isEqualTo("삼성전자 실적 호조");
+        assertThat(article.getRelevance()).isEqualTo(NewsArticle.RelevanceStatus.FINANCIAL);
+    }
+
+    @Test
+    @DisplayName("같은 STOCK 코드가 중복 반환되면 한 번만 저장된다")
+    void tagPendingArticles_duplicateStockCode_deduplicated() throws Exception {
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [
+                    {"code": "005930", "name": "삼성전자"},
+                    {"code": "005930", "name": "삼성"}
+                  ],
+                  "sectors": [{"code": "TECH", "name": "기술"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        taggingService.tagPendingArticles();
+
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        long stockCount = tagsCaptor.getValue().stream()
+                .filter(t -> t.getTagType() == NewsArticleTag.TagType.STOCK)
+                .count();
+        assertThat(stockCount).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("공백 포함 STOCK 코드는 trim 후 매칭된다")
+    void tagPendingArticles_whitespaceInStockCode_trimmed() throws Exception {
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": " 005930 ", "name": "삼성전자"}],
+                  "sectors": [{"code": "TECH", "name": "기술"}],
+                  "topics": [{"code": "EARNINGS", "name": "실적"}]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        taggingService.tagPendingArticles();
+
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        assertThat(tagsCaptor.getValue()).extracting(NewsArticleTag::getTagCode)
+                .contains("005930"); // trim 후 매칭 + 저장된 코드도 trim된 값
+    }
+
+    @Test
+    @DisplayName("SECTOR/TOPIC 코드는 대소문자/공백 정규화 + 중복 제거된다")
+    void tagPendingArticles_sectorTopic_normalizedAndDeduped() throws Exception {
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": "005930", "name": "삼성전자"}],
+                  "sectors": [
+                    {"code": "Tech", "name": "기술"},
+                    {"code": " TECH ", "name": "Technology"}
+                  ],
+                  "topics": [
+                    {"code": "earnings", "name": "실적"},
+                    {"code": "EARNINGS", "name": "실적"}
+                  ]
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        taggingService.tagPendingArticles();
+
+        verify(persistenceService).saveTagsBatch(tagsCaptor.capture(), any());
+        List<NewsArticleTag> saved = tagsCaptor.getValue();
+
+        // SECTOR는 TECH 1개 (대소문자/공백 중복 제거)
+        assertThat(saved.stream().filter(t -> t.getTagType() == NewsArticleTag.TagType.SECTOR))
+                .hasSize(1)
+                .allMatch(t -> t.getTagCode().equals("TECH"));
+
+        // TOPIC은 EARNINGS 1개
+        assertThat(saved.stream().filter(t -> t.getTagType() == NewsArticleTag.TagType.TOPIC))
+                .hasSize(1)
+                .allMatch(t -> t.getTagCode().equals("EARNINGS"));
+    }
+
+    @Test
+    @DisplayName("유효 태그 0개 경로에서 loadStockMap → markProcessing → markFailed 순서 보장")
+    void tagPendingArticles_zeroValidTags_inOrder() throws Exception {
+        List<NewsArticle> articles = createArticles(1);
+        stubFindTargets(articles);
+
+        String json = """
+                {
+                  "stocks": [{"code": "999999", "name": "없는종목"}],
+                  "sectors": [],
+                  "topics": []
+                }
+                """;
+        TaggingResult result = objectMapper.readValue(json, TaggingResult.class);
+        given(openAiTaggingClient.analyzeTags(anyString(), anyString())).willReturn(result);
+
+        taggingService.tagPendingArticles();
+
+        InOrder inOrder = inOrder(stockCodeValidator, persistenceService);
+        inOrder.verify(stockCodeValidator).loadStockMap();
+        inOrder.verify(persistenceService).markProcessing(anyList());
+        inOrder.verify(persistenceService).markFailed(eq(1L), anyString());
+    }
+
+    @Test
+    @DisplayName("종목 마스터 로드 실패 시 markProcessing 호출 없이 예외 전파")
+    void tagPendingArticles_stockMapLoadFailure_doesNotMarkProcessing() {
+        // given
+        List<NewsArticle> articles = createArticles(2);
+        stubFindTargets(articles);
+        given(stockCodeValidator.loadStockMap())
+                .willThrow(new RuntimeException("DB 일시 장애"));
+
+        // when / then — 예외 전파되고 markProcessing은 호출되지 않아야 다음 배치에서 즉시 재시도 가능
+        try {
+            taggingService.tagPendingArticles();
+        } catch (RuntimeException ignored) {
+        }
+        verify(persistenceService, never()).markProcessing(anyList());
     }
 
     private void stubFindTargets(List<NewsArticle> articles) {

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -471,19 +472,19 @@ class TaggingServiceTest {
     }
 
     @Test
-    @DisplayName("종목 마스터 로드 실패 시 markProcessing 호출 없이 예외 전파")
-    void tagPendingArticles_stockMapLoadFailure_doesNotMarkProcessing() {
+    @DisplayName("종목 마스터 로드 실패 시 예외가 전파되고 markProcessing은 호출되지 않는다")
+    void tagPendingArticles_stockMapLoadFailure_throwsAndDoesNotMarkProcessing() {
         // given
         List<NewsArticle> articles = createArticles(2);
         stubFindTargets(articles);
         given(stockCodeValidator.loadStockMap())
                 .willThrow(new RuntimeException("DB 일시 장애"));
 
-        // when / then — 예외 전파되고 markProcessing은 호출되지 않아야 다음 배치에서 즉시 재시도 가능
-        try {
-            taggingService.tagPendingArticles();
-        } catch (RuntimeException ignored) {
-        }
+        // when / then — 예외가 실제로 전파되는지 assertThrows로 고정.
+        // markProcessing이 호출되지 않아야 다음 배치 틱에서 stale 대기 없이 즉시 재시도 가능
+        assertThatThrownBy(() -> taggingService.tagPendingArticles())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("DB 일시 장애");
         verify(persistenceService, never()).markProcessing(anyList());
     }
 


### PR DESCRIPTION
## 📌 PR 설명
AI 태깅 결과의 종목 코드를 `stock` 마스터 테이블과 대조하여 할루시네이션 코드(예: 쿠팡을 `357600`으로 반환)가 피드/상세 화면에 노출되는 것을 차단했습니다. 추가로 AI가 올바른 코드에 잘못된 종목명을 붙이는 케이스도 마스터의 표준 종목명으로 정규화하여 인기 태그 집계에서 `code/name` 불일치로 그룹이 쪼개지는 문제를 예방하도록 하였습니다. 

1. **종목 마스터 스냅샷 로드 (배치당 1회)**
   `StockRepository.findAllStockCodeNamePairs()` projection을 추가하여 엔티티 전체 로드를 피하고 code/name만 읽어옵니다. `StockCodeValidator`가 배치 시작 시 `Map<code, name>` 스냅샷을 만들어 메모리 조회로 검증합니다.

2. **할루시네이션 종목 코드 차단**
   AI가 반환한 STOCK 코드가 마스터에 없으면 해당 태그를 스킵하고 `rejectedCode`, `tagName`을 WARN 로그로 남깁니다. trim 후 비교하여 `" 005930 "` 같은 사소한 포맷 차이도 허용합니다. 같은 코드가 중복 반환되면 한 번만 저장합니다.

3. **Canonical name 강제**
   유효 코드에 대해 `tagName`은 AI 응답 대신 마스터의 정식 종목명으로 덮어씁니다. AI가 `"005930", "삼전"`을 주더라도 `"005930", "삼성전자"`로 저장되어, `findPopularTags`의 `GROUP BY (tagCode, tagName)`에서 동일 종목이 다른 이름으로 쪼개지지 않습니다.

4. **유효 태그 0개 정책 + PROCESSING 잔류 방지**
   필터링 후 STOCK/SECTOR/TOPIC 모두 비면 기사를 `markFailed`로 전환합니다(기존엔 `saveTagsBatch`가 호출되지 않아 PROCESSING에 남을 수 있었음). 기존 `markTaggingFailed`가 `retryCount++`를 수행하고 `findTaggingTargets`가 `MAX_RETRY(3)` 초과 시 대상에서 제외하므로 무한 재시도는 발생하지 않습니다.


<br>

## ✅ 완료한 기능 명세
### 신규
1. `StockCodeValidator.java` — 종목 마스터 스냅샷 로더 (new)

### 수정 (기능)
2. `StockRepository.java` — `findAllStockCodeNamePairs()` projection 추가 (modified)
3. `TaggingService.java` — 순수 함수 `extractTags()`, 유효 태그 0개 정책, 정규화/dedup, 로드 순서 조정 (modified)
4. `OpenAiTaggingClient.java` — 프롬프트에서 국내 종목만 허용 명시 (modified)

### 수정 (테스트)
5. `TaggingServiceTest.java` — 검증 시나리오 9건 추가 (modified)

<br>

## 📸 스크린샷
<img width="832" height="752" alt="image" src="https://github.com/user-attachments/assets/3de37656-1194-440e-83fd-5894dbe3ebc3" />


알맞게 주식 종목과 코드가 표시되는 것을 확인했습니다!
<img width="854" height="193" alt="image" src="https://github.com/user-attachments/assets/9e0b2e94-5495-48f5-b9f6-812c29346eca" />

<br>

## 💭 고민과 해결과정

### 1. 매 기사 조회 vs 배치당 스냅샷

옵션을 비교했습니다:
- **A. 매 태그마다 `existsByStockCode`** — 태그당 SELECT 1회 (기사×5 최대). DB 라운드트립 많음
- **B. 배치당 스냅샷 (Set/Map)** — 2,772개 ≈ 20KB 메모리, 쿼리 1회
- **C. IN 쿼리로 배치 단위 검증** — 구조 변경 폭 큼

B 채택. 태깅 배치는 30분 주기라 그 안에 마스터가 변경될 가능성이 매우 낮고, 메모리 부담도 적다고 판단하였습니다.

### 2. Set → Map 전환 (canonical name 강제)

초기 구현은 `Set<String>`로 코드 존재 여부만 검증했으나, AI가 올바른 코드에 잘못된 이름을 붙이면 `(code, name)` 기준 집계에서 그룹이 쪼개지는 문제가 남았습니다. `Map<code, name>`으로 바꿔 이름도 마스터값으로 강제하도록 하였습니다.

### 3. 엔티티 부작용 분리
기존에는 `generateTagsForArticle`에서 AI 응답을 받은 직후 `article.updateSummary()`, `article.updateRelevance()`를 바로 호출했습니다. 이 상태에서 이후 태그 필터링을 진행하다가 유효한 태그가 0개인 경우 FAILED 경로로 빠지더라도, summary와 relevance는 이미 변경된 상태로 영속성 컨텍스트에 남게 됩니다. 이로 인해 트랜잭션 경계에 따라 “FAILED 상태인데 relevance는 IRRELEVANT로 변경된 기사”처럼 일부만 반영된 불일치 상태가 발생할 수 있었습니다.

이를 해결하기 위해 `extractTags()`를 순수 함수로 분리하고, 엔티티를 직접 수정하지 않고 `TagExtraction(tags, summary, relevance)` 형태의 결과만 반환하도록 변경했습니다. 이후 호출부에서 먼저 유효 태그가 존재하는지를 판단하고, 태그가 있는 경우에만 `article.updateSummary()`와 `article.updateRelevance()`를 수행하도록 구조를 수정했습니다. 이렇게 함으로써 모든 검증이 완료된 이후에만 엔티티 상태가 변경되도록 보장했습니다.


<br>

### 🔗 관련 이슈
Closes #190

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 마스터 종목 맵을 불러와 주식 태그 검증 및 표준명 강제 적용
  * 태그 추출 시 요약·관련도는 유효 태그가 있을 때만 갱신

* **버그 수정**
  * 한국 상장사 6자리 종목코드만 주식 태그로 허용(미국 티커·지수·암호화폐 제외)
  * 섹터/마켓 관련 소식은 섹터로 일관 분류
  * 유효 태그 0개인 경우 기사 실패 처리 및 저장 방지
  * 인기 태그 집계에서 이름 불일치로 인한 분할 집계 수정

* **테스트**
  * 검증·정규화·중복·예외 경로를 포함한 테스트 확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->