### PR TITLE
[WEF-604] 주문/체결 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/order/dto/OrderSearchCondition.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/dto/OrderSearchCondition.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.trading.order.dto;
+
+import java.time.LocalDate;
+
+import com.solv.wefin.domain.trading.order.entity.OrderStatus;
+
+public record OrderSearchCondition(
+	OrderStatus status,
+	Long stockId,
+	LocalDate startDate,
+	LocalDate endDate
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepository.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepository.java
@@ -15,7 +15,7 @@ import com.solv.wefin.domain.trading.order.entity.Order;
 import jakarta.persistence.LockModeType;
 
 @Repository
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 
 	Optional<Order> findByOrderNo(UUID orderNo);
 

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,26 @@
+package com.solv.wefin.domain.trading.order.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.solv.wefin.domain.trading.order.dto.OrderSearchCondition;
+import com.solv.wefin.domain.trading.order.entity.Order;
+
+public interface OrderRepositoryCustom {
+
+	/**
+	 * 주문 내역 검색 (커서 기반 페이지네이션 + 동적 필터)
+	 */
+	List<Order> searchOrders(Long virtualAccountId, OrderSearchCondition condition,
+							 Long cursor, int size);
+
+	/**
+	 * 미체결 주문 조회 (PENDING만)
+	 */
+	List<Order> findPendingOrders(Long virtualAccountId);
+
+	/**
+	 * 오늘 체결 주문 조회 (FILLED + 당일)
+	 */
+	List<Order> findTodayFilledOrders(Long virtualAccountId, LocalDate today);
+}

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryImpl.java
@@ -1,0 +1,103 @@
+package com.solv.wefin.domain.trading.order.repository;
+
+import static com.solv.wefin.domain.trading.order.entity.QOrder.order;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.solv.wefin.domain.trading.order.dto.OrderSearchCondition;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderStatus;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Order> searchOrders(Long virtualAccountId, OrderSearchCondition condition,
+									Long cursor, int size) {
+		return queryFactory
+			.selectFrom(order)
+			.where(
+				accountEq(virtualAccountId),
+				statusEq(condition.status()),
+				stockIdEq(condition.stockId()),
+				createdAtGoe(condition.startDate()),
+				createdAtLt(condition.endDate()),
+				cursorLt(cursor)
+			)
+			.orderBy(order.orderId.desc())
+			.limit(size + 1)
+			.fetch();
+	}
+
+	@Override
+	public List<Order> findPendingOrders(Long virtualAccountId) {
+		return queryFactory
+			.selectFrom(order)
+			.where(
+				accountEq(virtualAccountId),
+				order.status.eq(OrderStatus.PENDING)
+			)
+			.orderBy(order.orderId.desc())
+			.fetch();
+	}
+
+	@Override
+	public List<Order> findTodayFilledOrders(Long virtualAccountId, LocalDate today) {
+		OffsetDateTime startOfDay = today.atStartOfDay(KST).toOffsetDateTime();
+		OffsetDateTime startOfNextDay = today.plusDays(1)
+			.atStartOfDay(KST).toOffsetDateTime();
+
+		return queryFactory
+			.selectFrom(order)
+			.where(
+				accountEq(virtualAccountId),
+				order.status.eq(OrderStatus.FILLED),
+				order.createdAt.goe(startOfDay),
+				order.createdAt.lt(startOfNextDay)
+			)
+			.orderBy(order.orderId.desc())
+			.fetch();
+	}
+
+	private BooleanExpression accountEq(Long virtualAccountId) {
+		return order.virtualAccountId.eq(virtualAccountId);
+	}
+
+	private BooleanExpression statusEq(OrderStatus status) {
+		return status != null ? order.status.eq(status) : null;
+	}
+
+	private BooleanExpression stockIdEq(Long stockId) {
+		return stockId != null ? order.stockId.eq(stockId) : null;
+	}
+
+	private BooleanExpression createdAtGoe(LocalDate startDate) {
+		if (startDate == null)
+			return null;
+		OffsetDateTime start = startDate.atStartOfDay(KST).toOffsetDateTime();
+		return order.createdAt.goe(start);
+	}
+
+	private BooleanExpression createdAtLt(LocalDate endDate) {
+		if (endDate == null)
+			return null;
+		OffsetDateTime end = endDate.plusDays(1)
+			.atStartOfDay(KST).toOffsetDateTime();
+		return order.createdAt.lt(end);
+	}
+
+	private BooleanExpression cursorLt(Long cursor) {
+		return cursor != null ? order.orderId.lt(cursor) : null;
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -253,7 +253,7 @@ public class OrderService {
 		return orderRepository.findPendingOrders(virtualAccountId);
 	}
 
-	public List<Order> findTodayOrders(Long virtualAccountId) {
+	public List<Order> findTodayFilledOrders(Long virtualAccountId) {
 		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 		return orderRepository.findTodayFilledOrders(virtualAccountId, today);
 	}

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -4,6 +4,9 @@ import static com.solv.wefin.domain.trading.common.TradingConstants.*;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -17,6 +20,7 @@ import com.solv.wefin.domain.trading.common.StockInfoProvider;
 import com.solv.wefin.domain.trading.matching.event.OrderMatchedEvent;
 import com.solv.wefin.domain.trading.order.dto.OrderCancelInfo;
 import com.solv.wefin.domain.trading.order.dto.OrderInfo;
+import com.solv.wefin.domain.trading.order.dto.OrderSearchCondition;
 import com.solv.wefin.domain.trading.order.entity.Order;
 import com.solv.wefin.domain.trading.order.entity.OrderSide;
 import com.solv.wefin.domain.trading.order.entity.OrderType;
@@ -238,6 +242,20 @@ public class OrderService {
 
 		return new OrderInfo(order, stock.getStockCode(), stock.getStockName(),
 			newPrice, totalAmount, order.getTax(), BigDecimal.ZERO, account.getBalance());
+	}
+
+	public List<Order> searchOrders(Long virtualAccountId, OrderSearchCondition condition,
+									Long cursor, int size) {
+		return orderRepository.searchOrders(virtualAccountId, condition, cursor, size);
+	}
+
+	public List<Order> findPendingOrders(Long virtualAccountId) {
+		return orderRepository.findPendingOrders(virtualAccountId);
+	}
+
+	public List<Order> findTodayOrders(Long virtualAccountId) {
+		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+		return orderRepository.findTodayFilledOrders(virtualAccountId, today);
 	}
 
 	private static void validateQuantity(Integer quantity) {

--- a/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
@@ -9,7 +9,9 @@ import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -41,6 +43,14 @@ public class StockService implements StockInfoProvider {
         return stockRepository.search(keyword, market).stream()
                 .map(StockSearchResponse::from)
                 .toList();
+    }
+
+    public Optional<Stock> findByStockCode(String stockCode) {
+        return stockRepository.findByStockCode(stockCode);
+    }
+
+    public List<Stock> findAllByIdIn(Collection<Long> stockIds) {
+        return stockRepository.findAllById(stockIds);
     }
 
     private Stock findByCodeOrThrow(String stockCode) {

--- a/src/main/java/com/solv/wefin/domain/trading/trade/dto/TradeSearchCondition.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/dto/TradeSearchCondition.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.trading.trade.dto;
+
+import java.time.LocalDate;
+
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+
+public record TradeSearchCondition(
+	Long stockId,
+	OrderSide side,
+	LocalDate startDate,
+	LocalDate endDate
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/trade/repository/TradeRepository.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/repository/TradeRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import com.solv.wefin.domain.trading.trade.entity.Trade;
 
 @Repository
-public interface TradeRepository extends JpaRepository<Trade, Long> {
+public interface TradeRepository extends JpaRepository<Trade, Long>, TradeRepositoryCustom {
 
 	Optional<Trade> findByTradeNo(UUID tradeNo);
 

--- a/src/main/java/com/solv/wefin/domain/trading/trade/repository/TradeRepositoryCustom.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/repository/TradeRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.trading.trade.repository;
+
+import java.util.List;
+
+import com.solv.wefin.domain.trading.trade.dto.TradeSearchCondition;
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+
+public interface TradeRepositoryCustom {
+
+	List<Trade> searchTrades(Long virtualAccountId, TradeSearchCondition condition,
+							 Long cursor, int size);
+}

--- a/src/main/java/com/solv/wefin/domain/trading/trade/repository/TradeRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/repository/TradeRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.solv.wefin.domain.trading.trade.repository;
+
+import static com.solv.wefin.domain.trading.trade.entity.QTrade.trade;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.trade.dto.TradeSearchCondition;
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TradeRepositoryImpl implements TradeRepositoryCustom {
+
+	private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Trade> searchTrades(Long virtualAccountId, TradeSearchCondition condition, Long cursor, int size) {
+		return queryFactory
+			.selectFrom(trade)
+			.where(
+				accountEq(virtualAccountId),
+				stockIdEq(condition.stockId()),
+				sideEq(condition.side()),
+				createdAtGoe(condition.startDate()),
+				createdAtLt(condition.endDate()),
+				cursorLt(cursor)
+			)
+			.orderBy(trade.tradeId.desc())
+			.limit(size + 1)
+			.fetch();
+	}
+
+	private BooleanExpression accountEq(Long virtualAccountId) {
+		return trade.virtualAccountId.eq(virtualAccountId);
+	}
+
+	private BooleanExpression stockIdEq(Long stockId) {
+		return stockId != null ? trade.stockId.eq(stockId) : null;
+	}
+
+	private BooleanExpression createdAtGoe(LocalDate startDate) {
+		if (startDate == null)
+			return null;
+		OffsetDateTime start = startDate.atStartOfDay(KST).toOffsetDateTime();
+		return trade.createdAt.goe(start);
+	}
+
+	private BooleanExpression createdAtLt(LocalDate endDate) {
+		if (endDate == null)
+			return null;
+		OffsetDateTime end = endDate.plusDays(1)
+			.atStartOfDay(KST).toOffsetDateTime();
+		return trade.createdAt.lt(end);
+	}
+
+	private BooleanExpression cursorLt(Long cursor) {
+		return cursor != null ? trade.tradeId.lt(cursor) : null;
+	}
+
+	private BooleanExpression sideEq(OrderSide side) {
+		return side != null ? trade.side.eq(side) : null;
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/trade/service/TradeService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/trade/service/TradeService.java
@@ -1,11 +1,13 @@
 package com.solv.wefin.domain.trading.trade.service;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.solv.wefin.domain.trading.portfolio.entity.Currency;
+import com.solv.wefin.domain.trading.trade.dto.TradeSearchCondition;
 import com.solv.wefin.domain.trading.trade.entity.Trade;
 import com.solv.wefin.domain.trading.trade.repository.TradeRepository;
 
@@ -33,5 +35,10 @@ public class TradeService {
 								 Currency currency, BigDecimal exchangeRate) {
 		return tradeRepository.save(Trade.createSellTrade(orderId, virtualAccountId, stockId, quantity,
 			price, totalAmount, fee, tax, realizedProfit, currency, exchangeRate));
+	}
+
+	public List<Trade> searchTrades(Long virtualAccountId, TradeSearchCondition condition,
+									Long cursor, int size) {
+		return tradeRepository.searchTrades(virtualAccountId, condition, cursor, size);
 	}
 }

--- a/src/main/java/com/solv/wefin/global/common/CursorResponse.java
+++ b/src/main/java/com/solv/wefin/global/common/CursorResponse.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.global.common;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record CursorResponse<T> (
+	List<T> content,
+	Long nextCursor,
+	boolean hasNext
+) {
+
+	public static <T, R> CursorResponse<R> from(
+			List<T> items,
+			int requestedSize,
+			Function<T, R> mapper,
+			Function<T, Long> cursorExtractor) {
+
+		boolean hasNext = items.size() > requestedSize;
+		List<T> content = hasNext ? items.subList(0, requestedSize) : items;
+		Long nextCursor = hasNext ? cursorExtractor.apply(content.get(content.size() - 1)) : null;
+
+		return new CursorResponse<>(
+			content.stream().map(mapper).toList(),
+			nextCursor,
+			hasNext
+		);
+	}
+
+	public static <T> CursorResponse<T> empty() {
+		return new CursorResponse<>(List.of(), null, false);
+	}
+}

--- a/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
@@ -32,6 +32,8 @@ import com.solv.wefin.domain.trading.stock.entity.Stock;
 import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.common.CursorResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.trading.order.dto.request.OrderBuyRequest;
 import com.solv.wefin.web.trading.order.dto.request.OrderModifyRequest;
 import com.solv.wefin.web.trading.order.dto.request.OrderSellRequest;
@@ -118,10 +120,14 @@ public class OrderController {
 			@RequestParam(required = false) Long cursor,
 			@RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
 
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			throw new BusinessException(ErrorCode.MARKET_INVALID_DATE);
+		}
+
 		VirtualAccount account = accountService.getAccountByUserId(userId);
 
 		Long stockId = null;
-		if (stockCode != null) {
+		if (stockCode != null && !stockCode.isBlank()) {
 			Stock stock = stockService.findByStockCode(stockCode).orElse(null);
 			if (stock == null) {
 				return ApiResponse.success(CursorResponse.empty());
@@ -132,9 +138,7 @@ public class OrderController {
 		OrderSearchCondition condition = new OrderSearchCondition(status, stockId, startDate, endDate);
 		List<Order> orders = orderService.searchOrders(account.getVirtualAccountId(), condition, cursor, size);
 
-		List<Long> stockIds = orders.stream().map(Order::getStockId).distinct().toList();
-		Map<Long, Stock> stockMap = stockService.findAllByIdIn(stockIds).stream()
-			.collect(Collectors.toMap(Stock::getId, Function.identity()));
+		Map<Long, Stock> stockMap = buildStockMap(orders);
 
 		return ApiResponse.success(CursorResponse.from(
 			orders, size,
@@ -149,13 +153,7 @@ public class OrderController {
 	}
 
 	private List<OrderHistoryResponse> toOrderHistoryResponse(List<Order> orders) {
-		List<Long> stockIds = orders.stream()
-			.map(Order::getStockId)
-			.distinct()
-			.toList();
-
-		Map<Long, Stock> stockMap = stockService.findAllByIdIn(stockIds).stream()
-			.collect(Collectors.toMap(Stock::getId, Function.identity()));
+		Map<Long, Stock> stockMap = buildStockMap(orders);
 
 		return orders.stream()
 			.map(order -> {
@@ -165,5 +163,15 @@ public class OrderController {
 					stock != null ? stock.getStockName() : null);
 			})
 			.toList();
+	}
+
+	private Map<Long, Stock> buildStockMap(List<Order> orders) {
+		List<Long> stockIds = orders.stream()
+			.map(Order::getStockId)
+			.distinct()
+			.toList();
+
+		return stockService.findAllByIdIn(stockIds).stream()
+			.collect(Collectors.toMap(Stock::getId, Function.identity()));
 	}
 }

--- a/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
@@ -106,7 +106,7 @@ public class OrderController {
 	@GetMapping("/today")
 	public ApiResponse<List<OrderHistoryResponse>> getTodayOrders(@AuthenticationPrincipal UUID userId) {
 		VirtualAccount account = accountService.getAccountByUserId(userId);
-		List<Order> orders = orderService.findTodayOrders(account.getVirtualAccountId());
+		List<Order> orders = orderService.findTodayFilledOrders(account.getVirtualAccountId());
 		return ApiResponse.success(toOrderHistoryResponse(orders));
 	}
 
@@ -128,7 +128,7 @@ public class OrderController {
 
 		Long stockId = null;
 		if (stockCode != null && !stockCode.isBlank()) {
-			Stock stock = stockService.findByStockCode(stockCode).orElse(null);
+			Stock stock = stockService.findByStockCode(stockCode.strip()).orElse(null);
 			if (stock == null) {
 				return ApiResponse.success(CursorResponse.empty());
 			}

--- a/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
@@ -1,31 +1,50 @@
 package com.solv.wefin.web.trading.order;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
 import com.solv.wefin.domain.trading.order.dto.OrderCancelInfo;
 import com.solv.wefin.domain.trading.order.dto.OrderInfo;
+import com.solv.wefin.domain.trading.order.dto.OrderSearchCondition;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderStatus;
 import com.solv.wefin.domain.trading.order.service.OrderService;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.common.CursorResponse;
 import com.solv.wefin.web.trading.order.dto.request.OrderBuyRequest;
 import com.solv.wefin.web.trading.order.dto.request.OrderModifyRequest;
 import com.solv.wefin.web.trading.order.dto.request.OrderSellRequest;
 import com.solv.wefin.web.trading.order.dto.response.OrderCancelResponse;
+import com.solv.wefin.web.trading.order.dto.response.OrderHistoryResponse;
 import com.solv.wefin.web.trading.order.dto.response.OrderResponse;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
+@Validated
 @RestController
 @RequestMapping("/api/order")
 @RequiredArgsConstructor
@@ -33,6 +52,7 @@ public class OrderController {
 
 	private final OrderService orderService;
 	private final VirtualAccountService accountService;
+	private final StockService stockService;
 
 	@PostMapping("/buy")
 	public ApiResponse<OrderResponse> buy(@AuthenticationPrincipal UUID userId,
@@ -72,5 +92,78 @@ public class OrderController {
 		OrderCancelInfo cancelInfo = orderService.cancelOrder(account.getVirtualAccountId(), orderNo);
 		OrderCancelResponse response = OrderCancelResponse.from(cancelInfo);
 		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/pending")
+	public ApiResponse<List<OrderHistoryResponse>> getPendingOrders(@AuthenticationPrincipal UUID userId) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
+		List<Order> orders = orderService.findPendingOrders(account.getVirtualAccountId());
+		return ApiResponse.success(toOrderHistoryResponse(orders));
+	}
+
+	@GetMapping("/today")
+	public ApiResponse<List<OrderHistoryResponse>> getTodayOrders(@AuthenticationPrincipal UUID userId) {
+		VirtualAccount account = accountService.getAccountByUserId(userId);
+		List<Order> orders = orderService.findTodayOrders(account.getVirtualAccountId());
+		return ApiResponse.success(toOrderHistoryResponse(orders));
+	}
+
+	@GetMapping("/history")
+	public ApiResponse<CursorResponse<OrderHistoryResponse>> getOrderHistory(
+			@AuthenticationPrincipal UUID userId,
+			@RequestParam(required = false) OrderStatus status,
+			@RequestParam(required = false) String stockCode,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+			@RequestParam(required = false) Long cursor,
+			@RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
+
+		VirtualAccount account = accountService.getAccountByUserId(userId);
+
+		Long stockId = null;
+		if (stockCode != null) {
+			Stock stock = stockService.findByStockCode(stockCode).orElse(null);
+			if (stock == null) {
+				return ApiResponse.success(CursorResponse.empty());
+			}
+			stockId = stock.getId();
+		}
+
+		OrderSearchCondition condition = new OrderSearchCondition(status, stockId, startDate, endDate);
+		List<Order> orders = orderService.searchOrders(account.getVirtualAccountId(), condition, cursor, size);
+
+		List<Long> stockIds = orders.stream().map(Order::getStockId).distinct().toList();
+		Map<Long, Stock> stockMap = stockService.findAllByIdIn(stockIds).stream()
+			.collect(Collectors.toMap(Stock::getId, Function.identity()));
+
+		return ApiResponse.success(CursorResponse.from(
+			orders, size,
+			order -> {
+				Stock stock = stockMap.get(order.getStockId());
+				return OrderHistoryResponse.from(order,
+					stock != null ? stock.getStockCode() : null,
+					stock != null ? stock.getStockName() : null);
+			},
+			Order::getOrderId
+		));
+	}
+
+	private List<OrderHistoryResponse> toOrderHistoryResponse(List<Order> orders) {
+		List<Long> stockIds = orders.stream()
+			.map(Order::getStockId)
+			.distinct()
+			.toList();
+
+		Map<Long, Stock> stockMap = stockService.findAllByIdIn(stockIds).stream()
+			.collect(Collectors.toMap(Stock::getId, Function.identity()));
+
+		return orders.stream()
+			.map(order -> {
+				Stock stock = stockMap.get(order.getStockId());
+				return OrderHistoryResponse.from(order,
+					stock != null ? stock.getStockCode() : null,
+					stock != null ? stock.getStockName() : null);
+			})
+			.toList();
 	}
 }

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/response/OrderHistoryResponse.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/response/OrderHistoryResponse.java
@@ -1,0 +1,39 @@
+package com.solv.wefin.web.trading.order.dto.response;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.solv.wefin.domain.trading.order.entity.Order;
+
+public record OrderHistoryResponse(
+	Long orderId,
+	UUID orderNo,
+	String stockCode,
+	String stockName,
+	String side,
+	String orderType,
+	Integer quantity,
+	BigDecimal requestPrice,
+	String status,
+	BigDecimal fee,
+	BigDecimal tax,
+	OffsetDateTime createdAt
+) {
+	public static OrderHistoryResponse from(Order order, String stockCode, String stockName) {
+		return new OrderHistoryResponse(
+			order.getOrderId(),
+			order.getOrderNo(),
+			stockCode,
+			stockName,
+			order.getSide().name(),
+			order.getOrderType().name(),
+			order.getQuantity(),
+			order.getRequestPrice(),
+			order.getStatus().name(),
+			order.getFee(),
+			order.getTax(),
+			order.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/com/solv/wefin/web/trading/trade/TradeController.java
+++ b/src/main/java/com/solv/wefin/web/trading/trade/TradeController.java
@@ -25,6 +25,8 @@ import com.solv.wefin.domain.trading.trade.entity.Trade;
 import com.solv.wefin.domain.trading.trade.service.TradeService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.common.CursorResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.trading.trade.dto.TradeHistoryResponse;
 
 import jakarta.validation.constraints.Max;
@@ -51,10 +53,14 @@ public class TradeController {
 			@RequestParam(required = false) Long cursor,
 			@RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
 
+		if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
+			throw new BusinessException(ErrorCode.MARKET_INVALID_DATE);
+		}
+
 		VirtualAccount account = accountService.getAccountByUserId(userId);
 
 		Long stockId = null;
-		if (stockCode != null) {
+		if (stockCode != null && !stockCode.isBlank()) {
 			Stock stock = stockService.findByStockCode(stockCode).orElse(null);
 			if (stock == null) {
 				return ApiResponse.success(CursorResponse.empty());

--- a/src/main/java/com/solv/wefin/web/trading/trade/TradeController.java
+++ b/src/main/java/com/solv/wefin/web/trading/trade/TradeController.java
@@ -61,7 +61,7 @@ public class TradeController {
 
 		Long stockId = null;
 		if (stockCode != null && !stockCode.isBlank()) {
-			Stock stock = stockService.findByStockCode(stockCode).orElse(null);
+			Stock stock = stockService.findByStockCode(stockCode.strip()).orElse(null);
 			if (stock == null) {
 				return ApiResponse.success(CursorResponse.empty());
 			}

--- a/src/main/java/com/solv/wefin/web/trading/trade/TradeController.java
+++ b/src/main/java/com/solv/wefin/web/trading/trade/TradeController.java
@@ -1,0 +1,83 @@
+package com.solv.wefin.web.trading.trade;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.domain.trading.trade.dto.TradeSearchCondition;
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+import com.solv.wefin.domain.trading.trade.service.TradeService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.common.CursorResponse;
+import com.solv.wefin.web.trading.trade.dto.TradeHistoryResponse;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+@Validated
+@RestController
+@RequestMapping("/api/trade")
+@RequiredArgsConstructor
+public class TradeController {
+
+	private final TradeService tradeService;
+	private final VirtualAccountService accountService;
+	private final StockService stockService;
+
+	@GetMapping("/history")
+	public ApiResponse<CursorResponse<TradeHistoryResponse>> getTradeHistory(
+			@AuthenticationPrincipal UUID userId,
+			@RequestParam(required = false) String stockCode,
+			@RequestParam(required = false) OrderSide side,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+			@RequestParam(required = false) Long cursor,
+			@RequestParam(defaultValue = "20") @Min(1) @Max(100) int size) {
+
+		VirtualAccount account = accountService.getAccountByUserId(userId);
+
+		Long stockId = null;
+		if (stockCode != null) {
+			Stock stock = stockService.findByStockCode(stockCode).orElse(null);
+			if (stock == null) {
+				return ApiResponse.success(CursorResponse.empty());
+			}
+			stockId = stock.getId();
+		}
+
+		TradeSearchCondition condition = new TradeSearchCondition(stockId, side, startDate, endDate);
+		List<Trade> trades = tradeService.searchTrades(account.getVirtualAccountId(), condition, cursor, size);
+
+		List<Long> stockIds = trades.stream().map(Trade::getStockId).distinct().toList();
+		Map<Long, Stock> stockMap = stockService.findAllByIdIn(stockIds).stream()
+			.collect(Collectors.toMap(Stock::getId, Function.identity()));
+
+		return ApiResponse.success(CursorResponse.from(
+			trades, size,
+			trade -> {
+				Stock stock = stockMap.get(trade.getStockId());
+				return TradeHistoryResponse.from(trade,
+					stock != null ? stock.getStockCode() : null,
+					stock != null ? stock.getStockName() : null);
+			},
+			Trade::getTradeId
+		));
+	}
+}

--- a/src/main/java/com/solv/wefin/web/trading/trade/dto/TradeHistoryResponse.java
+++ b/src/main/java/com/solv/wefin/web/trading/trade/dto/TradeHistoryResponse.java
@@ -1,0 +1,39 @@
+package com.solv.wefin.web.trading.trade.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+
+public record TradeHistoryResponse(
+	Long tradeId,
+	UUID tradeNo,
+	String stockCode,
+	String stockName,
+	String side,
+	Integer quantity,
+	BigDecimal price,
+	BigDecimal totalAmount,
+	BigDecimal fee,
+	BigDecimal tax,
+	BigDecimal realizedProfit,
+	OffsetDateTime createdAt
+) {
+	public static TradeHistoryResponse from(Trade trade, String stockCode, String stockName) {
+		return new TradeHistoryResponse(
+			trade.getTradeId(),
+			trade.getTradeNo(),
+			stockCode,
+			stockName,
+			trade.getSide().name(),
+			trade.getQuantity(),
+			trade.getPrice(),
+			trade.getTotalAmount(),
+			trade.getFee(),
+			trade.getTax(),
+			trade.getRealizedProfit(),
+			trade.getCreatedAt()
+		);
+	}
+}

--- a/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.UUID;
 
 import com.solv.wefin.domain.trading.order.dto.OrderCancelInfo;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.config.security.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +45,8 @@ class OrderControllerTest {
 	private VirtualAccountService accountService;
 	@MockitoBean
 	private JwtProvider jwtProvider;
+	@MockitoBean
+	private StockService stockService;
 
 	private VirtualAccount mockAccount;
 	private UUID testUserId;
@@ -152,6 +156,79 @@ class OrderControllerTest {
 			.andExpect(jsonPath("$.data.status").value("CANCELLED"));
 	}
 
+	@Test
+	void 미체결_조회_성공() throws Exception {
+		// given
+		Order mockOrder = createMockOrder(OrderSide.BUY, OrderType.LIMIT, OrderStatus.PENDING);
+		given(mockOrder.getOrderId()).willReturn(1L);
+		given(mockOrder.getStockId()).willReturn(100L);
+		given(mockOrder.getRequestPrice()).willReturn(new BigDecimal("50000"));
+
+		Stock stock = mockStock(100L, "005930", "삼성전자");
+
+		given(orderService.findPendingOrders(anyLong())).willReturn(List.of(mockOrder));
+		given(stockService.findAllByIdIn(anyList())).willReturn(List.of(stock));
+
+		// when & then
+		mockMvc.perform(get("/api/order/pending")
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].status").value("PENDING"))
+			.andExpect(jsonPath("$.data[0].stockCode").value("005930"));
+	}
+
+	@Test
+	void 주문내역_커서_조회_성공() throws Exception {
+		// given
+		Order mockOrder = createMockOrder(OrderSide.BUY, OrderType.MARKET, OrderStatus.FILLED);
+		given(mockOrder.getOrderId()).willReturn(1L);
+		given(mockOrder.getStockId()).willReturn(100L);
+		given(mockOrder.getRequestPrice()).willReturn(null);
+
+		Stock stock = mockStock(100L, "005930", "삼성전자");
+
+		given(orderService.searchOrders(anyLong(), any(), any(), anyInt()))
+			.willReturn(List.of(mockOrder));
+		given(stockService.findAllByIdIn(anyList())).willReturn(List.of(stock));
+
+		// when & then
+		mockMvc.perform(get("/api/order/history")
+				.param("size", "20")
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content[0].stockCode").value("005930"))
+			.andExpect(jsonPath("$.data.hasNext").value(false));
+	}
+
+	@Test
+	void 오늘_체결_조회_성공() throws Exception {
+		// given
+		Order mockOrder = createMockOrder(OrderSide.BUY, OrderType.MARKET, OrderStatus.FILLED);
+		given(mockOrder.getOrderId()).willReturn(1L);
+		given(mockOrder.getStockId()).willReturn(100L);
+		given(mockOrder.getRequestPrice()).willReturn(null);
+
+		Stock stock = mockStock(100L, "005930", "삼성전자");
+
+		given(orderService.findTodayOrders(anyLong())).willReturn(List.of(mockOrder));
+		given(stockService.findAllByIdIn(anyList())).willReturn(List.of(stock));
+
+		// when & then
+		mockMvc.perform(get("/api/order/today")
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data[0].status").value("FILLED"))
+			.andExpect(jsonPath("$.data[0].stockCode").value("005930"));
+
+	}
+
 	private Order createMockOrder(OrderSide side, OrderType type, OrderStatus status) {
 		Order mockOrder = mock(Order.class);
 		given(mockOrder.getOrderNo()).willReturn(UUID.randomUUID());
@@ -160,7 +237,16 @@ class OrderControllerTest {
 		given(mockOrder.getQuantity()).willReturn(10);
 		given(mockOrder.getStatus()).willReturn(status);
 		given(mockOrder.getFee()).willReturn(new BigDecimal("146"));
+		given(mockOrder.getTax()).willReturn(BigDecimal.ZERO);
 		given(mockOrder.getCreatedAt()).willReturn(OffsetDateTime.now());
 		return mockOrder;
+	}
+
+	private Stock mockStock(Long stockId, String stockCode, String stockName) {
+		Stock mockStock = mock(Stock.class);
+		given(mockStock.getId()).willReturn(stockId);
+		given(mockStock.getStockCode()).willReturn(stockCode);
+		given(mockStock.getStockName()).willReturn(stockName);
+		return mockStock;
 	}
 }

--- a/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
@@ -215,7 +215,7 @@ class OrderControllerTest {
 
 		Stock stock = mockStock(100L, "005930", "삼성전자");
 
-		given(orderService.findTodayOrders(anyLong())).willReturn(List.of(mockOrder));
+		given(orderService.findTodayFilledOrders(anyLong())).willReturn(List.of(mockOrder));
 		given(stockService.findAllByIdIn(anyList())).willReturn(List.of(stock));
 
 		// when & then

--- a/src/test/java/com/solv/wefin/web/trading/trade/TradeControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/trade/TradeControllerTest.java
@@ -1,0 +1,106 @@
+package com.solv.wefin.web.trading.trade;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.domain.trading.trade.entity.Trade;
+import com.solv.wefin.domain.trading.trade.service.TradeService;
+import com.solv.wefin.global.config.security.JwtProvider;
+
+@WebMvcTest(TradeController.class)
+class TradeControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private TradeService tradeService;
+	@MockitoBean
+	private VirtualAccountService accountService;
+	@MockitoBean
+	private StockService stockService;
+	@MockitoBean
+	private JwtProvider jwtProvider;
+
+	private VirtualAccount mockAccount;
+	private UUID testUserId;
+
+	@BeforeEach
+	void setUp() {
+		testUserId = UUID.randomUUID();
+		mockAccount = mock(VirtualAccount.class);
+		given(mockAccount.getVirtualAccountId()).willReturn(1L);
+		given(accountService.getAccountByUserId(any())).willReturn(mockAccount);
+	}
+
+	@Test
+	void 체결내역_조회_성공() throws Exception {
+		// given
+		Trade trade = mockTrade(1L, 100L);
+		Stock stock = mockStock(100L, "005930", "삼성전자");
+
+		given(tradeService.searchTrades(anyLong(), any(), any(), anyInt()))
+			.willReturn(List.of(trade));
+		given(stockService.findAllByIdIn(anyList()))
+			.willReturn(List.of(stock));
+
+		// when & then
+		mockMvc.perform(get("/api/trade/history")
+				.param("size", "20")
+				.with(authentication(
+					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
+				)))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.content").isArray())
+			.andExpect(jsonPath("$.data.content[0].stockCode").value("005930"))
+			.andExpect(jsonPath("$.data.content[0].side").value("SELL"))
+			.andExpect(jsonPath("$.data.content[0].realizedProfit").value(10000))
+			.andExpect(jsonPath("$.data.hasNext").value(false));
+	}
+
+	private Trade mockTrade(Long tradeId, Long stockId) {
+		Trade trade = mock(Trade.class);
+		given(trade.getTradeId()).willReturn(tradeId);
+		given(trade.getTradeNo()).willReturn(UUID.randomUUID());
+		given(trade.getStockId()).willReturn(stockId);
+		given(trade.getSide()).willReturn(OrderSide.SELL);
+		given(trade.getQuantity()).willReturn(10);
+		given(trade.getPrice()).willReturn(new BigDecimal("50000"));
+		given(trade.getTotalAmount()).willReturn(new BigDecimal("500000"));
+		given(trade.getFee()).willReturn(BigDecimal.ZERO);
+		given(trade.getTax()).willReturn(BigDecimal.ZERO);
+		given(trade.getRealizedProfit()).willReturn(new BigDecimal("10000"));
+		given(trade.getCreatedAt()).willReturn(OffsetDateTime.now());
+		return trade;
+	}
+
+	private Stock mockStock(Long stockId, String stockCode, String stockName) {
+		Stock mockStock = mock(Stock.class);
+		given(mockStock.getId()).willReturn(stockId);
+		given(mockStock.getStockCode()).willReturn(stockCode);
+		given(mockStock.getStockName()).willReturn(stockName);
+		return mockStock;
+	}
+
+}


### PR DESCRIPTION
## 📌 PR 설명
  주문(Order) 내역과 체결(Trade) 내역을 조회하는 API 구현.
  동적 필터(상태, 종목, 날짜, 매수/매도)와 커서 기반 페이지네이션을 QueryDSL로 처리한다.

  <br>

  ## ✅ 완료한 기능 명세

  - [x] `GET /api/order/pending` — 미체결 주문 조회
  - [x] `GET /api/order/today` — 오늘 체결 주문 조회
  - [x] `GET /api/order/history` — 전체 주문 내역 (동적 필터 + 커서 페이지네이션)
  - [x] `GET /api/trade/history` — 체결 내역 (동적 필터 + 커서 페이지네이션)
  - [x] `CursorResponse<T>` 공통 커서 응답 래퍼 생성
  - [x] QueryDSL 동적 쿼리 (OrderRepositoryCustom, TradeRepositoryCustom)
  - [x] 종목명 매핑 (stockId → Stock IN 쿼리 1회, N+1 방지)
  - [x] size 파라미터 검증 (@Min(1) @Max(100))
  - [x] 존재하지 않는 stockCode 검색 시 빈 결과 반환 (early return)
  - [x] OrderControllerTest 3개 + TradeControllerTest 1개

  <br>


  ## 💭 고민과 해결과정

  ### 1. 커서 기반 vs 오프셋 기반
  프로젝트 전체(채팅, 뉴스)가 커서 기반 페이지네이션 사용 중. 주문/체결 내역은 실시간으로 데이터가 쌓이므로 오프셋 방식은 중복/누락 발생 가능.
  커서 기반으로 통일했다.

  ### 2. QueryDSL BooleanExpression 동적 필터
  null-safe 헬퍼 메서드 패턴으로 조건이 null이면 where절에서 자동 제외. StockRepositoryImpl 기존 패턴과 동일하게 구현.

  ### 3. 종목명 매핑 — IN 쿼리 1회
  Order/Trade에 stockName이 없어서 stockId로 Stock 일괄 조회 후 Map 매핑. 페이지 사이즈 기준 최대 20개 stockId → IN 쿼리 1회로 N+1 방지.

  ### 4. 레포지토리 날짜 결정 → 서비스로 이동
  findTodayFilledOrders에서 LocalDate.now()를 레포지토리 안에서 호출하고 있었는데, "오늘이 언제냐"를 결정하는 건 서비스 책임이므로 파라미터로 분리했다.

  ### 5. 존재하지 않는 stockCode 처리
  stockCode가 잘못된 값이면 stockId가 null → 필터 무시되어 전체 결과 반환되는 문제. CursorResponse.empty()로 early return 처리.

  <br>

  ### 🔗 관련 이슈
  Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 주문 조회 강화: 미체결 목록, 당일 체결, 상태/종목/날짜 필터 기반 주문 이력 조회(커서 페이징) 제공
  * 거래 이력 조회 추가: 종목·매매방향·날짜 필터로 거래 이력 조회(커서 페이징) 제공
  * 통합된 커서 기반 응답 포맷으로 페이지네이션 메타데이터 제공

* **테스트**
  * 주문/거래 컨트롤러 대상 통합형 HTTP 테스트 추가 및 응답 구조 검증
<!-- end of auto-generated comment: release notes by coderabbit.ai -->