### PR TITLE
[WEF-618] 프론트 연동 백엔드 API 수정/보완

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/order/dto/OrderSearchCondition.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/dto/OrderSearchCondition.java
@@ -1,11 +1,12 @@
 package com.solv.wefin.domain.trading.order.dto;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.solv.wefin.domain.trading.order.entity.OrderStatus;
 
 public record OrderSearchCondition(
-	OrderStatus status,
+	List<OrderStatus> statuses,
 	Long stockId,
 	LocalDate startDate,
 	LocalDate endDate

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryImpl.java
@@ -29,7 +29,7 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 			.selectFrom(order)
 			.where(
 				accountEq(virtualAccountId),
-				statusEq(condition.status()),
+				statusIn(condition.statuses()),
 				stockIdEq(condition.stockId()),
 				createdAtGoe(condition.startDate()),
 				createdAtLt(condition.endDate()),
@@ -74,8 +74,8 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 		return order.virtualAccountId.eq(virtualAccountId);
 	}
 
-	private BooleanExpression statusEq(OrderStatus status) {
-		return status != null ? order.status.eq(status) : null;
+	private BooleanExpression statusIn(List<OrderStatus> statuses) {
+		return (statuses != null && !statuses.isEmpty()) ? order.status.in(statuses) : null;
 	}
 
 	private BooleanExpression stockIdEq(Long stockId) {

--- a/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
@@ -60,8 +60,10 @@ public class OrderController {
 	public ApiResponse<OrderResponse> buy(@AuthenticationPrincipal UUID userId,
 										  @Valid @RequestBody OrderBuyRequest request) {
 		VirtualAccount account = accountService.getAccountByUserId(userId);
+		Stock stock = stockService.findByStockCode(request.stockCode())
+			.orElseThrow(() -> new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
 		OrderInfo orderInfo = orderService.buyMarket(account.getVirtualAccountId(),
-			request.stockId(), request.quantity());
+			stock.getId(), request.quantity());
 		OrderResponse response = OrderResponse.from(orderInfo);
 		return ApiResponse.success(response);
 	}
@@ -70,8 +72,10 @@ public class OrderController {
 	public ApiResponse<OrderResponse> sell(@AuthenticationPrincipal UUID userId,
 										   @Valid @RequestBody OrderSellRequest request) {
 		VirtualAccount account = accountService.getAccountByUserId(userId);
+		Stock stock = stockService.findByStockCode(request.stockCode())
+			.orElseThrow(() -> new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
 		OrderInfo orderInfo = orderService.sellMarket(account.getVirtualAccountId(),
-			request.stockId(), request.quantity());
+			stock.getId(), request.quantity());
 		OrderResponse response = OrderResponse.from(orderInfo);
 		return ApiResponse.success(response);
 	}
@@ -113,7 +117,7 @@ public class OrderController {
 	@GetMapping("/history")
 	public ApiResponse<CursorResponse<OrderHistoryResponse>> getOrderHistory(
 			@AuthenticationPrincipal UUID userId,
-			@RequestParam(required = false) OrderStatus status,
+			@RequestParam(required = false) List<OrderStatus> status,
 			@RequestParam(required = false) String stockCode,
 			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
 			@RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,

--- a/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/OrderController.java
@@ -60,7 +60,7 @@ public class OrderController {
 	public ApiResponse<OrderResponse> buy(@AuthenticationPrincipal UUID userId,
 										  @Valid @RequestBody OrderBuyRequest request) {
 		VirtualAccount account = accountService.getAccountByUserId(userId);
-		Stock stock = stockService.findByStockCode(request.stockCode())
+		Stock stock = stockService.findByStockCode(request.stockCode().strip())
 			.orElseThrow(() -> new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
 		OrderInfo orderInfo = orderService.buyMarket(account.getVirtualAccountId(),
 			stock.getId(), request.quantity());
@@ -72,7 +72,7 @@ public class OrderController {
 	public ApiResponse<OrderResponse> sell(@AuthenticationPrincipal UUID userId,
 										   @Valid @RequestBody OrderSellRequest request) {
 		VirtualAccount account = accountService.getAccountByUserId(userId);
-		Stock stock = stockService.findByStockCode(request.stockCode())
+		Stock stock = stockService.findByStockCode(request.stockCode().strip())
 			.orElseThrow(() -> new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
 		OrderInfo orderInfo = orderService.sellMarket(account.getVirtualAccountId(),
 			stock.getId(), request.quantity());

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/request/OrderBuyRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/request/OrderBuyRequest.java
@@ -1,10 +1,11 @@
 package com.solv.wefin.web.trading.order.dto.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record OrderBuyRequest(
-	@NotNull Long stockId,
+	@NotBlank String stockCode,
 	@NotNull @Min(1) Integer quantity
 ) {
 }

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/request/OrderSellRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/request/OrderSellRequest.java
@@ -1,10 +1,11 @@
 package com.solv.wefin.web.trading.order.dto.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record OrderSellRequest(
-	@NotNull Long stockId,
+	@NotBlank String stockCode,
 	@NotNull @Min(1) Integer quantity
 ) {
 }

--- a/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/order/OrderControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import com.solv.wefin.domain.trading.order.dto.OrderCancelInfo;
@@ -68,13 +69,15 @@ class OrderControllerTest {
 			new BigDecimal("178000"), new BigDecimal("9024854"),
 			BigDecimal.ZERO, BigDecimal.ZERO, new BigDecimal("9024854"));
 
+		Stock stock = mockStock(1L, "005930", "삼성전자");
+		given(stockService.findByStockCode("005930")).willReturn(Optional.of(stock));
 		given(orderService.buyMarket(anyLong(), anyLong(), anyInt()))
 			.willReturn(mockOrderInfo);
 
 		// when & then
 		mockMvc.perform(post("/api/order/buy")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"stockId\": 1, \"quantity\": 10}")
+				.content("{\"stockCode\": \"005930\", \"quantity\": 10}")
 				.with(csrf())
 				.with(authentication(
 					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())
@@ -94,13 +97,15 @@ class OrderControllerTest {
 			new BigDecimal("178000"), new BigDecimal("9013931"),
 			new BigDecimal("3204"), new BigDecimal("80000"), new BigDecimal("9024582"));
 
+		Stock stock = mockStock(1L, "005930", "삼성전자");
+		given(stockService.findByStockCode("005930")).willReturn(Optional.of(stock));
 		given(orderService.sellMarket(anyLong(), anyLong(), anyInt()))
 			.willReturn(mockOrderInfo);
 
 		// when & then
 		mockMvc.perform(post("/api/order/sell")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"stockId\": 1, \"quantity\": 10}")
+				.content("{\"stockCode\": \"005930\", \"quantity\": 10}")
 				.with(csrf())
 				.with(authentication(
 					new UsernamePasswordAuthenticationToken(testUserId, null, List.of())


### PR DESCRIPTION
 ## 📌 PR 설명
  프론트 연동 과정에서 발견된 백엔드 API 수정 사항 반영.

  <br>

  ## ✅ 완료한 기능 명세

  - [x] OrderBuyRequest/SellRequest — `stockId(Long)` → `stockCode(String)` 변경 + `@NotBlank` 검증
  - [x] OrderController buy/sell — stockCode → stockId 변환 로직 추가
  - [x] GET /api/order/history — status 파라미터 다중 값 지원 (`List<OrderStatus>`)
  - [x] OrderSearchCondition — `status` → `List<OrderStatus> statuses`
  - [x] OrderRepositoryImpl — `statusEq` → `statusIn` (QueryDSL `.in()`)
  - [x] OrderControllerTest — stockService stub 추가 + stockCode 기반 테스트

<br>

  ## 💭 고민과 해결과정

  ### 1. stockId → stockCode 변경
  프론트 URL이 `/stocks/:code` (예: 005930) 기반이라 주문 시 stockId(DB PK)를 모름. 실제 증권사 API도 종목코드 기반이 표준. 컨트롤러에서
  stockCode → stockId 변환 후 서비스에 전달하는 구조로 변경.

  ### 2. status 다중 값 지원
  주문내역 "미체결" 탭에서 PENDING + PARTIAL 두 상태를 한 번에 조회해야 함. `OrderStatus` 단일 → `List<OrderStatus>` 변경, QueryDSL `.eq()` →
  `.in()` 으로 변경.

  <br>

  ### 🔗 관련 이슈
  Closes #232

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 이력 조회 시 여러 주문 상태를 동시에 필터링 가능

* **개선 사항**
  * 주문 생성(매수/매도) 요청에서 종목 식별자를 숫자 ID에서 종목코드(예: 005930)로 변경
  * 종목코드 검증 및 존재 여부 확인 추가(존재하지 않을 경우 오류 반환)

* **테스트**
  * 주문 관련 API 테스트 요청 페이로드 및 모킹 갱신
<!-- end of auto-generated comment: release notes by coderabbit.ai -->