### PR TITLE
[WEF-611] 턴 전환 투표 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/batch/BatchAsyncConfig.java
+++ b/src/main/java/com/solv/wefin/domain/game/batch/BatchAsyncConfig.java
@@ -24,4 +24,18 @@ public class BatchAsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean("newsBatchExecutor")
+    public Executor newsBatchExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(1);
+        executor.setQueueCapacity(1);
+        executor.setThreadNamePrefix("batch-news-");
+        executor.setRejectedExecutionHandler((r, e) -> {
+            throw new RuntimeException("뉴스 배치가 이미 실행 중입니다");
+        });
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/game/batch/service/StockCollectService.java
+++ b/src/main/java/com/solv/wefin/domain/game/batch/service/StockCollectService.java
@@ -180,9 +180,6 @@ public class StockCollectService {
     }
 
     private String resolveMarketCode(String market) {
-        if ("KOSDAQ".equalsIgnoreCase(market)) {
-            return "Q";
-        }
         return "J";
     }
 

--- a/src/main/java/com/solv/wefin/domain/game/news/service/NewsBatchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/service/NewsBatchService.java
@@ -31,7 +31,7 @@ public class NewsBatchService {
     /**
      * 비동기로 배치를 실행한다. Controller에서 즉시 응답 반환용.
      */
-    @Async("batchExecutor")
+    @Async("newsBatchExecutor")
     public void collectBatchAsync(int days) {
         collectBatch(days);
     }

--- a/src/main/java/com/solv/wefin/domain/game/vote/VoteBroadcaster.java
+++ b/src/main/java/com/solv/wefin/domain/game/vote/VoteBroadcaster.java
@@ -1,0 +1,17 @@
+package com.solv.wefin.domain.game.vote;
+
+import java.util.UUID;
+
+/**
+ * 투표 이벤트를 클라이언트에게 브로드캐스트하는 인터페이스.
+ * domain 계층에 인터페이스를 두고, web 계층에서 WebSocket으로 구현한다.
+ * (domain -> web 의존 방지)
+ */
+public interface VoteBroadcaster {
+
+    void broadcastStart(UUID roomId, UUID initiatorId, int totalCount, int timeoutSeconds);
+
+    void broadcastUpdate(UUID roomId, long agreeCount, long disagreeCount, int totalCount);
+
+    void broadcastResult(UUID roomId, boolean passed, long agreeCount, long disagreeCount);
+}

--- a/src/main/java/com/solv/wefin/domain/game/vote/VoteSession.java
+++ b/src/main/java/com/solv/wefin/domain/game/vote/VoteSession.java
@@ -1,0 +1,130 @@
+package com.solv.wefin.domain.game.vote;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 턴 전환 투표 1건의 상태를 관리하는 POJO.
+ * DB에 저장하지 않으며, 투표 종료(최대 15초) 시 폐기된다.
+ */
+public class VoteSession {
+
+    private final UUID roomId;
+    private final UUID initiatorId;
+    private final int totalCount;
+    private final int requiredAgree;
+    private final ConcurrentHashMap<UUID, Boolean> votes = new ConcurrentHashMap<>();
+    private final AtomicBoolean completed = new AtomicBoolean(false);
+    private final Instant deadline;
+    private ScheduledFuture<?> timeoutTask;
+
+    private VoteSession(UUID roomId, UUID initiatorId, int totalCount, Instant deadline) {
+        this.roomId = roomId;
+        this.initiatorId = initiatorId;
+        this.totalCount = totalCount;
+        this.requiredAgree = totalCount / 2 + 1;
+        this.deadline = deadline;
+    }
+
+    public static VoteSession create(UUID roomId, UUID initiatorId, int totalCount,
+                                     int timeoutSeconds) {
+        Instant deadline = Instant.now().plusSeconds(timeoutSeconds);
+        return new VoteSession(roomId, initiatorId, totalCount, deadline);
+    }
+
+    /**
+     * 투표를 기록한다.
+     *
+     * @return true면 정상 기록, false면 이미 투표한 사용자 (중복)
+     */
+    public boolean castVote(UUID userId, boolean agree) {
+        return votes.putIfAbsent(userId, agree) == null;
+    }
+
+    /**
+     * 현재 찬성 수.
+     */
+    public long getAgreeCount() {
+        return votes.values().stream().filter(v -> v).count();
+    }
+
+    /**
+     * 현재 반대 수.
+     */
+    public long getDisagreeCount() {
+        return votes.values().stream().filter(v -> !v).count();
+    }
+
+    /**
+     * 전원 투표 완료 여부.
+     */
+    public boolean isAllVoted() {
+        return votes.size() >= totalCount;
+    }
+
+    /**
+     * 과반수 찬성 도달 여부.
+     */
+    public boolean isMajorityReached() {
+        return getAgreeCount() >= requiredAgree;
+    }
+
+    /**
+     * 부결 확정 여부: 반대가 (총원 - 과반수 + 1) 이상이면 찬성이 과반수에 도달 불가.
+     */
+    public boolean isRejectionCertain() {
+        return getDisagreeCount() > totalCount - requiredAgree;
+    }
+
+    /**
+     * 종료 처리를 시도한다. CAS로 딱 1번만 true를 반환.
+     * 타이머 만료와 마지막 투표가 동시에 호출해도 1회만 실행됨을 보장.
+     */
+    public boolean tryComplete() {
+        return completed.compareAndSet(false, true);
+    }
+
+    public boolean isCompleted() {
+        return completed.get();
+    }
+
+    public void setTimeoutTask(ScheduledFuture<?> timeoutTask) {
+        this.timeoutTask = timeoutTask;
+    }
+
+    /**
+     * 타이머를 취소한다. 과반수 조기 달성 시 호출.
+     */
+    public void cancelTimeout() {
+        if (timeoutTask != null) {
+            timeoutTask.cancel(false);
+        }
+    }
+
+    public UUID getRoomId() {
+        return roomId;
+    }
+
+    public UUID getInitiatorId() {
+        return initiatorId;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public int getRequiredAgree() {
+        return requiredAgree;
+    }
+
+    public Instant getDeadline() {
+        return deadline;
+    }
+
+    public int getVotedCount() {
+        return votes.size();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/vote/service/GameVoteService.java
+++ b/src/main/java/com/solv/wefin/domain/game/vote/service/GameVoteService.java
@@ -1,0 +1,204 @@
+package com.solv.wefin.domain.game.vote.service;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.service.TurnAdvanceService;
+import com.solv.wefin.domain.game.vote.VoteBroadcaster;
+import com.solv.wefin.domain.game.vote.VoteSession;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameVoteService {
+
+    private static final int VOTE_TIMEOUT_SECONDS = 15;
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final TurnAdvanceService turnAdvanceService;
+    private final VoteBroadcaster voteBroadcaster;
+    private final ScheduledExecutorService voteScheduler;
+
+    private final ConcurrentHashMap<UUID, VoteSession> activeSessions = new ConcurrentHashMap<>();
+
+    /**
+     * 투표를 시작하거나, 진행 중인 투표에 참여한다.
+     *
+     * - 진행 중인 투표 없음 + 방장 -> 새 세션 생성 + 방장 찬성 1표 + 15초 타이머
+     * - 진행 중인 투표 있음 -> 투표 기록
+     *
+     * @return 투표 기록 후의 VoteSession
+     */
+    public VoteSession vote(UUID roomId, UUID userId, boolean agree) {
+        // 1. 게임방 상태 검증
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() != RoomStatus.IN_PROGRESS) {
+            throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
+        }
+
+        // 2. 참가자 검증
+        GameParticipant participant = gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. 세션 조회 또는 생성
+        VoteSession session = activeSessions.get(roomId);
+
+        if (session == null) {
+            // 진행 중인 투표 없음 -> 새 투표 시작 (방장만 가능)
+            return startNewVote(roomId, gameRoom, participant, userId, agree);
+        }
+
+        // 4. 진행 중인 투표에 참여
+        if (session.isCompleted()) {
+            throw new BusinessException(ErrorCode.VOTE_NOT_IN_PROGRESS);
+        }
+
+        if (!session.castVote(userId, agree)) {
+            throw new BusinessException(ErrorCode.VOTE_ALREADY_CAST);
+        }
+
+        log.info("[투표] 기록: roomId={}, userId={}, agree={}, 현황={}/{}",
+                roomId, userId, agree, session.getAgreeCount(), session.getTotalCount());
+
+        // 5. 브로드캐스트: 투표 현황
+        voteBroadcaster.broadcastUpdate(
+                roomId, session.getAgreeCount(), session.getDisagreeCount(), session.getTotalCount());
+
+        // 6. 판정 시도
+        checkAndResolve(roomId, session);
+
+        return session;
+    }
+
+    /**
+     * 새 투표 세션을 시작한다. 방장만 가능.
+     */
+    private VoteSession startNewVote(UUID roomId, GameRoom gameRoom, GameParticipant participant,
+                                     UUID userId, boolean agree) {
+        // 방장 확인 -- GameRoom.userId가 아닌 participant.isLeader로 판단해야
+        // 방장 위임 후에도 새 방장이 투표를 시작할 수 있다.
+        if (!participant.getIsLeader()) {
+            throw new BusinessException(ErrorCode.ROOM_NOT_HOST);
+        }
+
+        // 활성 참가자 수
+        int totalCount = gameParticipantRepository
+                .countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+
+        // computeIfAbsent로 동시 생성 방지
+        VoteSession session = activeSessions.computeIfAbsent(roomId,
+                key -> VoteSession.create(roomId, userId, totalCount, VOTE_TIMEOUT_SECONDS));
+
+        // 다른 스레드가 먼저 생성한 경우 (방장이 아닌 세션)
+        if (!session.getInitiatorId().equals(userId)) {
+            throw new BusinessException(ErrorCode.VOTE_ALREADY_IN_PROGRESS);
+        }
+
+        // 방장은 투표 시작 시 무조건 찬성 (feature-spec: "방장 찬성 1표 자동")
+        session.castVote(userId, true);
+
+        log.info("[투표] 시작: roomId={}, initiator={}, totalCount={}", roomId, userId, totalCount);
+
+        // 타이머 예약
+        session.setTimeoutTask(voteScheduler.schedule(
+                () -> expireVote(roomId),
+                VOTE_TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        // 브로드캐스트: 투표 시작
+        voteBroadcaster.broadcastStart(roomId, userId, totalCount, VOTE_TIMEOUT_SECONDS);
+
+        // 방장 투표 현황도 브로드캐스트
+        voteBroadcaster.broadcastUpdate(
+                roomId, session.getAgreeCount(), session.getDisagreeCount(), session.getTotalCount());
+
+        // 1인 방 등 즉시 과반수 도달 시
+        checkAndResolve(roomId, session);
+
+        return session;
+    }
+
+    /**
+     * 과반수 도달 / 부결 확정 / 전원 투표 완료 시 즉시 결과를 확정한다.
+     */
+    private void checkAndResolve(UUID roomId, VoteSession session) {
+        boolean shouldResolve = session.isMajorityReached()
+                || session.isRejectionCertain()
+                || session.isAllVoted();
+
+        if (!shouldResolve) {
+            return;
+        }
+
+        // CAS: 타이머와 경합 시 1회만 실행
+        if (!session.tryComplete()) {
+            return;
+        }
+
+        session.cancelTimeout();
+        resolve(roomId, session);
+    }
+
+    /**
+     * 타이머 만료 시 호출. 미투표자는 기권 처리.
+     */
+    private void expireVote(UUID roomId) {
+        VoteSession session = activeSessions.get(roomId);
+        if (session == null) {
+            return;
+        }
+
+        // CAS: 마지막 투표와 경합 시 1회만 실행
+        if (!session.tryComplete()) {
+            return;
+        }
+
+        log.info("[투표] 타이머 만료: roomId={}, 찬성={}, 반대={}, 미투표={}",
+                roomId, session.getAgreeCount(), session.getDisagreeCount(),
+                session.getTotalCount() - session.getVotedCount());
+
+        resolve(roomId, session);
+    }
+
+    /**
+     * 투표 결과를 확정하고 후속 처리를 수행한다.
+     */
+    private void resolve(UUID roomId, VoteSession session) {
+        boolean passed = session.isMajorityReached();
+
+        log.info("[투표] 결과: roomId={}, passed={}, 찬성={}, 반대={}",
+                roomId, passed, session.getAgreeCount(), session.getDisagreeCount());
+
+        // 브로드캐스트: 투표 결과
+        voteBroadcaster.broadcastResult(
+                roomId, passed, session.getAgreeCount(), session.getDisagreeCount());
+
+        // 세션 제거
+        activeSessions.remove(roomId);
+
+        // 통과 시 턴 전환
+        if (passed) {
+            try {
+                turnAdvanceService.advanceTurn(roomId, session.getInitiatorId());
+            } catch (Exception e) {
+                log.error("[투표] 턴 전환 실패: roomId={}, error={}", roomId, e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/vote/service/GameVoteService.java
+++ b/src/main/java/com/solv/wefin/domain/game/vote/service/GameVoteService.java
@@ -185,20 +185,21 @@ public class GameVoteService {
         log.info("[투표] 결과: roomId={}, passed={}, 찬성={}, 반대={}",
                 roomId, passed, session.getAgreeCount(), session.getDisagreeCount());
 
-        // 브로드캐스트: 투표 결과
-        voteBroadcaster.broadcastResult(
-                roomId, passed, session.getAgreeCount(), session.getDisagreeCount());
-
-        // 세션 제거
-        activeSessions.remove(roomId);
-
-        // 통과 시 턴 전환
+        // 통과 시 턴 전환을 먼저 시도 — 실패하면 부결로 전환
         if (passed) {
             try {
                 turnAdvanceService.advanceTurn(roomId, session.getInitiatorId());
             } catch (Exception e) {
                 log.error("[투표] 턴 전환 실패: roomId={}, error={}", roomId, e.getMessage(), e);
+                passed = false;
             }
         }
+
+        // 브로드캐스트: 투표 결과 (턴 전환 성공 여부 반영)
+        voteBroadcaster.broadcastResult(
+                roomId, passed, session.getAgreeCount(), session.getDisagreeCount());
+
+        // 세션 제거
+        activeSessions.remove(roomId);
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/VoteSchedulerConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/VoteSchedulerConfig.java
@@ -1,0 +1,17 @@
+package com.solv.wefin.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Configuration
+public class VoteSchedulerConfig {
+
+    @Bean(destroyMethod = "shutdown")
+    public ScheduledExecutorService voteScheduler() {
+        return Executors.newSingleThreadScheduledExecutor(
+                r -> new Thread(r, "vote-timer"));
+    }
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -154,7 +154,12 @@ public enum ErrorCode {
 
     // GameStock
     GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다."),
-    GAME_STOCK_PRICE_NOT_FOUND(404, "해당 날짜의 주가 데이터가 없습니다.");
+    GAME_STOCK_PRICE_NOT_FOUND(404, "해당 날짜의 주가 데이터가 없습니다."),
+
+    // Vote
+    VOTE_ALREADY_CAST(409, "이미 투표하였습니다."),
+    VOTE_NOT_IN_PROGRESS(400, "진행 중인 투표가 없습니다."),
+    VOTE_ALREADY_IN_PROGRESS(409, "이미 투표가 진행 중입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/game/vote/GameVoteController.java
+++ b/src/main/java/com/solv/wefin/web/game/vote/GameVoteController.java
@@ -1,0 +1,34 @@
+package com.solv.wefin.web.game.vote;
+
+import com.solv.wefin.domain.game.vote.VoteSession;
+import com.solv.wefin.domain.game.vote.service.GameVoteService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.vote.dto.request.VoteRequest;
+import com.solv.wefin.web.game.vote.dto.response.VoteResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/rooms/{roomId}/votes")
+@RequiredArgsConstructor
+public class GameVoteController {
+
+    private final GameVoteService gameVoteService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<VoteResponse>> vote(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody VoteRequest request) {
+
+        VoteSession session = gameVoteService.vote(roomId, userId, request.getAgree());
+        VoteResponse response = VoteResponse.from(session);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/vote/broadcaster/VoteWebSocketBroadcaster.java
+++ b/src/main/java/com/solv/wefin/web/game/vote/broadcaster/VoteWebSocketBroadcaster.java
@@ -62,6 +62,11 @@ public class VoteWebSocketBroadcaster implements VoteBroadcaster {
     }
 
     private void send(UUID roomId, Map<String, Object> payload) {
-        messagingTemplate.convertAndSend("/topic/rooms/" + roomId + "/vote", payload);
+        try {
+            messagingTemplate.convertAndSend("/topic/rooms/" + roomId + "/vote", payload);
+        } catch (Exception e) {
+            log.error("[투표 WS] 전송 실패: roomId={}, type={}, error={}",
+                    roomId, payload.get("type"), e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/vote/broadcaster/VoteWebSocketBroadcaster.java
+++ b/src/main/java/com/solv/wefin/web/game/vote/broadcaster/VoteWebSocketBroadcaster.java
@@ -1,0 +1,67 @@
+package com.solv.wefin.web.game.vote.broadcaster;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.vote.VoteBroadcaster;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VoteWebSocketBroadcaster implements VoteBroadcaster {
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final UserRepository userRepository;
+
+    @Override
+    public void broadcastStart(UUID roomId, UUID initiatorId, int totalCount, int timeoutSeconds) {
+        String nickname = userRepository.findById(initiatorId)
+                .map(user -> user.getNickname())
+                .orElse("알 수 없음");
+
+        Map<String, Object> payload = Map.of(
+                "type", "VOTE_START",
+                "initiator", nickname,
+                "totalCount", totalCount,
+                "timeoutSeconds", timeoutSeconds
+        );
+
+        send(roomId, payload);
+        log.info("[투표 WS] VOTE_START: roomId={}, initiator={}, totalCount={}", roomId, nickname, totalCount);
+    }
+
+    @Override
+    public void broadcastUpdate(UUID roomId, long agreeCount, long disagreeCount, int totalCount) {
+        Map<String, Object> payload = Map.of(
+                "type", "VOTE_UPDATE",
+                "agreeCount", agreeCount,
+                "disagreeCount", disagreeCount,
+                "totalCount", totalCount
+        );
+
+        send(roomId, payload);
+    }
+
+    @Override
+    public void broadcastResult(UUID roomId, boolean passed, long agreeCount, long disagreeCount) {
+        Map<String, Object> payload = Map.of(
+                "type", "VOTE_RESULT",
+                "passed", passed,
+                "agreeCount", agreeCount,
+                "disagreeCount", disagreeCount
+        );
+
+        send(roomId, payload);
+        log.info("[투표 WS] VOTE_RESULT: roomId={}, passed={}, 찬성={}, 반대={}",
+                roomId, passed, agreeCount, disagreeCount);
+    }
+
+    private void send(UUID roomId, Map<String, Object> payload) {
+        messagingTemplate.convertAndSend("/topic/rooms/" + roomId + "/vote", payload);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/vote/dto/request/VoteRequest.java
+++ b/src/main/java/com/solv/wefin/web/game/vote/dto/request/VoteRequest.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.game.vote.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoteRequest {
+
+    @NotNull(message = "찬성/반대 여부는 필수입니다")
+    private Boolean agree;
+}

--- a/src/main/java/com/solv/wefin/web/game/vote/dto/response/VoteResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/vote/dto/response/VoteResponse.java
@@ -1,0 +1,24 @@
+package com.solv.wefin.web.game.vote.dto.response;
+
+import com.solv.wefin.domain.game.vote.VoteSession;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VoteResponse {
+
+    private boolean voted;
+    private long agreeCount;
+    private long disagreeCount;
+    private int totalCount;
+
+    public static VoteResponse from(VoteSession session) {
+        return new VoteResponse(
+                true,
+                session.getAgreeCount(),
+                session.getDisagreeCount(),
+                session.getTotalCount()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/vote/service/GameVoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/vote/service/GameVoteServiceTest.java
@@ -1,0 +1,359 @@
+package com.solv.wefin.domain.game.vote.service;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.service.TurnAdvanceService;
+import com.solv.wefin.domain.game.vote.VoteBroadcaster;
+import com.solv.wefin.domain.game.vote.VoteSession;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class GameVoteServiceTest {
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private TurnAdvanceService turnAdvanceService;
+    @Mock
+    private VoteBroadcaster voteBroadcaster;
+
+    private ScheduledExecutorService voteScheduler;
+    private GameVoteService gameVoteService;
+
+    private static final UUID ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID HOST_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final UUID USER_A = UUID.fromString("00000000-0000-4000-a000-000000000003");
+    private static final UUID USER_B = UUID.fromString("00000000-0000-4000-a000-000000000004");
+    private static final Long GROUP_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        voteScheduler = Executors.newSingleThreadScheduledExecutor();
+        gameVoteService = new GameVoteService(
+                gameRoomRepository, gameParticipantRepository,
+                turnAdvanceService, voteBroadcaster, voteScheduler);
+    }
+
+    private GameRoom createRoom(RoomStatus status) {
+        GameRoom room = GameRoom.create(
+                GROUP_ID, HOST_ID, new BigDecimal("10000000"),
+                12, 7, LocalDate.of(2022, 1, 3), LocalDate.of(2023, 1, 3));
+        if (status == RoomStatus.IN_PROGRESS) {
+            room.start();
+        }
+        return room;
+    }
+
+    private void setupCommonMocks(GameRoom room, UUID userId) {
+        setupCommonMocks(room, userId, false);
+    }
+
+    private void setupCommonMocks(GameRoom room, UUID userId, boolean isLeader) {
+        given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+        GameParticipant participant = isLeader
+                ? GameParticipant.createLeader(room, userId)
+                : GameParticipant.createMember(room, userId);
+        given(gameParticipantRepository.findByGameRoomAndUserId(room, userId))
+                .willReturn(Optional.of(participant));
+    }
+
+    // === 투표 시작 성공 ===
+
+    @Nested
+    @DisplayName("투표 시작 성공")
+    class VoteStartSuccess {
+
+        @Test
+        @DisplayName("방장이 투표 시작 -- 세션 생성 + 찬성 1표")
+        void host_starts_vote() {
+            // Given
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+
+            // When
+            VoteSession session = gameVoteService.vote(ROOM_ID, HOST_ID, true);
+
+            // Then
+            assertThat(session).isNotNull();
+            assertThat(session.getAgreeCount()).isEqualTo(1);
+            assertThat(session.getTotalCount()).isEqualTo(3);
+            assertThat(session.getInitiatorId()).isEqualTo(HOST_ID);
+
+            verify(voteBroadcaster).broadcastStart(eq(ROOM_ID), eq(HOST_ID), eq(3), eq(15));
+            verify(voteBroadcaster).broadcastUpdate(eq(ROOM_ID), eq(1L), eq(0L), eq(3));
+        }
+    }
+
+    // === 투표 참여 성공 ===
+
+    @Nested
+    @DisplayName("투표 참여 성공")
+    class VoteCastSuccess {
+
+        @Test
+        @DisplayName("참가자가 찬성 투표")
+        void participant_votes_agree() {
+            // Given -- 먼저 방장이 투표 시작
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true);
+
+            // 참가자 mock 재설정
+            setupCommonMocks(room, USER_A);
+
+            // When
+            VoteSession session = gameVoteService.vote(ROOM_ID, USER_A, true);
+
+            // Then
+            assertThat(session.getAgreeCount()).isEqualTo(2);
+            assertThat(session.getDisagreeCount()).isEqualTo(0);
+        }
+
+        @Test
+        @DisplayName("참가자가 반대 투표")
+        void participant_votes_disagree() {
+            // Given
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true);
+
+            setupCommonMocks(room, USER_A);
+
+            // When
+            VoteSession session = gameVoteService.vote(ROOM_ID, USER_A, false);
+
+            // Then
+            assertThat(session.getAgreeCount()).isEqualTo(1);
+            assertThat(session.getDisagreeCount()).isEqualTo(1);
+        }
+    }
+
+    // === 과반수 도달 -> 턴 전환 ===
+
+    @Nested
+    @DisplayName("투표 판정")
+    class VoteResolve {
+
+        @Test
+        @DisplayName("과반수 찬성 -- 턴 전환 호출")
+        void majority_reached_advances_turn() {
+            // Given -- 3명 중 2명 찬성이면 과반수
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true); // 찬성 1
+
+            setupCommonMocks(room, USER_A);
+
+            // When -- 찬성 2 -> 과반수 도달
+            gameVoteService.vote(ROOM_ID, USER_A, true);
+
+            // Then
+            verify(voteBroadcaster).broadcastResult(eq(ROOM_ID), eq(true), eq(2L), eq(0L));
+            verify(turnAdvanceService).advanceTurn(ROOM_ID, HOST_ID);
+        }
+
+        @Test
+        @DisplayName("부결 확정 -- 턴 전환 안 함")
+        void rejection_certain_no_advance() {
+            // Given -- 3명 중 과반수 2명 필요. 방장은 무조건 찬성(1)
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true); // 찬성 1
+
+            setupCommonMocks(room, USER_A);
+            gameVoteService.vote(ROOM_ID, USER_A, false); // 반대 1
+
+            setupCommonMocks(room, USER_B);
+
+            // When -- 반대 2 -> 부결 확정 (찬성 1, 반대 2이므로 과반수 불가)
+            gameVoteService.vote(ROOM_ID, USER_B, false);
+
+            // Then
+            verify(voteBroadcaster).broadcastResult(eq(ROOM_ID), eq(false), eq(1L), eq(2L));
+            verify(turnAdvanceService, never()).advanceTurn(any(), any());
+        }
+    }
+
+    // === 실패 케이스 ===
+
+    @Nested
+    @DisplayName("투표 실패")
+    class VoteFail {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void room_not_found() {
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameVoteService.vote(ROOM_ID, HOST_ID, true))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("게임 미시작이면 GAME_NOT_STARTED")
+        void game_not_started() {
+            GameRoom room = createRoom(RoomStatus.WAITING);
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> gameVoteService.vote(ROOM_ID, HOST_ID, true))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("참가자가 아니면 ROOM_NOT_PARTICIPANT")
+        void not_participant() {
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, HOST_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameVoteService.vote(ROOM_ID, HOST_ID, true))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("방장 아닌 사람이 투표 시작 시 ROOM_NOT_HOST")
+        void non_host_starts_vote() {
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, USER_A);
+
+            assertThatThrownBy(() -> gameVoteService.vote(ROOM_ID, USER_A, true))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_HOST);
+        }
+
+        @Test
+        @DisplayName("중복 투표 시 VOTE_ALREADY_CAST")
+        void duplicate_vote() {
+            // Given
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(4);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true);
+
+            // 같은 사용자가 다시 투표
+            setupCommonMocks(room, HOST_ID, true);
+
+            // When & Then
+            assertThatThrownBy(() -> gameVoteService.vote(ROOM_ID, HOST_ID, true))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VOTE_ALREADY_CAST);
+        }
+
+        @Test
+        @DisplayName("완료된 투표에 투표 시도 시 ROOM_NOT_HOST")
+        void vote_after_completed() {
+            // Given -- 3명 방에서 과반수 2명, 방장 찬성 + USER_A 찬성 -> 종료
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true);
+
+            setupCommonMocks(room, USER_A);
+            gameVoteService.vote(ROOM_ID, USER_A, true); // 2/3 과반수 -> 종료
+
+            // 다른 참가자가 뒤늦게 투표 시도
+            setupCommonMocks(room, USER_B);
+
+            // When & Then -- 세션 제거됨 -> 새 투표 시작 시도 -> 방장 아님
+            assertThatThrownBy(() -> gameVoteService.vote(ROOM_ID, USER_B, true))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_HOST);
+        }
+    }
+
+    // === 방장 찬성 강제 ===
+
+    @Nested
+    @DisplayName("방장 투표 시작")
+    class HostVoteStart {
+
+        @Test
+        @DisplayName("방장이 agree:false로 시작해도 찬성으로 기록됨")
+        void host_agree_forced_true() {
+            // Given
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(4);
+
+            // When -- agree: false로 보내도
+            VoteSession session = gameVoteService.vote(ROOM_ID, HOST_ID, false);
+
+            // Then -- 찬성으로 기록
+            assertThat(session.getAgreeCount()).isEqualTo(1);
+            assertThat(session.getDisagreeCount()).isEqualTo(0);
+        }
+    }
+
+    // === 전원 투표 완료 ===
+
+    @Nested
+    @DisplayName("전원 투표 완료")
+    class AllVoted {
+
+        @Test
+        @DisplayName("전원 투표 완료 -- 찬성 미달 시 부결")
+        void all_voted_not_enough_agrees() {
+            // Given -- 3명 중 과반수 2명 필요. 방장 찬성 1 + 반대 2 -> 전원 투표 완료, 부결
+            GameRoom room = createRoom(RoomStatus.IN_PROGRESS);
+            setupCommonMocks(room, HOST_ID, true);
+            given(gameParticipantRepository.countByGameRoomAndStatus(
+                    eq(room), eq(ParticipantStatus.ACTIVE))).willReturn(3);
+            gameVoteService.vote(ROOM_ID, HOST_ID, true); // 찬성 1
+
+            setupCommonMocks(room, USER_A);
+            gameVoteService.vote(ROOM_ID, USER_A, false); // 반대 1
+
+            setupCommonMocks(room, USER_B);
+            gameVoteService.vote(ROOM_ID, USER_B, false); // 반대 2 -> 부결 확정 (2 > 3-2=1)
+
+            // Then
+            verify(voteBroadcaster).broadcastResult(eq(ROOM_ID), eq(false), eq(1L), eq(2L));
+            verify(turnAdvanceService, never()).advanceTurn(any(), any());
+        }
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/vote/service/GameVoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/vote/service/GameVoteServiceTest.java
@@ -11,6 +11,7 @@ import com.solv.wefin.domain.game.vote.VoteBroadcaster;
 import com.solv.wefin.domain.game.vote.VoteSession;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,6 +61,11 @@ class GameVoteServiceTest {
         gameVoteService = new GameVoteService(
                 gameRoomRepository, gameParticipantRepository,
                 turnAdvanceService, voteBroadcaster, voteScheduler);
+    }
+
+    @AfterEach
+    void tearDown() {
+        voteScheduler.shutdownNow();
     }
 
     private GameRoom createRoom(RoomStatus status) {


### PR DESCRIPTION
## 📌 PR 설명
<br>방장이 투표를 시작하면 자동으로 찬성 1표가 기록되고, 15초 타이머가 시작됩니다. 참가자들이 찬성/반대를 선택하면 실시간으로     
  WebSocket을 통해 투표 현황이 브로드캐스트되며, 과반수 찬성 시 즉시 턴이 전환됩니다. 과반수 도달이 불가능해진 시점에 부결이 확정되고, 타이머 만료 시 미투표자는 기권 처리됩니다.                                                                                                                                                
동시성 제어를 위해 ConcurrentHashMap으로 투표를 기록하고, AtomicBoolean의 compareAndSet으로 결과 확정이 정확히 1회만 실행되도록 보장했습니다. 세션 생성 시 computeIfAbsent를 사용해 동시 요청에 의한 중복 생성을 방지했습니다.

## ✅ 완료한 기능 명세

- [x] 참가자 찬 반 투표
- [x] 타임아웃 로직
- [x] 턴 넘기기 권환 위임
- [x] ws 예외처리
- [x] 에러코드 
- [x] 테스트코드


<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #222 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게임 라운드 전환을 위한 투표 시스템 추가(투표 세션 관리, 타임아웃, 다중 동시성 보호)
  * 실시간 WebSocket 브로드캐스트로 투표 시작/갱신/결과 전파
  * REST API로 투표 제출 지원 및 스케줄러 기반 타임아웃 처리

* **Bug Fixes**
  * 뉴스 배치 처리를 위한 별도 실행기 추가로 배치 충돌 방지
  * 주식 수집 시 시장 코드 매핑 로직 수정으로 불일치 해결

* **Tests**
  * 투표 서비스 동작을 검증하는 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->