### PR TITLE
[WEF-529] NewsClusterQueryService 집계 로직 분리 및 DTO 구조 정리

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/dto/ArticleSourceInfo.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/dto/ArticleSourceInfo.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.news.cluster.dto;
+
+/**
+ * 상세 화면 출처 카드용 기사 정보 (id + title + 언론사 + 원본 URL)
+ *
+ * 상세/섹션 출처 양쪽에서 공용으로 사용된다
+ */
+public record ArticleSourceInfo(
+        Long articleId,
+        String title,
+        String publisherName,
+        String url
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/dto/SourceInfo.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/dto/SourceInfo.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.news.cluster.dto;
+
+/**
+ * 피드 목록 카드용 출처 정보 (언론사명 + 원본 URL)
+ *
+ * 피드 카드에서는 title 없이 언론사만 노출하므로 상세용 ArticleSourceInfo와 분리되어 있다
+ */
+public record SourceInfo(String publisherName, String url) {
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/dto/StockInfo.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/dto/StockInfo.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.news.cluster.dto;
+
+/**
+ * 클러스터 관련 종목 정보 (code + canonical name)
+ *
+ * 피드 아이템과 상세 응답 양쪽에서 공용으로 사용된다
+ */
+public record StockInfo(String code, String name) {
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
@@ -1,0 +1,197 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 클러스터별 태그/출처 집계 전담 컴포넌트
+ *
+ * 피드 목록과 상세 조회 양쪽에서 공통으로 쓰이는 부가 정보(출처, 관련 종목,
+ * 마켓 태그, 상세용 출처 카드) 집계 로직을 담는다. {@link NewsClusterQueryService}의
+ * 책임 크기를 줄이고 집계 단위의 단위 테스트를 가능하게 한다
+ */
+@Component
+@RequiredArgsConstructor
+public class ClusterTagAggregator {
+
+    private static final int MAX_SOURCES_PER_CLUSTER = 3;
+
+    private final NewsArticleRepository newsArticleRepository;
+    private final NewsArticleTagRepository articleTagRepository;
+
+    /**
+     * 클러스터별 출처(언론사) 상위 N개를 집계한다
+     *
+     * 정책: 같은 언론사는 1번만 포함(publisherName 기준 dedup), 최대
+     * {@link #MAX_SOURCES_PER_CLUSTER}개까지
+     *
+     * @param clusterArticleMap clusterId → 소속 articleIds
+     * @param allArticleIds     IN 절 조회용 전체 기사 ID (중복 제거된)
+     * @return clusterId → 출처 목록
+     */
+    public Map<Long, List<SourceInfo>> aggregateSources(Map<Long, List<Long>> clusterArticleMap,
+                                                        List<Long> allArticleIds) {
+        Map<Long, NewsArticleRepository.SourceProjection> projectionMap =
+                newsArticleRepository.findSourceInfoByIdIn(allArticleIds).stream()
+                        .collect(Collectors.toMap(NewsArticleRepository.SourceProjection::getId, p -> p));
+
+        Map<Long, List<SourceInfo>> result = new HashMap<>();
+
+        for (var entry : clusterArticleMap.entrySet()) {
+            Set<String> seenPublishers = new HashSet<>();
+            List<SourceInfo> sources = new ArrayList<>();
+
+            for (Long articleId : entry.getValue()) {
+                var projection = projectionMap.get(articleId);
+
+                if (projection != null
+                        && projection.getPublisherName() != null
+                        && seenPublishers.add(projection.getPublisherName())) {
+
+                    sources.add(new SourceInfo(projection.getPublisherName(), projection.getOriginalUrl()));
+
+                    if (sources.size() >= MAX_SOURCES_PER_CLUSTER) break;
+                }
+            }
+            result.put(entry.getKey(), sources);
+        }
+        return result;
+    }
+
+    /**
+     * 단일 클러스터용 — 기사 목록의 관련 STOCK 태그를 집계한다
+     *
+     * 상세 조회 경로에서 {@code Map.of(id, articleIds)} 래핑 없이 직접 호출하기 위한
+     * 편의 오버로드
+     */
+    public List<StockInfo> aggregateStocksForCluster(List<Long> articleIds) {
+        if (articleIds.isEmpty()) {
+            return List.of();
+        }
+        Map<String, StockInfo> seen = new LinkedHashMap<>();
+        List<NewsArticleTag> stockTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                articleIds, TagType.STOCK);
+        for (NewsArticleTag t : stockTags) {
+            seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName()));
+        }
+        return new ArrayList<>(seen.values());
+    }
+
+    /**
+     * 단일 클러스터용 — 기사 목록의 TOPIC 태그명을 집계한다 (편의 오버로드)
+     */
+    public List<String> aggregateMarketTagsForCluster(List<Long> articleIds) {
+        if (articleIds.isEmpty()) {
+            return List.of();
+        }
+        Set<String> seen = new LinkedHashSet<>();
+        List<NewsArticleTag> topicTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                articleIds, TagType.TOPIC);
+        for (NewsArticleTag t : topicTags) {
+            seen.add(t.getTagName());
+        }
+        return new ArrayList<>(seen);
+    }
+
+    /**
+     * 클러스터별 관련 STOCK 태그(code + name)를 집계한다
+     *
+     * 같은 종목 코드가 여러 기사에서 반복되면 한 번만 포함한다
+     */
+    public Map<Long, List<StockInfo>> aggregateStocks(Map<Long, List<Long>> clusterArticleMap,
+                                                      List<Long> allArticleIds) {
+        List<NewsArticleTag> stockTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                allArticleIds, TagType.STOCK);
+        Map<Long, List<NewsArticleTag>> tagsByArticle = stockTags.stream()
+                .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
+
+        Map<Long, List<StockInfo>> result = new HashMap<>();
+        for (var entry : clusterArticleMap.entrySet()) {
+            Map<String, StockInfo> seen = new LinkedHashMap<>();
+            for (Long articleId : entry.getValue()) {
+                tagsByArticle.getOrDefault(articleId, List.of()).forEach(t ->
+                        seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName())));
+            }
+            result.put(entry.getKey(), new ArrayList<>(seen.values()));
+        }
+        return result;
+    }
+
+    /**
+     * 클러스터별 마켓 태그(TOPIC 태그명)를 집계한다
+     */
+    public Map<Long, List<String>> aggregateMarketTags(Map<Long, List<Long>> clusterArticleMap,
+                                                       List<Long> allArticleIds) {
+        List<NewsArticleTag> topicTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                allArticleIds, TagType.TOPIC);
+        Map<Long, List<NewsArticleTag>> tagsByArticle = topicTags.stream()
+                .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
+
+        Map<Long, List<String>> result = new HashMap<>();
+        for (var entry : clusterArticleMap.entrySet()) {
+            Set<String> topics = new LinkedHashSet<>();
+            for (Long articleId : entry.getValue()) {
+                tagsByArticle.getOrDefault(articleId, List.of())
+                        .forEach(t -> topics.add(t.getTagName()));
+            }
+            result.put(entry.getKey(), new ArrayList<>(topics));
+        }
+        return result;
+    }
+
+    /**
+     * 상세 조회용 출처 카드 목록을 반환한다 (title 포함, 상위 N개, 언론사 중복 제거)
+     *
+     * 섹션 출처에 등장하는 기사(prioritizedArticleIds)를 top-level 출처 앞쪽에
+     * 배치하여 섹션 출처와 top-level 출처가 일관되도록 한다
+     *
+     * @param articleIds              클러스터 소속 기사 ID (정렬 순서 유지)
+     * @param prioritizedArticleIds   섹션 출처로 선택된 기사 ID 집합 (우선 배치)
+     * @return 상세 화면 출처 카드 목록 (최대 {@link #MAX_SOURCES_PER_CLUSTER}개)
+     */
+    public List<ArticleSourceInfo> aggregateDetailSources(List<Long> articleIds,
+                                                         Set<Long> prioritizedArticleIds) {
+        Map<Long, NewsArticleRepository.ArticleSourceProjection> projectionMap =
+                newsArticleRepository.findArticleSourceInfoByIdIn(articleIds).stream()
+                        .collect(Collectors.toMap(
+                                NewsArticleRepository.ArticleSourceProjection::getId, p -> p));
+
+        // 섹션 출처 기사를 앞쪽으로 (comparator 0 < 1), 동순위는 articleIds 입력 순서 유지 (stable sort).
+        // projection이 없는 id(삭제/크롤 실패)는 제외
+        List<NewsArticleRepository.ArticleSourceProjection> sorted = articleIds.stream()
+                .map(projectionMap::get)
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparingInt(p -> prioritizedArticleIds.contains(p.getId()) ? 0 : 1))
+                .toList();
+
+        Set<String> seenPublishers = new HashSet<>();
+        List<ArticleSourceInfo> result = new ArrayList<>();
+
+        for (NewsArticleRepository.ArticleSourceProjection p : sorted) {
+            if (p.getPublisherName() != null && seenPublishers.add(p.getPublisherName())) {
+                result.add(new ArticleSourceInfo(p.getId(), p.getTitle(), p.getPublisherName(), p.getOriginalUrl()));
+                if (result.size() >= MAX_SOURCES_PER_CLUSTER) break;
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
@@ -45,7 +45,7 @@ public class ClusterTagAggregator {
      * {@link #MAX_SOURCES_PER_CLUSTER}개까지
      *
      * @param clusterArticleMap clusterId → 소속 articleIds
-     * @param allArticleIds     IN 절 조회용 전체 기사 ID (중복 제거된)
+     * @param allArticleIds     IN 절 조회용 전체 기사 ID
      * @return clusterId → 출처 목록
      */
     public Map<Long, List<SourceInfo>> aggregateSources(Map<Long, List<Long>> clusterArticleMap,
@@ -79,9 +79,6 @@ public class ClusterTagAggregator {
 
     /**
      * 단일 클러스터용 — 기사 목록의 관련 STOCK 태그를 집계한다
-     *
-     * 상세 조회 경로에서 {@code Map.of(id, articleIds)} 래핑 없이 직접 호출하기 위한
-     * 편의 오버로드
      */
     public List<StockInfo> aggregateStocksForCluster(List<Long> articleIds) {
         if (articleIds.isEmpty()) {
@@ -97,7 +94,7 @@ public class ClusterTagAggregator {
     }
 
     /**
-     * 단일 클러스터용 — 기사 목록의 TOPIC 태그명을 집계한다 (편의 오버로드)
+     * 단일 클러스터용 — 기사 목록의 TOPIC 태그명을 집계한다
      */
     public List<String> aggregateMarketTagsForCluster(List<Long> articleIds) {
         if (articleIds.isEmpty()) {
@@ -114,8 +111,6 @@ public class ClusterTagAggregator {
 
     /**
      * 클러스터별 관련 STOCK 태그(code + name)를 집계한다
-     *
-     * 같은 종목 코드가 여러 기사에서 반복되면 한 번만 포함한다
      */
     public Map<Long, List<StockInfo>> aggregateStocks(Map<Long, List<Long>> clusterArticleMap,
                                                       List<Long> allArticleIds) {
@@ -170,6 +165,10 @@ public class ClusterTagAggregator {
      */
     public List<ArticleSourceInfo> aggregateDetailSources(List<Long> articleIds,
                                                          Set<Long> prioritizedArticleIds) {
+        if (articleIds == null || articleIds.isEmpty()) {
+            return List.of();
+        }
+
         Map<Long, NewsArticleRepository.ArticleSourceProjection> projectionMap =
                 newsArticleRepository.findArticleSourceInfoByIdIn(articleIds).stream()
                         .collect(Collectors.toMap(

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
@@ -72,7 +72,7 @@ public class ClusterTagAggregator {
                     if (sources.size() >= MAX_SOURCES_PER_CLUSTER) break;
                 }
             }
-            result.put(entry.getKey(), sources);
+            result.put(entry.getKey(), List.copyOf(sources));
         }
         return result;
     }
@@ -90,7 +90,7 @@ public class ClusterTagAggregator {
         for (NewsArticleTag t : stockTags) {
             seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName()));
         }
-        return new ArrayList<>(seen.values());
+        return List.copyOf(seen.values());
     }
 
     /**
@@ -106,7 +106,7 @@ public class ClusterTagAggregator {
         for (NewsArticleTag t : topicTags) {
             seen.add(t.getTagName());
         }
-        return new ArrayList<>(seen);
+        return List.copyOf(seen);
     }
 
     /**
@@ -126,7 +126,7 @@ public class ClusterTagAggregator {
                 tagsByArticle.getOrDefault(articleId, List.of()).forEach(t ->
                         seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName())));
             }
-            result.put(entry.getKey(), new ArrayList<>(seen.values()));
+            result.put(entry.getKey(), List.copyOf(seen.values()));
         }
         return result;
     }
@@ -148,7 +148,7 @@ public class ClusterTagAggregator {
                 tagsByArticle.getOrDefault(articleId, List.of())
                         .forEach(t -> topics.add(t.getTagName()));
             }
-            result.put(entry.getKey(), new ArrayList<>(topics));
+            result.put(entry.getKey(), List.copyOf(topics));
         }
         return result;
     }
@@ -191,6 +191,6 @@ public class ClusterTagAggregator {
                 if (result.size() >= MAX_SOURCES_PER_CLUSTER) break;
             }
         }
-        return result;
+        return List.copyOf(result);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -1,9 +1,7 @@
 package com.solv.wefin.domain.news.cluster.service;
 
-import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
 import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
-import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.news.cluster.entity.ClusterSuggestedQuestion;
 import com.solv.wefin.domain.news.cluster.entity.ClusterSummarySection;
 import com.solv.wefin.domain.news.cluster.entity.ClusterSummarySectionSource;
@@ -19,6 +17,9 @@ import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepositor
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -44,7 +45,6 @@ import java.util.stream.Collectors;
 public class NewsClusterQueryService {
 
     private static final List<SummaryStatus> VISIBLE_STATUSES = List.of(SummaryStatus.GENERATED, SummaryStatus.STALE);
-    private static final int MAX_SOURCES_PER_CLUSTER = 3;
     // ETC는 "전체" 탭에서만 노출되므로 탭 필터 대상에서 제외
     private static final Set<String> VALID_CATEGORIES = Set.of(
             "FINANCE", "TECH", "INDUSTRY", "ENERGY", "BIO", "CRYPTO");
@@ -52,12 +52,12 @@ public class NewsClusterQueryService {
     private final NewsClusterRepository newsClusterRepository;
     private final NewsClusterArticleRepository clusterArticleRepository;
     private final NewsArticleRepository newsArticleRepository;
-    private final NewsArticleTagRepository articleTagRepository;
     private final UserNewsClusterReadRepository readRepository;
     private final UserNewsClusterFeedbackRepository feedbackRepository;
     private final ClusterSuggestedQuestionRepository questionRepository;
     private final ClusterSummarySectionRepository sectionRepository;
     private final ClusterSummarySectionSourceRepository sectionSourceRepository;
+    private final ClusterTagAggregator tagAggregator;
 
     /**
      * 피드 목록을 커서 기반으로 조회한다.
@@ -127,13 +127,13 @@ public class NewsClusterQueryService {
         // 모든 기사 ID flat 추출 (중복 제거)
         List<Long> allArticleIds = clusterArticleMap.values().stream().flatMap(List::stream).distinct().toList();
 
-        // 출처 / 종목 / 읽음 여부 일괄 조회 (빈 리스트면 IN 절 오류 방지)
+        // 출처 / 종목 / 토픽 / 읽음 여부 일괄 조회 (빈 리스트면 IN 절 오류 방지)
         Map<Long, List<SourceInfo>> sourcesMap = allArticleIds.isEmpty()
-                ? Map.of() : getSourcesMap(clusterArticleMap, allArticleIds);
+                ? Map.of() : tagAggregator.aggregateSources(clusterArticleMap, allArticleIds);
         Map<Long, List<StockInfo>> stocksMap = allArticleIds.isEmpty()
-                ? Map.of() : getRelatedStocksMap(clusterArticleMap, allArticleIds);
+                ? Map.of() : tagAggregator.aggregateStocks(clusterArticleMap, allArticleIds);
         Map<Long, List<String>> topicsMap = allArticleIds.isEmpty()
-                ? Map.of() : getMarketTagsMap(clusterArticleMap, allArticleIds);
+                ? Map.of() : tagAggregator.aggregateMarketTags(clusterArticleMap, allArticleIds);
         Set<Long> readClusterIds = getReadClusterIds(clusterIds, userId);
 
         // 클러스터 → 응답 DTO 변환
@@ -229,91 +229,6 @@ public class NewsClusterQueryService {
     }
 
     /**
-     * 클러스터별 출처(publisher) 상위 N개를 조회한다.
-     *
-     * 정책:
-     * - 같은 언론사는 1번만 포함 (publisherName 기준 dedup)
-     * - 최대 MAX_SOURCES_PER_CLUSTER 개까지만 노출
-     */
-    private Map<Long, List<SourceInfo>> getSourcesMap(Map<Long, List<Long>> clusterArticleMap,
-                                                      List<Long> allArticleIds) {
-        // projection 조회 (엔티티 전체 로딩 방지)
-        Map<Long, NewsArticleRepository.SourceProjection> projectionMap =
-                newsArticleRepository.findSourceInfoByIdIn(allArticleIds).stream()
-                        .collect(Collectors.toMap(NewsArticleRepository.SourceProjection::getId, p -> p));
-
-        Map<Long, List<SourceInfo>> result = new HashMap<>();
-
-        // clusterId별로 순회
-        for (var entry : clusterArticleMap.entrySet()) {
-            Set<String> seenPublishers = new HashSet<>(); // publisherName 기준 중복 제거용 Set
-            List<SourceInfo> sources = new ArrayList<>(); // 최종 출처 리스트
-
-            for (Long articleId : entry.getValue()) {
-                var projection = projectionMap.get(articleId); // O(1)로 projection 조회
-
-                if (projection != null
-                        && projection.getPublisherName() != null
-                        && seenPublishers.add(projection.getPublisherName())) {
-
-                    // 출처 정보 추가
-                    sources.add(new SourceInfo(projection.getPublisherName(), projection.getOriginalUrl()));
-
-                    // 최대 개수 제한
-                    if (sources.size() >= MAX_SOURCES_PER_CLUSTER) break;
-                }
-            }
-            result.put(entry.getKey(), sources);
-        }
-        return result;
-    }
-
-    /**
-     * 클러스터별 관련 STOCK 태그를 조회한다. (code + name)
-     */
-    private Map<Long, List<StockInfo>> getRelatedStocksMap(Map<Long, List<Long>> clusterArticleMap,
-                                                            List<Long> allArticleIds) {
-        List<NewsArticleTag> stockTags = articleTagRepository.findByNewsArticleIdInAndTagType(
-                allArticleIds, TagType.STOCK);
-        Map<Long, List<NewsArticleTag>> tagsByArticle = stockTags.stream()
-                .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
-
-        Map<Long, List<StockInfo>> result = new HashMap<>();
-        for (var entry : clusterArticleMap.entrySet()) {
-            Map<String, StockInfo> seen = new LinkedHashMap<>();
-            for (Long articleId : entry.getValue()) {
-                tagsByArticle.getOrDefault(articleId, List.of()).forEach(t ->
-                        seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName())));
-            }
-
-            result.put(entry.getKey(), new ArrayList<>(seen.values()));
-        }
-        return result;
-    }
-
-    /**
-     * 클러스터별 TOPIC 태그(marketTags)를 조회한다.
-     */
-    private Map<Long, List<String>> getMarketTagsMap(Map<Long, List<Long>> clusterArticleMap,
-                                                      List<Long> allArticleIds) {
-        List<NewsArticleTag> topicTags = articleTagRepository.findByNewsArticleIdInAndTagType(
-                allArticleIds, TagType.TOPIC);
-        Map<Long, List<NewsArticleTag>> tagsByArticle = topicTags.stream()
-                .collect(Collectors.groupingBy(NewsArticleTag::getNewsArticleId));
-
-        Map<Long, List<String>> result = new HashMap<>();
-        for (var entry : clusterArticleMap.entrySet()) {
-            Set<String> topics = new LinkedHashSet<>();
-            for (Long articleId : entry.getValue()) {
-                tagsByArticle.getOrDefault(articleId, List.of())
-                        .forEach(t -> topics.add(t.getTagName()));
-            }
-            result.put(entry.getKey(), new ArrayList<>(topics));
-        }
-        return result;
-    }
-
-    /**
      * 사용자가 읽은 클러스터 ID Set을 반환한다.
      */
     private Set<Long> getReadClusterIds(List<Long> clusterIds, UUID userId) {
@@ -364,18 +279,11 @@ public class NewsClusterQueryService {
         // 출처 (섹션 출처 기사 우선, 상위 N개, 언론사 중복 제거)
         List<ArticleSourceInfo> sources = articleIds.isEmpty()
                 ? List.of()
-                : getDetailSources(articleIds, sectionSourceArticleIds);
+                : tagAggregator.aggregateDetailSources(articleIds, sectionSourceArticleIds);
 
-        // 관련 종목
-        Map<Long, List<Long>> clusterArticleMap = Map.of(clusterId, articleIds);
-        List<StockInfo> stocks = articleIds.isEmpty()
-                ? List.of()
-                : getRelatedStocksMap(clusterArticleMap, articleIds).getOrDefault(clusterId, List.of());
-
-        // 마켓 태그
-        List<String> marketTags = articleIds.isEmpty()
-                ? List.of()
-                : getMarketTagsMap(clusterArticleMap, articleIds).getOrDefault(clusterId, List.of());
+        // 관련 종목 / 마켓 태그 — 단건 전용 오버로드 사용 (Map 래핑 불필요)
+        List<StockInfo> stocks = tagAggregator.aggregateStocksForCluster(articleIds);
+        List<String> marketTags = tagAggregator.aggregateMarketTagsForCluster(articleIds);
 
         // 읽음 여부
         boolean isRead = userId != null
@@ -408,44 +316,6 @@ public class NewsClusterQueryService {
                 cluster.getArticleCount(), sources, stocks, marketTags, isRead,
                 feedbackType, sectionDetails, suggestedQuestions, articleContent
         );
-    }
-
-    /**
-     * 상세 조회용 출처 기사 목록을 반환한다 (title 포함, 상위 N개, 언론사 중복 제거)
-     * 섹션 출처에 등장하는 기사를 우선 배치하여 top-level 출처와 섹션 출처가 일관되도록 한다
-     */
-    private List<ArticleSourceInfo> getDetailSources(List<Long> articleIds,
-                                                      Set<Long> sectionSourceArticleIds) {
-        Map<Long, NewsArticleRepository.ArticleSourceProjection> projectionMap =
-                newsArticleRepository.findArticleSourceInfoByIdIn(articleIds).stream()
-                        .collect(Collectors.toMap(
-                                NewsArticleRepository.ArticleSourceProjection::getId, p -> p));
-
-        // 섹션 출처 기사 우선, 나머지 후순위
-        List<NewsArticleRepository.ArticleSourceProjection> sorted = new ArrayList<>();
-        for (Long id : articleIds) {
-            NewsArticleRepository.ArticleSourceProjection p = projectionMap.get(id);
-            if (p != null && sectionSourceArticleIds.contains(id)) {
-                sorted.add(p);
-            }
-        }
-        for (Long id : articleIds) {
-            NewsArticleRepository.ArticleSourceProjection p = projectionMap.get(id);
-            if (p != null && !sectionSourceArticleIds.contains(id)) {
-                sorted.add(p);
-            }
-        }
-
-        Set<String> seenPublishers = new HashSet<>();
-        List<ArticleSourceInfo> result = new ArrayList<>();
-
-        for (NewsArticleRepository.ArticleSourceProjection p : sorted) {
-            if (p.getPublisherName() != null && seenPublishers.add(p.getPublisherName())) {
-                result.add(new ArticleSourceInfo(p.getId(), p.getTitle(), p.getPublisherName(), p.getOriginalUrl()));
-                if (result.size() >= MAX_SOURCES_PER_CLUSTER) break;
-            }
-        }
-        return result;
     }
 
     /**
@@ -530,14 +400,6 @@ public class NewsClusterQueryService {
     ) {
     }
 
-    public record StockInfo(String code, String name) {}
-
-    /**
-     * 출처 정보 (언론사, 원본 URL)
-     */
-    public record SourceInfo(String publisherName, String url) {
-    }
-
     /**
      * 클러스터 상세 조회 결과
      */
@@ -571,14 +433,4 @@ public class NewsClusterQueryService {
     ) {
     }
 
-    /**
-     * 섹션 출처 카드용 기사 정보
-     */
-    public record ArticleSourceInfo(
-            Long articleId,
-            String title,
-            String publisherName,
-            String url
-    ) {
-    }
 }

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterDetailResponse.java
@@ -1,9 +1,9 @@
 package com.solv.wefin.web.news.dto.response;
 
-import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ArticleSourceInfo;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterDetailResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.SectionDetail;
-import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.StockInfo;
+import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
@@ -2,8 +2,8 @@ package com.solv.wefin.web.news.dto.response;
 
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedItem;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
-import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.SourceInfo;
-import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.StockInfo;
+import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 
 import java.time.OffsetDateTime;
 import java.util.List;

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregatorTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregatorTest.java
@@ -1,0 +1,292 @@
+package com.solv.wefin.domain.news.cluster.service;
+
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository.ArticleSourceProjection;
+import com.solv.wefin.domain.news.article.repository.NewsArticleRepository.SourceProjection;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ClusterTagAggregatorTest {
+
+    @Mock private NewsArticleRepository newsArticleRepository;
+    @Mock private NewsArticleTagRepository articleTagRepository;
+
+    @InjectMocks private ClusterTagAggregator aggregator;
+
+    // ---------- aggregateSources ----------
+
+    @Test
+    @DisplayName("aggregateSources — 같은 언론사는 1개만, 최대 3개까지")
+    void aggregateSources_dedupAndCap() {
+        Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L, 20L, 30L, 40L, 50L));
+        given(newsArticleRepository.findSourceInfoByIdIn(any())).willReturn(List.of(
+                sourceProjection(10L, "매일경제", "url1"),
+                sourceProjection(20L, "매일경제", "url2"),    // 같은 언론사 dedup
+                sourceProjection(30L, "한경", "url3"),
+                sourceProjection(40L, "연합", "url4"),
+                sourceProjection(50L, "동아", "url5")          // 4번째 — 최대 3개 컷
+        ));
+
+        Map<Long, List<SourceInfo>> result = aggregator.aggregateSources(
+                clusterMap, List.of(10L, 20L, 30L, 40L, 50L));
+
+        assertThat(result.get(1L)).extracting(SourceInfo::publisherName)
+                .containsExactly("매일경제", "한경", "연합");
+        assertThat(result.get(1L)).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("aggregateSources — publisherName이 null이면 스킵")
+    void aggregateSources_skipsNullPublisher() {
+        Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L, 20L));
+        given(newsArticleRepository.findSourceInfoByIdIn(any())).willReturn(List.of(
+                sourceProjection(10L, null, "url1"),
+                sourceProjection(20L, "한경", "url2")
+        ));
+
+        Map<Long, List<SourceInfo>> result = aggregator.aggregateSources(
+                clusterMap, List.of(10L, 20L));
+
+        assertThat(result.get(1L)).extracting(SourceInfo::publisherName).containsExactly("한경");
+    }
+
+    // ---------- aggregateStocks (TagType.STOCK 쿼리) ----------
+
+    @Test
+    @DisplayName("aggregateStocks — TagType.STOCK으로 조회하고 code 기준 dedup")
+    void aggregateStocks_queriesStockTypeAndDedupsByCode() {
+        Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L, 20L));
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK)))
+                .willReturn(List.of(
+                        stockTag(10L, "005930", "삼성전자"),
+                        stockTag(20L, "005930", "삼성전자"),  // dedup 대상
+                        stockTag(20L, "000660", "SK하이닉스")
+                ));
+
+        Map<Long, List<StockInfo>> result = aggregator.aggregateStocks(
+                clusterMap, List.of(10L, 20L));
+
+        assertThat(result.get(1L))
+                .extracting(StockInfo::code)
+                .containsExactly("005930", "000660");
+    }
+
+    // ---------- aggregateMarketTags (TagType.TOPIC 쿼리) ----------
+
+    @Test
+    @DisplayName("aggregateMarketTags — TagType.TOPIC으로 조회하고 name 기준 dedup")
+    void aggregateMarketTags_queriesTopicTypeAndReturnsNames() {
+        Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L, 20L));
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC)))
+                .willReturn(List.of(
+                        topicTag(10L, "EARNINGS", "실적"),
+                        topicTag(20L, "EARNINGS", "실적"),   // dedup
+                        topicTag(20L, "AI", "AI")
+                ));
+
+        Map<Long, List<String>> result = aggregator.aggregateMarketTags(
+                clusterMap, List.of(10L, 20L));
+
+        assertThat(result.get(1L)).containsExactly("실적", "AI");
+    }
+
+    @Test
+    @DisplayName("aggregateMarketTags — TagType.STOCK은 조회하지 않는다 (분기 회귀 방지)")
+    void aggregateMarketTags_doesNotQueryStockType() {
+        Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L));
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC)))
+                .willReturn(List.of());
+
+        aggregator.aggregateMarketTags(clusterMap, List.of(10L));
+
+        org.mockito.Mockito.verify(articleTagRepository)
+                .findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC));
+        org.mockito.Mockito.verify(articleTagRepository, org.mockito.Mockito.never())
+                .findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK));
+    }
+
+    // ---------- aggregateDetailSources ----------
+
+    @Test
+    @DisplayName("aggregateDetailSources — 섹션 출처 기사가 앞쪽에 배치되고 publisher dedup + 최대 3개")
+    void aggregateDetailSources_prioritizesSectionArticlesAndDedupsAndCaps() {
+        // 기사 순서: 10, 20, 30, 40, 50 (20과 40만 섹션 출처)
+        List<Long> articleIds = List.of(10L, 20L, 30L, 40L, 50L);
+        Set<Long> sectionSourceIds = Set.of(20L, 40L);
+
+        given(newsArticleRepository.findArticleSourceInfoByIdIn(articleIds)).willReturn(List.of(
+                articleSourceProjection(10L, "기사A", "매일경제", "url1"),
+                articleSourceProjection(20L, "기사B", "한경", "url2"),       // 섹션 출처
+                articleSourceProjection(30L, "기사C", "한경", "url3"),       // dedup 대상
+                articleSourceProjection(40L, "기사D", "연합", "url4"),       // 섹션 출처
+                articleSourceProjection(50L, "기사E", "동아", "url5")        // 4번째로 들어가 컷
+        ));
+
+        List<ArticleSourceInfo> result = aggregator.aggregateDetailSources(articleIds, sectionSourceIds);
+
+        // 정책 검증:
+        // 1) 섹션 출처(20, 40)가 비섹션 출처(10)보다 먼저
+        // 2) 30L은 20L과 같은 "한경"이라 dedup
+        // 3) 최대 3개
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(ArticleSourceInfo::articleId)
+                .containsExactly(20L, 40L, 10L);
+        assertThat(result).extracting(ArticleSourceInfo::publisherName)
+                .containsExactly("한경", "연합", "매일경제");
+    }
+
+    @Test
+    @DisplayName("aggregateDetailSources — projectionMap에 없는 id는 제외된다 (크롤 실패/삭제)")
+    void aggregateDetailSources_missingProjection_isExcluded() {
+        List<Long> articleIds = List.of(10L, 20L, 30L);
+        // 20L은 삭제되어 projection에서 누락
+        given(newsArticleRepository.findArticleSourceInfoByIdIn(articleIds)).willReturn(List.of(
+                articleSourceProjection(10L, "기사A", "매일경제", "url1"),
+                articleSourceProjection(30L, "기사C", "한경", "url3")
+        ));
+
+        List<ArticleSourceInfo> result = aggregator.aggregateDetailSources(articleIds, Set.of());
+
+        assertThat(result).extracting(ArticleSourceInfo::articleId).containsExactly(10L, 30L);
+    }
+
+    // ---------- multi-cluster 비간섭 ----------
+
+    @Test
+    @DisplayName("aggregateSources — 여러 클러스터가 있을 때 각자의 기사만 집계한다 (간섭 없음)")
+    void aggregateSources_multipleClusters_independentResults() {
+        Map<Long, List<Long>> clusterMap = Map.of(
+                1L, List.of(10L, 20L),
+                2L, List.of(30L, 40L));
+        given(newsArticleRepository.findSourceInfoByIdIn(any())).willReturn(List.of(
+                sourceProjection(10L, "매일경제", "u1"),
+                sourceProjection(20L, "한경", "u2"),
+                sourceProjection(30L, "연합", "u3"),
+                sourceProjection(40L, "매일경제", "u4")  // 클러스터 1의 매일경제와 같은 이름이지만 클러스터 2에 속함
+        ));
+
+        Map<Long, List<SourceInfo>> result = aggregator.aggregateSources(
+                clusterMap, List.of(10L, 20L, 30L, 40L));
+
+        // 클러스터 1: 매일경제 + 한경
+        assertThat(result.get(1L)).extracting(SourceInfo::publisherName)
+                .containsExactly("매일경제", "한경");
+        // 클러스터 2: 연합 + 매일경제 (클러스터 1의 매일경제에 영향받지 않음)
+        assertThat(result.get(2L)).extracting(SourceInfo::publisherName)
+                .containsExactly("연합", "매일경제");
+    }
+
+    // ---------- putIfAbsent 고정 동작 ----------
+
+    @Test
+    @DisplayName("aggregateStocks — 같은 code에 다른 name이 오면 먼저 본 name을 고정한다 (putIfAbsent)")
+    void aggregateStocks_sameCodeDifferentName_keepsFirstSeenName() {
+        Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L, 20L));
+        // articleId 10이 먼저 순회되므로 "삼성전자"가 고정
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK)))
+                .willReturn(List.of(
+                        stockTag(10L, "005930", "삼성전자"),
+                        stockTag(20L, "005930", "삼전")
+                ));
+
+        Map<Long, List<StockInfo>> result = aggregator.aggregateStocks(
+                clusterMap, List.of(10L, 20L));
+
+        assertThat(result.get(1L)).hasSize(1);
+        assertThat(result.get(1L).get(0).name()).isEqualTo("삼성전자");
+    }
+
+    // ---------- 단건 오버로드 ----------
+
+    @Test
+    @DisplayName("aggregateStocksForCluster — 단건 편의 오버로드")
+    void aggregateStocksForCluster_returnsDedupedStocks() {
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(eq(List.of(10L, 20L)), eq(TagType.STOCK)))
+                .willReturn(List.of(
+                        stockTag(10L, "005930", "삼성전자"),
+                        stockTag(20L, "000660", "SK하이닉스")
+                ));
+
+        List<StockInfo> result = aggregator.aggregateStocksForCluster(List.of(10L, 20L));
+
+        assertThat(result).extracting(StockInfo::code).containsExactly("005930", "000660");
+    }
+
+    @Test
+    @DisplayName("aggregateMarketTagsForCluster — 단건 편의 오버로드, 빈 입력은 빈 리스트")
+    void aggregateMarketTagsForCluster_emptyInput_returnsEmpty() {
+        assertThat(aggregator.aggregateMarketTagsForCluster(List.of())).isEmpty();
+        // 빈 입력이면 repository 호출도 없음
+        org.mockito.Mockito.verifyNoInteractions(articleTagRepository);
+    }
+
+    @Test
+    @DisplayName("aggregateDetailSources — 섹션 출처 없음 시 articleIds 순서 유지")
+    void aggregateDetailSources_noSectionSources_preservesOrder() {
+        List<Long> articleIds = List.of(10L, 20L);
+        given(newsArticleRepository.findArticleSourceInfoByIdIn(articleIds)).willReturn(List.of(
+                articleSourceProjection(10L, "기사A", "매일경제", "url1"),
+                articleSourceProjection(20L, "기사B", "한경", "url2")
+        ));
+
+        List<ArticleSourceInfo> result = aggregator.aggregateDetailSources(articleIds, Set.of());
+
+        assertThat(result).extracting(ArticleSourceInfo::articleId).containsExactly(10L, 20L);
+    }
+
+    // ---------- helpers ----------
+
+    private SourceProjection sourceProjection(Long id, String publisher, String url) {
+        return new SourceProjection() {
+            public Long getId() { return id; }
+            public String getPublisherName() { return publisher; }
+            public String getOriginalUrl() { return url; }
+        };
+    }
+
+    private ArticleSourceProjection articleSourceProjection(Long id, String title, String publisher, String url) {
+        return new ArticleSourceProjection() {
+            public Long getId() { return id; }
+            public String getTitle() { return title; }
+            public String getPublisherName() { return publisher; }
+            public String getOriginalUrl() { return url; }
+        };
+    }
+
+    private NewsArticleTag stockTag(Long articleId, String code, String name) {
+        return tag(articleId, TagType.STOCK, code, name);
+    }
+
+    private NewsArticleTag topicTag(Long articleId, String code, String name) {
+        return tag(articleId, TagType.TOPIC, code, name);
+    }
+
+    private NewsArticleTag tag(Long articleId, TagType type, String code, String name) {
+        return NewsArticleTag.builder()
+                .newsArticleId(articleId)
+                .tagType(type)
+                .tagCode(code)
+                .tagName(name)
+                .build();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class NewsClusterQueryServiceTest {
@@ -61,14 +62,17 @@ class NewsClusterQueryServiceTest {
 
     @BeforeEach
     void setUp() {
+        // aggregator는 실제 구현으로 wiring (내부에서 NewsArticleRepository/TagRepository 사용)
+        ClusterTagAggregator tagAggregator = new ClusterTagAggregator(newsArticleRepository, articleTagRepository);
         queryService = new NewsClusterQueryService(
                 newsClusterRepository, clusterArticleRepository,
-                newsArticleRepository, articleTagRepository, readRepository,
-                feedbackRepository, questionRepository, sectionRepository, sectionSourceRepository);
+                newsArticleRepository, readRepository, feedbackRepository,
+                questionRepository, sectionRepository, sectionSourceRepository,
+                tagAggregator);
     }
 
     @Test
-    @DisplayName("첫 페이지 조회 — 클러스터 목록을 반환한다")
+    @DisplayName("첫 페이지 조회 — STOCK/TOPIC 분기별 쿼리 + relatedStocks/marketTags 반영")
     void getFeed_firstPage() {
         NewsCluster cluster = createCluster(1L, "삼성전자 실적 호조", "반도체 부문 회복...",
                 OffsetDateTime.now(), 3);
@@ -79,20 +83,27 @@ class NewsClusterQueryServiceTest {
                 .willReturn(List.of(NewsClusterArticle.create(1L, 100L, 0, false)));
         given(newsArticleRepository.findSourceInfoByIdIn(any()))
                 .willReturn(List.of(createSourceProjection(100L, "매일경제", "https://example.com/100")));
-        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), any()))
+        // STOCK과 TOPIC은 분기별로 stub — 매퍼 연결 실수 방어
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK)))
                 .willReturn(List.of(createTag(100L, TagType.STOCK, "005930", "삼성전자")));
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC)))
+                .willReturn(List.of(createTag(100L, TagType.TOPIC, "EARNINGS", "실적")));
 
         ClusterFeedResult result = queryService.getFeed(null, null, 10, null, null, null);
 
         assertThat(result.items()).hasSize(1);
         assertThat(result.items().get(0).title()).isEqualTo("삼성전자 실적 호조");
-        assertThat(result.items().get(0).sourceCount()).isEqualTo(3);
         assertThat(result.items().get(0).sources()).hasSize(1);
         assertThat(result.items().get(0).relatedStocks()).hasSize(1);
         assertThat(result.items().get(0).relatedStocks().get(0).code()).isEqualTo("005930");
         assertThat(result.items().get(0).relatedStocks().get(0).name()).isEqualTo("삼성전자");
+        assertThat(result.items().get(0).marketTags()).containsExactly("실적");
         assertThat(result.items().get(0).isRead()).isFalse();
         assertThat(result.hasNext()).isFalse();
+
+        // QueryService → aggregator 경로에서 STOCK/TOPIC 쿼리 모두 발생했는지 검증
+        verify(articleTagRepository).findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK));
+        verify(articleTagRepository).findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC));
     }
 
     @Test
@@ -195,6 +206,52 @@ class NewsClusterQueryServiceTest {
         assertThat(result.sections().get(1).heading()).isEqualTo("소제목2");
         assertThat(result.sections().get(1).sourceCount()).isEqualTo(1);
         assertThat(result.sources()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("상세 조회 — 상세 출처는 섹션 출처 기사 우선, publisher dedup, 최대 3개")
+    void getDetail_sourcesPrioritizeSectionArticles() {
+        NewsCluster cluster = createCluster(1L, "제목", "요약", OffsetDateTime.now(), 5);
+
+        given(newsClusterRepository.findById(1L)).willReturn(Optional.of(cluster));
+        // 기사 순서: 100, 200, 300, 400, 500 — 200과 400만 섹션 출처
+        given(clusterArticleRepository.findByNewsClusterId(1L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(1L, 100L, 0, false),
+                        NewsClusterArticle.create(1L, 200L, 1, false),
+                        NewsClusterArticle.create(1L, 300L, 2, false),
+                        NewsClusterArticle.create(1L, 400L, 3, false),
+                        NewsClusterArticle.create(1L, 500L, 4, false)));
+
+        given(newsArticleRepository.findArticleSourceInfoByIdIn(any()))
+                .willReturn(List.of(
+                        createArticleSourceProjection(100L, "기사A", "매일경제", "https://a.com"),
+                        createArticleSourceProjection(200L, "기사B", "한경", "https://b.com"),     // 섹션 출처
+                        createArticleSourceProjection(300L, "기사C", "한경", "https://c.com"),     // dedup 대상
+                        createArticleSourceProjection(400L, "기사D", "연합", "https://d.com"),     // 섹션 출처
+                        createArticleSourceProjection(500L, "기사E", "동아", "https://e.com")));   // cap 컷
+
+        // 섹션 두 개 — 각각 200, 400을 출처로 가짐
+        ClusterSummarySection s1 = createSection(10L, 1L, 0, "소제목1", "본문1");
+        ClusterSummarySection s2 = createSection(20L, 1L, 1, "소제목2", "본문2");
+        given(sectionRepository.findByNewsClusterIdOrderBySectionOrderAsc(1L))
+                .willReturn(List.of(s1, s2));
+        given(sectionSourceRepository.findByClusterSummarySectionIdIn(List.of(10L, 20L)))
+                .willReturn(List.of(
+                        ClusterSummarySectionSource.create(10L, 200L),
+                        ClusterSummarySectionSource.create(20L, 400L)));
+
+        ClusterDetailResult result = queryService.getDetail(1L, null);
+
+        // 정책:
+        // 1) 섹션 출처(200, 400)가 비섹션 출처(100)보다 앞
+        // 2) 300은 200과 같은 "한경"이라 dedup
+        // 3) 최대 3개 (500은 컷)
+        assertThat(result.sources()).hasSize(3);
+        assertThat(result.sources()).extracting(s -> s.articleId())
+                .containsExactly(200L, 400L, 100L);
+        assertThat(result.sources()).extracting(s -> s.publisherName())
+                .containsExactly("한경", "연합", "매일경제");
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 설명
`NewsClusterQueryService`에 피드 목록과 상세 조회에 걸쳐 sources/stocks/topics 집계 로직이 중복되어 있었습니다. 집계 책임을 `ClusterTagAggregator` 컴포넌트로 분리해 클래스 크기를 줄이고 집계 단위의 단위 테스트가 가능해지도록 리팩토링했습니다.

### ClusterTagAggregator



1. **집계 컴포넌트 추출 — `ClusterTagAggregator`**
     `ClusterTagAggregator`는 클러스터에 포함된 부가 정보(출처, 관련 종목, 마켓 태그)를 집계하는 헬퍼 컴포넌트입니다.  
    피드 목록과 상세 조회에서 공통으로 사용되던 집계 로직을 한 곳으로 모아 중복을 제거했습니다.
    | 구분 | 메서드 | 용도 |
    |------|--------|------|
    | 피드용 (일괄) | aggregateSources, aggregateStocks, aggregateMarketTags | 여러 클러스터를 `Map<clusterId, 결과>` 형태로 일괄 집계 |
    | 상세용 (단건) | aggregateStocksForCluster, aggregateMarketTagsForCluster, <br/> aggregateDetailSources | 단일 클러스터 기준으로 집계 |

   `@Component`로 분리된 집계 전담 클래스를 신규 추가했습니다. 피드 경로는 `Map<Long, List<SourceInfo/StockInfo/String>>` 형태의 일괄 집계, 상세 경로는 `*ForCluster` 단건 오버로드로 호출 편의를 제공합니다. `aggregateDetailSources`는 섹션 출처 기사 우선 + publisher dedup + 최대 3개 정책을 담당합니다.

   

2. **공용 DTO 패키지 신설 — `domain.news.cluster.dto`**
   기존에 `NewsClusterQueryService` 내부 중첩 public record로 있던 `SourceInfo`, `StockInfo`, `ArticleSourceInfo`를 `domain.news.cluster.dto` 패키지로 이동했습니다.



### 역할 분리

- NewsClusterQueryService  
  - 조회 흐름 오케스트레이션 담당

- ClusterTagAggregator  
  - 기사 목록 기반 태그/출처 집계 담당

이 구조로 분리하면서 Aggregator는 독립적인 단위 테스트가 가능해졌고, QueryService는 역할이 단순해졌습니다.

<br>

## ✅ 수정 파일

### 신규
1. `domain/news/cluster/dto/SourceInfo.java` — 공용 DTO (new)
2. `domain/news/cluster/dto/StockInfo.java` — 공용 DTO (new)
3. `domain/news/cluster/dto/ArticleSourceInfo.java` — 공용 DTO (new)
4. `domain/news/cluster/service/ClusterTagAggregator.java` — 집계 전담 컴포넌트 (new)
5. `test/.../ClusterTagAggregatorTest.java` — 단위 테스트 11건 (new)

### 수정
6. `NewsClusterQueryService.java` — 집계 메서드 제거 + aggregator 위임 + 단건 오버로드 적용 (585 → 453줄)
7. `web/.../ClusterDetailResponse.java` — 공용 DTO 패키지로 import 경로 변경
8. `web/.../ClusterFeedResponse.java` — 공용 DTO 패키지로 import 경로 변경
9. `test/.../NewsClusterQueryServiceTest.java` — setUp에 실제 aggregator wiring + STOCK/TOPIC 분기 stub + 상세 출처 정책 테스트 추가

<br>

## 💭 고민과 해결과정

### 1. 분리 범위 — Aggregator만 분리한 이유

585줄이지만 크게 보면 책임은 (a) 피드 조회 오케스트레이션(여러 로직을 연결해서 하나의 흐름으로 만드는 조립 역할), (b) 상세 조회 오케스트레이션, (c) sources/stocks/topics 집계 세 가지였습니다. (a)/(b)는 public API 경계라 쪼개면 오히려 호출처 변경이 커집니다. 반면 (c)는 피드/상세가 공통으로 쓰는 헬퍼 성격이라 재사용 단위로 적합해 이것만 분리했습니다. `buildSectionDetails`는 상세 전용이라 남겼고, 읽음/피드백 조회는 각 경로에서 한 번씩만 쓰여 분리 이익이 없어 그대로 뒀습니다.


### 2. `aggregateDetailSources` 두 번 순회 → stable sort
원래는 두 번의 for-loop로 섹션 출처를 우선 배치하도록 구현했지만, projection에 없는 id(삭제되었거나 크롤링에 실패한 경우)가 두 루프 모두에서 자연스럽게 스킵되면서 처리 의도가 코드 상에서 명확하게 드러나지 않았습니다. 이를 `stream().filter(Objects::nonNull).sorted(Comparator.comparingInt(...))` 방식으로 변경하면서, 누락된 id를 명시적으로 제외한다는 의도가 코드에 분명히 드러나도록 개선했습니다. 또한 stable sort를 사용해 동일 우선순위 내에서는 `articleIds`의 입력 순서가 그대로 유지되도록 했습니다.


### 3. STOCK + TOPIC 단일 쿼리 통합은 다음 PR

피드 경로에서 `findByNewsArticleIdInAndTagType`이 STOCK/TOPIC 각 1회씩 호출되는 문제를 `findByNewsArticleIdInAndTagTypeIn(..., Set.of(STOCK, TOPIC))` 한 번으로 줄이는 최적화를 진행할 수 있었지만 Repository 메서드 추가가 필요해 이번 PR 범위를 넘어가므로 다음 PR에서 구현하고자 합니다.
<br>

## 📊 결과

| | Before | After |
|---|--------|-------|
| `NewsClusterQueryService` line 수 | 585 | 453 |
| `NewsClusterQueryService` 의존성 | 9 | 8 (tag repo 제거) |
| 집계 로직 단위 테스트 가능 여부 | 불가 | 가능 (ClusterTagAggregatorTest 11건) |
| 상세 경로 Map.of 래핑 | 2곳 | 0 |

<br>

### 🔗 관련 이슈
Refs #133
