### PR TITLE
[WEF-625] 게임 랭킹 조회 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/snapshot/dto/RankingInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/dto/RankingInfo.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.game.snapshot.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record RankingInfo(
+        int rank,
+        UUID userId,
+        String userName,
+        BigDecimal totalAsset,
+        BigDecimal profitRate
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/repository/GamePortfolioSnapshotRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/repository/GamePortfolioSnapshotRepository.java
@@ -1,9 +1,13 @@
 package com.solv.wefin.domain.game.snapshot.repository;
 
 import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface GamePortfolioSnapshotRepository extends JpaRepository<GamePortfolioSnapshot, UUID> {
+
+    List<GamePortfolioSnapshot> findByTurnOrderByTotalAssetDesc(GameTurn turn);
 }

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/service/GameRankingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/service/GameRankingService.java
@@ -1,0 +1,128 @@
+package com.solv.wefin.domain.game.snapshot.service;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.dto.RankingInfo;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameRankingService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final GamePortfolioSnapshotRepository snapshotRepository;
+    private final UserRepository userRepository;
+
+    public List<RankingInfo> getRankings(UUID roomId, UUID userId) {
+
+        // 1. 방 조회 + 상태 검증
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() == RoomStatus.WAITING) {
+            throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
+        }
+
+        // 2. 참가자 검증
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        // 3. 최신 완료 턴의 스냅샷 조회
+        //    스냅샷은 턴 전환 시 "완료되는 턴"에 저장됨
+        //    → 완료 턴 중 turnNumber가 가장 큰 것 = 최신 스냅샷
+        List<GamePortfolioSnapshot> snapshots = gameTurnRepository
+                .findFirstByGameRoomAndStatusOrderByTurnNumberDesc(gameRoom, TurnStatus.COMPLETED)
+                .map(snapshotRepository::findByTurnOrderByTotalAssetDesc)
+                .orElse(List.of());
+
+        if (snapshots.isEmpty()) {
+            // 첫 턴: 스냅샷 없음 → 전원 seedMoney 동률
+            return buildInitialRankings(gameRoom);
+        }
+
+        // 4. 닉네임 일괄 조회
+        List<UUID> userIds = snapshots.stream()
+                .map(s -> s.getParticipant().getUserId())
+                .toList();
+
+        Map<UUID, String> nicknameMap = buildNicknameMap(userIds);
+
+        // 5. 순위 부여 — 동률(같은 totalAsset)이면 같은 순위 (1위, 1위, 3위)
+        List<RankingInfo> rankings = new ArrayList<>();
+        for (int i = 0; i < snapshots.size(); i++) {
+            GamePortfolioSnapshot s = snapshots.get(i);
+            int rank = (i == 0) ? 1
+                    : snapshots.get(i - 1).getTotalAsset().compareTo(s.getTotalAsset()) == 0
+                            ? rankings.get(i - 1).rank()
+                            : i + 1;
+
+            rankings.add(new RankingInfo(
+                    rank,
+                    s.getParticipant().getUserId(),
+                    nicknameMap.getOrDefault(s.getParticipant().getUserId(), "알 수 없음"),
+                    s.getTotalAsset(),
+                    s.getProfitRate()));
+        }
+
+        return rankings;
+    }
+
+    /**
+     * 첫 턴: 스냅샷이 없으므로 전원 seedMoney 기준 동률 랭킹 생성.
+     */
+    private List<RankingInfo> buildInitialRankings(GameRoom gameRoom) {
+        List<GameParticipant> participants = gameParticipantRepository
+                .findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+
+        List<UUID> userIds = participants.stream()
+                .map(GameParticipant::getUserId)
+                .toList();
+
+        Map<UUID, String> nicknameMap = buildNicknameMap(userIds);
+
+        BigDecimal seedMoney = gameRoom.getSeed();
+        AtomicInteger rankCounter = new AtomicInteger(1);
+
+        return participants.stream()
+                .map(p -> new RankingInfo(
+                        rankCounter.getAndIncrement(),
+                        p.getUserId(),
+                        nicknameMap.getOrDefault(p.getUserId(), "알 수 없음"),
+                        seedMoney,
+                        BigDecimal.ZERO))
+                .toList();
+    }
+
+    private Map<UUID, String> buildNicknameMap(List<UUID> userIds) {
+        return userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(
+                        user -> user.getUserId(),
+                        user -> user.getNickname()
+                ));
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/service/GameRankingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/service/GameRankingService.java
@@ -23,7 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 @Service
@@ -106,11 +105,10 @@ public class GameRankingService {
         Map<UUID, String> nicknameMap = buildNicknameMap(userIds);
 
         BigDecimal seedMoney = gameRoom.getSeed();
-        AtomicInteger rankCounter = new AtomicInteger(1);
 
         return participants.stream()
                 .map(p -> new RankingInfo(
-                        rankCounter.getAndIncrement(),
+                        1,
                         p.getUserId(),
                         nicknameMap.getOrDefault(p.getUserId(), "알 수 없음"),
                         seedMoney,

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -12,5 +12,5 @@ public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
 
     Optional<GameTurn> findByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
 
-
+    Optional<GameTurn> findFirstByGameRoomAndStatusOrderByTurnNumberDesc(GameRoom gameRoom, TurnStatus status);
 }

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -75,21 +75,26 @@ public class TurnAdvanceService {
         GameTurn currentTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
-        // 4. 모든 활성 참가자의 보유종목 평가 + 스냅샷 저장
+        // 4. 다음 거래일 계산
+        LocalDate nextDate = calculateNextTradeDate(currentTurn.getTurnDate(), gameRoom.getMoveDays());
+        boolean isGameOver = nextDate.isAfter(gameRoom.getEndDate());
+
+        // 5. 모든 활성 참가자의 보유종목 평가 + 스냅샷 저장
+        //    게임 종료 시: 현재 턴 종가 기준 (마지막 턴의 최종 자산)
+        //    계속 진행 시: 다음 턴 종가 기준 (다음 턴 시작 시점 총자산)
+        LocalDate evaluationDate = isGameOver ? currentTurn.getTurnDate() : nextDate;
+
         List<GameParticipant> activeParticipants =
                 gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
 
         List<GamePortfolioSnapshot> snapshots =
-                saveSnapshotsForAll(currentTurn, activeParticipants, gameRoom.getSeed());
+                saveSnapshotsForAll(currentTurn, activeParticipants, gameRoom.getSeed(), evaluationDate);
 
-        // 5. 현재 턴 완료 처리
+        // 6. 현재 턴 완료 처리
         currentTurn.complete();
 
-        // 6. 다음 거래일 계산
-        LocalDate nextDate = calculateNextTradeDate(currentTurn.getTurnDate(), gameRoom.getMoveDays());
-
-        // 7. 종료 판단: 다음 날짜가 endDate 초과 시 게임 종료
-        if (nextDate.isAfter(gameRoom.getEndDate())) {
+        // 7. 종료 판단
+        if (isGameOver) {
             gameRoom.finish();
             log.info("[턴 전환] 게임 종료: roomId={}, 마지막 턴={}", roomId, currentTurn.getTurnNumber());
             return null;
@@ -127,15 +132,15 @@ public class TurnAdvanceService {
      */
     private List<GamePortfolioSnapshot> saveSnapshotsForAll(GameTurn turn,
                                                              List<GameParticipant> participants,
-                                                             BigDecimal seedMoney) {
-        LocalDate turnDate = turn.getTurnDate();
+                                                             BigDecimal seedMoney,
+                                                             LocalDate evaluationDate) {
         List<GamePortfolioSnapshot> savedSnapshots = new ArrayList<>();
 
         for (GameParticipant participant : participants) {
             List<GameHolding> holdings =
                     gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0);
 
-            BigDecimal stockValue = evaluateHoldings(holdings, turnDate);
+            BigDecimal stockValue = evaluateHoldings(holdings, evaluationDate);
 
             GamePortfolioSnapshot snapshot = GamePortfolioSnapshot.create(
                     turn, participant, participant.getSeed(), stockValue, seedMoney);

--- a/src/main/java/com/solv/wefin/web/game/ranking/GameRankingController.java
+++ b/src/main/java/com/solv/wefin/web/game/ranking/GameRankingController.java
@@ -1,0 +1,35 @@
+package com.solv.wefin.web.game.ranking;
+
+import com.solv.wefin.domain.game.snapshot.service.GameRankingService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.ranking.dto.response.RankingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/rooms/{roomId}")
+@RequiredArgsConstructor
+public class GameRankingController {
+
+    private final GameRankingService rankingService;
+
+    @GetMapping("/rankings")
+    public ResponseEntity<ApiResponse<List<RankingResponse>>> getRankings(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        List<RankingResponse> response = rankingService.getRankings(roomId, userId).stream()
+                .map(RankingResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/ranking/dto/response/RankingResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/ranking/dto/response/RankingResponse.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.web.game.ranking.dto.response;
+
+import com.solv.wefin.domain.game.snapshot.dto.RankingInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class RankingResponse {
+
+    private int rank;
+    private UUID userId;
+    private String userName;
+    private BigDecimal totalAsset;
+    private BigDecimal profitRate;
+
+    public static RankingResponse from(RankingInfo info) {
+        return new RankingResponse(
+                info.rank(),
+                info.userId(),
+                info.userName(),
+                info.totalAsset(),
+                info.profitRate()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/snapshot/service/GameRankingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/snapshot/service/GameRankingServiceTest.java
@@ -95,6 +95,7 @@ class GameRankingServiceTest {
             // Then
             assertThat(rankings).hasSize(2);
             assertThat(rankings).allSatisfy(r -> {
+                assertThat(r.rank()).isEqualTo(1);
                 assertThat(r.totalAsset()).isEqualByComparingTo(SEED);
                 assertThat(r.profitRate()).isEqualByComparingTo(BigDecimal.ZERO);
             });

--- a/src/test/java/com/solv/wefin/domain/game/snapshot/service/GameRankingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/snapshot/service/GameRankingServiceTest.java
@@ -1,0 +1,311 @@
+package com.solv.wefin.domain.game.snapshot.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.dto.RankingInfo;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.entity.TurnStatus;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class GameRankingServiceTest {
+
+    @InjectMocks
+    private GameRankingService rankingService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+    @Mock
+    private GamePortfolioSnapshotRepository snapshotRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private static final UUID ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID USER_A = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final UUID USER_B = UUID.fromString("00000000-0000-4000-a000-000000000003");
+    private static final UUID USER_C = UUID.fromString("00000000-0000-4000-a000-000000000004");
+    private static final Long GROUP_ID = 1L;
+    private static final LocalDate START_DATE = LocalDate.of(2022, 3, 2);
+    private static final BigDecimal SEED = new BigDecimal("10000000");
+
+    // === 성공 테스트 ===
+
+    @Nested
+    @DisplayName("랭킹 조회 성공")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("첫 턴 — 스냅샷 없음, 전원 동률")
+        void firstTurn_allEqual() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameTurnRepository.findFirstByGameRoomAndStatusOrderByTurnNumberDesc(room, TurnStatus.COMPLETED))
+                    .willReturn(Optional.empty());
+            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                    .willReturn(List.of(participantA, participantB));
+
+            User userA = mockUser(USER_A, "재훈");
+            User userB = mockUser(USER_B, "길동");
+            given(userRepository.findAllById(List.of(USER_A, USER_B)))
+                    .willReturn(List.of(userA, userB));
+
+            // When
+            List<RankingInfo> rankings = rankingService.getRankings(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(rankings).hasSize(2);
+            assertThat(rankings).allSatisfy(r -> {
+                assertThat(r.totalAsset()).isEqualByComparingTo(SEED);
+                assertThat(r.profitRate()).isEqualByComparingTo(BigDecimal.ZERO);
+            });
+        }
+
+        @Test
+        @DisplayName("턴 전환 후 — 스냅샷 기준 순위 부여")
+        void afterTurnAdvance_rankedByTotalAsset() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+            GameParticipant participantC = GameParticipant.createMember(room, USER_C);
+
+            GameTurn completedTurn = GameTurn.createFirst(room);
+
+            // 스냅샷: B > C > A 순서 (totalAsset DESC로 정렬된 상태)
+            GamePortfolioSnapshot snapB = GamePortfolioSnapshot.create(
+                    completedTurn, participantB, new BigDecimal("5000000"),
+                    new BigDecimal("6500000"), SEED);
+            GamePortfolioSnapshot snapC = GamePortfolioSnapshot.create(
+                    completedTurn, participantC, new BigDecimal("7000000"),
+                    new BigDecimal("3000000"), SEED);
+            GamePortfolioSnapshot snapA = GamePortfolioSnapshot.create(
+                    completedTurn, participantA, new BigDecimal("8000000"),
+                    new BigDecimal("1000000"), SEED);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameTurnRepository.findFirstByGameRoomAndStatusOrderByTurnNumberDesc(room, TurnStatus.COMPLETED))
+                    .willReturn(Optional.of(completedTurn));
+            given(snapshotRepository.findByTurnOrderByTotalAssetDesc(completedTurn))
+                    .willReturn(List.of(snapB, snapC, snapA));
+
+            User userA = mockUser(USER_A, "재훈");
+            User userB = mockUser(USER_B, "길동");
+            User userC = mockUser(USER_C, "철수");
+            given(userRepository.findAllById(any()))
+                    .willReturn(List.of(userA, userB, userC));
+
+            // When
+            List<RankingInfo> rankings = rankingService.getRankings(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(rankings).hasSize(3);
+
+            // 1위: B (totalAsset = 11,500,000)
+            assertThat(rankings.get(0).rank()).isEqualTo(1);
+            assertThat(rankings.get(0).userName()).isEqualTo("길동");
+            assertThat(rankings.get(0).totalAsset()).isEqualByComparingTo(new BigDecimal("11500000"));
+
+            // 2위: C (totalAsset = 10,000,000)
+            assertThat(rankings.get(1).rank()).isEqualTo(2);
+            assertThat(rankings.get(1).userName()).isEqualTo("철수");
+
+            // 3위: A (totalAsset = 9,000,000)
+            assertThat(rankings.get(2).rank()).isEqualTo(3);
+            assertThat(rankings.get(2).userName()).isEqualTo("재훈");
+        }
+
+        @Test
+        @DisplayName("동률 처리 — 같은 totalAsset이면 같은 순위 (1위, 1위, 3위)")
+        void tieBreaking_sameTotalAsset_sameRank() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+            GameParticipant participantC = GameParticipant.createMember(room, USER_C);
+
+            GameTurn completedTurn = GameTurn.createFirst(room);
+
+            // A와 B가 동일 totalAsset, C는 낮음
+            // create(turn, participant, stockValue, cash, seed)
+            // totalAsset = stockValue + cash
+            GamePortfolioSnapshot snapA = GamePortfolioSnapshot.create(
+                    completedTurn, participantA, new BigDecimal("6000000"),
+                    new BigDecimal("5000000"), SEED);  // total = 11,000,000
+            GamePortfolioSnapshot snapB = GamePortfolioSnapshot.create(
+                    completedTurn, participantB, new BigDecimal("4000000"),
+                    new BigDecimal("7000000"), SEED);  // total = 11,000,000
+            GamePortfolioSnapshot snapC = GamePortfolioSnapshot.create(
+                    completedTurn, participantC, new BigDecimal("3000000"),
+                    new BigDecimal("5000000"), SEED);  // total = 8,000,000
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameTurnRepository.findFirstByGameRoomAndStatusOrderByTurnNumberDesc(room, TurnStatus.COMPLETED))
+                    .willReturn(Optional.of(completedTurn));
+            given(snapshotRepository.findByTurnOrderByTotalAssetDesc(completedTurn))
+                    .willReturn(List.of(snapA, snapB, snapC));  // DESC 정렬: A=B > C
+
+            User userA = mockUser(USER_A, "재훈");
+            User userB = mockUser(USER_B, "길동");
+            User userC = mockUser(USER_C, "철수");
+            given(userRepository.findAllById(any()))
+                    .willReturn(List.of(userA, userB, userC));
+
+            // When
+            List<RankingInfo> rankings = rankingService.getRankings(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(rankings).hasSize(3);
+
+            // 1위: A (totalAsset = 11,000,000)
+            assertThat(rankings.get(0).rank()).isEqualTo(1);
+            assertThat(rankings.get(0).totalAsset()).isEqualByComparingTo(new BigDecimal("11000000"));
+
+            // 1위: B (totalAsset = 11,000,000 — 동률)
+            assertThat(rankings.get(1).rank()).isEqualTo(1);
+            assertThat(rankings.get(1).totalAsset()).isEqualByComparingTo(new BigDecimal("11000000"));
+
+            // 3위: C (totalAsset = 8,000,000 — 1위가 2명이므로 3위)
+            assertThat(rankings.get(2).rank()).isEqualTo(3);
+            assertThat(rankings.get(2).totalAsset()).isEqualByComparingTo(new BigDecimal("8000000"));
+        }
+
+        @Test
+        @DisplayName("게임 종료(FINISHED) 상태에서도 랭킹 조회 가능")
+        void finishedRoom_canQueryRankings() {
+            // Given
+            GameRoom room = createStartedRoom();
+            room.finish();  // FINISHED 상태
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+
+            GameTurn completedTurn = GameTurn.createFirst(room);
+            GamePortfolioSnapshot snapA = GamePortfolioSnapshot.create(
+                    completedTurn, participantA, new BigDecimal("5000000"),
+                    new BigDecimal("5000000"), SEED);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameTurnRepository.findFirstByGameRoomAndStatusOrderByTurnNumberDesc(room, TurnStatus.COMPLETED))
+                    .willReturn(Optional.of(completedTurn));
+            given(snapshotRepository.findByTurnOrderByTotalAssetDesc(completedTurn))
+                    .willReturn(List.of(snapA));
+
+            User userA = mockUser(USER_A, "재훈");
+            given(userRepository.findAllById(any())).willReturn(List.of(userA));
+
+            // When
+            List<RankingInfo> rankings = rankingService.getRankings(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(rankings).hasSize(1);
+            assertThat(rankings.get(0).rank()).isEqualTo(1);
+            assertThat(rankings.get(0).userName()).isEqualTo("재훈");
+        }
+    }
+
+    // === 실패 테스트 ===
+
+    @Nested
+    @DisplayName("랭킹 조회 실패")
+    class FailTests {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void roomNotFound() {
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> rankingService.getRankings(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("게임 미시작이면 GAME_NOT_STARTED")
+        void gameNotStarted() {
+            GameRoom room = createWaitingRoom();
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> rankingService.getRankings(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("참가자가 아니면 ROOM_NOT_PARTICIPANT")
+        void notParticipant() {
+            GameRoom room = createStartedRoom();
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> rankingService.getRankings(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createStartedRoom() {
+        GameRoom room = GameRoom.create(GROUP_ID, USER_A, SEED,
+                6, 7, START_DATE, START_DATE.plusMonths(6));
+        room.start();
+        return room;
+    }
+
+    private GameRoom createWaitingRoom() {
+        return GameRoom.create(GROUP_ID, USER_A, SEED,
+                6, 7, START_DATE, START_DATE.plusMonths(6));
+    }
+
+    private User mockUser(UUID userId, String nickname) {
+        User user = mock(User.class);
+        given(user.getUserId()).willReturn(userId);
+        given(user.getNickname()).willReturn(nickname);
+        return user;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
@@ -145,7 +145,8 @@ class TurnAdvanceServiceTest {
             setupCommonMocks(room, currentTurn, participant);
             given(gameHoldingRepository.findAllByParticipantAndQuantityGreaterThan(participant, 0))
                     .willReturn(List.of(holding));
-            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(stockInfo), START_DATE))
+            // 스냅샷은 다음 턴 종가 기준으로 평가하므로 nextTradeDate로 stub
+            given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(stockInfo), nextTradeDate))
                     .willReturn(List.of(daily));
             given(stockDailyRepository.findLatestTradeDateOnOrBefore(START_DATE.plusDays(7)))
                     .willReturn(Optional.of(nextTradeDate));


### PR DESCRIPTION
## 📌 PR 설명
<br>게임방 참가자들의 수익률 랭킹을 조회하는 API를 구현했습니다. 최신 턴의 스냅샷을 기반으로 총자산·수익률을 계산하고, 동일 수익률일 경우 같은 순위를 부여합니다(ex 1,1,3). 

## ✅ 완료한 기능 명세

- [x] 랭킹조회 api
- [x] 턴 전환 시 ws로 차트 랭킹 갱신
- [x] 테스트 코드

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #237 
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게임 랭킹 조회 기능 추가: `/api/rooms/{roomId}/rankings` 엔드포인트로 참가자 순위 조회 가능(순위, 사용자명, 총 자산, 수익률 포함)
  * 첫 회차(스냅샷 없음)에는 참가자 초기 자산(시드)으로 랭킹 생성
  * 동일 자산 보유 시 같은 순위 부여, 다음 순위는 건너뜀
  * 닉네임 미확인 시 기본 표시값 제공

* **Tests**
  * 게임 랭킹 서비스 단위 테스트 추가(성공/실패/동점 처리 등)
  * 턴 진행 서비스 테스트 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->