### PR TITLE
[WEF-617] 유저 SECTOR, TOPIC 관심사 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/interest/dto/InterestInfo.java
+++ b/src/main/java/com/solv/wefin/domain/interest/dto/InterestInfo.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.interest.dto;
+
+/**
+ * 관심사 조회 결과 (SECTOR/TOPIC)
+ */
+public record InterestInfo(String code, String name) {
+}

--- a/src/main/java/com/solv/wefin/domain/interest/service/InterestService.java
+++ b/src/main/java/com/solv/wefin/domain/interest/service/InterestService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -110,8 +111,7 @@ public class InterestService {
         if (trimmed.isEmpty() || trimmed.length() > MAX_CODE_LENGTH) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
-        // tag_code는 AI 생성 시점에 정규화되어 저장되므로 여기서는 공백/길이만 방어하고 저장된 그대로 매칭한다
-        return trimmed;
+        return trimmed.toUpperCase(Locale.ROOT);
     }
 
     private NewsArticleTag.TagType toTagType(InterestType type) {

--- a/src/main/java/com/solv/wefin/domain/interest/service/InterestService.java
+++ b/src/main/java/com/solv/wefin/domain/interest/service/InterestService.java
@@ -1,0 +1,120 @@
+package com.solv.wefin.domain.interest.service;
+
+import com.solv.wefin.domain.interest.dto.InterestInfo;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * SECTOR / TOPIC 관심사 등록·조회·해제 서비스
+ *
+ * STOCK은 trading 도메인의 {@link com.solv.wefin.domain.trading.watchlist.service.WatchlistService}가
+ * 담당하며, 본 서비스는 동일한 {@code user_interest} 테이블을 interest_type으로 구분해 공유한다.
+ *
+ * 수동 등록 관심사와 피드백 기반 추천 가중치는 {@code manual_registered} 컬럼으로 분리되어,
+ * 본 서비스의 목록/개수 제한/삭제는 {@code manual_registered = true} row만 대상으로 한다
+ */
+@Service
+@RequiredArgsConstructor
+public class InterestService {
+
+    public static final BigDecimal ADD_WEIGHT = new BigDecimal(5); // 관심사 등록 가중치
+    public static final int MAX_INTERESTS_PER_TYPE = 10; // 타입별 수동 등록 관심사 최대 개수
+    private static final int MAX_CODE_LENGTH = 100; // 태그 코드 최대 길이
+
+    private final UserInterestRepository userInterestRepository;
+    private final NewsArticleTagRepository newsArticleTagRepository;
+    private final ManualInterestLockService manualInterestLockService;
+
+    public List<InterestInfo> list(UUID userId, InterestType type) {
+        assertSectorOrTopic(type);
+
+        List<UserInterest> interests = userInterestRepository
+                .findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, type.name());
+        if (interests.isEmpty()) return List.of();
+
+        List<String> codes = interests.stream().map(UserInterest::getInterestValue).toList();
+        Map<String, String> nameByCode = newsArticleTagRepository
+                .findTagNamesByTagTypeAndTagCodes(type.name(), codes)
+                .stream()
+                .collect(Collectors.toMap(
+                        NewsArticleTagRepository.TagNameProjection::getCode,
+                        NewsArticleTagRepository.TagNameProjection::getName));
+
+        return interests.stream()
+                .map(interest -> {
+                    String code = interest.getInterestValue();
+                    return new InterestInfo(code, nameByCode.getOrDefault(code, code));
+                })
+                .toList();
+    }
+
+    @Transactional
+    public void add(UUID userId, InterestType type, String rawCode) {
+        assertSectorOrTopic(type);
+        String code = normalize(rawCode);
+
+        // 자유 입력 방지 — AI가 실제 부여한 태그만 관심사로 등록 가능
+        if (!newsArticleTagRepository.existsByTagTypeAndTagCode(toTagType(type), code)) {
+            throw new BusinessException(ErrorCode.INTEREST_TAG_NOT_FOUND);
+        }
+
+        // count + insert가 별도 쿼리라 동시 요청에서 한도가 깨질 수 있어 (userId, type) 단위 직렬화
+        manualInterestLockService.acquire(userId, type);
+
+        if (userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+                userId, type.name(), code)) {
+            throw new BusinessException(ErrorCode.INTEREST_ALREADY_EXISTS);
+        }
+
+        if (userInterestRepository.countByUserIdAndInterestTypeAndManualRegisteredTrue(userId, type.name())
+                >= MAX_INTERESTS_PER_TYPE) {
+            throw new BusinessException(ErrorCode.INTEREST_LIMIT_EXCEEDED);
+        }
+
+        userInterestRepository.save(UserInterest.createManual(userId, type.name(), code, ADD_WEIGHT));
+    }
+
+    @Transactional
+    public void delete(UUID userId, InterestType type, String rawCode) {
+        assertSectorOrTopic(type);
+        String code = normalize(rawCode);
+        // 피드백 기반 추천 가중치(manual_registered=false) row는 그대로 두고 수동 등록 row만 삭제
+        userInterestRepository
+                .deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+                        userId, type.name(), code);
+    }
+
+    private void assertSectorOrTopic(InterestType type) {
+        if (type != InterestType.SECTOR && type != InterestType.TOPIC) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private String normalize(String rawCode) {
+        if (rawCode == null) throw new BusinessException(ErrorCode.INVALID_INPUT);
+        String trimmed = rawCode.trim();
+        if (trimmed.isEmpty() || trimmed.length() > MAX_CODE_LENGTH) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        // tag_code는 AI 생성 시점에 정규화되어 저장되므로 여기서는 공백/길이만 방어하고 저장된 그대로 매칭한다
+        return trimmed;
+    }
+
+    private NewsArticleTag.TagType toTagType(InterestType type) {
+        return NewsArticleTag.TagType.valueOf(type.name());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/interest/service/ManualInterestLockService.java
+++ b/src/main/java/com/solv/wefin/domain/interest/service/ManualInterestLockService.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.interest.service;
+
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * 수동 관심사 등록 시 (userId, interestType) 단위 직렬화를 보장하는 PostgreSQL advisory lock helper.
+ *
+ * count + insert가 별도 쿼리로 실행되는 구조라, 서로 다른 code의 concurrent add 요청이
+ * 들어오면 둘 다 한도 미만이라고 판단하고 저장해 타입별 10개 제한이 깨질 수 있다.
+ * 같은 (userId, interestType) 키에 대한 요청만 대기시키고, 다른 사용자/다른 타입 요청은
+ * 블로킹되지 않도록 pg_advisory_xact_lock을 트랜잭션 경계 안에서 획득한다
+ */
+@Component
+public class ManualInterestLockService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * 현재 트랜잭션 동안 (userId, type) 키에 대한 advisory lock(사용자 정의 락)을 획득한다.
+     *
+     * 트랜잭션이 커밋/롤백되면 자동 해제되므로 별도 unlock 호출은 필요 없다.
+     * 반드시 {@code @Transactional} 경계 안에서 호출해야 한다
+     */
+    public void acquire(UUID userId, InterestType type) {
+        String key = userId + ":" + type.name();
+        entityManager
+                .createNativeQuery("SELECT pg_advisory_xact_lock(hashtextextended(?, 0))")
+                .setParameter(1, key)
+                .getSingleResult();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleTagRepository.java
@@ -57,6 +57,45 @@ public interface NewsArticleTagRepository extends JpaRepository<NewsArticleTag, 
     List<NewsArticleTag> findByNewsArticleIdInAndTagType(List<Long> newsArticleIds, NewsArticleTag.TagType tagType);
 
     /**
+     * 특정 (tagType, tagCode) 조합이 하나라도 존재하는지 확인한다.
+     *
+     * 관심사 SECTOR/TOPIC 등록 시 자유 입력 대신 실제 부여한 태그만 허용하기 위한 유효성 검증에 사용한다
+     */
+    boolean existsByTagTypeAndTagCode(NewsArticleTag.TagType tagType, String tagCode);
+
+    /**
+     * 특정 (tagType, tagCode)의 표시명(tagName)을 가장 최근 기사 기준으로 조회한다.
+     *
+     * AI가 동일 code에 여러 표기를 시간에 따라 부여한 경우가 있어, 사전순(MIN) 대신
+     * 최신 삽입된 tagName을 선택해 "최근 운영에서 사용 중인 명칭"을 보여준다.
+     * 여러 건을 batch로 조회하는 {@link #findTagNamesByTagTypeAndTagCodes}를 우선 사용하라
+     */
+    @Query(value = "SELECT tag_name FROM news_article_tag " +
+            "WHERE tag_type = :tagType AND tag_code = :tagCode " +
+            "ORDER BY news_article_tag_id DESC LIMIT 1", nativeQuery = true)
+    String findTagNameByTagTypeAndTagCode(@Param("tagType") String tagType,
+                                          @Param("tagCode") String tagCode);
+
+    /**
+     * 여러 tagCode의 표시명을 한 번에 조회한다 (N+1 방지).
+     *
+     * 같은 code에 여러 tagName이 존재할 경우 {@link #findTagNameByTagTypeAndTagCode}와
+     * 동일하게 최신 삽입된 값을 선택한다
+     */
+    @Query(value = "SELECT DISTINCT ON (tag_code) tag_code AS code, tag_name AS name " +
+            "FROM news_article_tag " +
+            "WHERE tag_type = :tagType AND tag_code IN (:tagCodes) " +
+            "ORDER BY tag_code, news_article_tag_id DESC", nativeQuery = true)
+    List<TagNameProjection> findTagNamesByTagTypeAndTagCodes(
+            @Param("tagType") String tagType,
+            @Param("tagCodes") java.util.Collection<String> tagCodes);
+
+    interface TagNameProjection {
+        String getCode();
+        String getName();
+    }
+
+    /**
      * 특정 기사의 태그를 전부 삭제한다. 재태깅 시 기존 태그 정리에 사용한다.
      */
     void deleteByNewsArticleId(Long newsArticleId);

--- a/src/main/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistService.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.trading.watchlist.service;
 
+import com.solv.wefin.domain.interest.service.ManualInterestLockService;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import com.solv.wefin.domain.trading.stock.entity.Stock;
@@ -22,18 +23,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class WatchlistService {
 
-    /** 관심 종목 등록 가중치. 명시적 선호 신호이므로 HELPFUL 피드백(+1) 5회분에 해당 */
-    public static final BigDecimal ADD_WATCHLIST_WEIGHT = new BigDecimal(5);
-    /** 관심 종목 해제 가중치. 등록과 동일 절대값 차감 */
-    public static final BigDecimal DELETE_WATCHLIST_WEIGHT = new BigDecimal(-5);
+    public static final BigDecimal ADD_WATCHLIST_WEIGHT = new BigDecimal(5); // 관심 종목을 수동 등록할 때 부여되는 기본 weight.
+    private static final int MAX_WATCHLIST_SIZE = 10; // 타입별(예: STOCK) 수동 등록 관심사의 최대 개수 제한
 
     private final MarketService marketService;
     private final UserInterestRepository userInterestRepository;
     private final StockRepository stockRepository;
+    private final ManualInterestLockService manualInterestLockService;
 
     public List<WatchlistInfo> getStockList(UUID userId) {
         List<UserInterest> interests = userInterestRepository
-                .findByUserIdAndInterestType(userId,  InterestType.STOCK.name());
+                .findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, InterestType.STOCK.name());
 
         return interests.stream()
                 .map(interest -> {
@@ -51,20 +51,25 @@ public class WatchlistService {
             throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
         }
 
-        if (userInterestRepository.existsByUserIdAndInterestTypeAndInterestValue(userId, InterestType.STOCK.name(), stockCode)) {
+        manualInterestLockService.acquire(userId, InterestType.STOCK);
+
+        if (userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+                userId, InterestType.STOCK.name(), stockCode)) {
             throw new BusinessException(ErrorCode.INTEREST_ALREADY_EXISTS);
         }
 
-        if (userInterestRepository.countByUserIdAndInterestType(userId, InterestType.STOCK.name()) >= 10) {
+        if (userInterestRepository.countByUserIdAndInterestTypeAndManualRegisteredTrue(
+                userId, InterestType.STOCK.name()) >= MAX_WATCHLIST_SIZE) {
             throw new BusinessException(ErrorCode.INTEREST_LIMIT_EXCEEDED);
         }
 
-        userInterestRepository.save(UserInterest.create(userId, InterestType.STOCK.name(), stockCode, ADD_WATCHLIST_WEIGHT));
+        userInterestRepository.save(UserInterest.createManual(
+                userId, InterestType.STOCK.name(), stockCode, ADD_WATCHLIST_WEIGHT));
     }
 
     @Transactional
     public void deleteUserInterest(UUID userId, String stockCode) {
-        userInterestRepository.upsertWeight(userId, InterestType.STOCK.name(), stockCode, DELETE_WATCHLIST_WEIGHT);
-        userInterestRepository.deleteByUserIdAndInterestTypeAndInterestValue(userId, InterestType.STOCK.name(), stockCode);
+        userInterestRepository.deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+                userId, InterestType.STOCK.name(), stockCode);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/user/entity/UserInterest.java
+++ b/src/main/java/com/solv/wefin/domain/user/entity/UserInterest.java
@@ -40,6 +40,9 @@ public class UserInterest {
     @Column(name = "weight", precision = 5, scale = 2)
     private BigDecimal weight;
 
+    @Column(name = "manual_registered", nullable = false)
+    private boolean manualRegistered; //사용자가 명시적으로 등록한 관심사 여부
+
     @Column(name = "created_at")
     private OffsetDateTime createdAt;
 
@@ -56,14 +59,17 @@ public class UserInterest {
     }
 
     /**
-     * 새 관심사를 생성한다 (피드백에 의한 자동 생성)
+     * 사용자가 명시적으로 등록한 관심사를 생성한다.
+     *
+     * Watchlist(STOCK) 및 Interest API(SECTOR/TOPIC)의 저장 경로에서 사용한다
      */
-    public static UserInterest create(UUID userId, String interestType, String interestValue, BigDecimal weight) {
+    public static UserInterest createManual(UUID userId, String interestType, String interestValue, BigDecimal weight) {
         UserInterest interest = new UserInterest();
         interest.userId = userId;
         interest.interestType = interestType;
         interest.interestValue = interestValue;
         interest.weight = weight;
+        interest.manualRegistered = true;
         return interest;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/user/entity/UserInterest.java
+++ b/src/main/java/com/solv/wefin/domain/user/entity/UserInterest.java
@@ -17,8 +17,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "user_interest",
         uniqueConstraints = @UniqueConstraint(
-                name = "uk_user_interest_user_type_value",
-                columnNames = {"user_id", "interest_type", "interest_value"}))
+                name = "uk_user_interest_user_type_value_manual",
+                columnNames = {"user_id", "interest_type", "interest_value", "manual_registered"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserInterest {

--- a/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/com/solv/wefin/domain/user/repository/UserInterestRepository.java
@@ -16,24 +16,44 @@ public interface UserInterestRepository extends JpaRepository<UserInterest, Long
     Optional<UserInterest> findByUserIdAndInterestTypeAndInterestValue(
             UUID userId, String interestType, String interestValue);
 
-    List<UserInterest> findByUserIdAndInterestType(UUID userId, String interestType);
+    /**
+     * 사용자가 명시적으로 등록한 관심사 목록만 조회한다.
+     *
+     * 피드백 기반 upsert row(manualRegistered=false)는 제외된다
+     */
+    List<UserInterest> findByUserIdAndInterestTypeAndManualRegisteredTrue(
+            UUID userId, String interestType);
 
-    boolean existsByUserIdAndInterestTypeAndInterestValue(UUID userId, String interestType, String interestValue);
+    /** 수동 등록 관심사의 존재 여부. Watchlist/Interest 중복 등록 방지에 사용 */
+    boolean existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+            UUID userId, String interestType, String interestValue);
 
-    long countByUserIdAndInterestType(UUID userId, String interestType);
+    /** 수동 등록 관심사 개수. 타입별 10개 제한 계산에 사용 */
+    long countByUserIdAndInterestTypeAndManualRegisteredTrue(UUID userId, String interestType);
 
-    void deleteByUserIdAndInterestTypeAndInterestValue(UUID userId, String interestType, String interestValue);
+    /** 수동 등록 관심사 row만 삭제한다. */
+    void deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+            UUID userId, String interestType, String interestValue);
 
     /**
-     * 가중치를 원자적으로 upsert한다.
-     * 존재하면 weight를 증감하고, 없으면 새로 생성한다.
-     * weight 범위는 0~30으로 제한된다.
-     * PostgreSQL INSERT ON CONFLICT DO UPDATE로 단일 쿼리 실행
+     * 추천 기반 관심사 weight를 upsert(없으면 생성, 있으면 누적)한다.
+     *
+     * - manual_registered는 INSERT에서 명시하지 않아 기본값(FALSE)을 사용한다.
+     *   → 이 쿼리는 추천 기반 row(manual=false)만 대상으로 한다.
+     *
+     * - ON CONFLICT는 (user_id, interest_type, interest_value, manual_registered) 기준으로 동작한다.
+     *   → manual=true(수동 등록 관심사) row와는 충돌하지 않으므로 절대 수정되지 않는다.
+     *
+     * - 동작 방식:
+     *   1. 동일한 추천 row가 없으면 → 새로 생성
+     *   2. 있으면 → 기존 weight에 delta를 더함
+     *
+     * - weight는 항상 0 ~ 30 범위로 제한된다.
      */
     @Modifying
     @Query(value = "INSERT INTO user_interest (user_id, interest_type, interest_value, weight, created_at) " +
             "VALUES (:userId, :type, :value, LEAST(GREATEST(:delta, 0), 30), NOW()) " +
-            "ON CONFLICT (user_id, interest_type, interest_value) " +
+            "ON CONFLICT (user_id, interest_type, interest_value, manual_registered) " +
             "DO UPDATE SET weight = LEAST( GREATEST( COALESCE(user_interest.weight, 0) + :delta, 0 ), 30 )",
             nativeQuery = true)
     void upsertWeight(@Param("userId") UUID userId,

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -100,8 +100,9 @@ public enum ErrorCode {
     MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 20개까지 가능합니다."),
 
     // Interest
-    INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심종목입니다."),
-    INTEREST_LIMIT_EXCEEDED(400, "관심종목은 최대 10개까지 등록할 수 있습니다."),
+    INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심사입니다."),
+    INTEREST_LIMIT_EXCEEDED(400, "관심사는 타입별로 최대 10개까지 등록할 수 있습니다."),
+    INTEREST_TAG_NOT_FOUND(404, "등록할 수 없는 관심사입니다."),
 
     // Embedding
     EMBEDDING_ARTICLE_NOT_FOUND(500, "임베딩 대상 기사를 찾을 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/interest/InterestController.java
+++ b/src/main/java/com/solv/wefin/web/interest/InterestController.java
@@ -1,0 +1,71 @@
+package com.solv.wefin.web.interest;
+
+import com.solv.wefin.domain.interest.service.InterestService;
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.interest.dto.InterestResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 관심사 API (SECTOR / TOPIC)
+ *
+ * STOCK은 {@code /api/watchlist}에서 이미 제공되며, 본 컨트롤러는 동일 저장소를 공유하되
+ * 경로를 분리해 리소스 구조를 Watchlist와 일관되게 유지한다
+ */
+@RestController
+@RequestMapping("/api/interests")
+@RequiredArgsConstructor
+public class InterestController {
+
+    private final InterestService interestService;
+
+    @GetMapping("/sectors")
+    public ApiResponse<List<InterestResponse>> getSectors(@AuthenticationPrincipal UUID userId) {
+        List<InterestResponse> body = interestService.list(userId, InterestType.SECTOR).stream()
+                .map(InterestResponse::from)
+                .toList();
+        return ApiResponse.success(body);
+    }
+
+    @PostMapping("/sectors/{code}")
+    public ApiResponse<Void> addSector(@AuthenticationPrincipal UUID userId, @PathVariable String code) {
+        interestService.add(userId, InterestType.SECTOR, code);
+        return ApiResponse.success(null);
+    }
+
+    @DeleteMapping("/sectors/{code}")
+    public ApiResponse<Void> deleteSector(@AuthenticationPrincipal UUID userId, @PathVariable String code) {
+        interestService.delete(userId, InterestType.SECTOR, code);
+        return ApiResponse.success(null);
+    }
+
+    @GetMapping("/topics")
+    public ApiResponse<List<InterestResponse>> getTopics(@AuthenticationPrincipal UUID userId) {
+        List<InterestResponse> body = interestService.list(userId, InterestType.TOPIC).stream()
+                .map(InterestResponse::from)
+                .toList();
+        return ApiResponse.success(body);
+    }
+
+    @PostMapping("/topics/{code}")
+    public ApiResponse<Void> addTopic(@AuthenticationPrincipal UUID userId, @PathVariable String code) {
+        interestService.add(userId, InterestType.TOPIC, code);
+        return ApiResponse.success(null);
+    }
+
+    @DeleteMapping("/topics/{code}")
+    public ApiResponse<Void> deleteTopic(@AuthenticationPrincipal UUID userId, @PathVariable String code) {
+        interestService.delete(userId, InterestType.TOPIC, code);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/interest/dto/InterestResponse.java
+++ b/src/main/java/com/solv/wefin/web/interest/dto/InterestResponse.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.web.interest.dto;
+
+import com.solv.wefin.domain.interest.dto.InterestInfo;
+
+/**
+ * 관심사 조회 응답 (SECTOR/TOPIC)
+ */
+public record InterestResponse(String code, String name) {
+    public static InterestResponse from(InterestInfo info) {
+        return new InterestResponse(info.code(), info.name());
+    }
+}

--- a/src/main/resources/db/migration/V31__separate_manual_user_interest.sql
+++ b/src/main/resources/db/migration/V31__separate_manual_user_interest.sql
@@ -1,0 +1,24 @@
+
+-- 등록 경로(Watchlist/Interest API)가 TRUE로 저장한 row만 수동 등록으로 간주한다
+ALTER TABLE user_interest
+    ADD COLUMN IF NOT EXISTS manual_registered BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- unique 제약 확장: 수동 등록 row와 피드백 추천 row가 같은 (user, type, code) 조합으로 공존할 수 있어야 한다.
+-- Watchlist(manual=TRUE)에 종목 A 등록 + 같은 종목에 HELPFUL 피드백(manual=FALSE upsert) 동시 허용.
+-- 기존 (user_id, interest_type, interest_value) unique는 이를 허용하지 않아 재등록 시 ON CONFLICT가
+-- manual=TRUE row의 weight를 덮어쓰거나 INSERT가 깨질 수 있다.
+ALTER TABLE user_interest
+    DROP CONSTRAINT IF EXISTS uk_user_interest_user_type_value;
+
+-- 재실행 안전성: 이전 실행이 이 제약을 남긴 채 실패했을 수 있어 먼저 DROP IF EXISTS로 정리한다
+ALTER TABLE user_interest
+    DROP CONSTRAINT IF EXISTS uk_user_interest_user_type_value_manual;
+
+ALTER TABLE user_interest
+    ADD CONSTRAINT uk_user_interest_user_type_value_manual
+        UNIQUE (user_id, interest_type, interest_value, manual_registered);
+
+-- 관심사 allowlist 검증(NewsArticleTagRepository.existsByTagTypeAndTagCode)과 표시명 조회가
+-- tag_type + tag_code 기준으로 매번 실행되므로 보조 인덱스를 추가한다.
+CREATE INDEX IF NOT EXISTS idx_news_article_tag_type_code
+    ON news_article_tag (tag_type, tag_code);

--- a/src/test/java/com/solv/wefin/domain/interest/service/InterestManualFeedbackCoexistenceIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/interest/service/InterestManualFeedbackCoexistenceIntegrationTest.java
@@ -1,0 +1,139 @@
+package com.solv.wefin.domain.interest.service;
+
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 수동 등록 row와 피드백 upsert row가 같은 (user, type, code)에 공존 가능한지,
+ * 재등록 흐름(manual row 삭제 → 피드백 upsert → 재등록)에서 unique 충돌이 없는지 DB로 검증한다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class InterestManualFeedbackCoexistenceIntegrationTest {
+
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>(
+                    DockerImageName.parse("pgvector/pgvector:pg16")
+                            .asCompatibleSubstituteFor("postgres"))
+                    .withDatabaseName("wefin_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    static {
+        postgres.start();
+    }
+
+    @Autowired private UserInterestRepository userInterestRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(tx -> {
+            entityManager.createNativeQuery("DELETE FROM user_interest WHERE user_id = ?")
+                    .setParameter(1, userId).executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM users WHERE user_id = ?")
+                    .setParameter(1, userId).executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("같은 (user,type,code)에 manual=TRUE와 manual=FALSE가 동시에 존재할 수 있다")
+    void manualAndFeedback_canCoexist() {
+        seedUser();
+
+        // manual 등록
+        transactionTemplate.executeWithoutResult(tx ->
+                userInterestRepository.save(UserInterest.createManual(
+                        userId, InterestType.SECTOR.name(), "SEMICON", BigDecimal.valueOf(5))));
+
+        // 피드백 upsert (manual_registered=FALSE)
+        transactionTemplate.executeWithoutResult(tx ->
+                userInterestRepository.upsertWeight(
+                        userId, InterestType.SECTOR.name(), "SEMICON", BigDecimal.valueOf(2)));
+
+        Number total = (Number) entityManager
+                .createNativeQuery("SELECT COUNT(*) FROM user_interest WHERE user_id = ? AND interest_value = ?")
+                .setParameter(1, userId)
+                .setParameter(2, "SEMICON")
+                .getSingleResult();
+        assertThat(total.longValue()).isEqualTo(2L);
+
+        List<UserInterest> manualOnly = userInterestRepository
+                .findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, InterestType.SECTOR.name());
+        assertThat(manualOnly).hasSize(1);
+        assertThat(manualOnly.get(0).getWeight()).isEqualByComparingTo(new BigDecimal("5"));
+    }
+
+    @Test
+    @DisplayName("manual 삭제 → 피드백 upsert → 재등록해도 unique 제약 충돌 없이 동작한다")
+    void reregister_doesNotCollideWithFeedbackRow() {
+        seedUser();
+
+        // 최초 manual 등록
+        transactionTemplate.executeWithoutResult(tx ->
+                userInterestRepository.save(UserInterest.createManual(
+                        userId, InterestType.SECTOR.name(), "SEMICON", BigDecimal.valueOf(5))));
+
+        // 해제 (수동 row만 삭제)
+        transactionTemplate.executeWithoutResult(tx ->
+                userInterestRepository.deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+                        userId, InterestType.SECTOR.name(), "SEMICON"));
+
+        // 피드백 upsert로 manual=FALSE row 생성
+        transactionTemplate.executeWithoutResult(tx ->
+                userInterestRepository.upsertWeight(
+                        userId, InterestType.SECTOR.name(), "SEMICON", BigDecimal.valueOf(3)));
+
+        // 재등록 — unique 충돌 없이 성공해야 한다
+        transactionTemplate.executeWithoutResult(tx ->
+                userInterestRepository.save(UserInterest.createManual(
+                        userId, InterestType.SECTOR.name(), "SEMICON", BigDecimal.valueOf(5))));
+
+        List<UserInterest> manualOnly = userInterestRepository
+                .findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, InterestType.SECTOR.name());
+        assertThat(manualOnly).hasSize(1);
+
+        Number total = (Number) entityManager
+                .createNativeQuery("SELECT COUNT(*) FROM user_interest WHERE user_id = ? AND interest_value = ?")
+                .setParameter(1, userId)
+                .setParameter(2, "SEMICON")
+                .getSingleResult();
+        assertThat(total.longValue()).isEqualTo(2L);
+    }
+
+    private void seedUser() {
+        transactionTemplate.executeWithoutResult(tx ->
+                entityManager.createNativeQuery(
+                                "INSERT INTO users(user_id, email, nickname, password) VALUES (?, ?, ?, ?) ON CONFLICT (user_id) DO NOTHING")
+                        .setParameter(1, userId)
+                        .setParameter(2, "coexist-" + userId + "@example.com")
+                        .setParameter(3, "coex")
+                        .setParameter(4, "x")
+                        .executeUpdate());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/interest/service/InterestServiceConcurrencyIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/interest/service/InterestServiceConcurrencyIntegrationTest.java
@@ -1,0 +1,172 @@
+package com.solv.wefin.domain.interest.service;
+
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 타입별 10개 한도가 동시 요청에서도 유지되는지 검증하는 통합 테스트.
+ *
+ * 기존에는 exists/count/save가 별도 쿼리로 실행되어 서로 다른 code의 concurrent add 두 건이
+ * 둘 다 한도 미만으로 판단돼 11개가 저장될 수 있었다. {@link ManualInterestLockService}가
+ * (userId, interestType) 단위 advisory lock을 잡아 직렬화하는지 실제 DB로 확인한다
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class InterestServiceConcurrencyIntegrationTest {
+
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>(
+                    DockerImageName.parse("pgvector/pgvector:pg16")
+                            .asCompatibleSubstituteFor("postgres"))
+                    .withDatabaseName("wefin_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    static {
+        postgres.start();
+    }
+
+    @Autowired private InterestService interestService;
+    @Autowired private UserInterestRepository userInterestRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(tx -> {
+            entityManager.createNativeQuery("DELETE FROM user_interest WHERE user_id = ?")
+                    .setParameter(1, userId).executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM news_article_tag WHERE tag_code LIKE 'CONCUR_%'")
+                    .executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM news_article WHERE title LIKE 'seed-CONCUR_%'")
+                    .executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM users WHERE user_id = ?")
+                    .setParameter(1, userId).executeUpdate();
+        });
+    }
+
+    @Test
+    @DisplayName("동시 add 2건이 한도(10개)를 초과하지 않는다 — 한 건은 LIMIT_EXCEEDED")
+    void concurrentAdds_enforceLimitAtDb() throws Exception {
+        // given — 9개 수동 등록 + 2개 태그 선행 등록(allowlist 통과용)
+        seedManualInterests(9);
+        seedArticleTag("CONCUR_A", "Alpha");
+        seedArticleTag("CONCUR_B", "Beta");
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger success = new AtomicInteger();
+        AtomicInteger limitBlocked = new AtomicInteger();
+
+        try {
+            pool.submit(() -> runAdd("CONCUR_A", ready, start, success, limitBlocked));
+            pool.submit(() -> runAdd("CONCUR_B", ready, start, success, limitBlocked));
+
+            ready.await();
+            start.countDown();
+            pool.shutdown();
+            boolean terminated = pool.awaitTermination(10, TimeUnit.SECONDS);
+            assertThat(terminated).isTrue();
+        } finally {
+            if (!pool.isTerminated()) pool.shutdownNow();
+        }
+
+        // then — 정확히 한 건만 성공, 한 건은 한도 초과로 차단
+        assertThat(success.get()).isEqualTo(1);
+        assertThat(limitBlocked.get()).isEqualTo(1);
+        long finalCount = userInterestRepository
+                .countByUserIdAndInterestTypeAndManualRegisteredTrue(userId, InterestType.SECTOR.name());
+        assertThat(finalCount).isEqualTo(10L);
+    }
+
+    private void runAdd(String code, CountDownLatch ready, CountDownLatch start,
+                        AtomicInteger success, AtomicInteger limitBlocked) {
+        try {
+            ready.countDown();
+            start.await();
+            interestService.add(userId, InterestType.SECTOR, code);
+            success.incrementAndGet();
+        } catch (BusinessException e) {
+            if (e.getErrorCode() == ErrorCode.INTEREST_LIMIT_EXCEEDED) {
+                limitBlocked.incrementAndGet();
+            }
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void seedManualInterests(int count) {
+        transactionTemplate.executeWithoutResult(tx -> {
+            entityManager.createNativeQuery(
+                            "INSERT INTO users(user_id, email, nickname, password) VALUES (?, ?, ?, ?) ON CONFLICT (user_id) DO NOTHING")
+                    .setParameter(1, userId)
+                    .setParameter(2, "concur-" + userId + "@example.com")
+                    .setParameter(3, "concur")
+                    .setParameter(4, "x")
+                    .executeUpdate();
+            for (int i = 0; i < count; i++) {
+                String code = "CONCUR_SEED_" + i;
+                seedArticleTagInternal(code, "Seed" + i);
+                userInterestRepository.save(UserInterest.createManual(
+                        userId, InterestType.SECTOR.name(), code, BigDecimal.valueOf(5)));
+            }
+        });
+    }
+
+    private void seedArticleTag(String tagCode, String tagName) {
+        transactionTemplate.executeWithoutResult(tx -> seedArticleTagInternal(tagCode, tagName));
+    }
+
+    private void seedArticleTagInternal(String tagCode, String tagName) {
+        // news_article_tag.news_article_id는 FK가 실제로 강제되지 않고(마이그레이션에 제약 없음)
+        // Repository는 tag_type + tag_code 기준 조회만 하므로 최소 컬럼으로 더미 article을 삽입한다
+        Long articleId = ((Number) entityManager.createNativeQuery(
+                        "INSERT INTO news_article(publisher_name, title, original_url, created_at) " +
+                                "VALUES (?, ?, ?, now()) RETURNING news_article_id")
+                .setParameter(1, "seedpub")
+                .setParameter(2, "seed-" + tagCode)
+                .setParameter(3, "https://example.com/" + tagCode)
+                .getSingleResult()).longValue();
+
+        entityManager.createNativeQuery(
+                        "INSERT INTO news_article_tag(news_article_id, tag_type, tag_code, tag_name, created_at) " +
+                                "VALUES (?, 'SECTOR', ?, ?, now())")
+                .setParameter(1, articleId)
+                .setParameter(2, tagCode)
+                .setParameter(3, tagName)
+                .executeUpdate();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/interest/service/InterestServiceTest.java
@@ -1,0 +1,161 @@
+package com.solv.wefin.domain.interest.service;
+
+import com.solv.wefin.domain.interest.dto.InterestInfo;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InterestServiceTest {
+
+    @Mock private UserInterestRepository userInterestRepository;
+    @Mock private NewsArticleTagRepository newsArticleTagRepository;
+    @Mock private ManualInterestLockService manualInterestLockService;
+    @InjectMocks private InterestService interestService;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("SECTOR 관심사 목록 — 한 번의 batch 쿼리로 표시명을 채워 반환한다")
+    void list_sector_resolvesDisplayName() {
+        UserInterest saved = UserInterest.createManual(userId, "SECTOR", "SEMICON", BigDecimal.valueOf(5));
+        when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "SECTOR"))
+                .thenReturn(List.of(saved));
+        when(newsArticleTagRepository.findTagNamesByTagTypeAndTagCodes("SECTOR", List.of("SEMICON")))
+                .thenReturn(List.of(stubProjection("SEMICON", "반도체")));
+
+        List<InterestInfo> result = interestService.list(userId, InterestType.SECTOR);
+
+        assertThat(result).containsExactly(new InterestInfo("SEMICON", "반도체"));
+    }
+
+    @Test
+    @DisplayName("list — 현재 표시명이 없으면 code로 fallback")
+    void list_fallbackToCode_whenNameMissing() {
+        UserInterest saved = UserInterest.createManual(userId, "TOPIC", "AI", BigDecimal.valueOf(5));
+        when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "TOPIC"))
+                .thenReturn(List.of(saved));
+        when(newsArticleTagRepository.findTagNamesByTagTypeAndTagCodes("TOPIC", List.of("AI")))
+                .thenReturn(List.of());
+
+        List<InterestInfo> result = interestService.list(userId, InterestType.TOPIC);
+
+        assertThat(result).containsExactly(new InterestInfo("AI", "AI"));
+    }
+
+    private NewsArticleTagRepository.TagNameProjection stubProjection(String code, String name) {
+        return new NewsArticleTagRepository.TagNameProjection() {
+            @Override public String getCode() { return code; }
+            @Override public String getName() { return name; }
+        };
+    }
+
+    @Test
+    @DisplayName("add — AI가 부여한 태그가 아니면 INTEREST_TAG_NOT_FOUND")
+    void add_invalidTag_throws() {
+        when(newsArticleTagRepository.existsByTagTypeAndTagCode(NewsArticleTag.TagType.SECTOR, "NOPE"))
+                .thenReturn(false);
+
+        assertThatThrownBy(() -> interestService.add(userId, InterestType.SECTOR, "NOPE"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTEREST_TAG_NOT_FOUND);
+
+        verify(userInterestRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("add — 이미 등록된 경우 INTEREST_ALREADY_EXISTS")
+    void add_duplicate_throws() {
+        when(newsArticleTagRepository.existsByTagTypeAndTagCode(NewsArticleTag.TagType.SECTOR, "SEMICON"))
+                .thenReturn(true);
+        when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(userId, "SECTOR", "SEMICON"))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> interestService.add(userId, InterestType.SECTOR, "SEMICON"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTEREST_ALREADY_EXISTS);
+
+        verify(userInterestRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("add — 타입별 10개 한도 초과 시 INTEREST_LIMIT_EXCEEDED")
+    void add_exceedsLimit_throws() {
+        when(newsArticleTagRepository.existsByTagTypeAndTagCode(NewsArticleTag.TagType.TOPIC, "AI"))
+                .thenReturn(true);
+        when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(userId, "TOPIC", "AI"))
+                .thenReturn(false);
+        when(userInterestRepository.countByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "TOPIC"))
+                .thenReturn(10L);
+
+        assertThatThrownBy(() -> interestService.add(userId, InterestType.TOPIC, "AI"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INTEREST_LIMIT_EXCEEDED);
+
+        verify(userInterestRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("add — 유효 태그 + 미등록 + 한도 미달이면 가중치 +5로 저장")
+    void add_valid_saves() {
+        when(newsArticleTagRepository.existsByTagTypeAndTagCode(NewsArticleTag.TagType.SECTOR, "SEMICON"))
+                .thenReturn(true);
+        when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(userId, "SECTOR", "SEMICON"))
+                .thenReturn(false);
+        when(userInterestRepository.countByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "SECTOR"))
+                .thenReturn(3L);
+
+        interestService.add(userId, InterestType.SECTOR, "SEMICON");
+
+        ArgumentCaptor<UserInterest> captor = ArgumentCaptor.forClass(UserInterest.class);
+        verify(userInterestRepository).save(captor.capture());
+        UserInterest saved = captor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(userId);
+        assertThat(saved.getInterestType()).isEqualTo("SECTOR");
+        assertThat(saved.getInterestValue()).isEqualTo("SEMICON");
+        assertThat(saved.getWeight()).isEqualByComparingTo(InterestService.ADD_WEIGHT);
+    }
+
+    @Test
+    @DisplayName("delete — 수동 등록 row만 삭제, 피드백 가중치(upsertWeight) row는 건드리지 않음")
+    void delete_removesManualRowOnly() {
+        interestService.delete(userId, InterestType.SECTOR, "SEMICON");
+
+        verify(userInterestRepository).deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
+                userId, "SECTOR", "SEMICON");
+        verify(userInterestRepository, never()).upsertWeight(any(), anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("STOCK 타입은 Watchlist가 담당 — InterestService는 INVALID_INPUT으로 차단")
+    void add_rejectsStockType() {
+        assertThatThrownBy(() -> interestService.add(userId, InterestType.STOCK, "005930"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+
+        verify(newsArticleTagRepository, never()).existsByTagTypeAndTagCode(any(), anyString());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryServiceTest.java
@@ -59,7 +59,7 @@ class MarketTrendQueryServiceTest {
     @DisplayName("MarketTrend 없으면 generated=false로 snapshot만 반환")
     void getOverview_noTrend_returnsEmptyGenerated() {
         given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
-        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.empty());
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), MarketTrend.SESSION_DAILY)).willReturn(Optional.empty());
 
         MarketTrendOverview result = queryService.getOverview();
 
@@ -85,11 +85,11 @@ class MarketTrendQueryServiceTest {
         String sourceIdsJson = "[10, 20]";
 
         MarketTrend trend = MarketTrend.createDaily(
-                LocalDate.now(), "오늘 시장 요약", "상세 내용",
+                LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), "오늘 시장 요약", "상세 내용",
                 insightCardsJson, keywordsJson,
                 sourceIdsJson, 56);
         ReflectionTestUtils.setField(trend, "updatedAt", OffsetDateTime.now());
-        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
 
         // 클러스터 정보 보강 — ACTIVE + GENERATED/STALE만 노출
         NewsCluster c10 = createCluster(10L, "삼성전자 실적", OffsetDateTime.now().minusHours(1));
@@ -119,10 +119,10 @@ class MarketTrendQueryServiceTest {
         given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
 
         MarketTrend trend = MarketTrend.createDaily(
-                LocalDate.now(), "제목", "요약", "[]", "[]",
+                LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), "제목", "요약", "[]", "[]",
                 "[10, 20, 30]", 30);
         ReflectionTestUtils.setField(trend, "updatedAt", OffsetDateTime.now());
-        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
 
         // 20번만 ACTIVE+GENERATED 상태로 반환됨 (10, 30은 노출 대상 아님)
         NewsCluster c20 = createCluster(20L, "유일 생존", OffsetDateTime.now());
@@ -143,11 +143,11 @@ class MarketTrendQueryServiceTest {
         given(marketSnapshotRepository.findAll()).willReturn(List.of(snapshot));
 
         MarketTrend trend = MarketTrend.createDaily(
-                LocalDate.now(), "제목", "요약",
+                LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), "제목", "요약",
                 "{invalid json", "[not an array",
                 "[broken", null);
         ReflectionTestUtils.setField(trend, "updatedAt", OffsetDateTime.now());
-        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
+        given(marketTrendRepository.findByTrendDateAndSessionAndTitleIsNotNullAndSummaryIsNotNull(java.time.LocalDate.now(java.time.ZoneId.of("Asia/Seoul")), MarketTrend.SESSION_DAILY)).willReturn(Optional.of(trend));
 
         MarketTrendOverview result = queryService.getOverview();
 

--- a/src/test/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistServiceTest.java
@@ -35,6 +35,7 @@ class WatchlistServiceTest {
     @Mock private UserInterestRepository userInterestRepository;
     @Mock private StockRepository stockRepository;
     @Mock private MarketService marketService;
+    @Mock private com.solv.wefin.domain.interest.service.ManualInterestLockService manualInterestLockService;
     @InjectMocks private WatchlistService watchlistService;
 
     private final UUID userId = UUID.randomUUID();
@@ -69,10 +70,10 @@ class WatchlistServiceTest {
         void success() {
             // given
             when(stockRepository.existsByStockCode("005930")).thenReturn(true);
-            when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValue(
+            when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
                     userId, InterestType.STOCK.name(), "005930"))
                     .thenReturn(false);
-            when(userInterestRepository.countByUserIdAndInterestType(
+            when(userInterestRepository.countByUserIdAndInterestTypeAndManualRegisteredTrue(
                     userId, InterestType.STOCK.name()))
                     .thenReturn(0L);
 
@@ -94,7 +95,7 @@ class WatchlistServiceTest {
         void alreadyExists() {
             // given
             when(stockRepository.existsByStockCode("005930")).thenReturn(true);
-            when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValue(
+            when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
                     userId, InterestType.STOCK.name(), "005930"))
                     .thenReturn(true);
 
@@ -110,10 +111,10 @@ class WatchlistServiceTest {
         void limitExceeded() {
             // given
             when(stockRepository.existsByStockCode("005930")).thenReturn(true);
-            when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValue(
+            when(userInterestRepository.existsByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
                     userId, InterestType.STOCK.name(), "005930"))
                     .thenReturn(false);
-            when(userInterestRepository.countByUserIdAndInterestType(
+            when(userInterestRepository.countByUserIdAndInterestTypeAndManualRegisteredTrue(
                     userId, InterestType.STOCK.name()))
                     .thenReturn(10L);
 
@@ -130,17 +131,15 @@ class WatchlistServiceTest {
     class DeleteUserInterest {
 
         @Test
-        @DisplayName("정상 삭제 — 가중치 차감 후 row 삭제")
+        @DisplayName("정상 삭제 — 수동 등록 row만 삭제, 피드백 가중치 row는 유지")
         void success() {
             // when
             watchlistService.deleteUserInterest(userId, "005930");
 
-            // then — upsertWeight가 delete보다 먼저 호출되는지 순서 검증
-            InOrder inOrder = inOrder(userInterestRepository);
-            inOrder.verify(userInterestRepository).upsertWeight(
-                    userId, InterestType.STOCK.name(), "005930", WatchlistService.DELETE_WATCHLIST_WEIGHT);
-            inOrder.verify(userInterestRepository).deleteByUserIdAndInterestTypeAndInterestValue(
+            // then
+            verify(userInterestRepository).deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
                     userId, InterestType.STOCK.name(), "005930");
+            verify(userInterestRepository, never()).upsertWeight(any(), anyString(), anyString(), any());
         }
     }
 
@@ -155,7 +154,7 @@ class WatchlistServiceTest {
             UserInterest interest = mock(UserInterest.class);
             when(interest.getInterestValue()).thenReturn("005930");
 
-            when(userInterestRepository.findByUserIdAndInterestType(userId, InterestType.STOCK.name()))
+            when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, InterestType.STOCK.name()))
                     .thenReturn(List.of(interest));
 
             Stock stock = mockStock();


### PR DESCRIPTION
## 📌 PR 설명
`GET/POST/DELETE /api/interests/{sectors|topics}/...` 관심사 API를 추가하고, 기존에 Watchlist(STOCK)와 피드백 기반 추천 가중치가 `user_interest` 테이블에 섞여 저장되던 구조를 `manual_registered` 플래그로 분리했습니다. 수동 등록 관심사는 타입별 최대 10개 제한·목록·삭제 대상이 되고, 피드백 upsert row(`manual_registered=false`)는 추천 가중치로만 사용됩니다.

### 배경

기존 `user_interest`는 두 경로가 같은 row를 공유하고 있었습니다.

1. Watchlist 등 사용자가 명시적으로 등록한 관심사 (weight=5 초기값)
2. `ClusterInterestWeightService`가 HELPFUL/NOT_HELPFUL 피드백으로 **자동 upsert**하는 추천 가중치 (±1.0 누적)

이 상태에서 SECTOR/TOPIC API를 그대로 얹으면 "목록 10개 제한"이 피드백 row까지 포함해버리고, 삭제 시 추천 가중치가 같이 사라지는 등 의미가 섞여 깨지는 문제가 있었습니다. 수동 등록 여부를 명시적으로 구분해 두 경로를 분리합니다.

<br>

## ✅ 완료한 기능 명세

1. **V31__separate_manual_user_interest.sql** — `manual_registered` 컬럼 추가(NOT NULL DEFAULT FALSE) + `uk_user_interest_user_type_value`를 `(user_id, interest_type, interest_value, manual_registered)` 조합으로 확장 + `news_article_tag(tag_type, tag_code)` 보조 인덱스. 운영 배포 전이라 기존 row backfill은 생략
2. **UserInterest.java** — `manualRegistered` 필드 + `createManual(...)` 정적 팩토리(기존 `create(...)` 대체)
3. **UserInterestRepository.java** — 수동 등록 필터 내장 조회/카운트/존재/삭제 메서드. `upsertWeight` native 쿼리의 `ON CONFLICT` 절도 `(user_id, interest_type, interest_value, manual_registered)`로 확장된 unique에 맞춤 (INSERT 시 `manual_registered`는 DB default FALSE로 채워져 피드백 row는 수동 row와 독립)
4. **NewsArticleTagRepository.java** — `existsByTagTypeAndTagCode`(allowlist 검증), `findTagNameByTagTypeAndTagCode`(단건, 최신 기사 기준), `findTagNamesByTagTypeAndTagCodes`(배치, `DISTINCT ON (tag_code) ... ORDER BY tag_code, news_article_tag_id DESC`) 추가
5. **InterestInfo.java** — 도메인 응답 record `(code, name)`
6. **ManualInterestLockService.java** — `pg_advisory_xact_lock(hashtextextended("{userId}:{type}", 0))` 로 (userId, interestType) 단위 직렬화. count + insert 사이 race 방지
7. **InterestService.java** — SECTOR/TOPIC 등록/조회/삭제. 태그 allowlist 검증 → advisory lock → 중복/한도 체크 → `createManual` 저장
8. **WatchlistService.java** (수정) — STOCK 경로도 동일 패턴 적용: `ManualInterestLockService` 사용 + `manual_registered=true` row만 대상. 삭제 시 추천 가중치 row 보존(기존 `upsertWeight(-5)` 제거)
9. **InterestController.java** — `/api/interests/sectors`, `/api/interests/topics` REST 엔드포인트 6개 (GET/POST/DELETE)
10. **InterestResponse.java** — 공개 응답 DTO `(code, name)`
11. **ErrorCode.java** (수정) — `INTEREST_TAG_NOT_FOUND(404)` 추가, `INTEREST_ALREADY_EXISTS`/`INTEREST_LIMIT_EXCEEDED` 메시지를 "관심종목" → "관심사"로 확장
12. **InterestServiceTest.java** — SECTOR/TOPIC 타입 가드, 태그 allowlist 실패, 중복 등록, 한도 초과, 정규화(공백/길이), manualRegistered=false row 격리, 삭제 범위 단위 테스트
13. **InterestServiceConcurrencyIntegrationTest.java** — 동일 (userId, type)에 서로 다른 code 동시 add 시 advisory lock 으로 한도 10이 깨지지 않음을 Testcontainers + PostgreSQL로 검증
14. **WatchlistServiceTest.java** (수정) — 신규 mock/메서드명 반영


## 🔄 데이터 흐름

```
[수동 등록 경로 — /api/watchlist, /api/interests]
  사용자 요청
    └─ InterestService.add / WatchlistService.addUserInterest
          ├─ 1. input 정규화 (trim, length ≤ 100)
          ├─ 2. (SECTOR/TOPIC) news_article_tag allowlist 검증
          ├─ 3. ManualInterestLockService.acquire(userId, type)    ← pg_advisory_xact_lock
          ├─ 4. existsBy...ManualRegisteredTrue 로 중복 체크
          ├─ 5. countBy...ManualRegisteredTrue >= 10 한도 체크
          └─ 6. UserInterest.createManual(...) 저장 (manual_registered=true)

[피드백 경로 — ClusterInterestWeightService]
  HELPFUL(+1.0) / NOT_HELPFUL(-1.0)
    └─ upsertWeight(...)  ← INSERT ... ON CONFLICT DO UPDATE (manual_registered 기본값 false)

[목록/삭제]
  /api/watchlist, /api/interests
    └─ manual_registered=true row 만 대상 → 피드백 가중치는 건드리지 않음
```
 

<br>

## 💭 고민과 해결과정
### 1. 테이블 분리 vs 플래그

수동 등록 관심사와 피드백 기반 추천 가중치를 다른 테이블로 분리할지 아니면 하나의 테이블에서 플래그로 구분할지 고민했습니다. 테이블을 분리하면 의미적으로는 더 깔끔해 보이지만 실제 로직에서는 두 데이터를 같은 키(userId, type, value) 기준으로 함께 사용해야 하는 경우가 많습니다. 특히 추천 가중치를 계산할 때는 수동 등록과 피드백 누적값을 합쳐서 판단해야 하므로, 분리할 경우 매번 조인이 필요해지고 쿼리와 upsert 로직이 복잡해집니다. 또한 동일한 키를 두 테이블에서 각각 관리하게 되면, 데이터 정합성을 맞추기 위한 추가적인 동기화 로직도 필요해집니다. 이런 점을 고려해 구조를 단순하게 유지하면서도 의미를 분리할 수 있는 방법으로, `manual_registered` 플래그 하나로 두 경로를 구분하는 방식을 선택했습니다.


### 2. unique 제약 확장 — manual/feedback 공존 문제

기존 unique 제약은 `(user_id, interest_type, interest_value)`이므로 같은 관심사에 대해 수동 등록 row와 피드백 row를 동시에 가질 수 없었습니다. 이로 인해 다음과 같은 문제가 발생할 수 있었습니다.

1. 사용자가 종목 A를 수동 등록 (manual=true)
2. 이후 삭제 → DB에서 해당 row 제거
3. 같은 종목에 대해 HELPFUL 피드백 발생 → 새로운 row 생성 (manual=false)
4. 다시 수동 등록 시도 → 기존 row와 unique 충돌 발생

→ 수동 등록과 피드백이 서로 덮어쓰거나 충돌하는 구조였습니다.

이를 해결하기 위해 unique 제약을 `(user_id, interest_type, interest_value, manual_registered)`로 확장하여

* 수동 등록 row (manual=true)
* 피드백 row (manual=false)

가 서로 독립적으로 공존할 수 있도록 변경했습니다.

또한 `upsertWeight`의 `ON CONFLICT` 대상도 동일하게 맞춰, 피드백 upsert가 수동 row의 weight를 덮어쓰지 않도록 보장했습니다.



### 3. 타입별 10개 한도 정책

관심사를 타입별로 최대 10개로 제한하는 정책을 도입하면서 여러 측면을 함께 고려해봤습니다

1. 추천 품질: 이 서비스는 관심사를 기반으로 AI가 맞춤형 요약과 카드 생성을 수행하는데, 관심사가 너무 많아지면 각 관심사의 영향력이 희석되어 결국 일반적인 요약과 차이가 없어지는 문제가 발생합니다.
2. 비용 문제: 관심사 개수가 많아질수록 프롬프트 길이가 길어지고, 필터링 대상 클러스터도 증가하면서 토큰 사용량이 선형적으로 증가합니다. 무제한으로 허용할 경우 특정 사용자가 과도한 비용을 유발할 수 있습니다.
3. DB 성능: 관심사 기반 조회는 `EXISTS`, `IN`, 서브쿼리 등에서 관심사 수에 영향을 받기 때문에, 개수가 많아질수록 쿼리 비용이 증가합니다.
4. 이상 입력 방지: 버그나 자동화 스크립트로 수백 개의 관심사가 등록되는 상황을 구조적으로 막을 필요가 있습니다.
5. UX: 관심사가 많으면 실제로 의미 있는 선택을 하기 힘들어집니다.

현재 값인 10은 명확한 테스트 결과보다는 기존 Watchlist 정책을 기반으로 한 초기 값이며, 추후 사용자 데이터가 쌓이면 조정할 수 있도록 상수로 관리하고 있습니다.


### 3-1. count + insert race 문제

관심사 등록 로직은 exists 체크, count 체크, save가 각각 별도의 쿼리로 수행됩니다. 이 상태에서 동시에 여러 요청이 들어오면 두 요청 모두 "아직 10개 미만"이라고 판단하여 11개 이상 저장되는 race condition 이 발생할 수 있습니다. 이를 해결하기 위해 여러 방법을 검토했습니다.

* SELECT FOR UPDATE → 대상 row가 없으면 락을 걸 수 없음
* unique 제약 활용 → 개수 제한은 표현 불가
* 애플리케이션 락 → 멀티 인스턴스 환경에서 무의미

결론적으로 PostgreSQL의 **`pg_advisory_xact_lock`**을 사용했습니다.

`(userId, type)` 기준으로 락을 걸어 해당 범위의 요청만 직렬화하고, 다른 사용자나 다른 타입은 영향을 받지 않도록 했습니다. 이 락은 트랜잭션 종료 시 자동 해제되기 때문에 관리 부담도 적습니다.


### 4. Watchlist 삭제 시 추천 가중치 처리

기존 로직에서는 관심사를 삭제할 때 `upsertWeight(-5)`를 수행하여 "삭제 = 부정적 신호"로 해석하는 방식이었습니다. 하지만 manual과 feedback을 분리한 이후에는 이 방식이 모호해졌습니다. 사용자가 단순히 관심사를 해제한 것인지 실제로 해당 항목을 싫어하는 것인지를 구분할 수 없기 때문입니다. 결과적으로, 수동 등록 삭제가 추천 시스템에 영향을 주는 것은 의도와 맞지 않는다고 판단했습니다. 그래서 정책을 단순화하여 수동 row만 삭제 피드백 row는 유지하도록 변경했습니다. 부정적 신호는 기존의 NOT_HELPFUL 피드백 경로를 통해 표현하도록 역할을 분리했습니다.




### 5. 표시명(tagName) 결정 방식 + N+1 문제

같은 `tag_code`라도 여러 기사에서 사용되면서 `tag_name`이 조금씩 다를 수 있습니다. 초기에는 `MIN(tagName)`으로 하나를 선택했지만, 이 방식은 사전순으로 가장 앞선 값이 고정되는 문제가 있습니다.

| news_article_id | tag_type | tag_code | tag_name     |
|-----------------|----------|----------|--------------|
| 101             | SECTOR   | SEMICON  | 반도체       |
| 102             | SECTOR   | SEMICON  | 반도체업종   |
| 103             | SECTOR   | SEMICON  | 반도체 산업  |

즉, 실제로는 최신 데이터에서 더 적절한 이름이 있어도 반영되지 않습니다. 이를 해결하기 위해 가장 최근 기사 기준으로 tagName을 선택하는 방식으로 변경했습니다. 또한 목록 조회 시 각 관심사마다 개별 쿼리를 날리는 N+1 문제가 있었는데, `DISTINCT ON`을 활용한 배치 쿼리로 한 번에 조회하도록 변경하여 성능을 개선했습니다.

<br>

### 🔗 관련 이슈
Closes #227 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 관심사 관리 API 추가: 섹터/토픽의 조회·등록·삭제 기능 제공.

* **Improvements**
  * 수동 등록 관심사와 자동 추천 분리로 충돌 방지.
  * 타입별 관심사 최대 10개 제한 적용.
  * 등록 시 코드 유효성 검사 및 오류 메시지 개선.

* **Bug Fixes**
  * 동시 등록 시 제한이 DB 수준에서 안전하게 적용되도록 개선.

* **Tests**
  * 수동/추천 공존 및 동시성 시나리오를 검증하는 통합·단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->