### PR TITLE
[WEF-530] 금융 동향 AI 요약 및 인사이트 카드 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/market/trend/client/OpenAiMarketTrendClient.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/client/OpenAiMarketTrendClient.java
@@ -1,0 +1,279 @@
+package com.solv.wefin.domain.market.trend.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.game.openai.OpenAiProperties;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientResponseException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * OpenAI로 오늘의 금융 동향(title + summary + 인사이트 카드 + 키워드)을 생성한다
+ *
+ * 입력: 4개 시장 지표 스냅샷 + 최근 24시간 주요 클러스터 제목/요약 + 태그 집계(STOCK/TOPIC).
+ * 출력 JSON: {@code title, summary, insightCards[4], relatedKeywords[]}.
+ */
+@Slf4j
+@Component
+public class OpenAiMarketTrendClient {
+
+    /** 프롬프트에 포함할 대표 클러스터 최대 개수 */
+    public static final int MAX_CLUSTERS_IN_PROMPT = 15;
+    /** 태그 집계 전달 상위 N */
+    public static final int MAX_TAGS_IN_PROMPT = 10;
+    /** 인사이트 카드 요구 개수 (고정) */
+    public static final int REQUIRED_INSIGHT_CARDS = 4;
+
+    private final RestClient restClient;
+    private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public OpenAiMarketTrendClient(
+            @Qualifier("openAiRestClient") RestClient restClient,
+            OpenAiProperties properties,
+            ObjectMapper objectMapper) {
+        this.restClient = restClient;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 금융 동향을 생성한다
+     *
+     * @param snapshots        4개 시장 지표
+     * @param clusterSummaries 프롬프트에 포함할 주요 클러스터 (인덱스 = 위치+1 → 호출자가 clusterId 매핑)
+     * @param risingStocks     떠오르는 STOCK 태그 이름 목록 (집계 상위 N)
+     * @param risingTopics     떠오르는 TOPIC 태그 이름 목록 (집계 상위 N)
+     * @return 파싱된 콘텐츠 (relatedClusterIndices는 prompt index 기준)
+     */
+    public MarketTrendRawResult generateTrend(List<MarketSnapshot> snapshots,
+                                              List<ClusterSummary> clusterSummaries,
+                                              List<String> risingStocks,
+                                              List<String> risingTopics) {
+        String userMessage = buildUserMessage(snapshots, clusterSummaries, risingStocks, risingTopics);
+
+        ChatRequest request = new ChatRequest(
+                properties.getModel(),
+                List.of(
+                        new ChatRequest.Message("system", SYSTEM_PROMPT),
+                        new ChatRequest.Message("user", userMessage)
+                ),
+                properties.getMaxTokens(),
+                properties.getTemperature(),
+                new ChatRequest.ResponseFormat("json_object")
+        );
+
+        ChatResponse response;
+        try {
+            response = restClient.post()
+                    .uri("/v1/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(ChatResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new MarketTrendAiException(
+                    "OpenAI Market Trend API HTTP 오류: " + e.getStatusCode(), e);
+        } catch (Exception e) {
+            throw new MarketTrendAiException(
+                    "OpenAI Market Trend API 호출 실패: " + e.getMessage(), e);
+        }
+
+        if (response == null || response.choices() == null || response.choices().isEmpty()) {
+            throw new MarketTrendAiException("OpenAI Market Trend API 응답이 비어있습니다", null);
+        }
+
+        ChatResponse.Choice choice = response.choices().get(0);
+        if (choice == null || choice.message() == null) {
+            throw new MarketTrendAiException("OpenAI Market Trend API message 누락", null);
+        }
+        String content = choice.message().content();
+        if (content == null || content.isBlank()) {
+            throw new MarketTrendAiException("OpenAI Market Trend API content 비어있음", null);
+        }
+        return parse(content);
+    }
+
+    private String buildUserMessage(List<MarketSnapshot> snapshots,
+                                    List<ClusterSummary> clusterSummaries,
+                                    List<String> risingStocks,
+                                    List<String> risingTopics) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("### 시장 지표\n");
+        for (MarketSnapshot s : snapshots) {
+            sb.append("- ").append(s.getLabel()).append(": ").append(s.getValue());
+            if (s.getChangeRate() != null) {
+                sb.append(" (").append(s.getChangeDirection()).append(" ").append(s.getChangeRate()).append("%)");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("\n### 최근 24시간 주요 뉴스 클러스터\n");
+        int limit = Math.min(clusterSummaries.size(), MAX_CLUSTERS_IN_PROMPT);
+        for (int i = 0; i < limit; i++) {
+            ClusterSummary c = clusterSummaries.get(i);
+            sb.append("[").append(i + 1).append("] ").append(c.title());
+            if (c.summary() != null && !c.summary().isBlank()) {
+                sb.append("\n    요약: ").append(c.summary());
+            }
+            sb.append("\n");
+        }
+
+        sb.append("\n### 떠오르는 종목 (언급 상위)\n");
+        sb.append(truncate(risingStocks, MAX_TAGS_IN_PROMPT).stream().collect(Collectors.joining(", ")));
+
+        sb.append("\n\n### 떠오르는 주제 (언급 상위)\n");
+        sb.append(truncate(risingTopics, MAX_TAGS_IN_PROMPT).stream().collect(Collectors.joining(", ")));
+
+        return sb.toString();
+    }
+
+    private static <T> List<T> truncate(List<T> list, int n) {
+        if (list == null) return List.of();
+        return list.size() <= n ? list : list.subList(0, n);
+    }
+
+    private MarketTrendRawResult parse(String json) {
+        try {
+            RawResponse raw = objectMapper.readValue(json, RawResponse.class);
+            if (raw == null) {
+                throw new MarketTrendAiException("Market Trend JSON이 비어있습니다", null);
+            }
+
+            List<InsightCardRaw> rawCards = raw.insightCards() != null ? raw.insightCards() : List.of();
+            List<ParsedCard> parsedCards = new ArrayList<>();
+            for (InsightCardRaw c : rawCards) {
+                if (c == null) continue;
+                parsedCards.add(new ParsedCard(
+                        c.headline(),
+                        c.body(),
+                        c.relatedClusterIndices() != null ? c.relatedClusterIndices() : List.of()
+                ));
+            }
+
+            return new MarketTrendRawResult(
+                    raw.title(),
+                    raw.summary(),
+                    parsedCards,
+                    raw.relatedKeywords() != null ? raw.relatedKeywords() : List.of()
+            );
+        } catch (JsonProcessingException e) {
+            throw new MarketTrendAiException("Market Trend JSON 파싱 실패: " + e.getOriginalMessage(), e);
+        }
+    }
+
+    // ── 시스템 프롬프트 ────────────────────────────────────────
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 한국 금융시장 전문 애널리스트입니다.
+            주어진 시장 지표와 최근 24시간 주요 뉴스 클러스터를 종합하여 오늘의 금융 동향을 작성합니다.
+
+            작성 규칙:
+            1. title: 오늘 시장 핵심 한 줄 요약 (50자 이내, 한글)
+            2. summary: 3~4문단 시장 전반 분석 (500~800자)
+               - 시장 지표의 변동과 뉴스 흐름을 연결해 설명
+               - 투자자가 오늘 주목해야 할 맥락 제공
+               - 일반적 표현 대신 구체적 수치/기업명/이슈를 인용
+            3. insightCards: 정확히 %d개
+               - 각 카드: headline(20자 내외) + body(100~200자) + relatedClusterIndices
+               - relatedClusterIndices는 입력 "주요 뉴스 클러스터"의 번호만 사용 (1-based)
+               - 각 카드는 서로 다른 테마를 다룰 것 (같은 이슈 중복 금지)
+            4. relatedKeywords: 오늘의 핵심 키워드 5~10개 (한글, 중복 없음, 구체적)
+               - 예: "반도체", "HBM", "기준금리", "엔비디아"
+
+            주의사항:
+            - 입력에 없는 사실을 만들지 말 것
+            - 숫자는 입력값을 그대로 사용할 것
+            - 특정 종목 매수/매도 권유성 표현 금지
+
+            반드시 아래 JSON 형식으로만 응답하세요:
+            {
+              "title": "...",
+              "summary": "...",
+              "insightCards": [
+                {"headline": "...", "body": "...", "relatedClusterIndices": [1, 3]}
+              ],
+              "relatedKeywords": ["...", "..."]
+            }
+            """.formatted(REQUIRED_INSIGHT_CARDS);
+
+    // ── 데이터 전달용 record ──────────────────────────────────
+
+    /** 프롬프트에 전달할 클러스터 경량 DTO */
+    public record ClusterSummary(Long clusterId, String title, String summary) {
+    }
+
+    /** 파싱 직후 결과 — 호출자가 relatedClusterIndices를 실제 clusterId로 매핑 */
+    public record MarketTrendRawResult(
+            String title,
+            String summary,
+            List<ParsedCard> cards,
+            List<String> relatedKeywords
+    ) {
+        public boolean isEmpty() {
+            return (title == null || title.isBlank())
+                    || (summary == null || summary.isBlank());
+        }
+    }
+
+    public record ParsedCard(String headline, String body, List<Integer> relatedClusterIndices) {
+        public boolean isValid() {
+            return headline != null && !headline.isBlank()
+                    && body != null && !body.isBlank();
+        }
+    }
+
+    // ── OpenAI 요청/응답 DTO ──────────────────────────────────
+
+    record ChatRequest(
+            String model,
+            List<Message> messages,
+            @JsonProperty("max_tokens") int maxTokens,
+            double temperature,
+            @JsonProperty("response_format") ResponseFormat responseFormat
+    ) {
+        record Message(String role, String content) {
+        }
+
+        record ResponseFormat(String type) {
+        }
+    }
+
+    record ChatResponse(List<Choice> choices) {
+        record Choice(Message message) {
+        }
+
+        record Message(String content) {
+        }
+    }
+
+    record RawResponse(
+            String title,
+            String summary,
+            List<InsightCardRaw> insightCards,
+            List<String> relatedKeywords
+    ) {
+    }
+
+    record InsightCardRaw(
+            String headline,
+            String body,
+            List<Integer> relatedClusterIndices
+    ) {
+    }
+
+    /** AI 호출/파싱 실패 전용 예외 (재시도 판정용) */
+    public static class MarketTrendAiException extends RuntimeException {
+        public MarketTrendAiException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/InsightCard.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/InsightCard.java
@@ -1,0 +1,16 @@
+package com.solv.wefin.domain.market.trend.dto;
+
+import java.util.List;
+
+/**
+ * 금융 동향 인사이트 카드
+ *
+ * AI가 뉴스 클러스터 태그 집계를 바탕으로 생성한 카드 단위 인사이트.
+ * {@code relatedClusterIds}는 프론트에서 상세 페이지(/news/:clusterId)로 이동할 때 사용된다
+ */
+public record InsightCard(
+        String headline,
+        String body,
+        List<Long> relatedClusterIds
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/MarketTrendContent.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/MarketTrendContent.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.domain.market.trend.dto;
+
+import java.util.List;
+
+/**
+ * AI가 생성한 금융 동향 콘텐츠 (배치 내부 전달 + 저장 직전 형태)
+ */
+public record MarketTrendContent(
+        String title,
+        String summary,
+        List<InsightCard> insightCards,
+        List<String> relatedKeywords
+) {
+    public boolean isEmpty() {
+        return (title == null || title.isBlank())
+                || (summary == null || summary.isBlank());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/MarketTrendOverview.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/MarketTrendOverview.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.domain.market.trend.dto;
+
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 금융 동향 overview 조회 결과
+ *
+ */
+public record MarketTrendOverview(
+        boolean generated,
+        LocalDate trendDate,
+        String title,
+        String summary,
+        List<InsightCard> insightCards,
+        List<String> relatedKeywords,
+        List<SourceClusterInfo> sourceClusters,
+        int sourceArticleCount,
+        OffsetDateTime updatedAt,
+        List<MarketSnapshot> marketSnapshots
+) {
+    public static MarketTrendOverview empty(List<MarketSnapshot> snapshots) {
+        return new MarketTrendOverview(false, null, null, null, List.of(), List.of(),
+                List.of(), 0, null, snapshots);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/SourceClusterInfo.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/SourceClusterInfo.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.market.trend.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 금융 동향 생성에 사용된 클러스터 출처 정보
+ */
+public record SourceClusterInfo(
+        Long clusterId,
+        String title,
+        OffsetDateTime publishedAt
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/entity/MarketTrend.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/entity/MarketTrend.java
@@ -1,0 +1,135 @@
+package com.solv.wefin.domain.market.trend.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+/**
+ * 오늘의 금융 동향 엔티티 (AI 생성 요약 + 인사이트 카드 + 키워드)
+ *
+ * 시장 지표(MarketSnapshot)와 최근 24시간 클러스터 태그 집계를 종합하여 AI가 생성한다.
+ * (trend_date, session) 기준으로 upsert되며 현재는 session='DAILY'로 고정하여
+ * 하루 1건만 최신화한다. 조회 API에서는 최신 1건을 가져와 MarketSnapshot과 함께 응답한다.
+ */
+@Entity
+@Table(name = "market_trend")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MarketTrend {
+
+    public static final String SESSION_DAILY = "DAILY";
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "market_trend_id")
+    private Long id;
+
+    @Column(name = "trend_date", nullable = false)
+    private LocalDate trendDate;
+
+    @Column(name = "session", nullable = false, length = 20)
+    private String session;
+
+    @Column(name = "title", columnDefinition = "TEXT")
+    private String title;
+
+    @Column(name = "summary", columnDefinition = "TEXT")
+    private String summary;
+
+    /**
+     * 인사이트 카드 배열. {@code [{"headline": "...", "body": "...", "relatedClusterIds": [1, 3]}]}
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "insight_cards", columnDefinition = "jsonb")
+    private String insightCardsJson;
+
+    /**
+     * 떠오르는 키워드 배열 (JSON 문자열). {@code ["반도체", "엔비디아", "금리"]}
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "related_keywords", columnDefinition = "jsonb")
+    private String relatedKeywordsJson;
+
+    /**
+     * 동향 생성에 사용된 클러스터 ID 목록 (JSON 배열 문자열). {@code [12, 14, 18]}.
+     * 조회 시점에 news_cluster를 JOIN하여 title/publishedAt을 함께 노출한다
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "source_cluster_ids", columnDefinition = "jsonb")
+    private String sourceClusterIdsJson;
+
+    /** 동향 생성에 사용된 기사 총 개수 (사용 클러스터 소속 기사 수의 합) */
+    @Column(name = "source_article_count")
+    private Integer sourceArticleCount;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private MarketTrend(LocalDate trendDate, String session, String title, String summary,
+                        String insightCardsJson, String relatedKeywordsJson,
+                        String sourceClusterIdsJson, Integer sourceArticleCount) {
+        this.trendDate = trendDate;
+        this.session = session;
+        this.title = title;
+        this.summary = summary;
+        this.insightCardsJson = insightCardsJson;
+        this.relatedKeywordsJson = relatedKeywordsJson;
+        this.sourceClusterIdsJson = sourceClusterIdsJson;
+        this.sourceArticleCount = sourceArticleCount;
+    }
+
+    @PrePersist
+    void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        this.updatedAt = OffsetDateTime.now();
+    }
+
+    /**
+     * 새 오늘 동향을 생성한다 (session={@link #SESSION_DAILY} 고정)
+     */
+    public static MarketTrend createDaily(LocalDate trendDate, String title, String summary,
+                                          String insightCardsJson, String relatedKeywordsJson,
+                                          String sourceClusterIdsJson, Integer sourceArticleCount) {
+        return MarketTrend.builder()
+                .trendDate(trendDate)
+                .session(SESSION_DAILY)
+                .title(title)
+                .summary(summary)
+                .insightCardsJson(insightCardsJson)
+                .relatedKeywordsJson(relatedKeywordsJson)
+                .sourceClusterIdsJson(sourceClusterIdsJson)
+                .sourceArticleCount(sourceArticleCount)
+                .build();
+    }
+
+    /**
+     * 기존 row의 콘텐츠를 최신 AI 생성 결과로 교체한다 (같은 날 재생성 대응)
+     */
+    public void updateContent(String title, String summary,
+                              String insightCardsJson, String relatedKeywordsJson,
+                              String sourceClusterIdsJson, Integer sourceArticleCount) {
+        this.title = title;
+        this.summary = summary;
+        this.insightCardsJson = insightCardsJson;
+        this.relatedKeywordsJson = relatedKeywordsJson;
+        this.sourceClusterIdsJson = sourceClusterIdsJson;
+        this.sourceArticleCount = sourceArticleCount;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/repository/MarketTrendRepository.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/repository/MarketTrendRepository.java
@@ -1,0 +1,59 @@
+package com.solv.wefin.domain.market.trend.repository;
+
+import com.solv.wefin.domain.market.trend.entity.MarketTrend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public interface MarketTrendRepository extends JpaRepository<MarketTrend, Long> {
+
+    /**
+     * 지정 날짜의 동향을 조회한다 (session + 콘텐츠 존재 필터).
+     */
+    Optional<MarketTrend> findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(
+            java.time.LocalDate trendDate, String session);
+
+    /**
+     * (trend_date, session) 기준으로 기존 row를 조회한다 (테스트 검증용)
+     */
+    Optional<MarketTrend> findByTrendDateAndSession(LocalDate trendDate, String session);
+
+    /**
+     * (trend_date, session) 충돌 시 콘텐츠를 갱신하는 native upsert.
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO market_trend (
+                trend_date, session, title, summary,
+                insight_cards, related_keywords,
+                source_cluster_ids, source_article_count,
+                created_at, updated_at
+            )
+            VALUES (
+                :trendDate, :session, :title, :summary,
+                CAST(:insightCardsJson AS jsonb), CAST(:relatedKeywordsJson AS jsonb),
+                CAST(:sourceClusterIdsJson AS jsonb), :sourceArticleCount,
+                now(), now()
+            )
+            ON CONFLICT (trend_date, session) DO UPDATE SET
+                title                = EXCLUDED.title,
+                summary              = EXCLUDED.summary,
+                insight_cards        = EXCLUDED.insight_cards,
+                related_keywords     = EXCLUDED.related_keywords,
+                source_cluster_ids   = EXCLUDED.source_cluster_ids,
+                source_article_count = EXCLUDED.source_article_count,
+                updated_at           = now()
+            """, nativeQuery = true)
+    void upsertDaily(@Param("trendDate") LocalDate trendDate,
+                     @Param("session") String session,
+                     @Param("title") String title,
+                     @Param("summary") String summary,
+                     @Param("insightCardsJson") String insightCardsJson,
+                     @Param("relatedKeywordsJson") String relatedKeywordsJson,
+                     @Param("sourceClusterIdsJson") String sourceClusterIdsJson,
+                     @Param("sourceArticleCount") Integer sourceArticleCount);
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/scheduler/MarketTrendScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/scheduler/MarketTrendScheduler.java
@@ -1,0 +1,54 @@
+package com.solv.wefin.domain.market.trend.scheduler;
+
+import com.solv.wefin.domain.market.trend.service.MarketTrendGenerationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 오늘의 금융 동향 생성 배치 스케줄러
+ *
+ * 기본 30분 간격. 환경변수 {@code market.trend.cron}로 조정 가능.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MarketTrendScheduler {
+
+    private final MarketTrendGenerationService generationService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Scheduled(cron = "${market.trend.cron:0 */30 * * * *}")
+    public void generateMarketTrend() {
+        try {
+            execute();
+        } catch (Exception e) {
+            log.error("금융 동향 생성 배치 실패: {}", e.getMessage(), e);
+        }
+    }
+
+    /**
+     * 수동 트리거에서도 호출 가능하도록 public.
+     * 이미 실행 중이면 false 반환
+     */
+    public boolean execute() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("금융 동향 생성이 이미 실행 중입니다. 스킵합니다.");
+            return false;
+        }
+
+        log.info("=== 금융 동향 생성 배치 시작 ===");
+        long start = System.currentTimeMillis();
+        try {
+            generationService.generateTodayTrend();
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 금융 동향 생성 배치 종료 ({}ms) ===", elapsed);
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendGenerationService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendGenerationService.java
@@ -1,0 +1,229 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ClusterSummary;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.MarketTrendRawResult;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ParsedCard;
+import com.solv.wefin.domain.market.trend.dto.InsightCard;
+import com.solv.wefin.domain.market.trend.dto.MarketTrendContent;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.service.ClusterTagAggregator;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * 오늘의 금융 동향 생성 배치 오케스트레이션
+ *
+ * 시장 지표 + 최근 주요 클러스터 + 태그 집계를 수집하여 AI 프롬프트를 조립하고,
+ * AI 응답의 relatedClusterIndices(1-based)를 실제 clusterId로 매핑한 뒤
+ * {@link MarketTrendPersistenceService}에 upsert를 위임한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketTrendGenerationService {
+
+    /** 프롬프트에 포함할 대표 클러스터 최대 개수 (AI 측과 동일 상수) */
+    private static final int MAX_CLUSTERS = OpenAiMarketTrendClient.MAX_CLUSTERS_IN_PROMPT;
+    private static final int MAX_TAGS = OpenAiMarketTrendClient.MAX_TAGS_IN_PROMPT;
+    private static final int REQUIRED_CARDS = OpenAiMarketTrendClient.REQUIRED_INSIGHT_CARDS;
+    private static final int MIN_KEYWORDS = 5;
+    private static final int MAX_KEYWORDS = 10;
+    /** 프롬프트 대상 클러스터의 최대 경과 시간 */
+    private static final java.time.Duration LOOKBACK = java.time.Duration.ofHours(24);
+    private static final List<SummaryStatus> VISIBLE_STATUSES =
+            List.of(SummaryStatus.GENERATED, SummaryStatus.STALE);
+    /** trend_date 계산 기준 timezone — 금융/뉴스 "오늘" 데이터 경계는 서비스 운영 지역(한국) 기준으로 고정 */
+    private static final ZoneId TREND_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final MarketSnapshotRepository marketSnapshotRepository;
+    private final NewsClusterRepository newsClusterRepository;
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final ClusterTagAggregator tagAggregator;
+    private final OpenAiMarketTrendClient openAiClient;
+    private final MarketTrendPersistenceService persistenceService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 오늘의 금융 동향을 생성하여 저장한다 (배치 entry point)
+     */
+    public void generateTodayTrend() {
+        // 1) 시장 지표 4건
+        List<MarketSnapshot> snapshots = marketSnapshotRepository.findAll();
+        if (snapshots.isEmpty()) {
+            log.warn("[MarketTrend] 시장 지표가 비어있음 — 생성 스킵");
+            return;
+        }
+
+        // 2) 최근 LOOKBACK(기본 24h) 이내 주요 클러스터 상위 N건 (publishedAt 최신순)
+        //    cutoff 조건은 DB 쿼리에서 직접 적용 — publishedAt이 null인 row가 상단에 오는 경우에도
+        //    유효한 최근 클러스터가 limit 밖으로 밀리지 않도록 보장
+        OffsetDateTime cutoff = OffsetDateTime.now().minus(LOOKBACK);
+        List<NewsCluster> clusters = newsClusterRepository.findRecentActiveClusters(
+                ClusterStatus.ACTIVE, VISIBLE_STATUSES, cutoff, PageRequest.of(0, MAX_CLUSTERS));
+        if (clusters.isEmpty()) {
+            log.warn("[MarketTrend] 최근 {}시간 내 가용 클러스터 없음 — 생성 스킵", LOOKBACK.toHours());
+            return;
+        }
+
+        // 3) 태그 집계용 article 매핑 구성
+        List<Long> clusterIds = clusters.stream().map(NewsCluster::getId).toList();
+        Map<Long, List<Long>> clusterArticleMap = clusterArticleRepository.findByNewsClusterIdIn(clusterIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        NewsClusterArticle::getNewsClusterId,
+                        Collectors.mapping(NewsClusterArticle::getNewsArticleId, Collectors.toList())));
+        List<Long> allArticleIds = clusterArticleMap.values().stream()
+                .flatMap(List::stream).distinct().toList();
+
+        List<String> risingStocks = collectTopStockNames(
+                allArticleIds.isEmpty() ? Map.of() : tagAggregator.aggregateStocks(clusterArticleMap, allArticleIds),
+                MAX_TAGS);
+        List<String> risingTopics = collectTopTopicNames(
+                allArticleIds.isEmpty() ? Map.of() : tagAggregator.aggregateMarketTags(clusterArticleMap, allArticleIds),
+                MAX_TAGS);
+
+        // 4) 프롬프트에 넘길 클러스터 요약
+        List<ClusterSummary> clusterSummaries = clusters.stream()
+                .map(c -> new ClusterSummary(c.getId(), c.getTitle(), c.getSummary()))
+                .toList();
+
+        // 5) AI 호출
+        MarketTrendRawResult raw;
+        try {
+            raw = openAiClient.generateTrend(snapshots, clusterSummaries, risingStocks, risingTopics);
+        } catch (OpenAiMarketTrendClient.MarketTrendAiException e) {
+            log.warn("[MarketTrend] AI 생성 실패 — 이번 실행 주기 스킵", e);
+            return;
+        }
+
+        if (raw.isEmpty()) {
+            log.warn("[MarketTrend] AI 결과에 title/summary 누락 — 저장 스킵");
+            return;
+        }
+
+        // 6) relatedClusterIndices(1-based prompt index) → 실제 clusterId 매핑
+        List<InsightCard> cards = mapCards(raw.cards(), clusterSummaries);
+
+        // 7) 카드/키워드 개수 계약 검증 (프론트 레이아웃 보장)
+        if (cards.size() != REQUIRED_CARDS) {
+            log.warn("[MarketTrend] 인사이트 카드 개수 불일치 — 저장 스킵, expected: {}, actual: {}",
+                    REQUIRED_CARDS, cards.size());
+            return;
+        }
+        // 각 카드가 최소 1개 이상의 유효한 출처 클러스터를 가져야 함. AI가 범위 밖 index만
+        // 반환한 경우 본문만 있고 관련 기사 링크가 비는 카드가 저장되는 것을 방지
+        boolean hasEmptySource = cards.stream().anyMatch(c -> c.relatedClusterIds().isEmpty());
+        if (hasEmptySource) {
+            log.warn("[MarketTrend] 일부 인사이트 카드에 유효한 출처 클러스터가 없음 — 저장 스킵");
+            return;
+        }
+        int keywordCount = raw.relatedKeywords().size();
+        if (keywordCount < MIN_KEYWORDS || keywordCount > MAX_KEYWORDS) {
+            log.warn("[MarketTrend] 키워드 개수 범위 벗어남 — 저장 스킵, range: {}~{}, actual: {}",
+                    MIN_KEYWORDS, MAX_KEYWORDS, keywordCount);
+            return;
+        }
+
+        // 8) 출처 메타 계산
+        //    - sourceClusterIds: AI가 insightCards에서 실제로 참조한 클러스터만 (중복 제거 + 입력 순서 유지).
+        //      프롬프트에 넘긴 15개 전부가 아니라 AI 동의한 것만 저장하여, 프론트의 "이 동향의 출처" 섹션이
+        //      본문과 실제로 관련된 카드만 노출하도록 보장
+        //    - sourceArticleCount: 전체 고유 기사 수. clusterArticleMap.values() 합산은 같은 기사가 복수
+        //      클러스터에 속할 때 중복 카운트되므로 allArticleIds.size()로 정확도 확보
+        java.util.LinkedHashSet<Long> referencedClusterIds = new java.util.LinkedHashSet<>();
+        for (InsightCard card : cards) {
+            referencedClusterIds.addAll(card.relatedClusterIds());
+        }
+        List<Long> sourceClusterIds = List.copyOf(referencedClusterIds);
+        int sourceArticleCount = allArticleIds.size();
+
+        // 9) 저장 (upsert)
+        MarketTrendContent content = new MarketTrendContent(
+                raw.title(), raw.summary(), cards, raw.relatedKeywords());
+        try {
+            persistenceService.upsertDailyTrend(
+                    LocalDate.now(TREND_ZONE), content,
+                    toJson(cards), toJson(raw.relatedKeywords()),
+                    toJson(sourceClusterIds), sourceArticleCount);
+        } catch (JsonProcessingException e) {
+            log.warn("[MarketTrend] JSON 직렬화 실패 — 저장 스킵", e);
+        }
+    }
+
+    /**
+     * 클러스터별 STOCK 태그를 flatten하여 상위 name을 반환한다.
+     */
+    private List<String> collectTopStockNames(Map<Long, List<StockInfo>> perCluster, int topN) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        Map<String, String> codeToName = new LinkedHashMap<>();
+        perCluster.values().forEach(list -> {
+            if (list == null) return;
+            list.forEach(info -> {
+                counts.merge(info.code(), 1, Integer::sum);
+                codeToName.putIfAbsent(info.code(), info.name());
+            });
+        });
+        return counts.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .limit(topN)
+                .map(e -> codeToName.get(e.getKey()))
+                .toList();
+    }
+
+    private List<String> collectTopTopicNames(Map<Long, List<String>> perCluster, int topN) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        perCluster.values().forEach(list -> {
+            if (list == null) return;
+            list.forEach(name -> counts.merge(name, 1, Integer::sum));
+        });
+        return counts.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .limit(topN)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    /**
+     * AI가 반환한 relatedClusterIndices(1-based)를 실제 clusterId로 매핑한다.
+     */
+    private List<InsightCard> mapCards(List<ParsedCard> parsed, List<ClusterSummary> clusterSummaries) {
+        List<InsightCard> result = new ArrayList<>();
+        for (ParsedCard p : parsed) {
+            if (p == null || !p.isValid()) continue;
+            List<Long> ids = new ArrayList<>();
+            for (Integer idx : p.relatedClusterIndices()) {
+                if (idx == null) continue;
+                if (idx < 1 || idx > clusterSummaries.size()) continue;
+                ids.add(clusterSummaries.get(idx - 1).clusterId());
+            }
+            result.add(new InsightCard(p.headline(), p.body(), List.copyOf(ids)));
+        }
+        return List.copyOf(result);
+    }
+
+    private String toJson(Object value) throws JsonProcessingException {
+        return value == null ? null : objectMapper.writeValueAsString(value);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendGenerationService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendGenerationService.java
@@ -212,7 +212,8 @@ public class MarketTrendGenerationService {
         List<InsightCard> result = new ArrayList<>();
         for (ParsedCard p : parsed) {
             if (p == null || !p.isValid()) continue;
-            List<Long> ids = new ArrayList<>();
+            // AI가 동일 index를 복수 반환하는 경우가 있어 카드 단위에서 중복 제거 (LinkedHashSet로 순서 유지)
+            java.util.LinkedHashSet<Long> ids = new java.util.LinkedHashSet<>();
             for (Integer idx : p.relatedClusterIndices()) {
                 if (idx == null) continue;
                 if (idx < 1 || idx > clusterSummaries.size()) continue;

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendPersistenceService.java
@@ -32,7 +32,7 @@ public class MarketTrendPersistenceService {
                 content.title(), content.summary(),
                 insightCardsJson, relatedKeywordsJson,
                 sourceClusterIdsJson, sourceArticleCount);
-        log.info("[MarketTrend] 오늘 동향 upsert 완료 — trendDate: {}, sourceClusters: {}, sourceArticles: {}",
+        log.info("[MarketTrend] 오늘 동향 upsert 완료 — trendDate: {}, insightCards: {}, sourceArticles: {}",
                 trendDate, content.insightCards().size(), sourceArticleCount);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendPersistenceService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendPersistenceService.java
@@ -1,0 +1,38 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.solv.wefin.domain.market.trend.dto.MarketTrendContent;
+import com.solv.wefin.domain.market.trend.entity.MarketTrend;
+import com.solv.wefin.domain.market.trend.repository.MarketTrendRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+/**
+ * 오늘의 금융 동향 저장을 전담하는 서비스 (트랜잭션 경계)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketTrendPersistenceService {
+
+    private final MarketTrendRepository marketTrendRepository;
+
+    /**
+     * 오늘 세션의 동향을 upsert한다 (native ON CONFLICT)
+     */
+    @Transactional
+    public void upsertDailyTrend(LocalDate trendDate, MarketTrendContent content,
+                                 String insightCardsJson, String relatedKeywordsJson,
+                                 String sourceClusterIdsJson, int sourceArticleCount) {
+        marketTrendRepository.upsertDaily(
+                trendDate, MarketTrend.SESSION_DAILY,
+                content.title(), content.summary(),
+                insightCardsJson, relatedKeywordsJson,
+                sourceClusterIdsJson, sourceArticleCount);
+        log.info("[MarketTrend] 오늘 동향 upsert 완료 — trendDate: {}, sourceClusters: {}, sourceArticles: {}",
+                trendDate, content.insightCards().size(), sourceArticleCount);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryService.java
@@ -1,0 +1,122 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import com.solv.wefin.domain.market.trend.dto.InsightCard;
+import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.market.trend.dto.SourceClusterInfo;
+import com.solv.wefin.domain.market.trend.entity.MarketTrend;
+import com.solv.wefin.domain.market.trend.repository.MarketTrendRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * 금융 동향 조회 서비스
+ *
+ * 최신 {@link MarketTrend} 1건과 현재 시장 지표 4건을 조합하여
+ * {@link MarketTrendOverview}로 반환한다. 아직 동향이 생성되지 않았어도 지표만으로
+ * 정상 응답(generated=false)을 내려 프론트가 지표만 먼저 노출할 수 있도록 한다
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MarketTrendQueryService {
+
+    private static final TypeReference<List<InsightCard>> CARDS_TYPE = new TypeReference<>() {
+    };
+    private static final TypeReference<List<String>> KEYWORDS_TYPE = new TypeReference<>() {
+    };
+    private static final TypeReference<List<Long>> CLUSTER_IDS_TYPE = new TypeReference<>() {
+    };
+    /** 출처 카드에 노출할 수 있는 클러스터 상태 (상세 API와 동일) */
+    private static final List<SummaryStatus> VISIBLE_SUMMARY_STATUSES =
+            List.of(SummaryStatus.GENERATED, SummaryStatus.STALE);
+    /** trend_date 조회 기준 timezone — 생성 서비스와 동일하게 Asia/Seoul 고정 */
+    private static final ZoneId TREND_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final MarketTrendRepository marketTrendRepository;
+    private final MarketSnapshotRepository marketSnapshotRepository;
+    private final NewsClusterRepository newsClusterRepository;
+    private final ObjectMapper objectMapper;
+
+    public MarketTrendOverview getOverview() {
+        List<MarketSnapshot> snapshots = marketSnapshotRepository.findAll();
+
+        // 오늘 날짜 기준 동향만 노출. 생성 실패/주말 등으로 오늘 row가 없으면 generated=false
+        Optional<MarketTrend> latest = marketTrendRepository
+                .findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(
+                        LocalDate.now(TREND_ZONE), MarketTrend.SESSION_DAILY);
+        if (latest.isEmpty()) {
+            return MarketTrendOverview.empty(snapshots);
+        }
+
+        MarketTrend trend = latest.get();
+        List<InsightCard> cards = parseList(trend.getInsightCardsJson(), CARDS_TYPE);
+        List<String> keywords = parseList(trend.getRelatedKeywordsJson(), KEYWORDS_TYPE);
+        List<SourceClusterInfo> sourceClusters = resolveSourceClusters(trend.getSourceClusterIdsJson());
+        int sourceArticleCount = trend.getSourceArticleCount() != null ? trend.getSourceArticleCount() : 0;
+
+        return new MarketTrendOverview(
+                true,
+                trend.getTrendDate(),
+                trend.getTitle(),
+                trend.getSummary(),
+                cards,
+                keywords,
+                sourceClusters,
+                sourceArticleCount,
+                trend.getUpdatedAt(),
+                snapshots
+        );
+    }
+
+    /**
+     * 저장된 클러스터 ID 목록을 현재 클러스터 정보로 보강한다.
+     */
+    private List<SourceClusterInfo> resolveSourceClusters(String json) {
+        List<Long> ids = parseList(json, CLUSTER_IDS_TYPE);
+        if (ids.isEmpty()) {
+            return List.of();
+        }
+
+        Map<Long, NewsCluster> byId = new HashMap<>();
+        newsClusterRepository
+                .findByIdInAndStatusAndSummaryStatusIn(ids, ClusterStatus.ACTIVE, VISIBLE_SUMMARY_STATUSES)
+                .forEach(c -> byId.put(c.getId(), c));
+
+        return ids.stream()
+                .map(byId::get)
+                .filter(java.util.Objects::nonNull)
+                .map(c -> new SourceClusterInfo(c.getId(), c.getTitle(), c.getPublishedAt()))
+                .toList();
+    }
+
+    private <T> List<T> parseList(String json, TypeReference<List<T>> type) {
+        if (json == null || json.isBlank()) {
+            return List.of();
+        }
+        try {
+            List<T> result = objectMapper.readValue(json, type);
+            return result != null ? result : List.of();
+        } catch (Exception e) {
+            log.warn("[MarketTrend] JSON 파싱 실패 — 빈 리스트로 fallback: {}", e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -20,7 +20,7 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
      * 클러스터 row에 비관적 쓰기 락을 걸고 조회한다
      *
      * 같은 클러스터에 대한 요약 저장이 병렬로 실행될 때(예: 배치가 다중 인스턴스에서
-     * 동시 실행되거나 앞선 배치가 길어져 다음 틱과 겹치는 경우), delete-then-insert 시
+     * 동시 실행되거나 앞선 배치가 길어져 다음 실행 주기와 겹치는 경우), delete-then-insert 시
      * question_order unique 제약 충돌을 방지한다. verifyArticlesUnchanged CAS는 기사
      * 집합 변경만 감지하므로, 같은 articleIds로 동시 진행되는 경우의 보호는 이 락이
      * 담당한다
@@ -33,6 +33,17 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
      * 특정 상태의 클러스터 목록을 조회한다.
      */
     List<NewsCluster> findByStatus(ClusterStatus status);
+
+    /**
+     * 주어진 ID 중 노출 가능한(특정 상태 + 요약 완료 상태) 클러스터만 조회한다.
+     *
+     * 금융 동향 출처 카드 등 외부 노출용 조회에서 INACTIVE/요약 미완료 클러스터를
+     * 자동으로 걸러낼 때 사용한다
+     */
+    List<NewsCluster> findByIdInAndStatusAndSummaryStatusIn(
+            java.util.Collection<Long> ids,
+            ClusterStatus status,
+            java.util.Collection<SummaryStatus> summaryStatuses);
 
     /**
      * 특정 상태이면서, 마지막 갱신 시각이 기준 시각 이전인 클러스터를 조회한다.
@@ -70,6 +81,25 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
     List<NewsCluster> findForFeedFirstPageByPublishedAt(
             @Param("status") ClusterStatus status,
             @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            Pageable pageable);
+
+    /**
+     * 금융 동향 생성용 — 최근 특정 시각 이후 발행된 클러스터를 최신순으로 조회한다
+     *
+     * {@code publishedAt}을 DB 조건으로 내려 nullable 상위 row로 인해 유효한 최근
+     * 클러스터가 limit 밖으로 밀리는 문제를 방지한다
+     */
+    @Query("SELECT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "AND c.publishedAt IS NOT NULL " +
+            "AND c.publishedAt >= :cutoff " +
+            "ORDER BY c.publishedAt DESC, c.id DESC")
+    List<NewsCluster> findRecentActiveClusters(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            @Param("cutoff") OffsetDateTime cutoff,
             Pageable pageable);
 
     // --- 피드 목록: updatedAt 정렬 ---

--- a/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/client/OpenAiSummaryClient.java
@@ -380,9 +380,9 @@ public class OpenAiSummaryClient {
      * 다건 클러스터는 요약 프롬프트에서 질문을 함께 생성하지만,
      * 단독 클러스터는 요약 흐름이 다르므로 별도 AI 호출이 필요하다.
      *
-     * 에러 분류 (CLAUDE.md 10번 규정):
+     * 에러 분류
      * - 재시도 가능 (HTTP 429/5xx, 네트워크 오류): OpenAiClientException 전파 →
-     *   호출자가 이번 틱 클러스터를 skip하거나 markFailed하여 다음 배치에서 재시도
+     *   호출자가 이번 실행 주기 클러스터를 skip하거나 markFailed하여 다음 배치에서 재시도
      * - 재시도 불가 (응답 비어있음, JSON 파싱 실패): 빈 리스트 반환. 요약은 정상 저장
      *
      * @param title 클러스터 제목

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**",
+                            "/api/market-trends/**",
                             "/api/stocks/**", "/api/ranking/**").permitAll()
                         .requestMatchers("/api/admin/**").permitAll() // 임시
                         .anyRequest().authenticated()

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -155,7 +155,10 @@ public enum ErrorCode {
 
     // GameStock
     GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다."),
-    GAME_STOCK_PRICE_NOT_FOUND(404, "해당 날짜의 주가 데이터가 없습니다.");
+    GAME_STOCK_PRICE_NOT_FOUND(404, "해당 날짜의 주가 데이터가 없습니다."),
+
+    // MarketTrend
+    MARKET_TREND_ALREADY_RUNNING(409, "금융 동향 생성이 이미 실행 중입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/market/trend/MarketTrendAdminController.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/MarketTrendAdminController.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.market.trend;
+
+import com.solv.wefin.domain.market.trend.scheduler.MarketTrendScheduler;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 금융 동향 수동 트리거 (로컬/개발 전용)
+ */
+@Profile({"local", "dev"})
+@RestController
+@RequestMapping("/api/admin/market-trends")
+@RequiredArgsConstructor
+public class MarketTrendAdminController {
+
+    private final MarketTrendScheduler marketTrendScheduler;
+
+    @PostMapping("/trigger")
+    public ApiResponse<String> trigger() {
+        boolean executed = marketTrendScheduler.execute();
+        if (!executed) {
+            throw new BusinessException(ErrorCode.MARKET_TREND_ALREADY_RUNNING);
+        }
+        return ApiResponse.success("금융 동향 생성 배치 실행 완료");
+    }
+}

--- a/src/main/java/com/solv/wefin/web/market/trend/MarketTrendController.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/MarketTrendController.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.web.market.trend;
+
+import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.market.trend.service.MarketTrendQueryService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.market.trend.dto.MarketTrendOverviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 오늘의 금융 동향 API
+ */
+@RestController
+@RequestMapping("/api/market-trends")
+@RequiredArgsConstructor
+public class MarketTrendController {
+
+    private final MarketTrendQueryService queryService;
+
+    /**
+     * 오늘 동향 조회 (비회원 가능)
+     */
+    @GetMapping("/overview")
+    public ApiResponse<MarketTrendOverviewResponse> getOverview() {
+        MarketTrendOverview overview = queryService.getOverview();
+        return ApiResponse.success(MarketTrendOverviewResponse.from(overview));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/market/trend/dto/MarketTrendOverviewResponse.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/dto/MarketTrendOverviewResponse.java
@@ -1,0 +1,98 @@
+package com.solv.wefin.web.market.trend.dto;
+
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.trend.dto.InsightCard;
+import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.market.trend.dto.SourceClusterInfo;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * 금융 동향 overview API 응답
+ *
+ * - {@code generated=false}이면 AI 동향은 아직 미생성.
+ */
+public record MarketTrendOverviewResponse(
+        boolean generated,
+        LocalDate trendDate,
+        String title,
+        String summary,
+        List<InsightCardResponse> insightCards,
+        List<String> relatedKeywords,
+        List<SourceClusterResponse> sourceClusters,
+        int sourceClusterCount,
+        int sourceArticleCount,
+        OffsetDateTime updatedAt,
+        List<MarketSnapshotResponse> marketSnapshots
+) {
+
+    public static MarketTrendOverviewResponse from(MarketTrendOverview overview) {
+        List<InsightCardResponse> cards = overview.insightCards().stream()
+                .map(InsightCardResponse::from)
+                .toList();
+        List<MarketSnapshotResponse> snapshots = overview.marketSnapshots().stream()
+                .map(MarketSnapshotResponse::from)
+                .toList();
+        List<SourceClusterResponse> sources = overview.sourceClusters().stream()
+                .map(SourceClusterResponse::from)
+                .toList();
+        return new MarketTrendOverviewResponse(
+                overview.generated(),
+                overview.trendDate(),
+                overview.title(),
+                overview.summary(),
+                cards,
+                overview.relatedKeywords(),
+                sources,
+                sources.size(),
+                overview.sourceArticleCount(),
+                overview.updatedAt(),
+                snapshots
+        );
+    }
+
+    public record SourceClusterResponse(
+            Long clusterId,
+            String title,
+            OffsetDateTime publishedAt
+    ) {
+        public static SourceClusterResponse from(SourceClusterInfo info) {
+            return new SourceClusterResponse(info.clusterId(), info.title(), info.publishedAt());
+        }
+    }
+
+    public record InsightCardResponse(
+            String headline,
+            String body,
+            List<Long> relatedClusterIds
+    ) {
+        public static InsightCardResponse from(InsightCard card) {
+            return new InsightCardResponse(card.headline(), card.body(), card.relatedClusterIds());
+        }
+    }
+
+    public record MarketSnapshotResponse(
+            String metricType,
+            String label,
+            BigDecimal value,
+            BigDecimal changeRate,
+            BigDecimal changeValue,
+            String unit,
+            String changeDirection
+    ) {
+        public static MarketSnapshotResponse from(MarketSnapshot s) {
+            return new MarketSnapshotResponse(
+                    s.getMetricType().name(),
+                    s.getLabel(),
+                    s.getValue(),
+                    s.getChangeRate(),
+                    s.getChangeValue(),
+                    s.getUnit().name(),
+                    s.getChangeDirection().name()
+            );
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,6 +66,10 @@ summary:
   collect:
     cron: "0 */30 * * * *"
 
+market:
+  trend:
+    cron: "0 */30 * * * *"
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/db/migration/V30__extend_market_trend_columns.sql
+++ b/src/main/resources/db/migration/V30__extend_market_trend_columns.sql
@@ -1,0 +1,24 @@
+-- 금융 동향(market_trend) 콘텐츠 확장
+-- V1에서 뼈대만 있던 테이블에 AI 생성 결과를 담을 컬럼을 추가하고
+-- 'DAILY' 세션을 허용하도록 체크 제약을 갱신한다
+--
+-- 저장 정책: (trend_date, session) 기준 upsert. 서비스 레이어에서 'DAILY' 고정값으로 사용하여
+-- 하루 1건만 최신화한다. 기존 MORNING/EVENING 값도 호환을 위해 허용 목록에 유지
+
+ALTER TABLE market_trend
+    ADD COLUMN IF NOT EXISTS title                TEXT,
+    ADD COLUMN IF NOT EXISTS summary              TEXT,
+    ADD COLUMN IF NOT EXISTS insight_cards        JSONB,
+    ADD COLUMN IF NOT EXISTS related_keywords     JSONB,
+    -- 동향 생성에 사용된 클러스터 ID 목록 + 기사 총 개수 (출처 표시용).
+    -- 클러스터 title 등 상세는 조회 시점에 news_cluster JOIN으로 보강
+    ADD COLUMN IF NOT EXISTS source_cluster_ids   JSONB,
+    ADD COLUMN IF NOT EXISTS source_article_count INT,
+    ADD COLUMN IF NOT EXISTS updated_at           TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- session 체크 제약을 DAILY까지 허용하도록 갱신
+-- (V1의 chk_market_trend_session은 MORNING/EVENING만 허용했음)
+ALTER TABLE market_trend DROP CONSTRAINT IF EXISTS chk_market_trend_session;
+ALTER TABLE market_trend
+    ADD CONSTRAINT chk_market_trend_session
+        CHECK (session IN ('MORNING', 'EVENING', 'DAILY'));

--- a/src/test/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryServiceTest.java
@@ -1,0 +1,170 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.market.trend.entity.MarketTrend;
+import com.solv.wefin.domain.market.trend.repository.MarketTrendRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MarketTrendQueryServiceTest {
+
+    @Mock private MarketTrendRepository marketTrendRepository;
+    @Mock private MarketSnapshotRepository marketSnapshotRepository;
+    @Mock private NewsClusterRepository newsClusterRepository;
+
+    private MarketTrendQueryService queryService;
+
+    private MarketSnapshot snapshot;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        queryService = new MarketTrendQueryService(
+                marketTrendRepository, marketSnapshotRepository, newsClusterRepository, objectMapper);
+
+        snapshot = MarketSnapshot.builder()
+                .metricType(MarketSnapshot.MetricType.KOSPI)
+                .label("코스피")
+                .value(new BigDecimal("2700.00"))
+                .changeRate(new BigDecimal("0.5"))
+                .changeValue(new BigDecimal("13.50"))
+                .unit(MarketSnapshot.Unit.POINT)
+                .changeDirection(MarketSnapshot.ChangeDirection.UP)
+                .build();
+    }
+
+    @Test
+    @DisplayName("MarketTrend 없으면 generated=false로 snapshot만 반환")
+    void getOverview_noTrend_returnsEmptyGenerated() {
+        given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.empty());
+
+        MarketTrendOverview result = queryService.getOverview();
+
+        assertThat(result.generated()).isFalse();
+        assertThat(result.title()).isNull();
+        assertThat(result.summary()).isNull();
+        assertThat(result.insightCards()).isEmpty();
+        assertThat(result.relatedKeywords()).isEmpty();
+        assertThat(result.marketSnapshots()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("MarketTrend 존재 — JSONB 직렬화 필드 파싱 + 클러스터 출처 보강")
+    void getOverview_withTrend_parsesJsonAndResolvesSources() {
+        given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
+
+        String insightCardsJson = """
+                [{"headline":"반도체 강세","body":"HBM 수요 증가","relatedClusterIds":[1,2]}]
+                """;
+        String keywordsJson = """
+                ["반도체","HBM","엔비디아"]
+                """;
+        String sourceIdsJson = "[10, 20]";
+
+        MarketTrend trend = MarketTrend.createDaily(
+                LocalDate.now(), "오늘 시장 요약", "상세 내용",
+                insightCardsJson, keywordsJson,
+                sourceIdsJson, 56);
+        ReflectionTestUtils.setField(trend, "updatedAt", OffsetDateTime.now());
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
+
+        // 클러스터 정보 보강 — ACTIVE + GENERATED/STALE만 노출
+        NewsCluster c10 = createCluster(10L, "삼성전자 실적", OffsetDateTime.now().minusHours(1));
+        NewsCluster c20 = createCluster(20L, "한은 금리 동결", OffsetDateTime.now().minusHours(2));
+        given(newsClusterRepository.findByIdInAndStatusAndSummaryStatusIn(
+                List.of(10L, 20L),
+                ClusterStatus.ACTIVE,
+                List.of(SummaryStatus.GENERATED, SummaryStatus.STALE)
+        )).willReturn(List.of(c10, c20));
+
+        MarketTrendOverview result = queryService.getOverview();
+
+        assertThat(result.generated()).isTrue();
+        assertThat(result.title()).isEqualTo("오늘 시장 요약");
+        assertThat(result.insightCards()).hasSize(1);
+        assertThat(result.relatedKeywords()).containsExactly("반도체", "HBM", "엔비디아");
+        assertThat(result.sourceArticleCount()).isEqualTo(56);
+        // 저장된 ID 입력 순서 유지
+        assertThat(result.sourceClusters()).extracting(s -> s.clusterId()).containsExactly(10L, 20L);
+        assertThat(result.sourceClusters()).extracting(s -> s.title())
+                .containsExactly("삼성전자 실적", "한은 금리 동결");
+    }
+
+    @Test
+    @DisplayName("저장된 클러스터 일부가 INACTIVE/요약 미생성이면 출처에서 제외")
+    void getOverview_someClustersHidden_skipsMissing() {
+        given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
+
+        MarketTrend trend = MarketTrend.createDaily(
+                LocalDate.now(), "제목", "요약", "[]", "[]",
+                "[10, 20, 30]", 30);
+        ReflectionTestUtils.setField(trend, "updatedAt", OffsetDateTime.now());
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
+
+        // 20번만 ACTIVE+GENERATED 상태로 반환됨 (10, 30은 노출 대상 아님)
+        NewsCluster c20 = createCluster(20L, "유일 생존", OffsetDateTime.now());
+        given(newsClusterRepository.findByIdInAndStatusAndSummaryStatusIn(
+                List.of(10L, 20L, 30L),
+                ClusterStatus.ACTIVE,
+                List.of(SummaryStatus.GENERATED, SummaryStatus.STALE)
+        )).willReturn(List.of(c20));
+
+        MarketTrendOverview result = queryService.getOverview();
+
+        assertThat(result.sourceClusters()).extracting(s -> s.clusterId()).containsExactly(20L);
+    }
+
+    @Test
+    @DisplayName("JSON 파싱 실패 시 빈 리스트 fallback (다른 필드는 정상 반환)")
+    void getOverview_invalidJson_fallsBackToEmptyLists() {
+        given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
+
+        MarketTrend trend = MarketTrend.createDaily(
+                LocalDate.now(), "제목", "요약",
+                "{invalid json", "[not an array",
+                "[broken", null);
+        ReflectionTestUtils.setField(trend, "updatedAt", OffsetDateTime.now());
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
+
+        MarketTrendOverview result = queryService.getOverview();
+
+        assertThat(result.generated()).isTrue();
+        assertThat(result.title()).isEqualTo("제목");
+        assertThat(result.insightCards()).isEmpty();
+        assertThat(result.relatedKeywords()).isEmpty();
+        assertThat(result.sourceClusters()).isEmpty();
+        assertThat(result.sourceArticleCount()).isEqualTo(0);
+    }
+
+    private NewsCluster createCluster(Long id, String title, OffsetDateTime publishedAt) {
+        float[] vector = {1.0f};
+        NewsCluster cluster = NewsCluster.createSingle(vector, id, null, publishedAt);
+        ReflectionTestUtils.setField(cluster, "id", id);
+        ReflectionTestUtils.setField(cluster, "title", title);
+        ReflectionTestUtils.setField(cluster, "publishedAt", publishedAt);
+        return cluster;
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,8 @@ market:
     base-url: https://ecos.bok.or.kr/api
   collect:
     cron: "-"
+  trend:
+    cron: "-"
 
 openai:
   api-key: test-openai-key


### PR DESCRIPTION
## 📌 PR 설명
시장 지표와 최근 24시간 뉴스 클러스터를 AI로 종합한 오늘의 금융 동향 엔드포인트(`GET /api/market-trends/overview`)를 추가했습니다. AI는 30분 주기 배치로 사전 생성되어 `market_trend` 테이블에 upsert되고, 조회 시에는 시장 지표 4개와 함께 응답됩니다.


### 데이터 흐름

```
[30분 배치]
  1. MarketSnapshot 최신 4건 조회 (KOSPI/NASDAQ/USD_KRW/BASE_RATE)
  2. 최근 24시간 ACTIVE 클러스터 조회
  3. 클러스터 태그 집계 (ClusterTagAggregator 재사용) → 떠오르는 STOCK/SECTOR/TOPIC
  4. AI 프롬프트 조합 → OpenAI 호출
  5. 결과 DB upsert (market_trend 테이블)

[조회 경로]
  GET /api/market-trends/overview
   → 최신 MarketTrend 1건 + 현재 MarketSnapshot 4건을 응답 DTO로 조합
```

<details>
<summary><strong>🔄 금융 동향 생성 흐름 (펼치기)</strong></summary>

```
[트리거]
  └─ MarketTrendScheduler (30분 cron) 또는 POST /api/admin/market-trends/trigger
        └─ MarketTrendGenerationService.generate()

[1. 입력 수집]                                  (No Transaction — 외부 호출 포함)
  ├─ 오늘자 market_snapshot 조회 (KOSPI/NASDAQ/환율 등)
  └─ 최근 24h 후보 클러스터 조회
        조건: status=ACTIVE
             ∧ summaryStatus IN (GENERATED, STALE)
             ∧ title NOT NULL
             ∧ publishedAt >= now() - 24h
        정렬: publishedAt DESC, id DESC
        상한: 15건 (MAX_CLUSTERS_IN_PROMPT)

[2. AI 호출]
  OpenAiMarketTrendClient
  입력: 시장 지표 + 15개 클러스터(번호/제목/요약/articleIds) + 떠오르는 종목·토픽 태그
  출력: { title, summary, insightCards[4], relatedKeywords[5~10], relatedClusterIndices }
  에러: HTTP/네트워크 예외 → propagate, 파싱 실패 → 다음 틱 재시도

[3. 검증]
  ├─ title/summary non-null
  ├─ insightCards.size() == 4
  └─ relatedKeywords.size() ∈ [5, 10]
     → 어긋나면 WARN + 저장 스킵 (프론트 레이아웃 보호)

[4. 출처 메타 계산]
  ├─ relatedClusterIndices(1-based) → 실제 clusterId로 매핑
  ├─ sourceClusterIds = insightCards.flatMap(relatedClusterIds) union
  │     (프롬프트 15개 전부가 아닌 AI 참조 클러스터만)
  └─ sourceArticleCount = allArticleIds.size()
        (클러스터별 List.size() 합산은 중복 카운트 위험)

[5. 저장]                                       (MarketTrendPersistenceService, @Transactional)
  INSERT INTO market_trend (..., trend_date=today, session='DAILY', ...)
  ON CONFLICT (trend_date, session) DO UPDATE SET ...
  → 같은 날 한 행을 30분마다 덮어쓰기 (updatedAt 갱신)

[6. 조회]                                       (MarketTrendQueryService, @Transactional(readOnly))
  GET /api/market-trends/overview (익명 허용)
  ├─ trend_date=today ∧ session=DAILY ∧ title/summary NOT NULL
  ├─ sourceClusterIds → findByIdInAndStatusAndSummaryStatusIn(ACTIVE, GENERATED/STALE)
  │     → INACTIVE 클러스터 런타임 필터 (상세 404 방지)
  └─ market_snapshot 조인 후 응답
     trend 미생성 시: generated=false + snapshot만 반환
```

</details>


### 응답 구조
```json
{
  "generated": true,
  "trendDate": "2026-04-14",
  "title": "...",
  "summary": "...",
  "insightCards": [
    { "headline": "...", "body": "...", "relatedClusterIds": [12, 14] }
  ],
  "relatedKeywords": ["반도체", "HBM", ...],
  "sourceClusters": [
    { "clusterId": 12, "title": "...", "publishedAt": "..." }
  ],
  "sourceClusterCount": 4,
  "sourceArticleCount": 56,
  "updatedAt": "...",
  "marketSnapshots": [...]
}
```

<br>

## ✅ 완료한 기능 명세
1. **V30__extend_market_trend_columns.sql** — market_trend에 콘텐츠 컬럼(title/summary/insight_cards JSONB/related_keywords JSONB/source_cluster_ids JSONB/source_article_count/updated_at) 추가 + session 체크 제약 DAILY 허용
2. **MarketTrend.java** — 금융 동향 Entity. `SESSION_DAILY` 상수 + `updateContent(...)` 도메인 메서드
3. **MarketTrendRepository.java** — 오늘자 DAILY 조회 + `ON CONFLICT (trend_date, session) DO UPDATE` native upsert
4. **InsightCard.java** — 인사이트 카드 (헤드라인/본문/관련 클러스터 ID)
5. **MarketTrendContent.java** — 저장 전 콘텐츠 묶음 record
6. **SourceClusterInfo.java** — 출처 클러스터 최소 정보 (id/title/publishedAt)
7. **MarketTrendOverview.java** — Query 서비스 응답용 내부 DTO (generated=false도 표현)
8. **OpenAiMarketTrendClient.java** — Chat Completions 호출 + 프롬프트 빌더 + JSON 파싱. `MarketTrendAiException`으로 실패 분류
9. **MarketTrendGenerationService.java** — 스냅샷·클러스터 수집 + AI 호출 + 계약 검증(카드 4개/키워드 5~10/카드별 출처≥1) 오케스트레이션. `@Transactional` 없음
10. **MarketTrendPersistenceService.java** — `@Transactional` native upsert 전담
11. **MarketTrendQueryService.java** — `@Transactional(readOnly)` 오늘 DAILY 조회 + ACTIVE/visible 출처 클러스터 조인
12. **MarketTrendScheduler.java** — 30분 cron + `AtomicBoolean` 중복 실행 방지
13. **MarketTrendController.java** — `GET /api/market-trends/overview` (비회원 허용)
14. **MarketTrendAdminController.java** — `POST /api/admin/market-trends/trigger` (로컬/dev 수동 트리거)
15. **MarketTrendOverviewResponse.java** — 공개 응답 DTO (프론트 계약)
16. **MarketTrendGenerationServiceTest.java** — 스킵/AI 예외/계약 검증/정상 생성 단위 테스트
17. **MarketTrendQueryServiceTest.java** — generated=false/INACTIVE 필터/JSON fallback 단위 테스트
18. **NewsClusterRepository.java** (수정) — `findRecentActiveClusters(status, statuses, cutoff, Pageable)` 추가. 24h 필터를 DB 조건으로 내림 + `findByIdInAndStatusAndSummaryStatusIn` 재사용
19. **SecurityConfig.java** (수정) — `/api/market-trends/**` GET 익명 허용
20. **ErrorCode.java** (수정) — `MARKET_TREND_ALREADY_RUNNING` 추가
21. **application.yml** / **application-test.yml** (수정) — `market.trend.cron` 추가 (테스트는 비활성)

<br>

## 📸 스크린샷
<img width="798" height="665" alt="image" src="https://github.com/user-attachments/assets/12d59d6c-a5ff-4133-9eae-42318e328c97" />
<img width="792" height="420" alt="image" src="https://github.com/user-attachments/assets/17f36769-eea1-4732-9596-514d3fe7954f" />

<br>

## 💭 고민과 해결과정

### 1. upsert race
초기엔 select-then-insert 방식이었지만 멀티 인스턴스에서 둘 다 "없음"으로 판단해 unique 충돌이 날 수 있어 **`INSERT ... ON CONFLICT (trend_date, session) DO UPDATE`** native 쿼리로 원자화했습니다.

### 2. 조회 안전장치
- `trend_date = today` 필터로 "어제 동향이 오늘의 동향으로 노출"되는 문제를 원천 차단 (주말/장애 시 `generated=false`로 응답)
- 응답에 `trendDate`를 포함해 프론트가 데이터 기준 시점을 표시할 수 있도록 함

### 3. 출처(sourceClusters) 정합성
- **AI가 insightCards에서 실제 참조한 클러스터 union만 저장** (프롬프트에 넘긴 15개 전부가 아니라). 사용자가 "이 동향의 출처" 카드를 눌렀을 때 본문과 실제 관련 있는 클러스터로만 이동
- `sourceArticleCount`는 중복 카운트 방지 위해 `allArticleIds.size()` 사용 (기사가 복수 클러스터에 속할 가능성 대비)
- 조회 시점에 `findByIdInAndStatusAndSummaryStatusIn(ACTIVE, GENERATED/STALE)`로 INACTIVE/요약 미완료 클러스터는 출처에서 제외 (상세 API 404 방지)

### 4. AI 응답 계약 강제
- `insightCards`는 정확히 4개, `relatedKeywords`는 5~10개일 때만 저장. 벗어나면 WARN 로그 후 저장 스킵 → 다음 틱 재시도
- 프론트 4-카드 레이아웃이 빈 슬롯/초과로 깨지지 않도록 서비스 레이어에서 보장

### 5. 최근 24시간 필터
프롬프트 주석과 실제 쿼리가 불일치(단순 최신 N건)하던 문제를 해결. `publishedAt >= now() - 24h` 필터를 서비스에서 적용해 뉴스가 드문 구간에 오래된 클러스터가 "오늘의 동향"에 들어가는 것을 방지합니다.

<br>

### 🔗 관련 이슈
 #135 

<br>
