### PR TITLE
[WEF-610] 턴 전환 소켓 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/news/dto/BriefingInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/dto/BriefingInfo.java
@@ -5,8 +5,15 @@ import java.time.LocalDate;
 /**
  * 게임 컨텍스트의 AI 브리핑 조회 결과.
  *
- * @param targetDate   브리핑 대상 날짜 (활성 턴의 날짜)
- * @param briefingText 캐시 또는 OpenAI 생성 결과 텍스트
+ * @param targetDate     브리핑 대상 날짜 (활성 턴의 날짜)
+ * @param marketOverview 시장 개요
+ * @param keyIssues      주요 이슈
+ * @param investmentHint 투자 힌트
  */
-public record BriefingInfo(LocalDate targetDate, String briefingText) {
+public record BriefingInfo(
+        LocalDate targetDate,
+        String marketOverview,
+        String keyIssues,
+        String investmentHint
+) {
 }

--- a/src/main/java/com/solv/wefin/domain/game/news/entity/BriefingCache.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/entity/BriefingCache.java
@@ -23,16 +23,27 @@ public class BriefingCache {
     @Column(name = "target_date", nullable = false, unique = true)
     private LocalDate targetDate;
 
-    @Column(name = "briefing_text", nullable = false, columnDefinition = "TEXT")
-    private String briefingText;
+    @Column(name = "market_overview", nullable = false, columnDefinition = "TEXT")
+    private String marketOverview;
+
+    @Column(name = "key_issues", nullable = false, columnDefinition = "TEXT")
+    private String keyIssues;
+
+    @Column(name = "investment_hint", nullable = false, columnDefinition = "TEXT")
+    private String investmentHint;
 
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt;
 
-    public static BriefingCache create(LocalDate targetDate, String briefingText) {
+    public static BriefingCache create(LocalDate targetDate,
+                                       String marketOverview,
+                                       String keyIssues,
+                                       String investmentHint) {
         BriefingCache cache = new BriefingCache();
         cache.targetDate = targetDate;
-        cache.briefingText = briefingText;
+        cache.marketOverview = marketOverview;
+        cache.keyIssues = keyIssues;
+        cache.investmentHint = investmentHint;
         cache.createdAt = OffsetDateTime.now();
         return cache;
     }

--- a/src/main/java/com/solv/wefin/domain/game/news/service/BriefingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/service/BriefingService.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.game.news.entity.GameNewsArchive;
 import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
 import com.solv.wefin.domain.game.openai.OpenAiBriefingClient;
 import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.ArticleSummary;
+import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -24,14 +25,14 @@ public class BriefingService {
     private final OpenAiBriefingClient openAiBriefingClient;
     private final BriefingCacheRepository briefingCacheRepository;
 
-    /** 날짜별 in-process 락 — 같은 날짜 동시 요청의 크롤링/OpenAI 중복 호출을 직렬화한다. */
+    /** 날짜별 in-process 락 — 같은 날짜 동시 요청의 크롤링/OpenAI 중복 호출을 직렬��한다. */
     private final ConcurrentHashMap<LocalDate, Object> dateLocks = new ConcurrentHashMap<>();
 
-    /** 특정 날짜의 AI 브리핑을 briefing_cache에서 조회하거나, 없으면 크롤링 + OpenAI로 생성해 저장한다. */
-    public String getBriefingForDate(LocalDate date) {
+    /** 특정 날짜의 AI 브리핑을 briefing_cache에서 조회��거나, 없으면 크롤링 + OpenAI로 생성해 저장한다. */
+    public BriefingParts getBriefingForDate(LocalDate date) {
         Optional<BriefingCache> cached = briefingCacheRepository.findByTargetDate(date);
         if (cached.isPresent()) {
-            return cached.get().getBriefingText();
+            return toParts(cached.get());
         }
 
         Object lock = dateLocks.computeIfAbsent(date, k -> new Object());
@@ -39,7 +40,7 @@ public class BriefingService {
             try {
                 Optional<BriefingCache> rechecked = briefingCacheRepository.findByTargetDate(date);
                 if (rechecked.isPresent()) {
-                    return rechecked.get().getBriefingText();
+                    return toParts(rechecked.get());
                 }
 
                 log.info("[브리핑] 생성 시작: date={}", date);
@@ -52,9 +53,9 @@ public class BriefingService {
                     return buildDefaultBriefing(date);
                 }
 
-                String briefingText;
+                BriefingParts parts;
                 try {
-                    briefingText = generateBriefingViaOpenAi(date, news);
+                    parts = generateBriefingViaOpenAi(date, news);
                 } catch (Exception e) {
                     log.error("[브리핑] OpenAI 호출 실패 → 폴백 반환, briefing_cache 미저장: date={}, error={}",
                             date, e.getMessage());
@@ -62,23 +63,32 @@ public class BriefingService {
                 }
 
                 try {
-                    BriefingCache cache = BriefingCache.create(date, briefingText);
+                    BriefingCache cache = BriefingCache.create(
+                            date, parts.marketOverview(), parts.keyIssues(), parts.investmentHint());
                     briefingCacheRepository.save(cache);
                 } catch (DataIntegrityViolationException e) {
                     log.info("[브리핑] 동시 생성 감지, 기존 캐시 사용: date={}", date);
                     return briefingCacheRepository.findByTargetDate(date)
-                            .map(BriefingCache::getBriefingText)
-                            .orElse(briefingText);
+                            .map(this::toParts)
+                            .orElse(parts);
                 }
 
-                return briefingText;
+                return parts;
             } finally {
                 dateLocks.remove(date);
             }
         }
     }
 
-    private String generateBriefingViaOpenAi(LocalDate date, List<GameNewsArchive> news) {
+    private BriefingParts toParts(BriefingCache cache) {
+        return new BriefingParts(
+                cache.getMarketOverview(),
+                cache.getKeyIssues(),
+                cache.getInvestmentHint()
+        );
+    }
+
+    private BriefingParts generateBriefingViaOpenAi(LocalDate date, List<GameNewsArchive> news) {
         List<ArticleSummary> summaries = news.stream()
                 .map(n -> new ArticleSummary(
                         n.getTitle(), n.getSummary(),
@@ -88,18 +98,25 @@ public class BriefingService {
         return openAiBriefingClient.generateBriefing(date, summaries);
     }
 
-    private String buildDefaultBriefing(LocalDate date) {
-        return String.format("[%s 시장 브리핑]\n이 날짜의 뉴스 데이터가 없습니다. "
-                + "주식 차트와 거래 데이터를 직접 분석하여 투자 결정을 내려보세요.", date);
+    private BriefingParts buildDefaultBriefing(LocalDate date) {
+        return new BriefingParts(
+                String.format("%s 날짜의 뉴스 데이터가 없습니다. "
+                        + "주식 차트와 거래 데이터를 직접 분석하여 투자 결정을 내려보세요.", date),
+                "",
+                ""
+        );
     }
 
-    private String buildDefaultBriefing(LocalDate date, List<GameNewsArchive> news) {
+    private BriefingParts buildDefaultBriefing(LocalDate date, List<GameNewsArchive> news) {
         String headlines = news.stream()
                 .limit(3)
-                .map(n -> "• " + n.getTitle())
+                .map(n -> "- " + n.getTitle())
                 .collect(Collectors.joining("\n"));
 
-        return String.format("[%s 시장 브리핑]\n\n주요 뉴스:\n%s\n\n"
-                + "차트와 거래량을 참고하여 신중하게 투자 결정을 내리세요.", date, headlines);
+        return new BriefingParts(
+                String.format("%s 시장 브리핑 — AI 분석에 실패하여 주요 헤드라인만 제공합니다.", date),
+                headlines,
+                "차트와 거래량을 참고하여 신중하게 투자 결정을 내리세요."
+        );
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/openai/OpenAiBriefingClient.java
+++ b/src/main/java/com/solv/wefin/domain/game/openai/OpenAiBriefingClient.java
@@ -1,6 +1,9 @@
 package com.solv.wefin.domain.game.openai;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -17,12 +20,15 @@ public class OpenAiBriefingClient {
 
     private final RestClient restClient;
     private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper;
 
     public OpenAiBriefingClient(
             @Qualifier("openAiRestClient") RestClient restClient,
-            OpenAiProperties properties) {
+            OpenAiProperties properties,
+            ObjectMapper objectMapper) {
         this.restClient = restClient;
         this.properties = properties;
+        this.objectMapper = objectMapper;
 
         if (properties.getApiKey() == null || properties.getApiKey().isBlank()) {
             log.warn("[OpenAI] API 키가 설정되지 않았습니다. 브리핑 생성이 실패합니다.");
@@ -34,9 +40,9 @@ public class OpenAiBriefingClient {
      * 뉴스 Entity에 의존하지 않고 제목/요약/URL/카테고리만 받는다.
      *
      * @return 생성된 브리핑 텍스트, 실패 시 빈 Optional 대신 예외를 던진다.
-     *         (폴백 처리는 호출하는 Service에서 담당)
+     *         (폴백 처리는 호출하는 Service에서 ��당)
      */
-    public String generateBriefing(LocalDate date, List<ArticleSummary> articles) {
+    public BriefingParts generateBriefing(LocalDate date, List<ArticleSummary> articles) {
         String newsContext = buildNewsContext(articles);
         String userPrompt = buildPrompt(date, newsContext);
 
@@ -49,7 +55,8 @@ public class OpenAiBriefingClient {
                         new ChatRequest.Message("user", userPrompt)
                 ),
                 properties.getMaxTokens(),
-                properties.getTemperature()
+                properties.getTemperature(),
+                new ChatRequest.ResponseFormat("json_object")
         );
 
         ChatResponse response = restClient.post()
@@ -64,7 +71,24 @@ public class OpenAiBriefingClient {
 
         String content = response.choices().get(0).message().content();
         log.info("[브리핑] OpenAI 호출 완료: date={}", date);
-        return content;
+        return parseBriefingJson(content);
+    }
+
+    private BriefingParts parseBriefingJson(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            String marketOverview = node.path("marketOverview").asText("");
+            String keyIssues = node.path("keyIssues").asText("");
+            String investmentHint = node.path("investmentHint").asText("");
+
+            if (marketOverview.isBlank() || keyIssues.isBlank() || investmentHint.isBlank()) {
+                throw new IllegalStateException("OpenAI JSON 응답에 필수 필드가 비어 있습니다: " + json);
+            }
+
+            return new BriefingParts(marketOverview, keyIssues, investmentHint);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("OpenAI JSON 파싱 실패: " + json, e);
+        }
     }
 
     // ── 내부 메서드 ──────────────────────────────────────────
@@ -79,7 +103,6 @@ public class OpenAiBriefingClient {
                             && !a.summary().isBlank()
                             && !a.summary().equals(a.title());
                     return "[" + a.category() + "] 제목: " + a.title()
-                            + "\n    URL: " + a.url()
                             + (hasSummary ? "\n    내용: " + a.summary() : "");
                 })
                 .collect(Collectors.joining("\n"));
@@ -87,7 +110,7 @@ public class OpenAiBriefingClient {
 
     private String buildPrompt(LocalDate date, String newsContext) {
         return String.format("""
-                아래는 %s 날짜의 금융 뉴스 기사들입니다.
+                아래는 특정 날짜의 금융 뉴스 기사들입니다.
 
                 [뉴스 기사]
                 %s
@@ -96,22 +119,20 @@ public class OpenAiBriefingClient {
                 - 위 기사들의 내용만 근거로 분석하세요.
                 - 기사에 없는 내용을 추측하거나 덧붙이지 마세요.
                 - 당신이 알고 있는 사전 지식은 절대 사용하지 마세요.
-                - 각 주요 이슈 끝에 해당 기사의 URL을 괄호 안에 넣으세요.
+                - URL이나 링크를 응답에 절대 포함하지 마세요.
+                - 날짜, 연도, 월, 일을 응답에 절대 포함하지 마세요. ("2021년", "올해", "1월" 등 금지)
                 - 번호 표기("기사 1" 등)는 절대 사용하지 마세요.
                 - 이모티콘을 사용하지 마세요.
 
-                반드시 아래 형식으로 응답하세요:
-
-                [시장 개요] (4~5문장, 전체 시장 동향을 구체적 수치와 함께 상세히 요약)
-                [주요 이슈]
-                - 가장 영향력 있는 섹터/이슈 (https://...)
-                - 두 번째 영향력 있는 섹터/이슈 (https://...)
-                - 세 번째 영향력 있는 섹터/이슈 (https://...)
-                [투자 힌트] (1~2문장, 특정 종목명 언급 금지)
+                반드시 아래 JSON 형식으로 응답하세요:
+                {
+                  "marketOverview": "5~7문장, 그 날 가장 중요한 섹터 2~3개를 중심으로 구체적 수치와 함께 상세히 분석",
+                  "keyIssues": "- 가장 영향력 있는 섹터/이슈\\n- 두 번째 영향력 있는 섹터/이슈\\n- 세 번째 영향력 있는 섹터/이슈",
+                  "investmentHint": "1~2문장, 특정 종목명 언급 금지"
+                }
 
                 주요 이슈는 기사들을 종합 분석하여 시장에 가장 영향력이 큰 3개만 선별하세요.
                 """,
-                date.toString(),
                 newsContext
         );
     }
@@ -137,13 +158,22 @@ public class OpenAiBriefingClient {
             String category
     ) {}
 
+    /** OpenAI JSON 응답을 파싱한 3파트 브리핑 결과. */
+    public record BriefingParts(
+            String marketOverview,
+            String keyIssues,
+            String investmentHint
+    ) {}
+
     record ChatRequest(
             String model,
             List<Message> messages,
             @JsonProperty("max_tokens") int maxTokens,
-            double temperature
+            double temperature,
+            @JsonProperty("response_format") ResponseFormat responseFormat
     ) {
         record Message(String role, String content) {}
+        record ResponseFormat(String type) {}
     }
 
     record ChatResponse(

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/entity/GamePortfolioSnapshot.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/entity/GamePortfolioSnapshot.java
@@ -1,0 +1,75 @@
+package com.solv.wefin.domain.game.snapshot.entity;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Entity
+@Table(name = "game_portfolio_snapshot",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"turn_id", "participant_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GamePortfolioSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "snapshot_id")
+    private UUID snapshotId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "turn_id", nullable = false)
+    private GameTurn turn;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    private GameParticipant participant;
+
+    @Column(name = "total_asset", nullable = false, precision = 18, scale = 2)
+    private BigDecimal totalAsset;
+
+    @Column(name = "cash", nullable = false, precision = 18, scale = 2)
+    private BigDecimal cash;
+
+    @Column(name = "stock_value", nullable = false, precision = 18, scale = 2)
+    private BigDecimal stockValue;
+
+    @Column(name = "profit_rate", nullable = false, precision = 8, scale = 2)
+    private BigDecimal profitRate;
+
+    @Builder
+    private GamePortfolioSnapshot(GameTurn turn, GameParticipant participant,
+                                   BigDecimal totalAsset, BigDecimal cash,
+                                   BigDecimal stockValue, BigDecimal profitRate) {
+        this.turn = turn;
+        this.participant = participant;
+        this.totalAsset = totalAsset;
+        this.cash = cash;
+        this.stockValue = stockValue;
+        this.profitRate = profitRate;
+    }
+
+    public static GamePortfolioSnapshot create(GameTurn turn, GameParticipant participant,
+                                                BigDecimal cash, BigDecimal stockValue,
+                                                BigDecimal seedMoney) {
+        BigDecimal totalAsset = cash.add(stockValue);
+        BigDecimal profitRate = totalAsset.subtract(seedMoney)
+                .multiply(BigDecimal.valueOf(100))
+                .divide(seedMoney, 2, java.math.RoundingMode.HALF_UP);
+
+        return GamePortfolioSnapshot.builder()
+                .turn(turn)
+                .participant(participant)
+                .totalAsset(totalAsset)
+                .cash(cash)
+                .stockValue(stockValue)
+                .profitRate(profitRate)
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/repository/GamePortfolioSnapshotRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/repository/GamePortfolioSnapshotRepository.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.game.snapshot.repository;
+
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface GamePortfolioSnapshotRepository extends JpaRepository<GamePortfolioSnapshot, UUID> {
+}

--- a/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/entity/GameTurn.java
@@ -58,8 +58,20 @@ public class GameTurn {
                 .build();
     }
 
+    public static GameTurn createNext(GameTurn currentTurn, LocalDate nextDate) {
+        return GameTurn.builder()
+                .gameRoom(currentTurn.getGameRoom())
+                .turnNumber(currentTurn.getTurnNumber() + 1)
+                .turnDate(nextDate)
+                .build();
+    }
+
     public void complete() {
         this.status = COMPLETED;
+    }
+
+    public void assignBriefing(UUID briefingId) {
+        this.briefingId = briefingId;
     }
 
 }

--- a/src/main/java/com/solv/wefin/domain/game/turn/event/TurnChangeEvent.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/event/TurnChangeEvent.java
@@ -1,7 +1,6 @@
 package com.solv.wefin.domain.game.turn.event;
 
-import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -10,17 +9,31 @@ import java.util.UUID;
  * 턴 전환 완료 시 발행되는 도메인 이벤트.
  * 리스너에서 WebSocket 브로드캐스트에 사용한다.
  *
- * @param roomId    게임방 ID — WebSocket topic 경로에 사용
+ * <p>Entity 대신 {@link SnapshotData}를 사용하여,
+ * AFTER_COMMIT 단계에서 Lazy Loading 없이 안전하게 접근할 수 있다.
+ *
+ * @param roomId     게임방 ID — WebSocket topic 경로에 사용
  * @param turnNumber 새 턴 번호
  * @param turnDate   새 턴 날짜
  * @param briefingId AI 브리핑 ID (없으면 null)
- * @param snapshots  이번 턴의 모든 참가자 스냅샷 (랭킹 계산용)
+ * @param snapshots  이번 턴의 모든 참가자 스냅샷 데이터 (랭킹 계산용)
  */
 public record TurnChangeEvent(
         UUID roomId,
         int turnNumber,
         LocalDate turnDate,
         UUID briefingId,
-        List<GamePortfolioSnapshot> snapshots
+        List<SnapshotData> snapshots
 ) {
+
+    /**
+     * AFTER_COMMIT 시점에서 안전하게 사용할 수 있는 스냅샷 경량 DTO.
+     * 트랜잭션 안에서 Entity → SnapshotData로 변환해서 이벤트에 담는다.
+     */
+    public record SnapshotData(
+            UUID userId,
+            BigDecimal totalAsset,
+            BigDecimal profitRate
+    ) {
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/game/turn/event/TurnChangeEvent.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/event/TurnChangeEvent.java
@@ -1,0 +1,26 @@
+package com.solv.wefin.domain.game.turn.event;
+
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 턴 전환 완료 시 발행되는 도메인 이벤트.
+ * 리스너에서 WebSocket 브로드캐스트에 사용한다.
+ *
+ * @param roomId    게임방 ID — WebSocket topic 경로에 사용
+ * @param turnNumber 새 턴 번호
+ * @param turnDate   새 턴 날짜
+ * @param briefingId AI 브리핑 ID (없으면 null)
+ * @param snapshots  이번 턴의 모든 참가자 스냅샷 (랭킹 계산용)
+ */
+public record TurnChangeEvent(
+        UUID roomId,
+        int turnNumber,
+        LocalDate turnDate,
+        UUID briefingId,
+        List<GamePortfolioSnapshot> snapshots
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/GameTurnService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/GameTurnService.java
@@ -1,7 +1,5 @@
-package com.solv.wefin.domain.game.news.service;
+package com.solv.wefin.domain.game.turn.service;
 
-import com.solv.wefin.domain.game.news.dto.BriefingInfo;
-import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
@@ -13,27 +11,20 @@ import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
-/**
- * 게임 컨텍스트의 AI 브리핑 조회 서비스.
- * 방/참가자/활성 턴 검증 후 {@link BriefingService}에 위임한다.
- *
- * <p>{@code @Transactional} 미부착: 내부 BriefingService가 캐시 미스 시 DB write +
- * 외부 API 호출(~30초)을 수행하므로, 상위에서 트랜잭션으로 감싸면 long-running tx 위험.
- * 검증 쿼리 3건은 각 auto-tx로 충분.
- */
 @Service
 @RequiredArgsConstructor
-public class GameBriefingService {
+@Transactional(readOnly = true)
+public class GameTurnService {
 
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
-    private final BriefingService briefingService;
 
-    public BriefingInfo getBriefingForRoom(UUID roomId, UUID userId) {
+    public GameTurn getCurrentTurn(UUID roomId, UUID userId) {
         // 1. 게임방 확인
         GameRoom gameRoom = gameRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
@@ -43,18 +34,13 @@ public class GameBriefingService {
                 .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
 
-        // 3. ACTIVE 턴 → 턴 날짜
-        GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+        // 3. 활성 턴 조회
+        return gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
-
-        // 4. 기존 BriefingService에 위임 (캐시 히트/미스 처리)
-        BriefingParts parts = briefingService.getBriefingForDate(activeTurn.getTurnDate());
-
-        return new BriefingInfo(
-                activeTurn.getTurnDate(),
-                parts.marketOverview(),
-                parts.keyIssues(),
-                parts.investmentHint()
-        );
     }
 }
+
+/**
+ 조회 쓰기없음
+ roomId 조회 -> 참가자 조회 userId 조회 (participant) -> turn 상태 조회 active 인지
+ */

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -20,6 +20,7 @@ import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.domain.game.turn.event.TurnChangeEvent;
+import com.solv.wefin.domain.game.turn.event.TurnChangeEvent.SnapshotData;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -105,9 +106,17 @@ public class TurnAdvanceService {
         log.info("[턴 전환] 새 턴 생성: roomId={}, turn={}, date={}", roomId, nextTurn.getTurnNumber(), nextDate);
 
         // 10. 턴 전환 이벤트 발행 (커밋 후 WebSocket 브로드캐스트)
+        // 트랜잭션 안에서 Entity → SnapshotData 변환 (AFTER_COMMIT 시 Lazy Loading 방지)
+        List<SnapshotData> snapshotDataList = snapshots.stream()
+                .map(s -> new SnapshotData(
+                        s.getParticipant().getUserId(),
+                        s.getTotalAsset(),
+                        s.getProfitRate()))
+                .toList();
+
         eventPublisher.publishEvent(new TurnChangeEvent(
                 roomId, nextTurn.getTurnNumber(), nextDate,
-                nextTurn.getBriefingId(), snapshots));
+                nextTurn.getBriefingId(), snapshotDataList));
 
         return nextTurn;
     }

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -1,0 +1,195 @@
+package com.solv.wefin.domain.game.turn.service;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
+import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.domain.game.turn.event.TurnChangeEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TurnAdvanceService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final GameHoldingRepository gameHoldingRepository;
+    private final StockDailyRepository stockDailyRepository;
+    private final GamePortfolioSnapshotRepository snapshotRepository;
+    private final BriefingCacheRepository briefingCacheRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * 턴 전환 핵심 로직.
+     * 투표 통과, REST 직접 호출 등 어디서든 이 메서드를 호출하면 턴이 전환된다.
+     *
+     * @return 새로 생성된 턴 (게임 종료 시 null)
+     */
+    @Transactional
+    public GameTurn advanceTurn(UUID roomId, UUID userId) {
+        // 1. 게임방 조회 + 상태 검증 (비관적 락)
+        GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() == RoomStatus.FINISHED) {
+            throw new BusinessException(ErrorCode.GAME_ALREADY_FINISHED);
+        }
+
+        // 2. 참가자 검증
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. 현재 활성 턴 조회
+        GameTurn currentTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        // 4. 모든 활성 참가자의 보유종목 평가 + 스냅샷 저장
+        List<GameParticipant> activeParticipants =
+                gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+
+        List<GamePortfolioSnapshot> snapshots =
+                saveSnapshotsForAll(currentTurn, activeParticipants, gameRoom.getSeed());
+
+        // 5. 현재 턴 완료 처리
+        currentTurn.complete();
+
+        // 6. 다음 거래일 계산
+        LocalDate nextDate = calculateNextTradeDate(currentTurn.getTurnDate(), gameRoom.getMoveDays());
+
+        // 7. 종료 판단: 다음 날짜가 endDate 초과 시 게임 종료
+        if (nextDate.isAfter(gameRoom.getEndDate())) {
+            gameRoom.finish();
+            log.info("[턴 전환] 게임 종료: roomId={}, 마지막 턴={}", roomId, currentTurn.getTurnNumber());
+            return null;
+        }
+
+        // 8. 새 턴 생성
+        GameTurn nextTurn = GameTurn.createNext(currentTurn, nextDate);
+
+        // 9. 브리핑 연결
+        briefingCacheRepository.findByTargetDate(nextDate)
+                .ifPresent(briefing -> nextTurn.assignBriefing(briefing.getBriefingId()));
+
+        gameTurnRepository.save(nextTurn);
+        log.info("[턴 전환] 새 턴 생성: roomId={}, turn={}, date={}", roomId, nextTurn.getTurnNumber(), nextDate);
+
+        // 10. 턴 전환 이벤트 발행 (커밋 후 WebSocket 브로드캐스트)
+        eventPublisher.publishEvent(new TurnChangeEvent(
+                roomId, nextTurn.getTurnNumber(), nextDate,
+                nextTurn.getBriefingId(), snapshots));
+
+        return nextTurn;
+    }
+
+    /**
+     * 모든 활성 참가자의 포트폴리오 스냅샷을 저장한다.
+     * 보유종목이 없는 참가자도 현금만으로 스냅샷을 생성한다.
+     */
+    private List<GamePortfolioSnapshot> saveSnapshotsForAll(GameTurn turn,
+                                                             List<GameParticipant> participants,
+                                                             BigDecimal seedMoney) {
+        LocalDate turnDate = turn.getTurnDate();
+        List<GamePortfolioSnapshot> savedSnapshots = new ArrayList<>();
+
+        for (GameParticipant participant : participants) {
+            List<GameHolding> holdings =
+                    gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0);
+
+            BigDecimal stockValue = evaluateHoldings(holdings, turnDate);
+
+            GamePortfolioSnapshot snapshot = GamePortfolioSnapshot.create(
+                    turn, participant, participant.getSeed(), stockValue, seedMoney);
+
+            savedSnapshots.add(snapshotRepository.save(snapshot));
+        }
+
+        return savedSnapshots;
+    }
+
+    /**
+     * 보유종목을 해당 날짜 종가로 평가한다.
+     * 종가 데이터가 없는 종목은 가장 가까운 이전 거래일의 종가를 사용한다.
+     */
+    private BigDecimal evaluateHoldings(List<GameHolding> holdings, LocalDate turnDate) {
+        if (holdings.isEmpty()) {
+            return BigDecimal.ZERO;
+        }
+
+        // 보유종목의 StockInfo 목록 추출
+        List<StockInfo> stockInfos = holdings.stream()
+                .map(GameHolding::getStockInfo)
+                .toList();
+
+        // 해당 날짜 종가 일괄 조회 (N+1 방지)
+        Map<StockInfo, StockDaily> priceMap = stockDailyRepository
+                .findAllByStockInfoInAndTradeDate(stockInfos, turnDate)
+                .stream()
+                .collect(Collectors.toMap(StockDaily::getStockInfo, Function.identity()));
+
+        BigDecimal totalValue = BigDecimal.ZERO;
+        for (GameHolding holding : holdings) {
+            StockDaily daily = priceMap.get(holding.getStockInfo());
+
+            BigDecimal closePrice;
+            if (daily != null) {
+                closePrice = daily.getClosePrice();
+            } else {
+                // 비거래일: 가장 가까운 이전 거래일 종가 사용
+                closePrice = findFallbackClosePrice(holding.getStockInfo(), turnDate);
+            }
+
+            totalValue = totalValue.add(closePrice.multiply(BigDecimal.valueOf(holding.getQuantity())));
+        }
+
+        return totalValue;
+    }
+
+    private BigDecimal findFallbackClosePrice(StockInfo stockInfo, LocalDate date) {
+        return stockDailyRepository.findLatestTradeDateOnOrBefore(date)
+                .flatMap(tradeDate -> stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, tradeDate))
+                .map(StockDaily::getClosePrice)
+                .orElse(BigDecimal.ZERO);
+    }
+
+    /**
+     * 다음 거래일을 계산한다.
+     * 현재 날짜 + moveDays 후, 비거래일이면 가장 가까운 이전 거래일로 보정.
+     */
+    private LocalDate calculateNextTradeDate(LocalDate currentDate, int moveDays) {
+        LocalDate targetDate = currentDate.plusDays(moveDays);
+
+        return stockDailyRepository.findLatestTradeDateOnOrBefore(targetDate)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -150,6 +150,7 @@ public enum ErrorCode {
 
     // GameTurn
     GAME_NOT_STARTED(400, "게임이 시작되지 않았습니다."),
+    GAME_ALREADY_FINISHED(400, "이미 종료된 게임입니다."),
 
     // GameStock
     GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/game/briefing/dto/response/BriefingResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/briefing/dto/response/BriefingResponse.java
@@ -11,12 +11,16 @@ import java.time.LocalDate;
 public class BriefingResponse {
 
     private LocalDate targetDate;
-    private String briefingText;
+    private String marketOverview;
+    private String keyIssues;
+    private String investmentHint;
 
     public static BriefingResponse from(BriefingInfo info) {
         return new BriefingResponse(
                 info.targetDate(),
-                info.briefingText()
+                info.marketOverview(),
+                info.keyIssues(),
+                info.investmentHint()
         );
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/turn/GameTurnController.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/GameTurnController.java
@@ -1,0 +1,48 @@
+package com.solv.wefin.web.game.turn;
+
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.service.GameTurnService;
+import com.solv.wefin.domain.game.turn.service.TurnAdvanceService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.turn.dto.response.CurrentTurnResponse;
+import com.solv.wefin.web.game.turn.dto.response.TurnAdvanceResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/rooms/{roomId}/turns")
+@RequiredArgsConstructor
+public class GameTurnController {
+
+    private final GameTurnService gameTurnService;
+    private final TurnAdvanceService turnAdvanceService;
+
+    @GetMapping("/current")
+    public ResponseEntity<ApiResponse<CurrentTurnResponse>> getCurrentTurn(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        GameTurn turn = gameTurnService.getCurrentTurn(roomId, userId);
+        CurrentTurnResponse response = CurrentTurnResponse.from(turn);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PostMapping("/next")
+    public ResponseEntity<ApiResponse<TurnAdvanceResponse>> advanceTurn(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        GameTurn nextTurn = turnAdvanceService.advanceTurn(roomId, userId);
+
+        TurnAdvanceResponse response = (nextTurn != null)
+                ? TurnAdvanceResponse.from(nextTurn)
+                : TurnAdvanceResponse.finished();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/turn/dto/response/CurrentTurnResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/dto/response/CurrentTurnResponse.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.web.game.turn.dto.response;
+
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record CurrentTurnResponse(
+        UUID turnId,
+        int turnNumber,
+        LocalDate turnDate,
+        TurnStatus status,
+        UUID briefingId
+) {
+    public static CurrentTurnResponse from(GameTurn turn) {
+        return new CurrentTurnResponse(
+                turn.getTurnId(),
+                turn.getTurnNumber(),
+                turn.getTurnDate(),
+                turn.getStatus(),
+                turn.getBriefingId()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnAdvanceResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnAdvanceResponse.java
@@ -1,0 +1,28 @@
+package com.solv.wefin.web.game.turn.dto.response;
+
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record TurnAdvanceResponse(
+        boolean gameFinished,
+        UUID turnId,
+        Integer turnNumber,
+        LocalDate turnDate,
+        UUID briefingId
+) {
+    public static TurnAdvanceResponse from(GameTurn nextTurn) {
+        return new TurnAdvanceResponse(
+                false,
+                nextTurn.getTurnId(),
+                nextTurn.getTurnNumber(),
+                nextTurn.getTurnDate(),
+                nextTurn.getBriefingId()
+        );
+    }
+
+    public static TurnAdvanceResponse finished() {
+        return new TurnAdvanceResponse(true, null, null, null, null);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnChangeMessage.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnChangeMessage.java
@@ -1,0 +1,57 @@
+package com.solv.wefin.web.game.turn.dto.response;
+
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * WebSocket /topic/rooms/{roomId}/turn 으로 브로드캐스트되는 턴 전환 메시지.
+ */
+public record TurnChangeMessage(
+        String type,
+        int turnNumber,
+        LocalDate turnDate,
+        UUID briefingId,
+        List<RankingEntry> rankings
+) {
+
+    public record RankingEntry(
+            int rank,
+            UUID userId,
+            String userName,
+            BigDecimal totalAsset,
+            BigDecimal profitRate
+    ) {
+    }
+
+    /**
+     * @param nicknameMap userId → nickname 매핑 (User 테이블에서 조회)
+     */
+    public static TurnChangeMessage from(int turnNumber, LocalDate turnDate,
+                                          UUID briefingId,
+                                          List<GamePortfolioSnapshot> snapshots,
+                                          Map<UUID, String> nicknameMap) {
+        AtomicInteger rankCounter = new AtomicInteger(1);
+
+        List<RankingEntry> rankings = snapshots.stream()
+                .sorted(Comparator.comparing(GamePortfolioSnapshot::getTotalAsset).reversed())
+                .map(s -> {
+                    UUID userId = s.getParticipant().getUserId();
+                    return new RankingEntry(
+                            rankCounter.getAndIncrement(),
+                            userId,
+                            nicknameMap.getOrDefault(userId, "알 수 없음"),
+                            s.getTotalAsset(),
+                            s.getProfitRate());
+                })
+                .toList();
+
+        return new TurnChangeMessage("TURN_CHANGE", turnNumber, turnDate, briefingId, rankings);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnChangeMessage.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnChangeMessage.java
@@ -1,6 +1,6 @@
 package com.solv.wefin.web.game.turn.dto.response;
 
-import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.turn.event.TurnChangeEvent.SnapshotData;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -35,21 +35,18 @@ public record TurnChangeMessage(
      */
     public static TurnChangeMessage from(int turnNumber, LocalDate turnDate,
                                           UUID briefingId,
-                                          List<GamePortfolioSnapshot> snapshots,
+                                          List<SnapshotData> snapshots,
                                           Map<UUID, String> nicknameMap) {
         AtomicInteger rankCounter = new AtomicInteger(1);
 
         List<RankingEntry> rankings = snapshots.stream()
-                .sorted(Comparator.comparing(GamePortfolioSnapshot::getTotalAsset).reversed())
-                .map(s -> {
-                    UUID userId = s.getParticipant().getUserId();
-                    return new RankingEntry(
-                            rankCounter.getAndIncrement(),
-                            userId,
-                            nicknameMap.getOrDefault(userId, "알 수 없음"),
-                            s.getTotalAsset(),
-                            s.getProfitRate());
-                })
+                .sorted(Comparator.comparing(SnapshotData::totalAsset).reversed())
+                .map(s -> new RankingEntry(
+                        rankCounter.getAndIncrement(),
+                        s.userId(),
+                        nicknameMap.getOrDefault(s.userId(), "알 수 없음"),
+                        s.totalAsset(),
+                        s.profitRate()))
                 .toList();
 
         return new TurnChangeMessage("TURN_CHANGE", turnNumber, turnDate, briefingId, rankings);

--- a/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnChangeMessage.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/dto/response/TurnChangeMessage.java
@@ -40,7 +40,9 @@ public record TurnChangeMessage(
         AtomicInteger rankCounter = new AtomicInteger(1);
 
         List<RankingEntry> rankings = snapshots.stream()
-                .sorted(Comparator.comparing(SnapshotData::totalAsset).reversed())
+                .sorted(Comparator.comparing(SnapshotData::totalAsset).reversed()
+                        .thenComparing(Comparator.comparing(SnapshotData::profitRate).reversed())
+                        .thenComparing(SnapshotData::userId))
                 .map(s -> new RankingEntry(
                         rankCounter.getAndIncrement(),
                         s.userId(),

--- a/src/main/java/com/solv/wefin/web/game/turn/listener/TurnChangeEventListener.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/listener/TurnChangeEventListener.java
@@ -27,9 +27,9 @@ public class TurnChangeEventListener {
 
     @TransactionalEventListener(phase = AFTER_COMMIT)
     public void handle(TurnChangeEvent event) {
-        // 참가자 userId 목록 추출 → User 테이블에서 닉네임 일괄 조회
+        // SnapshotData에서 userId 추출 → User 테이블에서 닉네임 일괄 조회
         List<UUID> userIds = event.snapshots().stream()
-                .map(s -> s.getParticipant().getUserId())
+                .map(TurnChangeEvent.SnapshotData::userId)
                 .toList();
 
         Map<UUID, String> nicknameMap = userRepository.findAllById(userIds).stream()

--- a/src/main/java/com/solv/wefin/web/game/turn/listener/TurnChangeEventListener.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/listener/TurnChangeEventListener.java
@@ -1,0 +1,48 @@
+package com.solv.wefin.web.game.turn.listener;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.turn.event.TurnChangeEvent;
+import com.solv.wefin.web.game.turn.dto.response.TurnChangeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TurnChangeEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final UserRepository userRepository;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handle(TurnChangeEvent event) {
+        // 참가자 userId 목록 추출 → User 테이블에서 닉네임 일괄 조회
+        List<UUID> userIds = event.snapshots().stream()
+                .map(s -> s.getParticipant().getUserId())
+                .toList();
+
+        Map<UUID, String> nicknameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getUserId, User::getNickname));
+
+        TurnChangeMessage message = TurnChangeMessage.from(
+                event.turnNumber(), event.turnDate(),
+                event.briefingId(), event.snapshots(), nicknameMap);
+
+        String destination = "/topic/rooms/" + event.roomId() + "/turn";
+        log.info("[턴 전환 WS] roomId={}, turn={}, rankings={}명",
+                event.roomId(), event.turnNumber(), message.rankings().size());
+
+        messagingTemplate.convertAndSend(destination, message);
+    }
+}

--- a/src/main/resources/db/migration/V29__alter_briefing_table_column.sql
+++ b/src/main/resources/db/migration/V29__alter_briefing_table_column.sql
@@ -1,0 +1,6 @@
+ALTER TABLE briefing_cache DROP COLUMN briefing_text;
+
+ALTER TABLE briefing_cache ADD COLUMN market_overview  TEXT NOT NULL;
+ALTER TABLE briefing_cache ADD COLUMN key_issues TEXT NOT NULL;
+
+ALTER TABLE briefing_cache ADD COLUMN investment_hint  TEXT NOT NULL;

--- a/src/test/java/com/solv/wefin/domain/game/news/service/BriefingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/BriefingServiceTest.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.game.news.entity.BriefingCache;
 import com.solv.wefin.domain.game.news.entity.GameNewsArchive;
 import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
 import com.solv.wefin.domain.game.openai.OpenAiBriefingClient;
+import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,7 +14,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
 import java.time.LocalDate;
-import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
@@ -53,15 +53,18 @@ class BriefingServiceTest {
     @DisplayName("캐시 히트 — 크롤링/OpenAI 호출 없이 기존 브리핑 반환")
     void getBriefingForDate_cacheHit() {
         // Given — 캐시에 브리핑이 이미 존재
-        BriefingCache cached = BriefingCache.create(TEST_DATE, "캐시된 브리핑 텍스트");
+        BriefingCache cached = BriefingCache.create(
+                TEST_DATE, "캐시된 시장 개요", "캐시된 주요 이슈", "캐시된 투자 힌트");
         given(briefingCacheRepository.findByTargetDate(TEST_DATE))
                 .willReturn(Optional.of(cached));
 
         // When
-        String result = briefingService.getBriefingForDate(TEST_DATE);
+        BriefingParts result = briefingService.getBriefingForDate(TEST_DATE);
 
         // Then — 캐시 데이터 반환, 크롤링/OpenAI 미호출
-        assertThat(result).isEqualTo("캐시된 브리핑 텍스트");
+        assertThat(result.marketOverview()).isEqualTo("캐시된 시장 개요");
+        assertThat(result.keyIssues()).isEqualTo("캐시된 주요 이슈");
+        assertThat(result.investmentHint()).isEqualTo("캐시된 투자 힌트");
         verify(newsCrawlService, never()).crawlAndSave(any());
         verify(openAiBriefingClient, never()).generateBriefing(any(), anyList());
     }
@@ -81,15 +84,21 @@ class BriefingServiceTest {
         );
         given(newsCrawlService.crawlAndSave(TEST_DATE)).willReturn(news);
 
-        String expectedBriefing = "[시장 개요] 반도체 호황과 금융 규제가 주요 이슈...";
+        BriefingParts expectedParts = new BriefingParts(
+                "반도체 호황과 금융 규제가 주요 이슈...",
+                "- 반도체 섹터\n- 금융 섹터\n- IT 섹터",
+                "반도체 관련 종목에 주목하세요."
+        );
         given(openAiBriefingClient.generateBriefing(eq(TEST_DATE), anyList()))
-                .willReturn(expectedBriefing);
+                .willReturn(expectedParts);
 
         // When
-        String result = briefingService.getBriefingForDate(TEST_DATE);
+        BriefingParts result = briefingService.getBriefingForDate(TEST_DATE);
 
         // Then — OpenAI 브리핑 반환, 캐시 저장 확인
-        assertThat(result).isEqualTo(expectedBriefing);
+        assertThat(result.marketOverview()).isEqualTo(expectedParts.marketOverview());
+        assertThat(result.keyIssues()).isEqualTo(expectedParts.keyIssues());
+        assertThat(result.investmentHint()).isEqualTo(expectedParts.investmentHint());
         verify(newsCrawlService).crawlAndSave(TEST_DATE);
         verify(openAiBriefingClient).generateBriefing(eq(TEST_DATE), anyList());
 
@@ -97,7 +106,9 @@ class BriefingServiceTest {
         verify(briefingCacheRepository).save(captor.capture());
         BriefingCache savedCache = captor.getValue();
         assertThat(savedCache.getTargetDate()).isEqualTo(TEST_DATE);
-        assertThat(savedCache.getBriefingText()).isEqualTo(expectedBriefing);
+        assertThat(savedCache.getMarketOverview()).isEqualTo(expectedParts.marketOverview());
+        assertThat(savedCache.getKeyIssues()).isEqualTo(expectedParts.keyIssues());
+        assertThat(savedCache.getInvestmentHint()).isEqualTo(expectedParts.investmentHint());
     }
 
     // === 뉴스 없을 때 기본 브리핑 ===
@@ -112,13 +123,12 @@ class BriefingServiceTest {
                 .willReturn(Collections.emptyList());
 
         // When
-        String result = briefingService.getBriefingForDate(TEST_DATE);
+        BriefingParts result = briefingService.getBriefingForDate(TEST_DATE);
 
         // Then — 기본 브리핑 텍스트 반환, OpenAI 미호출
-        assertThat(result).contains(TEST_DATE.toString());
-        assertThat(result).contains("뉴스 데이터가 없습니다");
+        assertThat(result.marketOverview()).contains(TEST_DATE.toString());
+        assertThat(result.marketOverview()).contains("뉴스 데이터가 없습니다");
         verify(openAiBriefingClient, never()).generateBriefing(any(), anyList());
-        // 폴백은 briefing_cache에 저장하지 않음
         verify(briefingCacheRepository, never()).save(any(BriefingCache.class));
     }
 
@@ -140,13 +150,12 @@ class BriefingServiceTest {
                 .willThrow(new RuntimeException("OpenAI API 타임아웃"));
 
         // When
-        String result = briefingService.getBriefingForDate(TEST_DATE);
+        BriefingParts result = briefingService.getBriefingForDate(TEST_DATE);
 
         // Then — 폴백 브리핑 반환 (뉴스 헤드라인 포함)
-        assertThat(result).contains(TEST_DATE.toString());
-        assertThat(result).contains("삼성전자 실적 발표");
-        assertThat(result).contains("코스피 상승세 지속");
-        // 폴백은 briefing_cache에 저장하지 않음
+        assertThat(result.marketOverview()).contains(TEST_DATE.toString());
+        assertThat(result.keyIssues()).contains("삼성전자 실적 발표");
+        assertThat(result.keyIssues()).contains("코스피 상승세 지속");
         verify(briefingCacheRepository, never()).save(any(BriefingCache.class));
     }
 
@@ -155,35 +164,29 @@ class BriefingServiceTest {
     @Test
     @DisplayName("[2차 방어선] 다른 JVM이 먼저 저장한 경우 — UNIQUE 위반 후 기존 캐시 반환")
     void getBriefingForDate_multiJvmConcurrentSave_returnsExistingCache() {
-        // Given — 단일 JVM에선 in-process 락이 막아주지만,
-        //         멀티 JVM 확장 시에는 save() 시점에 UNIQUE 위반이 발생할 수 있다.
-        //         이 테스트는 그 2차 방어선이 동작하는지 검증한다.
-        //
-        // 호출 순서:
-        //   1) fast-path findByTargetDate → empty (우리 JVM 캐시 없음)
-        //   2) 락 획득 후 re-check findByTargetDate → empty (아직 다른 JVM도 저장 전)
-        //   3) 크롤링 + OpenAI 진행 중 다른 JVM이 먼저 save 완료
-        //   4) 우리 JVM이 save → UNIQUE 위반 → catch 진입
-        //   5) catch 내부 findByTargetDate → Optional.of(다른 JVM이 저장한 캐시)
+        BriefingCache otherJvmCache = BriefingCache.create(
+                TEST_DATE, "다른 JVM 시장 개요", "다른 JVM 이슈", "다른 JVM 힌트");
         given(briefingCacheRepository.findByTargetDate(TEST_DATE))
-                .willReturn(Optional.empty())                                                      // (1) fast-path
-                .willReturn(Optional.empty())                                                      // (2) re-check (DCL)
-                .willReturn(Optional.of(BriefingCache.create(TEST_DATE, "다른 JVM이 먼저 저장한 브리핑"))); // (5) catch 내부
+                .willReturn(Optional.empty())
+                .willReturn(Optional.empty())
+                .willReturn(Optional.of(otherJvmCache));
 
         List<GameNewsArchive> news = List.of(createNewsArchive("뉴스"));
         given(newsCrawlService.crawlAndSave(TEST_DATE)).willReturn(news);
 
-        String generatedBriefing = "내가 생성한 브리핑";
+        BriefingParts generatedParts = new BriefingParts("내 시장 개요", "내 이슈", "내 힌트");
         given(openAiBriefingClient.generateBriefing(eq(TEST_DATE), anyList()))
-                .willReturn(generatedBriefing);
+                .willReturn(generatedParts);
         given(briefingCacheRepository.save(any(BriefingCache.class)))
                 .willThrow(new DataIntegrityViolationException("Unique constraint violation"));
 
         // When
-        String result = briefingService.getBriefingForDate(TEST_DATE);
+        BriefingParts result = briefingService.getBriefingForDate(TEST_DATE);
 
         // Then — 다른 JVM이 저장한 캐시 반환
-        assertThat(result).isEqualTo("다른 JVM이 먼저 저장한 브리핑");
+        assertThat(result.marketOverview()).isEqualTo("다른 JVM 시장 개요");
+        assertThat(result.keyIssues()).isEqualTo("다른 JVM 이슈");
+        assertThat(result.investmentHint()).isEqualTo("다른 JVM 힌트");
     }
 
     // === 1차 방어선: 단일 JVM in-process 락 동시성 검증 ===
@@ -191,44 +194,36 @@ class BriefingServiceTest {
     @Test
     @DisplayName("[1차 방어선] 같은 날짜 동시 요청 — 크롤링/OpenAI는 1번만 호출")
     void getBriefingForDate_concurrentSameDate_onlyOneGeneration() throws Exception {
-        // Given — 2개 스레드가 동시에 같은 날짜를 요청한다.
-        //         첫 스레드가 크롤링 중일 때 두 번째 스레드가 진입하도록
-        //         CountDownLatch로 타이밍을 정렬한다.
         final int threadCount = 2;
         final java.util.concurrent.CountDownLatch startGate = new java.util.concurrent.CountDownLatch(1);
         final java.util.concurrent.CountDownLatch insideCrawl = new java.util.concurrent.CountDownLatch(1);
         final java.util.concurrent.atomic.AtomicInteger crawlCallCount = new java.util.concurrent.atomic.AtomicInteger(0);
 
-        // 캐시는 항상 empty (어떤 호출이 와도 미스)
-        // → DCL 없으면 2번의 crawl/openai가 발생해야 맞지만, 락 덕분에 1번만 발생해야 한다.
-        //
-        // 단, 저장 이후 들어오는 재조회는 save된 것처럼 보여야 하므로
-        //   - 처음 2번 (fast-path, re-check): empty
-        //   - 이후: Optional.of(저장된 캐시)
-        BriefingCache savedCache = BriefingCache.create(TEST_DATE, "락으로 직렬화된 브리핑");
+        BriefingCache savedCache = BriefingCache.create(
+                TEST_DATE, "락으로 직렬화된 시장 개요", "락으로 직렬화된 이슈", "락으로 직렬화된 힌트");
         given(briefingCacheRepository.findByTargetDate(TEST_DATE))
                 .willReturn(Optional.empty())      // thread1 fast-path
                 .willReturn(Optional.empty())      // thread1 re-check
-                .willReturn(Optional.empty())      // thread2 fast-path (아직 저장 전이므로 empty)
-                .willReturn(Optional.of(savedCache)); // thread2 re-check — thread1이 save 완료한 시점
+                .willReturn(Optional.empty())      // thread2 fast-path
+                .willReturn(Optional.of(savedCache)); // thread2 re-check
 
-        // crawl 호출 시: 카운트 + 두 번째 스레드가 fast-path에 진입할 수 있도록 대기
         given(newsCrawlService.crawlAndSave(TEST_DATE)).willAnswer(inv -> {
             crawlCallCount.incrementAndGet();
-            insideCrawl.countDown();                  // thread2를 깨움
-            Thread.sleep(200);                         // thread2가 fast-path + 락 대기에 진입할 시간을 벌어줌
+            insideCrawl.countDown();
+            Thread.sleep(200);
             return List.of(createNewsArchive("뉴스"));
         });
 
+        BriefingParts generatedParts = new BriefingParts(
+                "락으로 직렬화된 시장 개요", "락으로 직렬화된 이슈", "락으로 직렬화된 힌트");
         given(openAiBriefingClient.generateBriefing(eq(TEST_DATE), anyList()))
-                .willReturn("락으로 직렬화된 브리핑");
+                .willReturn(generatedParts);
 
-        // When — 2 스레드 동시 실행
+        // When
         java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(threadCount);
         java.util.concurrent.CountDownLatch done = new java.util.concurrent.CountDownLatch(threadCount);
-        java.util.List<String> results = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        java.util.List<BriefingParts> results = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
 
-        // thread1: 먼저 진입해서 락을 잡고 crawl로 들어감
         pool.submit(() -> {
             try {
                 startGate.await();
@@ -240,11 +235,10 @@ class BriefingServiceTest {
             }
         });
 
-        // thread2: thread1이 crawl에 진입한 이후에 시작 → 락 대기
         pool.submit(() -> {
             try {
                 startGate.await();
-                insideCrawl.await();   // thread1이 crawl 내부에 들어갈 때까지 대기
+                insideCrawl.await();
                 results.add(briefingService.getBriefingForDate(TEST_DATE));
             } catch (Exception e) {
                 throw new RuntimeException(e);
@@ -257,14 +251,13 @@ class BriefingServiceTest {
         done.await(5, java.util.concurrent.TimeUnit.SECONDS);
         pool.shutdown();
 
-        // Then — crawl/OpenAI는 **1번만** 호출되어야 한다
+        // Then
         assertThat(crawlCallCount.get()).isEqualTo(1);
         verify(newsCrawlService).crawlAndSave(TEST_DATE);
         verify(openAiBriefingClient).generateBriefing(eq(TEST_DATE), anyList());
         verify(briefingCacheRepository).save(any(BriefingCache.class));
-        // 두 스레드 모두 같은 브리핑 결과를 받아야 한다
         assertThat(results).hasSize(2);
-        assertThat(results).allMatch(s -> s.equals("락으로 직렬화된 브리핑"));
+        assertThat(results).allMatch(p -> p.marketOverview().equals("락으로 직렬화된 시장 개요"));
     }
 
     // === 헬퍼 메서드 ===

--- a/src/test/java/com/solv/wefin/domain/game/news/service/GameBriefingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/GameBriefingServiceTest.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.game.news.service;
 
 import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
@@ -49,7 +50,11 @@ class GameBriefingServiceTest {
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
-    private static final String BRIEFING_TEXT = "2022-01-03 시장 브리핑: 코스피 상승 마감.";
+    private static final BriefingParts TEST_PARTS = new BriefingParts(
+            "코스피 상승 마감. 반도체 섹터 강세.",
+            "- 반도체 호황\n- 금융 규제",
+            "반도체 관련 종목에 주목하세요."
+    );
 
     // === 성공 케이스 ===
 
@@ -70,15 +75,17 @@ class GameBriefingServiceTest {
         given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
                 .willReturn(Optional.of(activeTurn));
         given(briefingService.getBriefingForDate(turnDate))
-                .willReturn(BRIEFING_TEXT);
+                .willReturn(TEST_PARTS);
 
         // When
         BriefingInfo result = gameBriefingService.getBriefingForRoom(roomId, TEST_USER_ID);
 
-        // Then — 활성 턴의 날짜와 브리핑 텍스트가 묶여서 반환
+        // Then — 활성 턴의 날짜와 3파트 브리핑이 묶여서 반환
         assertThat(result).isNotNull();
         assertThat(result.targetDate()).isEqualTo(turnDate);
-        assertThat(result.briefingText()).isEqualTo(BRIEFING_TEXT);
+        assertThat(result.marketOverview()).isEqualTo(TEST_PARTS.marketOverview());
+        assertThat(result.keyIssues()).isEqualTo(TEST_PARTS.keyIssues());
+        assertThat(result.investmentHint()).isEqualTo(TEST_PARTS.investmentHint());
 
         verify(briefingService).getBriefingForDate(turnDate);
     }

--- a/src/test/java/com/solv/wefin/domain/game/news/service/NewsBatchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/NewsBatchServiceTest.java
@@ -1,8 +1,7 @@
 package com.solv.wefin.domain.game.news.service;
 
 import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
-import com.solv.wefin.domain.game.news.service.BriefingService;
-import com.solv.wefin.domain.game.news.service.NewsBatchService;
+import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -22,8 +21,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -54,7 +55,7 @@ class NewsBatchServiceTest {
         given(briefingCacheRepository.findExistingDatesBetween(COLLECT_START, COLLECT_END))
                 .willReturn(existingDates);
         given(briefingService.getBriefingForDate(any(LocalDate.class)))
-                .willReturn("브리핑 텍스트");
+                .willReturn(new BriefingParts("시장 개요", "주요 이슈", "투자 힌트"));
 
         // When — 3일치 배치 처리 요청
         int result = newsBatchService.collectBatch(3);
@@ -82,7 +83,7 @@ class NewsBatchServiceTest {
         given(briefingCacheRepository.findExistingDatesBetween(COLLECT_START, COLLECT_END))
                 .willReturn(existingDates);
         given(briefingService.getBriefingForDate(any(LocalDate.class)))
-                .willReturn("브리핑 텍스트");
+                .willReturn(new BriefingParts("시장 개요", "주요 이슈", "투자 힌트"));
 
         // When — 2일치만 처리 요청
         int result = newsBatchService.collectBatch(2);
@@ -135,7 +136,7 @@ class NewsBatchServiceTest {
                 .willAnswer(invocation -> {
                     firstCallStarted.countDown();
                     allowFirstCallToFinish.await();
-                    return "브리핑";
+                    return new BriefingParts("시장 개요", "주요 이슈", "투자 힌트");
                 });
 
         ExecutorService executor = Executors.newFixedThreadPool(2);
@@ -184,10 +185,10 @@ class NewsBatchServiceTest {
         LocalDate day2 = LocalDate.of(2021, 1, 2);
         LocalDate day3 = LocalDate.of(2021, 1, 3);
 
-        given(briefingService.getBriefingForDate(day1)).willReturn("브리핑1");
+        given(briefingService.getBriefingForDate(day1)).willReturn(new BriefingParts("시장1", "이슈1", "힌트1"));
         given(briefingService.getBriefingForDate(day2))
                 .willThrow(new RuntimeException("크롤링 실패"));
-        given(briefingService.getBriefingForDate(day3)).willReturn("브리핑3");
+        given(briefingService.getBriefingForDate(day3)).willReturn(new BriefingParts("시장3", "이슈3", "힌트3"));
 
         // When
         int result = newsBatchService.collectBatch(3);

--- a/src/test/java/com/solv/wefin/domain/game/news/service/NewsCrawlServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/NewsCrawlServiceTest.java
@@ -4,7 +4,6 @@ import com.solv.wefin.domain.game.news.crawler.CrawledArticle;
 import com.solv.wefin.domain.game.news.crawler.NaverNewsCrawler;
 import com.solv.wefin.domain.game.news.entity.GameNewsArchive;
 import com.solv.wefin.domain.game.news.repository.GameNewsArchiveRepository;
-import com.solv.wefin.domain.game.news.service.NewsCrawlService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/com/solv/wefin/domain/game/order/service/GameOrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/order/service/GameOrderServiceTest.java
@@ -225,7 +225,7 @@ class GameOrderServiceTest {
         }
 
         @Test
-        @DisplayName("��도 성공 — 전량 매도, 보유종목 삭제")
+        @DisplayName("매도 성공 — 전량 매도, 보유종목 삭제")
         void sell_success_allQuantity_holdingDeleted() {
             // Given
             GameRoom room = createGameRoom();

--- a/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
@@ -59,7 +59,7 @@ class GamePortfolioServiceTest {
     private static final Long TEST_GROUP_ID = 1L;
     private static final LocalDate TEST_TRADE_DATE = LocalDate.of(2022, 3, 2);
 
-    // === 포트폴리오 성공 테스트 ===
+    // === 성공 테스트 ===
 
     @Nested
     @DisplayName("포트폴리오 조회 성공")
@@ -68,6 +68,7 @@ class GamePortfolioServiceTest {
         @Test
         @DisplayName("보유종목 없음 — cash = seed, stockValue = 0")
         void portfolio_noHoldings() {
+            // Given
             GameRoom room = createGameRoom();
             GameParticipant participant = createParticipant(room, new BigDecimal("10000000"));
             GameTurn turn = createGameTurn(room);
@@ -76,8 +77,10 @@ class GamePortfolioServiceTest {
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of());
 
+            // When
             PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
 
+            // Then
             assertThat(result.seedMoney()).isEqualByComparingTo(new BigDecimal("10000000"));
             assertThat(result.cash()).isEqualByComparingTo(new BigDecimal("10000000"));
             assertThat(result.stockValue()).isEqualByComparingTo(BigDecimal.ZERO);
@@ -88,6 +91,7 @@ class GamePortfolioServiceTest {
         @Test
         @DisplayName("보유종목 1개 — 종가 기준 평가금액 계산")
         void portfolio_oneHolding() {
+            // Given — 시드 1000만, 잔고 500만 (500만원어치 매수), 삼성전자 10주 보유
             GameRoom room = createGameRoom();
             GameParticipant participant = createParticipant(room, new BigDecimal("5000000"));
             GameTurn turn = createGameTurn(room);
@@ -101,10 +105,15 @@ class GamePortfolioServiceTest {
             given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung), TEST_TRADE_DATE))
                     .willReturn(List.of(stockDaily));
 
+            // When
             PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
 
+            // Then
+            // stockValue = 10 × 60000 = 600000
             assertThat(result.stockValue()).isEqualByComparingTo(new BigDecimal("600000"));
+            // totalAsset = 5000000 + 600000 = 5600000
             assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("5600000"));
+            // profitRate = (5600000 - 10000000) / 10000000 × 100 = -44.00
             BigDecimal expectedRate = new BigDecimal("5600000").subtract(new BigDecimal("10000000"))
                     .multiply(new BigDecimal("100"))
                     .divide(new BigDecimal("10000000"), 2, RoundingMode.HALF_UP);
@@ -114,6 +123,7 @@ class GamePortfolioServiceTest {
         @Test
         @DisplayName("보유종목 여러 개 — 전체 stockValue 합산")
         void portfolio_multipleHoldings() {
+            // Given — 시드 1000만, 잔고 300만, 삼성 10주 + SK 5주
             GameRoom room = createGameRoom();
             GameParticipant participant = createParticipant(room, new BigDecimal("3000000"));
             GameTurn turn = createGameTurn(room);
@@ -132,15 +142,20 @@ class GamePortfolioServiceTest {
             given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung, sk), TEST_TRADE_DATE))
                     .willReturn(List.of(samsungDaily, skDaily));
 
+            // When
             PortfolioInfo result = portfolioService.getPortfolio(TEST_ROOM_ID, TEST_USER_ID);
 
+            // Then
+            // stockValue = (10 × 60000) + (5 × 130000) = 600000 + 650000 = 1250000
             assertThat(result.stockValue()).isEqualByComparingTo(new BigDecimal("1250000"));
+            // totalAsset = 3000000 + 1250000 = 4250000
             assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("4250000"));
+            // profitRate = (4250000 - 10000000) / 10000000 × 100 = -57.50
             assertThat(result.profitRate()).isEqualByComparingTo(new BigDecimal("-57.50"));
         }
     }
 
-    // === 포트폴리오 실패 테스트 ===
+    // === 실패 테스트 ===
 
     @Nested
     @DisplayName("포트폴리오 조회 실패")
@@ -265,7 +280,9 @@ class GamePortfolioServiceTest {
             assertThat(info.quantity()).isEqualTo(10);
             assertThat(info.avgPrice()).isEqualByComparingTo(new BigDecimal("55000"));
             assertThat(info.currentPrice()).isEqualByComparingTo(new BigDecimal("60000"));
+            // evalAmount = 10 × 60000 = 600000
             assertThat(info.evalAmount()).isEqualByComparingTo(new BigDecimal("600000"));
+            // profitRate = (60000 - 55000) / 55000 × 100 = 9.09
             assertThat(info.profitRate()).isEqualByComparingTo(new BigDecimal("9.09"));
         }
 
@@ -293,6 +310,7 @@ class GamePortfolioServiceTest {
 
             assertThat(result).hasSize(2);
 
+            // SK하이닉스: profitRate = (130000 - 120000) / 120000 × 100 = 8.33
             HoldingInfo skInfo = result.stream()
                     .filter(h -> h.symbol().equals("000660"))
                     .findFirst().orElseThrow();

--- a/src/test/java/com/solv/wefin/domain/game/turn/service/GameTurnServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/turn/service/GameTurnServiceTest.java
@@ -1,0 +1,145 @@
+package com.solv.wefin.domain.game.turn.service;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GameTurnServiceTest {
+
+    @InjectMocks
+    private GameTurnService gameTurnService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+
+    private static final UUID TEST_ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final LocalDate TEST_START_DATE = LocalDate.of(2022, 3, 2);
+
+    // === 성공 케이스 ===
+
+    @Test
+    @DisplayName("현재 턴 조회 성공 — 활성 턴 반환")
+    void getCurrentTurn_success() {
+        // Given
+        GameRoom room = createGameRoom();
+        GameTurn turn = GameTurn.createFirst(room);
+        GameParticipant participant = GameParticipant.createLeader(room, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+        given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(turn));
+
+        // When
+        GameTurn result = gameTurnService.getCurrentTurn(TEST_ROOM_ID, TEST_USER_ID);
+
+        // Then
+        assertThat(result).isEqualTo(turn);
+        assertThat(result.getTurnNumber()).isEqualTo(1);
+        assertThat(result.getTurnDate()).isEqualTo(TEST_START_DATE);
+        assertThat(result.getStatus()).isEqualTo(TurnStatus.ACTIVE);
+    }
+
+    // === 실패 케이스 ===
+
+    @Nested
+    @DisplayName("검증 실패")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("실패 — 게임방이 존재하지 않음")
+        void fail_roomNotFound() {
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameTurnService.getCurrentTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 참가자가 아님")
+        void fail_notParticipant() {
+            GameRoom room = createGameRoom();
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameTurnService.getCurrentTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("실패 — 참가자가 비활성 상태 (LEFT)")
+        void fail_participantNotActive() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = GameParticipant.createLeader(room, TEST_USER_ID);
+            participant.leave();  // status → LEFT
+
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+
+            assertThatThrownBy(() -> gameTurnService.getCurrentTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("실패 — 활성 턴이 없음 (게임 미시작)")
+        void fail_noActiveTurn() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = GameParticipant.createLeader(room, TEST_USER_ID);
+
+            given(gameRoomRepository.findById(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameTurnService.getCurrentTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createGameRoom() {
+        GameRoom room = GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, new BigDecimal("10000000"),
+                6, 7, TEST_START_DATE, TEST_START_DATE.plusMonths(6));
+        room.start();
+        return room;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
@@ -297,6 +297,9 @@ class TurnAdvanceServiceTest {
                 .willReturn(Optional.of(turn));
         given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
                 .willReturn(List.of(participant));
+        // save()가 인자를 그대로 반환하도록 설정 (이벤트 발행 시 Entity → SnapshotData 변환에 필요)
+        given(snapshotRepository.save(any(GamePortfolioSnapshot.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
     }
 
     private GameRoom createGameRoom() {

--- a/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
@@ -1,0 +1,314 @@
+package com.solv.wefin.domain.game.turn.service;
+
+import com.solv.wefin.domain.game.holding.entity.GameHolding;
+import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
+import com.solv.wefin.domain.game.news.entity.BriefingCache;
+import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.domain.game.turn.event.TurnChangeEvent;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TurnAdvanceServiceTest {
+
+    @InjectMocks
+    private TurnAdvanceService turnAdvanceService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+    @Mock
+    private GameHoldingRepository gameHoldingRepository;
+    @Mock
+    private StockDailyRepository stockDailyRepository;
+    @Mock
+    private GamePortfolioSnapshotRepository snapshotRepository;
+    @Mock
+    private BriefingCacheRepository briefingCacheRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private static final UUID TEST_ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final Long TEST_GROUP_ID = 1L;
+    private static final BigDecimal SEED_MONEY = new BigDecimal("10000000");
+    private static final LocalDate START_DATE = LocalDate.of(2022, 3, 2);
+
+    // === 성공 케이스 ===
+
+    @Nested
+    @DisplayName("턴 전환 성공")
+    class AdvanceSuccess {
+
+        @Test
+        @DisplayName("보유종목 없이 턴 전환 — 현금만으로 스냅샷 생성 + 새 턴")
+        void advance_noHoldings_success() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn currentTurn = GameTurn.createFirst(room);
+            GameParticipant participant = createParticipant(room);
+            LocalDate nextTradeDate = START_DATE.plusDays(7);
+
+            setupCommonMocks(room, currentTurn, participant);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of());
+            given(stockDailyRepository.findLatestTradeDateOnOrBefore(START_DATE.plusDays(7)))
+                    .willReturn(Optional.of(nextTradeDate));
+            given(briefingCacheRepository.findByTargetDate(nextTradeDate))
+                    .willReturn(Optional.empty());
+            given(gameTurnRepository.save(any(GameTurn.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            GameTurn result = turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getTurnNumber()).isEqualTo(2);
+            assertThat(result.getTurnDate()).isEqualTo(nextTradeDate);
+            assertThat(result.getStatus()).isEqualTo(TurnStatus.ACTIVE);
+            assertThat(currentTurn.getStatus()).isEqualTo(TurnStatus.COMPLETED);
+
+            // 스냅샷 저장 검증
+            ArgumentCaptor<GamePortfolioSnapshot> captor = ArgumentCaptor.forClass(GamePortfolioSnapshot.class);
+            verify(snapshotRepository).save(captor.capture());
+            GamePortfolioSnapshot snapshot = captor.getValue();
+            assertThat(snapshot.getCash()).isEqualByComparingTo(SEED_MONEY);
+            assertThat(snapshot.getStockValue()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(snapshot.getTotalAsset()).isEqualByComparingTo(SEED_MONEY);
+            assertThat(snapshot.getProfitRate()).isEqualByComparingTo(BigDecimal.ZERO);
+
+            // 이벤트 발행 검증
+            ArgumentCaptor<TurnChangeEvent> eventCaptor = ArgumentCaptor.forClass(TurnChangeEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            TurnChangeEvent event = eventCaptor.getValue();
+            assertThat(event.roomId()).isEqualTo(TEST_ROOM_ID);
+            assertThat(event.turnNumber()).isEqualTo(2);
+            assertThat(event.turnDate()).isEqualTo(nextTradeDate);
+            assertThat(event.snapshots()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("보유종목 있는 턴 전환 — 종가 평가 포함 스냅샷")
+        void advance_withHoldings_evaluatesAtClosePrice() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn currentTurn = GameTurn.createFirst(room);
+            GameParticipant participant = createParticipant(room);
+            participant.deductCash(new BigDecimal("555000")); // 매수로 현금 차감
+            StockInfo stockInfo = StockInfo.create("005930", "삼성전자", "KOSPI", "전기전자");
+            GameHolding holding = GameHolding.create(participant, stockInfo, 10, new BigDecimal("55500"));
+            StockDaily daily = StockDaily.create(stockInfo, START_DATE,
+                    new BigDecimal("60000"), new BigDecimal("60000"),
+                    new BigDecimal("60000"), new BigDecimal("60000"),
+                    BigDecimal.valueOf(1000000), BigDecimal.ZERO);
+            LocalDate nextTradeDate = START_DATE.plusDays(7);
+
+            setupCommonMocks(room, currentTurn, participant);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of(holding));
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(stockInfo), START_DATE))
+                    .willReturn(List.of(daily));
+            given(stockDailyRepository.findLatestTradeDateOnOrBefore(START_DATE.plusDays(7)))
+                    .willReturn(Optional.of(nextTradeDate));
+            given(briefingCacheRepository.findByTargetDate(nextTradeDate))
+                    .willReturn(Optional.empty());
+            given(gameTurnRepository.save(any(GameTurn.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID);
+
+            // Then — 종가 60000 × 10주 = 600000
+            ArgumentCaptor<GamePortfolioSnapshot> captor = ArgumentCaptor.forClass(GamePortfolioSnapshot.class);
+            verify(snapshotRepository).save(captor.capture());
+            GamePortfolioSnapshot snapshot = captor.getValue();
+            assertThat(snapshot.getStockValue()).isEqualByComparingTo(new BigDecimal("600000"));
+            BigDecimal expectedCash = SEED_MONEY.subtract(new BigDecimal("555000"));
+            assertThat(snapshot.getCash()).isEqualByComparingTo(expectedCash);
+            assertThat(snapshot.getTotalAsset()).isEqualByComparingTo(expectedCash.add(new BigDecimal("600000")));
+        }
+
+        @Test
+        @DisplayName("브리핑 있는 날짜로 전환 — briefingId 연결")
+        void advance_withBriefing_assignsBriefingId() {
+            // Given
+            GameRoom room = createGameRoom();
+            GameTurn currentTurn = GameTurn.createFirst(room);
+            GameParticipant participant = createParticipant(room);
+            LocalDate nextTradeDate = START_DATE.plusDays(7);
+            BriefingCache briefing = BriefingCache.create(nextTradeDate, "개요", "이슈", "힌트");
+
+            setupCommonMocks(room, currentTurn, participant);
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of());
+            given(stockDailyRepository.findLatestTradeDateOnOrBefore(START_DATE.plusDays(7)))
+                    .willReturn(Optional.of(nextTradeDate));
+            given(briefingCacheRepository.findByTargetDate(nextTradeDate))
+                    .willReturn(Optional.of(briefing));
+            given(gameTurnRepository.save(any(GameTurn.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            GameTurn result = turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID);
+
+            // Then
+            assertThat(result.getBriefingId()).isEqualTo(briefing.getBriefingId());
+        }
+
+        @Test
+        @DisplayName("endDate 초과 — 게임 종료, null 반환")
+        void advance_exceedsEndDate_finishesGame() {
+            // Given — endDate가 START_DATE + 7일 이내
+            GameRoom room = GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, SEED_MONEY,
+                    1, 7, START_DATE, START_DATE.plusDays(5));
+            room.start();
+            GameTurn currentTurn = GameTurn.createFirst(room);
+            GameParticipant participant = createParticipant(room);
+            LocalDate nextTradeDate = START_DATE.plusDays(7); // endDate 초과
+
+            given(gameRoomRepository.findByIdForUpdate(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.of(currentTurn));
+            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                    .willReturn(List.of(participant));
+            given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
+                    .willReturn(List.of());
+            given(stockDailyRepository.findLatestTradeDateOnOrBefore(START_DATE.plusDays(7)))
+                    .willReturn(Optional.of(nextTradeDate));
+
+            // When
+            GameTurn result = turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID);
+
+            // Then
+            assertThat(result).isNull();
+            assertThat(room.getStatus()).isEqualTo(RoomStatus.FINISHED);
+            assertThat(currentTurn.getStatus()).isEqualTo(TurnStatus.COMPLETED);
+            verify(gameTurnRepository, never()).save(any(GameTurn.class));
+            verify(eventPublisher, never()).publishEvent(any(TurnChangeEvent.class));
+        }
+    }
+
+    // === 실패 케이스 ===
+
+    @Nested
+    @DisplayName("검증 실패")
+    class ValidationTests {
+
+        @Test
+        @DisplayName("실패 — 방이 없음")
+        void fail_roomNotFound() {
+            given(gameRoomRepository.findByIdForUpdate(TEST_ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 — 이미 종료된 게임")
+        void fail_gameAlreadyFinished() {
+            GameRoom room = createGameRoom();
+            room.finish();
+            given(gameRoomRepository.findByIdForUpdate(TEST_ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_ALREADY_FINISHED);
+        }
+
+        @Test
+        @DisplayName("실패 — 참가자 아님")
+        void fail_notParticipant() {
+            GameRoom room = createGameRoom();
+            given(gameRoomRepository.findByIdForUpdate(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("실패 — 활성 턴 없음")
+        void fail_noActiveTurn() {
+            GameRoom room = createGameRoom();
+            GameParticipant participant = createParticipant(room);
+            given(gameRoomRepository.findByIdForUpdate(TEST_ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private void setupCommonMocks(GameRoom room, GameTurn turn, GameParticipant participant) {
+        given(gameRoomRepository.findByIdForUpdate(TEST_ROOM_ID)).willReturn(Optional.of(room));
+        given(gameParticipantRepository.findByGameRoomAndUserId(room, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(room, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(turn));
+        given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                .willReturn(List.of(participant));
+    }
+
+    private GameRoom createGameRoom() {
+        GameRoom room = GameRoom.create(TEST_GROUP_ID, TEST_USER_ID, SEED_MONEY,
+                6, 7, START_DATE, START_DATE.plusMonths(6));
+        room.start();
+        return room;
+    }
+
+    private GameParticipant createParticipant(GameRoom room) {
+        GameParticipant participant = GameParticipant.createLeader(room, TEST_USER_ID);
+        participant.assignSeed(SEED_MONEY);
+        return participant;
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
<br> 턴 전환 api 구현. 턴 전환 시 참가자 포트폴리오 스냅샷 저장 후 수익률을 계산해줍니다. 포트폴리오 스냅샷 저장을 통해 랭킹 계산도 구현했습니다. 턴 전환은 웹소켓을 통해 실시간으로 동시에 이루어 집니다. **브피링 파일은 수집 방식 변경이라 turn 패키지 관련 파일만 보시면 될 거 같습니다!

## ✅ 완료한 기능 명세

- [x] 턴 전환 
- [x] 턴 전환 동시성 제어
- [x] 랭킹 계산 api 
- [x] ai 브리핑 3파트 분리
- [x] 테스트 코드   

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #214 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 턴 전환 기능 추가 - 포트폴리오 스냅샷 자동 저장 및 실시간 순위 업데이트
  * 마켓 개요, 주요 이슈, 투자 힌트로 구성된 향상된 브리핑 정보
  * 턴 전환 시 WebSocket을 통한 실시간 순위 알림

* **버그 수정**
  * 게임 종료 상태에서의 턴 전환 시도 방어

* **데이터베이스**
  * 포트폴리오 스냅샷 테이블 추가 및 브리핑 데이터 구조 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->