### PR TITLE
[WEF-446] 퀘스트 진행도 로직 구현 및 보상 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -16,6 +16,7 @@ import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -29,6 +30,7 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class AuthService {
 
     private static final String UK_USERS_EMAIL = "uk_users_email";
@@ -140,7 +142,11 @@ public class AuthService {
 
         refreshTokenRepository.save(refreshToken);
 
-        questProgressService.handleEvent(user.getUserId(), QuestEventType.LOGIN);
+        try {
+            questProgressService.handleEvent(user.getUserId(), QuestEventType.LOGIN);
+        } catch (RuntimeException e) {
+            log.warn("로그인 퀘스트 반영 실패 userId={}", user.getUserId(), e);
+        }
 
         return new LoginInfo(
                 user.getUserId(),

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -10,6 +10,8 @@ import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -37,6 +39,7 @@ public class AuthService {
     private final GroupService groupService;
     private final JwtProvider jwtProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final QuestProgressService questProgressService;
 
     @Transactional
     public SignupInfo signup(SignupCommand command) {
@@ -136,6 +139,8 @@ public class AuthService {
                         .build());
 
         refreshTokenRepository.save(refreshToken);
+
+        questProgressService.handleEvent(user.getUserId(), QuestEventType.LOGIN);
 
         return new LoginInfo(
                 user.getUserId(),

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -12,6 +12,7 @@ import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Comparator;
@@ -20,6 +21,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AiChatService {
 
     private static final int MAX_MESSAGE_LENGTH = 1000;
@@ -68,7 +70,11 @@ public class AiChatService {
         aiChatMessagePersistenceService.saveUserMessage(user, command.message());
         AiChatMessage aiMessage = aiChatMessagePersistenceService.saveAiMessage(user, answer);
 
-        questProgressService.handleEvent(userId, QuestEventType.USE_AI_CHAT);
+        try {
+            questProgressService.handleEvent(userId, QuestEventType.USE_AI_CHAT);
+        } catch (RuntimeException e) {
+            log.warn("퀘스트 진행도 반영 실패 userId={}", userId, e);
+        }
 
         return toInfo(aiMessage);
     }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -7,6 +7,8 @@ import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,7 @@ public class AiChatService {
     private final OpenAiChatClient openAiChatClient;
     private final AiChatMessagePersistenceService aiChatMessagePersistenceService;
     private final UserRepository userRepository;
+    private final QuestProgressService questProgressService;
 
     public AiChatMessagesInfo getMessages(UUID userId, Long beforeMessageId, int size) {
         validateUserId(userId);
@@ -64,6 +67,8 @@ public class AiChatService {
 
         aiChatMessagePersistenceService.saveUserMessage(user, command.message());
         AiChatMessage aiMessage = aiChatMessagePersistenceService.saveAiMessage(user, answer);
+
+        questProgressService.handleEvent(userId, QuestEventType.USE_AI_CHAT);
 
         return toInfo(aiMessage);
     }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -24,6 +24,7 @@ import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
@@ -123,7 +125,11 @@ public class ChatMessageService {
 
         eventPublisher.publishEvent(new ChatMessageCreatedEvent(group.getId(), info));
 
-        questProgressService.handleEvent(userId, QuestEventType.SHARE_NEWS);
+        try {
+            questProgressService.handleEvent(userId, QuestEventType.SHARE_NEWS);
+        } catch (RuntimeException e) {
+            log.warn("퀘스트 진행도 반영 실패 userId={}", userId, e);
+        }
 
         return info;
     }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -19,6 +19,8 @@ import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +47,7 @@ public class ChatMessageService {
     private final ApplicationEventPublisher eventPublisher;
     private final GroupMemberRepository groupMemberRepository;
     private final ChatSpamGuard chatSpamGuard;
+    private final QuestProgressService questProgressService;
 
     private static final long SPAM_WINDOW_SECONDS = 3L;
     private static final String SYSTEM = "시스템";
@@ -91,6 +94,8 @@ public class ChatMessageService {
 
             eventPublisher.publishEvent(toEvent(savedMessage));
         }
+
+        questProgressService.handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
     }
 
     @Transactional
@@ -117,6 +122,8 @@ public class ChatMessageService {
         ChatMessageInfo info = toInfo(chatMessage);
 
         eventPublisher.publishEvent(new ChatMessageCreatedEvent(group.getId(), info));
+
+        questProgressService.handleEvent(userId, QuestEventType.SHARE_NEWS);
 
         return info;
     }

--- a/src/main/java/com/solv/wefin/domain/quest/entity/QuestEventType.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/QuestEventType.java
@@ -3,10 +3,13 @@ package com.solv.wefin.domain.quest.entity;
 public enum QuestEventType {
     LOGIN,
     BUY_STOCK,
+    SELL_STOCK,
     SEND_GROUP_CHAT,
     SHARE_NEWS,
     USE_AI_CHAT,
     JOIN_GAME_ROOM,
     CREATE_GAME_ROOM,
-    CREATE_ACCOUNT
+    CREATE_ACCOUNT,
+    CHECK_PROFIT_RATE,
+    CHECK_GAME_RANK
 }

--- a/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
@@ -114,6 +114,47 @@ public class UserQuest extends BaseEntity {
         }
     }
 
+    public void completeWithProgress(int progress) {
+        if (progress < 0) {
+            throw new BusinessException(ErrorCode.QUEST_PROGRESS_INVALID);
+        }
+
+        if (this.status == QuestStatus.COMPLETED || this.status == QuestStatus.REWARDED) {
+            return;
+        }
+
+        this.progress = progress;
+
+        if (this.progress > 0 && this.status == QuestStatus.NOT_STARTED) {
+            this.status = QuestStatus.IN_PROGRESS;
+            this.startedAt = OffsetDateTime.now();
+        }
+
+        this.status = QuestStatus.COMPLETED;
+        this.completedAt = OffsetDateTime.now();
+
+        if (this.startedAt == null) {
+            this.startedAt = this.completedAt;
+        }
+    }
+
+    public void recordProgress(int progress) {
+        if (progress < 0) {
+            throw new BusinessException(ErrorCode.QUEST_PROGRESS_INVALID);
+        }
+
+        if (this.status == QuestStatus.COMPLETED || this.status == QuestStatus.REWARDED) {
+            return;
+        }
+
+        this.progress = progress;
+
+        if (this.progress > 0 && this.status == QuestStatus.NOT_STARTED) {
+            this.status = QuestStatus.IN_PROGRESS;
+            this.startedAt = OffsetDateTime.now();
+        }
+    }
+
     private void complete() {
 
         if (this.status == QuestStatus.COMPLETED || this.status == QuestStatus.REWARDED) {

--- a/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
+++ b/src/main/java/com/solv/wefin/domain/quest/entity/UserQuest.java
@@ -102,7 +102,8 @@ public class UserQuest extends BaseEntity {
         }
 
         Integer targetValue = this.dailyQuest.getTargetValue();
-        this.progress = targetValue != null ? Math.min(progress, targetValue) : progress;
+        int nextProgress = targetValue != null ? Math.min(progress, targetValue) : progress;
+        this.progress = Math.max(this.progress, nextProgress);
 
         if (progress > 0 && this.status == QuestStatus.NOT_STARTED) {
             this.status = QuestStatus.IN_PROGRESS;

--- a/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
@@ -34,4 +34,17 @@ public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
     and uq.user.userId = :userId
     """)
     Optional<UserQuest> findByIdAndUserIdForUpdate(Long questId, UUID userId);
+
+    // UserQuestRepository에 잠금 조회 메서드 추가 예시
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+    select uq
+    from UserQuest uq
+    join fetch uq.dailyQuest dq
+    join fetch dq.questTemplate qt
+    where uq.user.userId = :userId
+        and dq.questDate = :questDate
+    order by uq.id asc
+    """)
+    List<UserQuest> findTodayUserQuestsForUpdate(UUID userId, LocalDate questDate);
 }

--- a/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/quest/repository/UserQuestRepository.java
@@ -1,11 +1,14 @@
 package com.solv.wefin.domain.quest.repository;
 
 import com.solv.wefin.domain.quest.entity.UserQuest;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
@@ -21,4 +24,14 @@ public interface UserQuestRepository extends JpaRepository<UserQuest, Long> {
     """)
     List<UserQuest> findTodayUserQuests(UUID userId, LocalDate questDate);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+    select uq
+    from UserQuest uq
+    join fetch uq.dailyQuest dq
+    join fetch dq.questTemplate qt
+    where uq.id = :questId
+    and uq.user.userId = :userId
+    """)
+    Optional<UserQuest> findByIdAndUserIdForUpdate(Long questId, UUID userId);
 }

--- a/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/DailyQuestService.java
@@ -66,11 +66,19 @@ public class DailyQuestService {
     }
 
     private int resolveRandomTargetValue(QuestTemplate template) {
-        int baseTargetValue = template.getTargetValue() != null ? template.getTargetValue() : 1;
+        return switch (template.getCode()) {
+            case "LOGIN_DAILY" -> 1;
+            case "SHARE_NEWS_DAILY" -> randomBetween(1, 3);
+            case "USE_AI_CHAT_DAILY" -> randomBetween(1, 5);
+            case "SEND_GROUP_CHAT_DAILY" -> randomBetween(2, 5);
+            case "BUY_STOCK_DAILY" -> randomBetween(1, 5);
+            case "JOIN_GAME_ROOM_DAILY" -> randomBetween(1, 3);
+            case "CREATE_GAME_ROOM_DAILY" -> 1;
+            default -> template.getTargetValue();
+        };
+    }
 
-        int min = Math.max(1, baseTargetValue - 1);
-        int max = baseTargetValue + 1;
-
+    private int randomBetween(int min, int max) {
         return ThreadLocalRandom.current().nextInt(min, max + 1);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
@@ -1,0 +1,72 @@
+package com.solv.wefin.domain.quest.service;
+
+import com.solv.wefin.domain.quest.entity.QuestCompleteType;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import com.solv.wefin.domain.quest.repository.UserQuestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuestProgressService {
+
+    private final UserQuestRepository userQuestRepository;
+
+    public void handleEvent(UUID userId, QuestEventType eventType) {
+        List<UserQuest> todayUserQuests =
+                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+
+        todayUserQuests.stream()
+                .filter(userQuest -> userQuest.getDailyQuest()
+                        .getQuestTemplate()
+                        .getEventType() == eventType)
+                .forEach(userQuest ->
+                        userQuest.updateProgress(userQuest.getProgress() + 1)
+                );
+    }
+
+    public void handleProfitRate(UUID userId, BigDecimal profitRate) {
+        List<UserQuest> todayUserQuests =
+                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+
+        todayUserQuests.stream()
+                .filter(userQuest -> userQuest.getDailyQuest()
+                        .getQuestTemplate()
+                        .getEventType() == QuestEventType.CHECK_PROFIT_RATE)
+                .filter(userQuest -> userQuest.getDailyQuest()
+                        .getQuestTemplate()
+                        .getCompleteType() == QuestCompleteType.PERCENT)
+                .forEach(userQuest -> {
+                    int currentRate = profitRate.intValue();
+                    userQuest.updateProgress(currentRate);
+                });
+    }
+
+    public void handleGameRank(UUID userId, int rank) {
+        List<UserQuest> todayUserQuests =
+                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+
+        todayUserQuests.stream()
+                .filter(userQuest -> userQuest.getDailyQuest()
+                        .getQuestTemplate()
+                        .getEventType() == QuestEventType.CHECK_GAME_RANK)
+                .forEach(userQuest -> {
+                    Integer targetRank = userQuest.getDailyQuest().getTargetValue();
+
+                    if (targetRank != null && rank <= targetRank) {
+                        userQuest.completeWithProgress(rank);
+                        return;
+                    }
+
+                    userQuest.recordProgress(rank);
+                });
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.quest.entity.UserQuest;
 import com.solv.wefin.domain.quest.repository.UserQuestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -20,6 +21,7 @@ public class QuestProgressService {
 
     private final UserQuestRepository userQuestRepository;
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleEvent(UUID userId, QuestEventType eventType) {
         List<UserQuest> todayUserQuests =
                 userQuestRepository.findTodayUserQuestsForUpdate(userId, LocalDate.now());
@@ -33,6 +35,7 @@ public class QuestProgressService {
                 );
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleProfitRate(UUID userId, BigDecimal profitRate) {
         List<UserQuest> todayUserQuests =
                 userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
@@ -50,6 +53,7 @@ public class QuestProgressService {
                 });
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleGameRank(UUID userId, int rank) {
         List<UserQuest> todayUserQuests =
                 userQuestRepository.findTodayUserQuests(userId, LocalDate.now());

--- a/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
@@ -22,7 +22,7 @@ public class QuestProgressService {
 
     public void handleEvent(UUID userId, QuestEventType eventType) {
         List<UserQuest> todayUserQuests =
-                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+                userQuestRepository.findTodayUserQuestsForUpdate(userId, LocalDate.now());
 
         todayUserQuests.stream()
                 .filter(userQuest -> userQuest.getDailyQuest()
@@ -45,7 +45,7 @@ public class QuestProgressService {
                         .getQuestTemplate()
                         .getCompleteType() == QuestCompleteType.PERCENT)
                 .forEach(userQuest -> {
-                    int currentRate = profitRate.intValue();
+                    int currentRate = profitRate.max(BigDecimal.ZERO).intValue();
                     userQuest.updateProgress(currentRate);
                 });
     }

--- a/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/QuestProgressService.java
@@ -38,7 +38,7 @@ public class QuestProgressService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleProfitRate(UUID userId, BigDecimal profitRate) {
         List<UserQuest> todayUserQuests =
-                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+                userQuestRepository.findTodayUserQuestsForUpdate(userId, LocalDate.now());
 
         todayUserQuests.stream()
                 .filter(userQuest -> userQuest.getDailyQuest()
@@ -56,7 +56,7 @@ public class QuestProgressService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleGameRank(UUID userId, int rank) {
         List<UserQuest> todayUserQuests =
-                userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+                userQuestRepository.findTodayUserQuestsForUpdate(userId, LocalDate.now());
 
         todayUserQuests.stream()
                 .filter(userQuest -> userQuest.getDailyQuest()

--- a/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
+++ b/src/main/java/com/solv/wefin/domain/quest/service/UserQuestService.java
@@ -5,6 +5,8 @@ import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.quest.entity.DailyQuest;
 import com.solv.wefin.domain.quest.entity.UserQuest;
 import com.solv.wefin.domain.quest.repository.UserQuestRepository;
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -24,6 +27,7 @@ public class UserQuestService {
     private final UserRepository userRepository;
     private final UserQuestRepository userQuestRepository;
     private final DailyQuestService dailyQuestService;
+    private final VirtualAccountService virtualAccountService;
 
     public List<UserQuest> getOrIssueTodayUserQuests(UUID userId) {
         if (userId == null) {
@@ -58,5 +62,18 @@ public class UserQuestService {
     @Transactional(readOnly = true)
     public List<UserQuest> getTodayUserQuests(UUID userId) {
         return userQuestRepository.findTodayUserQuests(userId, LocalDate.now());
+    }
+
+    public UserQuest claimReward(UUID userId, Long questId) {
+        UserQuest userQuest = userQuestRepository.findByIdAndUserIdForUpdate(questId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_QUEST_NOT_FOUND));
+
+        VirtualAccount account = virtualAccountService.getAccountByUserId(userId);
+        BigDecimal rewardAmount = BigDecimal.valueOf(userQuest.getDailyQuest().getReward());
+
+        virtualAccountService.depositBalance(account.getVirtualAccountId(), rewardAmount);
+        userQuest.markRewarded();
+
+        return userQuest;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -6,6 +6,8 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.UUID;
 
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +45,7 @@ public class OrderService {
 	private final StockInfoProvider stockInfoProvider;
 	private final TradeService tradeService;
 	private final ApplicationEventPublisher eventPublisher;
+	private final QuestProgressService questProgressService;
 
 	@Transactional
 	public OrderInfo buyMarket(Long virtualAccountId, Long stockId, Integer quantity) {
@@ -82,6 +85,8 @@ public class OrderService {
 			order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
 			quantity, currentPrice, fee, account.getBalance()
 		));
+
+		questProgressService.handleEvent(account.getUserId(), QuestEventType.BUY_STOCK);
 
 		return new OrderInfo(order, stock.getStockCode(), stock.getStockName(), currentPrice,
 			totalAmount, BigDecimal.ZERO, BigDecimal.ZERO, account.getBalance());
@@ -149,6 +154,8 @@ public class OrderService {
 			order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
 			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance()
 		));
+
+		questProgressService.handleEvent(account.getUserId(), QuestEventType.SELL_STOCK);
 
 		return new OrderInfo(order, stock.getStockCode(), stock.getStockName(), currentPrice,
 			totalAmount, tax, realizedAmount, account.getBalance());

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import com.solv.wefin.domain.quest.entity.QuestEventType;
 import com.solv.wefin.domain.quest.service.QuestProgressService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class OrderService {
 
 	private final OrderRepository orderRepository;
@@ -155,7 +157,11 @@ public class OrderService {
 			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance()
 		));
 
-		questProgressService.handleEvent(account.getUserId(), QuestEventType.SELL_STOCK);
+		try {
+			questProgressService.handleEvent(account.getUserId(), QuestEventType.SELL_STOCK);
+		} catch (RuntimeException e) {
+			log.warn("퀘스트 진행도 반영 실패 userId={}", account.getUserId(), e);
+		}
 
 		return new OrderInfo(order, stock.getStockCode(), stock.getStockName(), currentPrice,
 			totalAmount, tax, realizedAmount, account.getBalance());

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -45,6 +45,7 @@ public enum ErrorCode {
     QUEST_REWARD_NOT_ALLOWED(400, "완료된 퀘스트만 보상 처리할 수 있습니다."),
     QUEST_TARGET_VALUE_INVALID(400, "퀘스트 목표치는 1 이상이어야 합니다."),
     QUEST_REWARD_INVALID(400, "퀘스트 보상은 0 이상이어야 합니다."),
+    USER_QUEST_NOT_FOUND(404, "사용자 퀘스트를 찾을 수 없습니다."),
 
     // Common
     INVALID_INPUT(400, "잘못된 입력입니다."),

--- a/src/main/java/com/solv/wefin/web/quest/QuestController.java
+++ b/src/main/java/com/solv/wefin/web/quest/QuestController.java
@@ -3,12 +3,11 @@ package com.solv.wefin.web.quest;
 import com.solv.wefin.domain.quest.entity.UserQuest;
 import com.solv.wefin.domain.quest.service.UserQuestService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.quest.dto.response.QuestResponse;
 import com.solv.wefin.web.quest.dto.response.TodayQuestListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -27,5 +26,14 @@ public class QuestController {
         List<UserQuest> userQuests = userQuestService.getOrIssueTodayUserQuests(userId);
 
         return ApiResponse.success(TodayQuestListResponse.from(userQuests));
+    }
+
+    @PostMapping("/{questId}/reward")
+    public ApiResponse<QuestResponse> claimReward(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable Long questId
+    ) {
+        UserQuest userQuest = userQuestService.claimReward(userId, questId);
+        return ApiResponse.success(QuestResponse.from(userQuest));
     }
 }

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -10,6 +10,8 @@ import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.service.GroupService;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -55,6 +57,9 @@ class AuthServiceTest {
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private QuestProgressService questProgressService;
 
     @InjectMocks
     private AuthService authService;
@@ -267,6 +272,7 @@ class AuthServiceTest {
                     () -> assertThat(savedToken.getExpiresAt()).isEqualTo(expiresAt),
                     () -> assertThat(savedToken.isRevoked()).isFalse()
             );
+            verify(questProgressService).handleEvent(userId, QuestEventType.LOGIN);
         }
 
         @Test

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -38,7 +38,10 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -276,6 +279,42 @@ class AuthServiceTest {
         }
 
         @Test
+        @DisplayName("퀘스트 반영이 실패해도 로그인은 정상적으로 성공한다")
+        void login_success_even_when_quest_progress_update_fails() {
+            UUID userId = UUID.randomUUID();
+            OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+            ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
+
+            when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pass1234", "encoded-password")).thenReturn(true);
+            when(jwtProvider.generateAccessToken(userId)).thenReturn("access-token");
+            when(jwtProvider.generateRefreshToken(userId)).thenReturn("refresh-token");
+            when(jwtProvider.getExpiration("refresh-token")).thenReturn(expiresAt);
+            when(refreshTokenRepository.findById(userId)).thenReturn(Optional.empty());
+            doThrow(new RuntimeException("quest failed"))
+                    .when(questProgressService).handleEvent(userId, QuestEventType.LOGIN);
+
+            LoginInfo result = authService.login("test@example.com", "pass1234");
+
+            verify(refreshTokenRepository).save(any(RefreshToken.class));
+            verify(questProgressService).handleEvent(userId, QuestEventType.LOGIN);
+            assertAll(
+                    () -> assertThat(result.userId()).isEqualTo(userId),
+                    () -> assertThat(result.nickname()).isEqualTo("testuser"),
+                    () -> assertThat(result.accessToken()).isEqualTo("access-token"),
+                    () -> assertThat(result.refreshToken()).isEqualTo("refresh-token")
+            );
+        }
+
+        @Test
         @DisplayName("이메일이 존재하지 않으면 로그인 실패 예외가 발생한다")
         void login_fail_when_user_not_found() {
             when(userRepository.findByEmail("test@example.com")).thenReturn(Optional.empty());
@@ -416,7 +455,7 @@ class AuthServiceTest {
         }
 
         @Test
-        @DisplayName("refresh 타입 토큰이 아니면 AUTH_INVALID_TOKEN 예외가 발생한다")
+        @DisplayName("refresh 토큰 타입이 아니면 AUTH_INVALID_TOKEN 예외가 발생한다")
         void refresh_fail_when_token_type_is_not_refresh() {
             when(jwtProvider.isValid("access-token")).thenReturn(true);
             when(jwtProvider.getTokenType("access-token")).thenReturn("access");

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -7,6 +7,8 @@ import com.solv.wefin.domain.chat.aiChat.dto.command.AiChatCommand;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatMessagesInfo;
 import com.solv.wefin.domain.chat.aiChat.entity.AiChatMessage;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +35,7 @@ class AiChatServiceTest {
     private AiChatMessagePersistenceService aiChatMessagePersistenceService;
     private UserRepository userRepository;
     private OpenAiChatClient openAiChatClient;
+    private QuestProgressService questProgressService;
     private AiChatService aiChatService;
 
     @BeforeEach
@@ -40,11 +43,13 @@ class AiChatServiceTest {
         aiChatMessagePersistenceService = mock(AiChatMessagePersistenceService.class);
         userRepository = mock(UserRepository.class);
         openAiChatClient = mock(OpenAiChatClient.class);
+        questProgressService = mock(QuestProgressService.class);
 
         aiChatService = new AiChatService(
                 openAiChatClient,
                 aiChatMessagePersistenceService,
-                userRepository
+                userRepository,
+                questProgressService
         );
     }
 
@@ -118,6 +123,7 @@ class AiChatServiceTest {
         verify(aiChatMessagePersistenceService).saveUserMessage(user, command.message());
         verify(aiChatMessagePersistenceService).saveAiMessage(user, "최근 실적 기준으로 설명드릴게요.");
         verify(openAiChatClient).ask(historyCaptor.capture(), eq(command.message()));
+        verify(questProgressService).handleEvent(userId, QuestEventType.USE_AI_CHAT);
 
         List<AiChatMessage> history = historyCaptor.getValue();
         assertEquals(1, history.size());

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -16,6 +16,8 @@ import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +53,7 @@ class ChatMessageServiceTest {
     private ChatMessageService chatMessageService;
     private NewsClusterRepository newsClusterRepository;
     private ChatMessageNewsShareService chatMessageNewsShareService;
+    private QuestProgressService questProgressService;
 
     @BeforeEach
     void setUp() {
@@ -61,6 +64,7 @@ class ChatMessageServiceTest {
         chatSpamGuard = mock(ChatSpamGuard.class);
         newsClusterRepository = mock(NewsClusterRepository.class);
         chatMessageNewsShareService = mock(ChatMessageNewsShareService.class);
+        questProgressService = mock(QuestProgressService.class);
 
         chatMessageService = new ChatMessageService(
                 chatMessageRepository,
@@ -68,6 +72,7 @@ class ChatMessageServiceTest {
                 eventPublisher,
                 groupMemberRepository,
                 chatSpamGuard,
+                questProgressService,
                 newsClusterRepository,
                 chatMessageNewsShareService
         );
@@ -128,6 +133,7 @@ class ChatMessageServiceTest {
                 .validate(eq(ChatScope.groupKey(1L, userId)), eq(0L), any(OffsetDateTime.class));
         verify(chatMessageRepository).save(captor.capture());
         verify(eventPublisher).publishEvent(any(ChatMessageCreatedEvent.class));
+        verify(questProgressService).handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
 
         ChatMessage capturedMessage = captor.getValue();
         assertEquals(group, capturedMessage.getGroup());
@@ -505,6 +511,7 @@ class ChatMessageServiceTest {
         ));
         verify(chatMessageNewsShareService).save(savedMessage, newsCluster);
         verify(eventPublisher).publishEvent(any(ChatMessageCreatedEvent.class));
+        verify(questProgressService).handleEvent(userId, QuestEventType.SHARE_NEWS);
 
         assertEquals(10L, result.messageId());
         assertEquals("NEWS", result.messageType());

--- a/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
@@ -102,6 +102,7 @@ class DailyQuestServiceTest {
     private QuestTemplate mockTemplate(Long id, Integer targetValue, Integer reward) {
         QuestTemplate template = mock(QuestTemplate.class);
         when(template.getId()).thenReturn(id);
+        when(template.getCode()).thenReturn("TEST_" + id);
         when(template.getTargetValue()).thenReturn(targetValue);
         when(template.getReward()).thenReturn(reward);
         return template;

--- a/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
@@ -66,7 +66,7 @@ class QuestProgressServiceTest {
         UserQuest profitRateQuest = createUserQuest(userId, QuestEventType.CHECK_PROFIT_RATE, QuestCompleteType.PERCENT, 5, 0);
         UserQuest countQuest = createUserQuest(userId, QuestEventType.CHECK_PROFIT_RATE, QuestCompleteType.COUNT, 3, 0);
 
-        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+        when(userQuestRepository.findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class)))
                 .thenReturn(List.of(profitRateQuest, countQuest));
 
         // when
@@ -77,7 +77,7 @@ class QuestProgressServiceTest {
         assertEquals(QuestStatus.COMPLETED, profitRateQuest.getStatus());
         assertEquals(0, countQuest.getProgress());
         assertEquals(QuestStatus.NOT_STARTED, countQuest.getStatus());
-        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+        verify(userQuestRepository).findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class));
     }
 
     @Test
@@ -87,7 +87,7 @@ class QuestProgressServiceTest {
         UUID userId = UUID.randomUUID();
         UserQuest rankQuest = createUserQuest(userId, QuestEventType.CHECK_GAME_RANK, QuestCompleteType.COUNT, 3, 0);
 
-        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+        when(userQuestRepository.findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class)))
                 .thenReturn(List.of(rankQuest));
 
         // when
@@ -96,7 +96,7 @@ class QuestProgressServiceTest {
         // then
         assertEquals(2, rankQuest.getProgress());
         assertEquals(QuestStatus.COMPLETED, rankQuest.getStatus());
-        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+        verify(userQuestRepository).findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class));
     }
 
     @Test
@@ -106,7 +106,7 @@ class QuestProgressServiceTest {
         UUID userId = UUID.randomUUID();
         UserQuest rankQuest = createUserQuest(userId, QuestEventType.CHECK_GAME_RANK, QuestCompleteType.COUNT, 3, 0);
 
-        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+        when(userQuestRepository.findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class)))
                 .thenReturn(List.of(rankQuest));
 
         // when
@@ -115,7 +115,7 @@ class QuestProgressServiceTest {
         // then
         assertEquals(5, rankQuest.getProgress());
         assertEquals(QuestStatus.IN_PROGRESS, rankQuest.getStatus());
-        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+        verify(userQuestRepository).findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class));
     }
 
     private UserQuest createUserQuest(

--- a/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
@@ -44,7 +44,7 @@ class QuestProgressServiceTest {
         UserQuest matchingQuest = createUserQuest(userId, QuestEventType.SEND_GROUP_CHAT, QuestCompleteType.COUNT, 3, 2);
         UserQuest nonMatchingQuest = createUserQuest(userId, QuestEventType.SHARE_NEWS, QuestCompleteType.COUNT, 1, 0);
 
-        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+        when(userQuestRepository.findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class)))
                 .thenReturn(List.of(matchingQuest, nonMatchingQuest));
 
         // when
@@ -55,7 +55,7 @@ class QuestProgressServiceTest {
         assertEquals(QuestStatus.COMPLETED, matchingQuest.getStatus());
         assertEquals(0, nonMatchingQuest.getProgress());
         assertEquals(QuestStatus.NOT_STARTED, nonMatchingQuest.getStatus());
-        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+        verify(userQuestRepository).findTodayUserQuestsForUpdate(eq(userId), any(LocalDate.class));
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
@@ -1,0 +1,151 @@
+package com.solv.wefin.domain.quest.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.quest.entity.DailyQuest;
+import com.solv.wefin.domain.quest.entity.QuestCompleteType;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.entity.QuestStatus;
+import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import com.solv.wefin.domain.quest.entity.UserQuest;
+import com.solv.wefin.domain.quest.repository.UserQuestRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class QuestProgressServiceTest {
+
+    private UserQuestRepository userQuestRepository;
+    private QuestProgressService questProgressService;
+
+    @BeforeEach
+    void setUp() {
+        userQuestRepository = mock(UserQuestRepository.class);
+        questProgressService = new QuestProgressService(userQuestRepository);
+    }
+
+    @Test
+    @DisplayName("이벤트 타입이 일치하는 퀘스트의 진행도를 증가시키고 목표 달성 시 완료 처리한다")
+    void handleEvent_updates_matching_user_quest() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserQuest matchingQuest = createUserQuest(userId, QuestEventType.SEND_GROUP_CHAT, QuestCompleteType.COUNT, 3, 2);
+        UserQuest nonMatchingQuest = createUserQuest(userId, QuestEventType.SHARE_NEWS, QuestCompleteType.COUNT, 1, 0);
+
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of(matchingQuest, nonMatchingQuest));
+
+        // when
+        questProgressService.handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
+
+        // then
+        assertEquals(3, matchingQuest.getProgress());
+        assertEquals(QuestStatus.COMPLETED, matchingQuest.getStatus());
+        assertEquals(0, nonMatchingQuest.getProgress());
+        assertEquals(QuestStatus.NOT_STARTED, nonMatchingQuest.getStatus());
+        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+    }
+
+    @Test
+    @DisplayName("수익률 퀘스트는 현재 수익률 정수값으로 진행도를 반영하고 완료 처리한다")
+    void handleProfitRate_updates_percent_quest() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserQuest profitRateQuest = createUserQuest(userId, QuestEventType.CHECK_PROFIT_RATE, QuestCompleteType.PERCENT, 5, 0);
+        UserQuest countQuest = createUserQuest(userId, QuestEventType.CHECK_PROFIT_RATE, QuestCompleteType.COUNT, 3, 0);
+
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of(profitRateQuest, countQuest));
+
+        // when
+        questProgressService.handleProfitRate(userId, new BigDecimal("5.8"));
+
+        // then
+        assertEquals(5, profitRateQuest.getProgress());
+        assertEquals(QuestStatus.COMPLETED, profitRateQuest.getStatus());
+        assertEquals(0, countQuest.getProgress());
+        assertEquals(QuestStatus.NOT_STARTED, countQuest.getStatus());
+        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+    }
+
+    @Test
+    @DisplayName("게임 순위가 목표 이내면 진행도를 기록하고 완료 처리한다")
+    void handleGameRank_completes_when_rank_is_within_target() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserQuest rankQuest = createUserQuest(userId, QuestEventType.CHECK_GAME_RANK, QuestCompleteType.COUNT, 3, 0);
+
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of(rankQuest));
+
+        // when
+        questProgressService.handleGameRank(userId, 2);
+
+        // then
+        assertEquals(2, rankQuest.getProgress());
+        assertEquals(QuestStatus.COMPLETED, rankQuest.getStatus());
+        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+    }
+
+    @Test
+    @DisplayName("게임 순위가 목표 밖이면 현재 순위만 반영하고 완료하지 않는다")
+    void handleGameRank_updates_progress_when_rank_is_outside_target() {
+        // given
+        UUID userId = UUID.randomUUID();
+        UserQuest rankQuest = createUserQuest(userId, QuestEventType.CHECK_GAME_RANK, QuestCompleteType.COUNT, 3, 0);
+
+        when(userQuestRepository.findTodayUserQuests(eq(userId), any(LocalDate.class)))
+                .thenReturn(List.of(rankQuest));
+
+        // when
+        questProgressService.handleGameRank(userId, 5);
+
+        // then
+        assertEquals(5, rankQuest.getProgress());
+        assertEquals(QuestStatus.IN_PROGRESS, rankQuest.getStatus());
+        verify(userQuestRepository).findTodayUserQuests(eq(userId), any(LocalDate.class));
+    }
+
+    private UserQuest createUserQuest(
+            UUID userId,
+            QuestEventType eventType,
+            QuestCompleteType completeType,
+            int targetValue,
+            int progress
+    ) {
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("quest-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        QuestTemplate template = mock(QuestTemplate.class);
+        when(template.getEventType()).thenReturn(eventType);
+        when(template.getCompleteType()).thenReturn(completeType);
+        when(template.getTargetValue()).thenReturn(targetValue);
+        when(template.getReward()).thenReturn(100_000);
+
+        DailyQuest dailyQuest = DailyQuest.create(template, LocalDate.now(), targetValue, 100_000);
+        UserQuest userQuest = UserQuest.assign(user, dailyQuest);
+        ReflectionTestUtils.setField(userQuest, "progress", progress);
+
+        if (progress > 0) {
+            ReflectionTestUtils.setField(userQuest, "status", QuestStatus.IN_PROGRESS);
+        }
+
+        return userQuest;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
@@ -4,8 +4,11 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.quest.entity.DailyQuest;
 import com.solv.wefin.domain.quest.entity.QuestTemplate;
+import com.solv.wefin.domain.quest.entity.QuestStatus;
 import com.solv.wefin.domain.quest.entity.UserQuest;
 import com.solv.wefin.domain.quest.repository.UserQuestRepository;
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +32,7 @@ class UserQuestServiceTest {
     private UserRepository userRepository;
     private UserQuestRepository userQuestRepository;
     private DailyQuestService dailyQuestService;
+    private VirtualAccountService virtualAccountService;
     private UserQuestService userQuestService;
 
     @BeforeEach
@@ -36,7 +40,8 @@ class UserQuestServiceTest {
         userRepository = mock(UserRepository.class);
         userQuestRepository = mock(UserQuestRepository.class);
         dailyQuestService = mock(DailyQuestService.class);
-        userQuestService = new UserQuestService(userRepository, userQuestRepository, dailyQuestService);
+        virtualAccountService = mock(VirtualAccountService.class);
+        userQuestService = new UserQuestService(userRepository, userQuestRepository, dailyQuestService, virtualAccountService);
     }
 
     @Test
@@ -131,5 +136,60 @@ class UserQuestServiceTest {
 
         // then
         assertEquals(ErrorCode.USER_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("완료된 퀘스트 보상 수령 시 보상을 지급하고 상태를 REWARDED로 변경한다")
+    void claimReward_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("questUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        QuestTemplate template = mock(QuestTemplate.class);
+        when(template.getReward()).thenReturn(100_000);
+
+        DailyQuest dailyQuest = DailyQuest.create(template, LocalDate.now(), 3, 100_000);
+        UserQuest userQuest = UserQuest.assign(user, dailyQuest);
+        ReflectionTestUtils.setField(userQuest, "id", 1L);
+        ReflectionTestUtils.setField(userQuest, "status", QuestStatus.COMPLETED);
+
+        VirtualAccount account = new VirtualAccount(userId);
+        ReflectionTestUtils.setField(account, "virtualAccountId", 11L);
+
+        when(userQuestRepository.findByIdAndUserIdForUpdate(1L, userId)).thenReturn(Optional.of(userQuest));
+        when(virtualAccountService.getAccountByUserId(userId)).thenReturn(account);
+
+        // when
+        UserQuest result = userQuestService.claimReward(userId, 1L);
+
+        // then
+        assertEquals(QuestStatus.REWARDED, result.getStatus());
+        verify(virtualAccountService).depositBalance(11L, java.math.BigDecimal.valueOf(100_000));
+    }
+
+    @Test
+    @DisplayName("보상 수령 대상 퀘스트가 없으면 예외가 발생한다")
+    void claimReward_fail_when_user_quest_not_found() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        when(userQuestRepository.findByIdAndUserIdForUpdate(1L, userId)).thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> userQuestService.claimReward(userId, 1L)
+        );
+
+        // then
+        assertEquals(ErrorCode.USER_QUEST_NOT_FOUND, exception.getErrorCode());
+        verify(virtualAccountService, never()).getAccountByUserId(any());
+        verify(virtualAccountService, never()).depositBalance(any(), any());
     }
 }

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.common.MarketPriceProvider;
@@ -50,6 +52,8 @@ class OrderServiceTest {
 	private StockInfoProvider stockInfoProvider;
 	@Mock
 	private ApplicationEventPublisher eventPublisher;
+	@Mock
+	private QuestProgressService questProgressService;
 
 	@InjectMocks
 	private OrderService orderService;
@@ -76,6 +80,7 @@ class OrderServiceTest {
 		verify(tradeService).createBuyTrade(any(), eq(1L), eq(1L), eq(20), any(), any(), any(), any(), any());
 		verify(portfolioService).addHolding(eq(1L), eq(1L), eq(20), any(), any());
 		verify(eventPublisher).publishEvent(any(OrderMatchedEvent.class));
+		verify(questProgressService).handleEvent(any(UUID.class), eq(QuestEventType.BUY_STOCK));
 	}
 
 	@Test
@@ -114,6 +119,7 @@ class OrderServiceTest {
 		given(virtualAccountService.getAccountWithLock(1L))
 			.willReturn(mockAccount);
 		given(mockAccount.getBalance()).willReturn(new BigDecimal("9000000"));
+		given(mockAccount.getUserId()).willReturn(UUID.randomUUID());
 
 		Portfolio mockPortfolio = mock(Portfolio.class);
 		given(mockPortfolio.getAvgPrice()).willReturn(new BigDecimal("170000"));
@@ -132,6 +138,7 @@ class OrderServiceTest {
 			any(), any(), any(), any(), any(), any(), any());
 		verify(portfolioService).deductQuantity(eq(1L), eq(1L), eq(10));
 		verify(eventPublisher).publishEvent(any(OrderMatchedEvent.class));
+		verify(questProgressService).handleEvent(any(UUID.class), eq(QuestEventType.SELL_STOCK));
 	}
 
 	@Test

--- a/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
+++ b/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.solv.wefin.common.IntegrationTestBase;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
@@ -49,10 +50,13 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 	private HantuMarketClient hantuMarketClient;
 	@MockitoBean
 	private HantuTokenManager hantuTokenManager;
+	@MockitoBean
+	private QuestProgressService questProgressService;
 
 	private UUID userId;
 	private Long stockId;
 	private Long accountId;
+	private String email;
 
 	@BeforeEach
 	void setUp() {
@@ -68,10 +72,11 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 		given(hantuMarketClient.fetchCurrentPrice(anyString())).willReturn(mockResponse);
 
 		userId = UUID.randomUUID();
+		email = "test-" + userId + "@test.com";
 
 		jdbcTemplate.execute(
 			"INSERT INTO users (user_id, email, nickname, password, created_at, updated_at) " +
-				"VALUES ('" + userId + "', 'test@test.com', 'tester', 'password', NOW(), NOW())"
+				"VALUES ('" + userId + "', '" + email + "', 'tester', 'password', NOW(), NOW())"
 		);
 
 		stockId = jdbcTemplate.queryForObject(
@@ -88,7 +93,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 		jdbcTemplate.execute("DELETE FROM orders");
 		jdbcTemplate.execute("DELETE FROM portfolio");
 		jdbcTemplate.execute("DELETE FROM virtual_account");
-		jdbcTemplate.execute("DELETE FROM users WHERE email = 'test@test.com'");
+		jdbcTemplate.execute("DELETE FROM users WHERE email = '" + email + "'");
 	}
 
 	@Test

--- a/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
+++ b/src/test/java/com/solv/wefin/integration/OrderConcurrencyTest.java
@@ -74,9 +74,10 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 		userId = UUID.randomUUID();
 		email = "test-" + userId + "@test.com";
 
-		jdbcTemplate.execute(
-			"INSERT INTO users (user_id, email, nickname, password, created_at, updated_at) " +
-				"VALUES ('" + userId + "', '" + email + "', 'tester', 'password', NOW(), NOW())"
+		jdbcTemplate.update(
+				"INSERT INTO users (user_id, email, nickname, password, created_at, updated_at) " +
+						"VALUES (?, ?, 'tester', 'password', NOW(), NOW())",
+				userId, email
 		);
 
 		stockId = jdbcTemplate.queryForObject(
@@ -93,7 +94,7 @@ public class OrderConcurrencyTest extends IntegrationTestBase {
 		jdbcTemplate.execute("DELETE FROM orders");
 		jdbcTemplate.execute("DELETE FROM portfolio");
 		jdbcTemplate.execute("DELETE FROM virtual_account");
-		jdbcTemplate.execute("DELETE FROM users WHERE email = '" + email + "'");
+		jdbcTemplate.update("DELETE FROM users WHERE email = ?", email);
 	}
 
 	@Test

--- a/src/test/java/com/solv/wefin/web/quest/QuestControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/quest/QuestControllerTest.java
@@ -30,7 +30,9 @@ import java.util.UUID;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -110,6 +112,70 @@ class QuestControllerTest {
                 .andExpect(status().isInternalServerError())
                 .andExpect(jsonPath("$.status").value(500))
                 .andExpect(jsonPath("$.code").value("QUEST_TEMPLATE_NOT_ENOUGH"));
+    }
+
+    @Test
+    @DisplayName("퀘스트 보상 수령 요청 시 REWARDED 상태를 반환한다")
+    void claimReward_success() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+        LocalDate today = LocalDate.now();
+
+        QuestTemplate template = buildTemplate();
+        DailyQuest dailyQuest = DailyQuest.create(template, today, 3, 100);
+        ReflectionTestUtils.setField(dailyQuest, "id", 11L);
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("questUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        UserQuest userQuest = UserQuest.assign(user, dailyQuest);
+        ReflectionTestUtils.setField(userQuest, "id", 21L);
+        ReflectionTestUtils.setField(userQuest, "status", QuestStatus.REWARDED);
+        ReflectionTestUtils.setField(userQuest, "progress", 3);
+
+        when(userQuestService.claimReward(userId, 21L)).thenReturn(userQuest);
+
+        // when // then
+        mockMvc.perform(post("/api/quests/21/reward")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.questId").value(21))
+                .andExpect(jsonPath("$.data.dailyQuestId").value(11))
+                .andExpect(jsonPath("$.data.status").value("REWARDED"))
+                .andExpect(jsonPath("$.data.progress").value(3))
+                .andExpect(jsonPath("$.data.reward").value(100));
+    }
+
+    @Test
+    @DisplayName("보상 수령 대상 퀘스트가 없으면 404 에러를 반환한다")
+    void claimReward_fail_when_user_quest_not_found() throws Exception {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        when(userQuestService.claimReward(userId, 21L))
+                .thenThrow(new BusinessException(ErrorCode.USER_QUEST_NOT_FOUND));
+
+        // when // then
+        mockMvc.perform(post("/api/quests/21/reward")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.code").value("USER_QUEST_NOT_FOUND"));
     }
 
     private QuestTemplate buildTemplate() {


### PR DESCRIPTION
## 📌 PR 설명

이벤트 기반으로 사용자의 퀘스트 진행도를 갱신하고, 조건 충족 시 완료 상태로 전환되도록 퀘스트 백엔드 흐름을 구현했습니다.  
이번 작업에서는 기존에 만들어둔 `quest_template` / `daily_quest` / `user_quest` 구조 위에 실제 사용자 행동을 연결해, 퀘스트가 단순 조회 데이터가 아니라 서비스 내 행동과 함께 변화하는 상태 데이터가 되도록 만드는 데 초점을 맞췄습니다.

특히 로그인, 그룹 채팅 전송, 뉴스 공유, AI 채팅 사용, 주식 매수/매도 같은 실제 액션 성공 지점에서 퀘스트 진행도를 갱신하도록 연결했고, 보상 수령 API까지 추가해 퀘스트의 기본 라이프사이클을 한 단계 더 완성했습니다.  
또한 수익률/게임 순위 같은 비교형 퀘스트를 처리할 수 있는 서비스 메서드와 테스트도 함께 정리해, 이후 비교형 퀘스트를 실제 서비스 흐름에 붙일 수 있는 기반도 마련했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[WEF-446] 이벤트 기반 퀘스트 진행도 및 완료 처리 구현**
- [x] `QuestProgressService`를 통한 이벤트 기반 퀘스트 진행도 갱신 로직 구현
- [x] COUNT형 퀘스트 진행도 증가 및 목표 달성 시 자동 완료 처리
- [x] 비교형 퀘스트 대응 메서드 추가
- [x] 로그인 성공 시 퀘스트 진행도 갱신 연결
- [x] 그룹 채팅 전송 성공 시 퀘스트 진행도 갱신 연결
- [x] 뉴스 공유 성공 시 퀘스트 진행도 갱신 연결
- [x] AI 채팅 사용 성공 시 퀘스트 진행도 갱신 연결
- [x] 주식 매수/매도 성공 시 퀘스트 진행도 갱신 연결
- [x] 퀘스트 보상 수령 서비스 및 API 구현
- [x] 보상 수령 시 중복 처리를 막기 위한 락 조회 적용
- [x] 퀘스트 진행도/보상 수령 관련 테스트 추가 및 보강

<br>

## 💭 고민과 해결과정

이번 작업에서 가장 먼저 고민했던 부분은 “퀘스트 진행도 업데이트를 어떤 방식으로 서비스에 연결할 것인가”였다.  
처음에는 별도 이벤트 객체를 만들어서 관리할지, 혹은 각 서비스에서 직접 퀘스트 로직을 처리할지 고민했지만, 현재 단계에서는 구조를 과하게 복잡하게 만들기보다 **기존 도메인 서비스의 성공 지점에서 `QuestProgressService`를 호출하는 방식**이 가장 적절하다고 판단했다. 이렇게 하면 로그인, 채팅, 뉴스 공유, 매수 같은 실제 행동이 성공했을 때만 퀘스트 진행도가 올라가도록 자연스럽게 연결할 수 있었다.

또 하나 고민했던 부분은 퀘스트마다 처리 방식이 달라진다는 점이었다.  
채팅 n회, 뉴스 공유 n회, 매수 n회 같은 퀘스트는 이벤트가 발생할 때마다 `+1`씩 진행도를 올리면 되지만, 수익률 n% 달성이나 게임 순위 n등 이내 같은 퀘스트는 단순 누적형으로 볼 수 없었다. 그래서 퀘스트 처리 로직을 전부 같은 방식으로 묶기보다는, **COUNT형 퀘스트는 `handleEvent(...)`, 비교형 퀘스트는 별도 메서드(`handleProfitRate(...)`, `handleGameRank(...)`)로 분리**하는 방식으로 설계를 정리했다. 이 덕분에 액션형과 비교형 퀘스트를 같은 서비스 안에서 다루되, 비교 기준이 다른 퀘스트의 특성은 유지할 수 있었다.

특히 게임 순위 퀘스트를 테스트하는 과정에서 도메인 로직의 문제도 발견할 수 있었다.  
기존 `updateProgress()`는 `progress >= targetValue`를 전제로 하는 구조라서, 순위처럼 숫자가 작을수록 좋은 비교형 퀘스트에는 맞지 않았다. 이 상태로는 목표 밖의 순위가 들어와도 잘못 완료 처리될 가능성이 있었다. 그래서 단순히 테스트만 추가하는 데서 끝내지 않고, **비교형 퀘스트용 진행도 기록 메서드(`recordProgress`)를 별도로 두고, 게임 순위 퀘스트는 그 메서드를 사용하도록 수정**했다. 이 과정은 퀘스트를 단순 상태값 저장이 아니라, 완료 조건 자체를 도메인 규칙으로 다뤄야 한다는 점을 다시 확인하게 해줬다.

보상 수령 로직에서도 상태 전이와 동시성 처리를 함께 고민했다.  
보상은 완료된 퀘스트에서만 수령 가능해야 하고, 동시에 여러 요청이 들어와도 중복 지급되면 안 된다. 이를 위해 `markRewarded()`는 `COMPLETED` 상태에서만 허용되도록 제한하고, 보상 수령 시 `UserQuest`를 `PESSIMISTIC_WRITE`로 조회해 중복 수령 경쟁 상황을 제어했다. 이후 계좌 잔고 반영은 기존 `VirtualAccountService`를 재사용하도록 구성해, 퀘스트 보상이 기존 가상 잔고 시스템과 자연스럽게 연결되도록 했다.

또한 홈 화면에서 퀘스트 진행도를 어떻게 보여줄지도 함께 고려했다.  
처음에는 “실시간으로 갱신하려면 웹소켓이 필요한가”라는 고민도 있었지만, 현재 단계에서는 각 액션 성공 후 프론트가 오늘의 퀘스트 조회 API를 다시 호출하는 방식만으로도 충분히 자연스러운 사용자 경험을 만들 수 있다고 판단했다. 그래서 이번 백엔드는 **행동 성공 시 서버 내부 상태를 갱신하고, 프론트는 `GET /api/quests/today`를 재조회해 반영하는 구조**를 전제로 잡았다. 이 방식은 구현과 운영 복잡도를 낮추면서도, 초기 버전의 퀘스트 UX를 안정적으로 제공할 수 있다는 장점이 있었다.

정리하면 이번 작업은 단순히 퀘스트 상태 컬럼을 업데이트하는 것이 아니라,  
**사용자 행동 → 퀘스트 진행도 반영 → 완료 상태 전환 → 보상 수령**으로 이어지는 퀘스트의 실제 생명주기를 서비스 안에 녹여낸 과정이었다.  
그 결과 현재는 COUNT형 퀘스트의 기본 흐름과 보상 수령까지 연결된 상태이고, 수익률/게임 순위 같은 비교형 퀘스트도 이후 실제 계산 서비스와 연결하면 바로 확장할 수 있는 기반까지 마련할 수 있었다.
<br>

### 🔗 관련 이슈
Closes #84

<br>


[WEF-446]: https://sol-v.atlassian.net/browse/WEF-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

## 새로운 기능
- 완료된 퀘스트 보상 청구 엔드포인트 추가 (POST /api/quests/{id}/reward)
- 로그인, AI 채팅, 그룹 채팅, 뉴스 공유, 매수/매도 등 사용자 활동에 따른 퀘스트 진행 자동 기록
- 수익률 확인 및 게임 순위 기반 신규 퀘스트 타입과 진행 규칙 도입

## 오류/응답
- 존재하지 않는 사용자 퀘스트 요청 시 404 응답 코드 추가 (USER_QUEST_NOT_FOUND)

## 테스트
- 퀘스트·인증·채팅·주문 관련 단위 및 통합 테스트 대폭 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->