### PR TITLE
[WEF-530] 사용자 관심사 기반 맞춤 동향 캐싱 및 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/interest/service/InterestService.java
+++ b/src/main/java/com/solv/wefin/domain/interest/service/InterestService.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.interest.service;
 
 import com.solv.wefin.domain.interest.dto.InterestInfo;
+import com.solv.wefin.domain.market.trend.service.UserMarketTrendCacheService;
 import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
 import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
@@ -39,7 +40,9 @@ public class InterestService {
     private final UserInterestRepository userInterestRepository;
     private final NewsArticleTagRepository newsArticleTagRepository;
     private final ManualInterestLockService manualInterestLockService;
+    private final UserMarketTrendCacheService userMarketTrendCacheService;
 
+    @Transactional(readOnly = true)
     public List<InterestInfo> list(UUID userId, InterestType type) {
         assertSectorOrTopic(type);
 
@@ -87,6 +90,8 @@ public class InterestService {
         }
 
         userInterestRepository.save(UserInterest.createManual(userId, type.name(), code, ADD_WEIGHT));
+        // 관심사 변경 시 맞춤 동향 캐시 무효화 → 다음 personalized 호출이 새 관심사로 AI 재호출
+        userMarketTrendCacheService.invalidateToday(userId);
     }
 
     @Transactional
@@ -97,6 +102,7 @@ public class InterestService {
         userInterestRepository
                 .deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
                         userId, type.name(), code);
+        userMarketTrendCacheService.invalidateToday(userId);
     }
 
     private void assertSectorOrTopic(InterestType type) {

--- a/src/main/java/com/solv/wefin/domain/market/trend/client/OpenAiMarketTrendClient.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/client/OpenAiMarketTrendClient.java
@@ -31,6 +31,12 @@ public class OpenAiMarketTrendClient {
     public static final int MAX_TAGS_IN_PROMPT = 10;
     /** 인사이트 카드 요구 개수 (고정) */
     public static final int REQUIRED_INSIGHT_CARDS = 4;
+    /** personalized 카드 본문 최대 길이 (overview는 100~200자라 별도) */
+    public static final int PERSONALIZED_BODY_MAX_LENGTH = 80;
+    /** personalized 카드 조언 박스 최대 길이 */
+    public static final int PERSONALIZED_ADVICE_MAX_LENGTH = 100;
+    /** personalized 카드 조언 라벨 화이트리스트 (백엔드가 한국어 문자열로 반환) */
+    public static final List<String> PERSONALIZED_ADVICE_LABELS = List.of("오늘의 제안", "투자 힌트");
 
     private final RestClient restClient;
     private final OpenAiProperties properties;
@@ -101,6 +107,118 @@ public class OpenAiMarketTrendClient {
         return parse(content);
     }
 
+    /**
+     * 사용자 관심사 기반 맞춤 금융 동향을 생성한다.
+     *
+     * overview와 달리 title은 생성하지 않고 (그라데이션 박스 헤더는 프론트 고정), 대신
+     * 카드별 advice/adviceLabel("오늘의 제안" / "투자 힌트")을 추가로 채워 5개 텍스트 블록
+     * (summary + 4 cards 각각의 body/advice)을 한 번의 호출로 반환한다
+     */
+    public PersonalizedTrendRawResult generatePersonalizedTrend(
+            List<MarketSnapshot> snapshots,
+            List<ClusterSummary> clusterSummaries,
+            List<String> risingStocks,
+            List<String> risingTopics,
+            List<String> interestStockNames,
+            List<String> interestSectorNames,
+            List<String> interestTopicNames) {
+        String userMessage = buildPersonalizedUserMessage(snapshots, clusterSummaries,
+                risingStocks, risingTopics,
+                interestStockNames, interestSectorNames, interestTopicNames);
+
+        ChatRequest request = new ChatRequest(
+                properties.getModel(),
+                List.of(
+                        new ChatRequest.Message("system", PERSONALIZED_SYSTEM_PROMPT),
+                        new ChatRequest.Message("user", userMessage)
+                ),
+                properties.getMaxTokens(),
+                properties.getTemperature(),
+                new ChatRequest.ResponseFormat("json_object")
+        );
+
+        ChatResponse response;
+        try {
+            response = restClient.post()
+                    .uri("/v1/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(ChatResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new MarketTrendAiException(
+                    "OpenAI Personalized Market Trend API HTTP 오류: " + e.getStatusCode(), e);
+        } catch (Exception e) {
+            throw new MarketTrendAiException(
+                    "OpenAI Personalized Market Trend API 호출 실패: " + e.getMessage(), e);
+        }
+
+        if (response == null || response.choices() == null || response.choices().isEmpty()) {
+            throw new MarketTrendAiException("OpenAI Personalized Market Trend 응답이 비어있습니다", null);
+        }
+        ChatResponse.Choice choice = response.choices().get(0);
+        if (choice == null || choice.message() == null) {
+            throw new MarketTrendAiException("OpenAI Personalized Market Trend message 누락", null);
+        }
+        String content = choice.message().content();
+        if (content == null || content.isBlank()) {
+            throw new MarketTrendAiException("OpenAI Personalized Market Trend content 비어있음", null);
+        }
+        return parsePersonalized(content);
+    }
+
+    /**
+     * 사용자 관심사와 매칭된 뉴스가 0건일 때 사용하는 시장 액션 브리핑
+     *
+     * 관심사 컨텍스트는 빼고, 오늘 시장 지표 + 일반 24시간 클러스터를 기반으로 일반 투자자가
+     * 어떤 액션을 취하면 좋을지를 카드별 advice로 제공한다.
+     */
+    public PersonalizedTrendRawResult generateMarketActionBriefing(
+            List<MarketSnapshot> snapshots,
+            List<ClusterSummary> clusterSummaries,
+            List<String> risingStocks,
+            List<String> risingTopics) {
+        String userMessage = buildUserMessage(snapshots, clusterSummaries, risingStocks, risingTopics);
+
+        ChatRequest request = new ChatRequest(
+                properties.getModel(),
+                List.of(
+                        new ChatRequest.Message("system", MARKET_ACTION_SYSTEM_PROMPT),
+                        new ChatRequest.Message("user", userMessage)
+                ),
+                properties.getMaxTokens(),
+                properties.getTemperature(),
+                new ChatRequest.ResponseFormat("json_object")
+        );
+
+        ChatResponse response;
+        try {
+            response = restClient.post()
+                    .uri("/v1/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(ChatResponse.class);
+        } catch (RestClientResponseException e) {
+            throw new MarketTrendAiException(
+                    "OpenAI Market Action Briefing HTTP 오류: " + e.getStatusCode(), e);
+        } catch (Exception e) {
+            throw new MarketTrendAiException(
+                    "OpenAI Market Action Briefing 호출 실패: " + e.getMessage(), e);
+        }
+
+        if (response == null || response.choices() == null || response.choices().isEmpty()) {
+            throw new MarketTrendAiException("OpenAI Market Action Briefing 응답이 비어있습니다", null);
+        }
+        ChatResponse.Choice choice = response.choices().get(0);
+        if (choice == null || choice.message() == null) {
+            throw new MarketTrendAiException("OpenAI Market Action Briefing message 누락", null);
+        }
+        String content = choice.message().content();
+        if (content == null || content.isBlank()) {
+            throw new MarketTrendAiException("OpenAI Market Action Briefing content 비어있음", null);
+        }
+        return parsePersonalized(content);
+    }
+
     private String buildUserMessage(List<MarketSnapshot> snapshots,
                                     List<ClusterSummary> clusterSummaries,
                                     List<String> risingStocks,
@@ -136,6 +254,55 @@ public class OpenAiMarketTrendClient {
         return sb.toString();
     }
 
+    private String buildPersonalizedUserMessage(List<MarketSnapshot> snapshots,
+                                                List<ClusterSummary> clusterSummaries,
+                                                List<String> risingStocks,
+                                                List<String> risingTopics,
+                                                List<String> interestStockNames,
+                                                List<String> interestSectorNames,
+                                                List<String> interestTopicNames) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("### 사용자 관심 종목\n");
+        sb.append(joinOrPlaceholder(interestStockNames));
+        sb.append("\n\n### 사용자 관심 분야\n");
+        sb.append(joinOrPlaceholder(interestSectorNames));
+        sb.append("\n\n### 사용자 관심 주제\n");
+        sb.append(joinOrPlaceholder(interestTopicNames));
+
+        sb.append("\n\n### 시장 지표\n");
+        for (MarketSnapshot s : snapshots) {
+            sb.append("- ").append(s.getLabel()).append(": ").append(s.getValue());
+            if (s.getChangeRate() != null) {
+                sb.append(" (").append(s.getChangeDirection()).append(" ").append(s.getChangeRate()).append("%)");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("\n### 사용자 관심사와 매칭된 최근 24시간 뉴스 클러스터\n");
+        int limit = Math.min(clusterSummaries.size(), MAX_CLUSTERS_IN_PROMPT);
+        for (int i = 0; i < limit; i++) {
+            ClusterSummary c = clusterSummaries.get(i);
+            sb.append("[").append(i + 1).append("] ").append(c.title());
+            if (c.summary() != null && !c.summary().isBlank()) {
+                sb.append("\n    요약: ").append(c.summary());
+            }
+            sb.append("\n");
+        }
+
+        sb.append("\n### 떠오르는 종목 (관심사 매칭 클러스터 기준)\n");
+        sb.append(truncate(risingStocks, MAX_TAGS_IN_PROMPT).stream().collect(Collectors.joining(", ")));
+        sb.append("\n\n### 떠오르는 주제 (관심사 매칭 클러스터 기준)\n");
+        sb.append(truncate(risingTopics, MAX_TAGS_IN_PROMPT).stream().collect(Collectors.joining(", ")));
+
+        return sb.toString();
+    }
+
+    private static String joinOrPlaceholder(List<String> names) {
+        if (names == null || names.isEmpty()) return "(없음)";
+        return String.join(", ", names);
+    }
+
     private static <T> List<T> truncate(List<T> list, int n) {
         if (list == null) return List.of();
         return list.size() <= n ? list : list.subList(0, n);
@@ -167,6 +334,36 @@ public class OpenAiMarketTrendClient {
             );
         } catch (JsonProcessingException e) {
             throw new MarketTrendAiException("Market Trend JSON 파싱 실패: " + e.getOriginalMessage(), e);
+        }
+    }
+
+    private PersonalizedTrendRawResult parsePersonalized(String json) {
+        try {
+            PersonalizedRawResponse raw = objectMapper.readValue(json, PersonalizedRawResponse.class);
+            if (raw == null) {
+                throw new MarketTrendAiException("Personalized Market Trend JSON이 비어있습니다", null);
+            }
+
+            List<PersonalizedInsightCardRaw> rawCards = raw.insightCards() != null ? raw.insightCards() : List.of();
+            List<PersonalizedParsedCard> parsedCards = new ArrayList<>();
+            for (PersonalizedInsightCardRaw c : rawCards) {
+                if (c == null) continue;
+                parsedCards.add(new PersonalizedParsedCard(
+                        c.headline(),
+                        c.body(),
+                        c.advice(),
+                        c.adviceLabel(),
+                        c.relatedClusterIndices() != null ? c.relatedClusterIndices() : List.of()
+                ));
+            }
+
+            return new PersonalizedTrendRawResult(
+                    raw.summary(),
+                    parsedCards,
+                    raw.relatedKeywords() != null ? raw.relatedKeywords() : List.of()
+            );
+        } catch (JsonProcessingException e) {
+            throw new MarketTrendAiException("Personalized Market Trend JSON 파싱 실패: " + e.getOriginalMessage(), e);
         }
     }
 
@@ -205,6 +402,104 @@ public class OpenAiMarketTrendClient {
             }
             """.formatted(REQUIRED_INSIGHT_CARDS);
 
+    private static final String PERSONALIZED_SYSTEM_PROMPT = """
+            당신은 한국 금융시장 전문 애널리스트로, 특정 사용자에게 맞춤형 동향과 조언을 제공합니다.
+            주어진 사용자의 관심 종목/분야/주제, 시장 지표, 그리고 관심사와 매칭된 최근 24시간 뉴스 클러스터를
+            바탕으로 사용자 관점의 시장 분석과 카드별 조언을 작성합니다.
+
+            작성 규칙:
+            1. summary: 3~4문단 사용자 맞춤 시장 분석 (300~600자)
+               - 어투는 2인칭 ("보유 중인 ...", "관심 분야인 ..." 등)
+               - 사용자 관심사를 본문에 명시적으로 인용
+               - 시장 지표 변동과 관심사를 연결해 설명
+            2. insightCards: 정확히 %d개. 각 카드는 사용자 관심사에 직접 연관된 주제만 다룬다.
+               각 카드 필드:
+               - headline: 20자 내외, "요새 X가 ~ 있어요" 같은 친근한 문체
+               - body: %d자 이내, 본문 분석. 구체적 수치/기업명/이슈 인용
+               - advice: 60~%d자, **구체적 행동 시사점**. 다음 4요소 중 2개 이상 포함:
+                 (a) 어떤 종목/섹터/지표를 봐야 하는지 (이름 명시)
+                 (b) 어떤 조건이 충족되면 어떤 신호로 해석해야 하는지
+                 (c) 어떤 리스크/체크포인트가 있는지 (구체)
+                 (d) 단기/중기 등 시간 프레임
+                 ❌ 나쁜 예: "관련 종목의 흐름을 고려해 보세요."
+                 ✅ 좋은 예: "보유 중인 삼성전자는 외국인 5거래일 연속 매수가 이어지면 단기 저항선 돌파 가능성. HBM 수요 둔화 지표는 매주 점검 필요."
+               - adviceLabel: "오늘의 제안" 또는 "투자 힌트" 중 하나만 사용
+                 * "오늘의 제안" — 호재/긍정 흐름 → 비중 확대 검토 등
+                 * "투자 힌트" — 변동성/주의 흐름 → 단기 조정 대비 등
+               - relatedClusterIndices: 입력 "매칭 클러스터" 번호 (1-based)
+            3. relatedKeywords: 사용자 관심사와 직접 관련된 핵심 키워드 5~10개 (한글, 중복 없음)
+
+            주의사항:
+            - 입력에 없는 사실/수치를 만들지 말 것
+            - 매수/매도 직접 권유 금지 — "비중 확대 검토", "분할 매수 시점 점검", "익절 라인 조정" 같은 분석 표현 사용
+            - 관심사와 무관한 종목/섹터를 카드 주제로 삼지 말 것
+            - advice는 일반론(예: "전략을 점검해 보세요") 금지. 반드시 구체적 신호/체크포인트/지표명을 포함
+
+            반드시 아래 JSON 형식으로만 응답:
+            {
+              "summary": "...",
+              "insightCards": [
+                {
+                  "headline": "...",
+                  "body": "...",
+                  "advice": "...",
+                  "adviceLabel": "오늘의 제안",
+                  "relatedClusterIndices": [1, 3]
+                }
+              ],
+              "relatedKeywords": ["...", "..."]
+            }
+            """.formatted(REQUIRED_INSIGHT_CARDS, PERSONALIZED_BODY_MAX_LENGTH, PERSONALIZED_ADVICE_MAX_LENGTH);
+
+    private static final String MARKET_ACTION_SYSTEM_PROMPT = """
+            당신은 한국 금융시장 전문 애널리스트입니다. 주어진 시장 지표와 최근 24시간 주요 뉴스 클러스터를
+            종합해 오늘 시장 흐름과 일반 투자자가 고려할 만한 액션을 카드별로 제안합니다.
+            (사용자의 개별 관심사 정보는 입력되지 않습니다 — 일반 시장 관점에서만 작성하세요)
+
+            작성 규칙:
+            1. summary: 3~4문단 오늘 시장 요약 (300~600자)
+               - 시장 지표 변동의 핵심 원인과 의미를 해석
+               - "오늘 시장이 이러하니 이런 흐름에 주목하세요" 식으로 액션 시사점 명시
+               - 어투는 분석가 톤 (3인칭, 정중)
+            2. insightCards: 정확히 %d개. 카드는 서로 다른 액션 테마를 다룬다
+               (예: 환율 흐름 대응 / 금리 시사점 / 호재 섹터 진입 검토 / 위험 회피 신호 등)
+               각 카드 필드:
+               - headline: 20자 내외, 액션 지향 ("환율 약세, 수출주에 우호적" 같이)
+               - body: %d자 이내, 시장 흐름 분석. 구체적 수치/이슈 인용
+               - advice: 60~%d자, **구체적 행동 시사점**. 다음 4요소 중 2개 이상 포함:
+                 (a) 봐야 할 구체적 종목/섹터/지표명
+                 (b) 어떤 조건이 충족되면 어떤 신호인지
+                 (c) 구체적 리스크/체크포인트
+                 (d) 단기/중기 시간 프레임
+                 ❌ 나쁜 예: "수출 관련 종목의 흐름을 고려해 보세요."
+                 ✅ 좋은 예: "원/달러 1450원 이탈 시 자동차·반도체 수출주 단기 모멘텀 약화 가능. 현대차·기아 4월 수출 데이터 발표 후 재평가 추천."
+               - adviceLabel: "오늘의 제안" 또는 "투자 힌트" 중 하나만 사용
+                 * "오늘의 제안" — 호재/긍정 흐름 기반 액션
+                 * "투자 힌트" — 변동성/주의 흐름 기반 액션
+               - relatedClusterIndices: 입력 클러스터 번호 (1-based), 카드별 1개 이상
+            3. relatedKeywords: 오늘의 핵심 키워드 5~10개 (한글, 중복 없음)
+
+            주의사항:
+            - 입력에 없는 사실/수치를 만들지 말 것
+            - 매수/매도 직접 권유 금지 — "비중 확대 검토", "분할 매수 시점 점검", "익절 라인 조정" 같은 분석 표현 사용
+            - advice는 일반론(예: "전략을 점검해 보세요") 금지. 반드시 구체적 신호/체크포인트/지표명을 포함
+
+            반드시 아래 JSON 형식으로만 응답:
+            {
+              "summary": "...",
+              "insightCards": [
+                {
+                  "headline": "...",
+                  "body": "...",
+                  "advice": "...",
+                  "adviceLabel": "오늘의 제안",
+                  "relatedClusterIndices": [1, 3]
+                }
+              ],
+              "relatedKeywords": ["...", "..."]
+            }
+            """.formatted(REQUIRED_INSIGHT_CARDS, PERSONALIZED_BODY_MAX_LENGTH, PERSONALIZED_ADVICE_MAX_LENGTH);
+
     // ── 데이터 전달용 record ──────────────────────────────────
 
     /** 프롬프트에 전달할 클러스터 경량 DTO */
@@ -228,6 +523,34 @@ public class OpenAiMarketTrendClient {
         public boolean isValid() {
             return headline != null && !headline.isBlank()
                     && body != null && !body.isBlank();
+        }
+    }
+
+    /**
+     * personalized 응답 — title 없음, 카드별 advice/adviceLabel 추가
+     */
+    public record PersonalizedTrendRawResult(
+            String summary,
+            List<PersonalizedParsedCard> cards,
+            List<String> relatedKeywords
+    ) {
+        public boolean isEmpty() {
+            return summary == null || summary.isBlank();
+        }
+    }
+
+    public record PersonalizedParsedCard(
+            String headline,
+            String body,
+            String advice,
+            String adviceLabel,
+            List<Integer> relatedClusterIndices
+    ) {
+        public boolean isValid() {
+            return headline != null && !headline.isBlank()
+                    && body != null && !body.isBlank()
+                    && advice != null && !advice.isBlank()
+                    && adviceLabel != null && PERSONALIZED_ADVICE_LABELS.contains(adviceLabel);
         }
     }
 
@@ -266,6 +589,22 @@ public class OpenAiMarketTrendClient {
     record InsightCardRaw(
             String headline,
             String body,
+            List<Integer> relatedClusterIndices
+    ) {
+    }
+
+    record PersonalizedRawResponse(
+            String summary,
+            List<PersonalizedInsightCardRaw> insightCards,
+            List<String> relatedKeywords
+    ) {
+    }
+
+    record PersonalizedInsightCardRaw(
+            String headline,
+            String body,
+            String advice,
+            String adviceLabel,
             List<Integer> relatedClusterIndices
     ) {
     }

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/InsightCard.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/InsightCard.java
@@ -1,16 +1,25 @@
 package com.solv.wefin.domain.market.trend.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 
 /**
  * 금융 동향 인사이트 카드
  *
- * AI가 뉴스 클러스터 태그 집계를 바탕으로 생성한 카드 단위 인사이트.
- * {@code relatedClusterIds}는 프론트에서 상세 페이지(/news/:clusterId)로 이동할 때 사용된다
+ * AI가 뉴스 클러스터 태그 집계를 바탕으로 생성한 카드 단위 인사이트
  */
+@JsonInclude(JsonInclude.Include.ALWAYS)
 public record InsightCard(
         String headline,
         String body,
+        String advice,
+        String adviceLabel,
         List<Long> relatedClusterIds
 ) {
+
+    /** overview 등 조언이 없는 카드 생성 헬퍼 */
+    public static InsightCard withoutAdvice(String headline, String body, List<Long> relatedClusterIds) {
+        return new InsightCard(headline, body, null, null, relatedClusterIds);
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/MarketTrendOverview.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/MarketTrendOverview.java
@@ -7,11 +7,22 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
- * 금융 동향 overview 조회 결과
+ * 금융 동향 overview/personalized 조회 결과
  *
+ * {@code mode}는 personalized 엔드포인트에서만 의미를 가진다 ({@link PersonalizationMode}).
+ * overview 엔드포인트 응답에서는 항상 {@code null}이다.
+ *
+ * {@code null} — /overview 엔드포인트 응답. personalized 분류 개념 미적용
+ * {@code MATCHED} — /personalized + 관심사 매칭 분석
+ * {@code ACTION_BRIEFING} — /personalized + 매칭 0건이라 일반 시장 액션 분석
+ * {@code OVERVIEW_FALLBACK} — /personalized + 관심사 0개·클러스터 0건·AI 실패 등으로 overview 콘텐츠 재사용
+ *
+ *
+ * {@code personalized()} 는 호환용 boolean accessor — {@code mode == MATCHED}와 동치
  */
 public record MarketTrendOverview(
         boolean generated,
+        PersonalizationMode mode,
         LocalDate trendDate,
         String title,
         String summary,
@@ -22,8 +33,21 @@ public record MarketTrendOverview(
         OffsetDateTime updatedAt,
         List<MarketSnapshot> marketSnapshots
 ) {
+    /** mode == MATCHED 동치. 응답 호환용 derived field */
+    public boolean personalized() {
+        return mode == PersonalizationMode.MATCHED;
+    }
+
     public static MarketTrendOverview empty(List<MarketSnapshot> snapshots) {
-        return new MarketTrendOverview(false, null, null, null, List.of(), List.of(),
-                List.of(), 0, null, snapshots);
+        // overview 엔드포인트 빈 응답은 mode=null (personalized 분류 미적용)
+        return new MarketTrendOverview(false, null, null,
+                null, null, List.of(), List.of(), List.of(), 0, null, snapshots);
+    }
+
+    /** 새로운 mode로 복제한다. overview를 fallback으로 재사용할 때 사용 */
+    public MarketTrendOverview withMode(PersonalizationMode newMode) {
+        return new MarketTrendOverview(generated, newMode, trendDate, title, summary,
+                insightCards, relatedKeywords, sourceClusters, sourceArticleCount, updatedAt,
+                marketSnapshots);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/PersonalizationMode.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/PersonalizationMode.java
@@ -1,0 +1,17 @@
+package com.solv.wefin.domain.market.trend.dto;
+
+/**
+ * 맞춤 동향 응답의 생성 방식을 명시적으로 구분한다.
+ *
+ *   @link #MATCHED} — 사용자 관심사와 매칭된 클러스터로 personalized prompt 생성.
+ *       프론트는 "내 관심 종목 맞춤 동향" 블록으로 노출.
+ *   @link #ACTION_BRIEFING} — 매칭 클러스터가 없어 일반 시장 액션 브리핑으로 폴백.
+ *       프론트는 "오늘의 시장 액션" 같은 일반 시장 분석 블록으로 노출.
+ *   @link #OVERVIEW_FALLBACK} — 관심사 0개 또는 일반 클러스터도 0건이라 overview 콘텐츠 그대로 반환.
+ *       프론트는 별도 personalized 블록을 노출하지 않거나 안내 배너로 처리.
+ */
+public enum PersonalizationMode {
+    MATCHED,
+    ACTION_BRIEFING,
+    OVERVIEW_FALLBACK
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/dto/PersonalizationMode.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/dto/PersonalizationMode.java
@@ -3,12 +3,14 @@ package com.solv.wefin.domain.market.trend.dto;
 /**
  * 맞춤 동향 응답의 생성 방식을 명시적으로 구분한다.
  *
- *   @link #MATCHED} — 사용자 관심사와 매칭된 클러스터로 personalized prompt 생성.
- *       프론트는 "내 관심 종목 맞춤 동향" 블록으로 노출.
- *   @link #ACTION_BRIEFING} — 매칭 클러스터가 없어 일반 시장 액션 브리핑으로 폴백.
- *       프론트는 "오늘의 시장 액션" 같은 일반 시장 분석 블록으로 노출.
- *   @link #OVERVIEW_FALLBACK} — 관심사 0개 또는 일반 클러스터도 0건이라 overview 콘텐츠 그대로 반환.
- *       프론트는 별도 personalized 블록을 노출하지 않거나 안내 배너로 처리.
+ * <ul>
+ *   <li>{@link #MATCHED} — 사용자 관심사와 매칭된 클러스터로 personalized prompt 생성.
+ *       프론트는 "내 관심 종목 맞춤 동향" 블록으로 노출.</li>
+ *   <li>{@link #ACTION_BRIEFING} — 매칭 클러스터가 없어 일반 시장 액션 브리핑으로 폴백.
+ *       프론트는 "오늘의 시장 액션" 같은 일반 시장 분석 블록으로 노출.</li>
+ *   <li>{@link #OVERVIEW_FALLBACK} — 관심사 0개 또는 일반 클러스터도 0건이라 overview 콘텐츠 그대로 반환.
+ *       프론트는 별도 personalized 블록을 노출하지 않거나 안내 배너로 처리.</li>
+ * </ul>
  */
 public enum PersonalizationMode {
     MATCHED,

--- a/src/main/java/com/solv/wefin/domain/market/trend/entity/UserMarketTrend.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/entity/UserMarketTrend.java
@@ -1,0 +1,74 @@
+package com.solv.wefin.domain.market.trend.entity;
+
+import com.solv.wefin.domain.market.trend.dto.PersonalizationMode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 사용자별 맞춤 금융 동향 캐시 (당일 1회 AI 호출 결과 보관용)
+ *
+ * {@code (user_id, trend_date)} 기준으로 unique하며, 다음 날부터는 자동 fresh.
+ * 관심사 변경(추가/삭제) 시 해당 사용자의 오늘자 row를 명시적으로 삭제해 무효화한다
+ */
+@Entity
+@Table(
+        name = "user_market_trend",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_market_trend_user_date",
+                columnNames = {"user_id", "trend_date"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserMarketTrend {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_market_trend_id")
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "trend_date", nullable = false)
+    private LocalDate trendDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", nullable = false, length = 30)
+    private PersonalizationMode mode;
+
+    @Column(name = "summary", nullable = false, columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(name = "insight_cards", nullable = false, columnDefinition = "jsonb")
+    private String insightCardsJson;
+
+    @Column(name = "related_keywords", nullable = false, columnDefinition = "jsonb")
+    private String relatedKeywordsJson;
+
+    @Column(name = "source_cluster_ids", nullable = false, columnDefinition = "jsonb")
+    private String sourceClusterIdsJson;
+
+    @Column(name = "source_article_count", nullable = false)
+    private int sourceArticleCount;
+
+    @Column(name = "created_at")
+    private OffsetDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/repository/UserMarketTrendRepository.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/repository/UserMarketTrendRepository.java
@@ -1,0 +1,63 @@
+package com.solv.wefin.domain.market.trend.repository;
+
+import com.solv.wefin.domain.market.trend.entity.UserMarketTrend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserMarketTrendRepository extends JpaRepository<UserMarketTrend, Long> {
+
+    /**
+     * 오늘자 캐시 row를 조회한다 (cache lookup)
+     */
+    Optional<UserMarketTrend> findByUserIdAndTrendDate(UUID userId, LocalDate trendDate);
+
+    /**
+     * 사용자별 맞춤 동향 캐시를 native upsert한다.
+     *
+     * 동일 (user_id, trend_date)에 충돌하면 콘텐츠를 최신화한다.
+     * personalized=false 폴백 결과는 호출자가 저장하지 않는다 (TTL이 같은 날 안에 다시 시도 가능)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO user_market_trend (
+                user_id, trend_date, mode, summary,
+                insight_cards, related_keywords, source_cluster_ids,
+                source_article_count, created_at, updated_at
+            )
+            VALUES (
+                :userId, :trendDate, :mode, :summary,
+                CAST(:insightCardsJson AS jsonb),
+                CAST(:relatedKeywordsJson AS jsonb),
+                CAST(:sourceClusterIdsJson AS jsonb),
+                :sourceArticleCount, now(), now()
+            )
+            ON CONFLICT (user_id, trend_date) DO UPDATE SET
+                mode                 = EXCLUDED.mode,
+                summary              = EXCLUDED.summary,
+                insight_cards        = EXCLUDED.insight_cards,
+                related_keywords     = EXCLUDED.related_keywords,
+                source_cluster_ids   = EXCLUDED.source_cluster_ids,
+                source_article_count = EXCLUDED.source_article_count,
+                updated_at           = now()
+            """, nativeQuery = true)
+    void upsert(@Param("userId") UUID userId,
+                @Param("trendDate") LocalDate trendDate,
+                @Param("mode") String mode,
+                @Param("summary") String summary,
+                @Param("insightCardsJson") String insightCardsJson,
+                @Param("relatedKeywordsJson") String relatedKeywordsJson,
+                @Param("sourceClusterIdsJson") String sourceClusterIdsJson,
+                @Param("sourceArticleCount") int sourceArticleCount);
+
+    /**
+     * 사용자의 오늘자 캐시를 삭제한다 (관심사 변경 시 무효화 트리거)
+     */
+    @Modifying(clearAutomatically = true)
+    void deleteByUserIdAndTrendDate(UUID userId, LocalDate trendDate);
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/repository/UserMarketTrendRepository.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/repository/UserMarketTrendRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -58,6 +59,7 @@ public interface UserMarketTrendRepository extends JpaRepository<UserMarketTrend
     /**
      * 사용자의 오늘자 캐시를 삭제한다 (관심사 변경 시 무효화 트리거)
      */
+    @Transactional
     @Modifying(clearAutomatically = true)
     void deleteByUserIdAndTrendDate(UUID userId, LocalDate trendDate);
 }

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendCardMapper.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendCardMapper.java
@@ -1,0 +1,122 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ClusterSummary;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ParsedCard;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.PersonalizedParsedCard;
+import com.solv.wefin.domain.market.trend.dto.InsightCard;
+import com.solv.wefin.domain.news.cluster.dto.StockInfo;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AI가 생성한 금융 동향 카드 응답을 도메인 모델로 변환하고ㅡ 카드 기반 출처 및 태그 메타데이터를 계산하는 매퍼 컴포넌트
+ *
+ * AI 응답은 clusterId가 아닌 1-based index를 기준으로 참조를 반환하므로 이를 실제 clusterId로 매핑하는 책임을 가진다.
+ * 카드 단위 중복 제거, 출처 클러스터 집계, 종목/토픽 빈도 계산 등 AI 결과 후처리 로직을 서비스 레이어에서 분리하기 위해 사용된다.
+ */
+@Component
+public class MarketTrendCardMapper {
+
+    /**
+     * AI overview 카드 응답을 InsightCard로 변환한다.
+     *
+     * AI가 반환한 cluster index를 실제 clusterId로 변환하며, 유효하지 않은 카드(isValid=false)는 제외한다.
+     * overview 카드에는 투자 조언이 없으므로 advice 필드는 비워둔다.
+     */
+    public List<InsightCard> mapOverviewCards(List<ParsedCard> parsed, List<ClusterSummary> clusterSummaries) {
+        List<InsightCard> result = new ArrayList<>();
+        for (ParsedCard p : parsed) {
+            if (p == null || !p.isValid()) continue;
+            List<Long> ids = mapClusterIndices(p.relatedClusterIndices(), clusterSummaries);
+            result.add(InsightCard.withoutAdvice(p.headline(), p.body(), ids));
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * AI personalized 카드 응답을 InsightCard로 변환한다.
+     *
+     * advice/adviceLabel은 AI 응답을 그대로 사용한다.
+     */
+    public List<InsightCard> mapPersonalizedCards(List<PersonalizedParsedCard> parsed,
+                                                  List<ClusterSummary> clusterSummaries) {
+        List<InsightCard> result = new ArrayList<>();
+        for (PersonalizedParsedCard p : parsed) {
+            if (p == null || !p.isValid()) continue;
+            List<Long> ids = mapClusterIndices(p.relatedClusterIndices(), clusterSummaries);
+            result.add(new InsightCard(p.headline(), p.body(), p.advice(), p.adviceLabel(), ids));
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * 카드들이 실제로 참조한 clusterId의 합집합을 반환한다.
+     *
+     * AI가 카드 생성에 사용한 클러스터만 출처로 기록하기 위해 사용된다.
+     */
+    public List<Long> collectReferencedClusterIds(List<InsightCard> cards) {
+        LinkedHashSet<Long> ids = new LinkedHashSet<>();
+        for (InsightCard card : cards) {
+            ids.addAll(card.relatedClusterIds());
+        }
+        return List.copyOf(ids);
+    }
+
+    /**
+     * 클러스터별 종목 태그를 flatten하여 등장 빈도 기준 상위 N개 종목명을 반환한다.
+     *
+     * 동일 종목은 code 기준으로 집계하며 name은 최초 등장 값을 사용한다.
+     */
+    public List<String> collectTopStockNames(Map<Long, List<StockInfo>> perCluster, int topN) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        Map<String, String> codeToName = new LinkedHashMap<>();
+        perCluster.values().forEach(list -> {
+            if (list == null) return;
+            list.forEach(info -> {
+                counts.merge(info.code(), 1, Integer::sum);
+                codeToName.putIfAbsent(info.code(), info.name());
+            });
+        });
+        return counts.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .limit(topN)
+                .map(e -> codeToName.get(e.getKey()))
+                .toList();
+    }
+
+    /**
+     * AI가 반환한 1-based cluster index를 실제 clusterId로 변환한다.
+     *
+     * AI 응답 특성상:
+     * - 동일 index가 중복될 수 있어 카드 단위에서 중복 제거
+     * - 범위를 벗어난 index가 포함될 수 있어 방어 처리
+     */
+    public List<String> collectTopTopicNames(Map<Long, List<String>> perCluster, int topN) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+        perCluster.values().forEach(list -> {
+            if (list == null) return;
+            list.forEach(name -> counts.merge(name, 1, Integer::sum));
+        });
+        return counts.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                .limit(topN)
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    private List<Long> mapClusterIndices(List<Integer> indices, List<ClusterSummary> clusterSummaries) {
+
+        LinkedHashSet<Long> ids = new LinkedHashSet<>(); // AI가 동일 index를 복수 반환하는 경우가 있어 카드 단위에서 중복 제거
+        for (Integer idx : indices) {
+            if (idx == null) continue;
+            if (idx < 1 || idx > clusterSummaries.size()) continue;
+            ids.add(clusterSummaries.get(idx - 1).clusterId());
+        }
+        return List.copyOf(ids);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendCardMapper.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendCardMapper.java
@@ -90,11 +90,7 @@ public class MarketTrendCardMapper {
     }
 
     /**
-     * AI가 반환한 1-based cluster index를 실제 clusterId로 변환한다.
-     *
-     * AI 응답 특성상:
-     * - 동일 index가 중복될 수 있어 카드 단위에서 중복 제거
-     * - 범위를 벗어난 index가 포함될 수 있어 방어 처리
+     * 클러스터별 TOPIC 이름 집계에서 등장 빈도 상위 N개를 반환한다.
      */
     public List<String> collectTopTopicNames(Map<Long, List<String>> perCluster, int topN) {
         Map<String, Integer> counts = new LinkedHashMap<>();
@@ -109,9 +105,16 @@ public class MarketTrendCardMapper {
                 .toList();
     }
 
+    /**
+     * AI가 반환한 1-based cluster index를 실제 clusterId로 변환한다.
+     *
+     * AI 응답 특성상:
+     * - 동일 index가 중복될 수 있어 카드 단위에서 중복 제거 (LinkedHashSet로 순서 유지)
+     * - 범위를 벗어난 index가 포함될 수 있어 방어 처리
+     */
     private List<Long> mapClusterIndices(List<Integer> indices, List<ClusterSummary> clusterSummaries) {
 
-        LinkedHashSet<Long> ids = new LinkedHashSet<>(); // AI가 동일 index를 복수 반환하는 경우가 있어 카드 단위에서 중복 제거
+        LinkedHashSet<Long> ids = new LinkedHashSet<>();
         for (Integer idx : indices) {
             if (idx == null) continue;
             if (idx < 1 || idx > clusterSummaries.size()) continue;

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendGenerationService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendGenerationService.java
@@ -7,7 +7,6 @@ import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
 import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient;
 import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ClusterSummary;
 import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.MarketTrendRawResult;
-import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ParsedCard;
 import com.solv.wefin.domain.market.trend.dto.InsightCard;
 import com.solv.wefin.domain.market.trend.dto.MarketTrendContent;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
@@ -17,7 +16,6 @@ import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.service.ClusterTagAggregator;
-import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -26,8 +24,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -63,6 +59,7 @@ public class MarketTrendGenerationService {
     private final ClusterTagAggregator tagAggregator;
     private final OpenAiMarketTrendClient openAiClient;
     private final MarketTrendPersistenceService persistenceService;
+    private final MarketTrendCardMapper cardMapper;
     private final ObjectMapper objectMapper;
 
     /**
@@ -97,10 +94,10 @@ public class MarketTrendGenerationService {
         List<Long> allArticleIds = clusterArticleMap.values().stream()
                 .flatMap(List::stream).distinct().toList();
 
-        List<String> risingStocks = collectTopStockNames(
+        List<String> risingStocks = cardMapper.collectTopStockNames(
                 allArticleIds.isEmpty() ? Map.of() : tagAggregator.aggregateStocks(clusterArticleMap, allArticleIds),
                 MAX_TAGS);
-        List<String> risingTopics = collectTopTopicNames(
+        List<String> risingTopics = cardMapper.collectTopTopicNames(
                 allArticleIds.isEmpty() ? Map.of() : tagAggregator.aggregateMarketTags(clusterArticleMap, allArticleIds),
                 MAX_TAGS);
 
@@ -124,7 +121,7 @@ public class MarketTrendGenerationService {
         }
 
         // 6) relatedClusterIndices(1-based prompt index) → 실제 clusterId 매핑
-        List<InsightCard> cards = mapCards(raw.cards(), clusterSummaries);
+        List<InsightCard> cards = cardMapper.mapOverviewCards(raw.cards(), clusterSummaries);
 
         // 7) 카드/키워드 개수 계약 검증 (프론트 레이아웃 보장)
         if (cards.size() != REQUIRED_CARDS) {
@@ -147,16 +144,9 @@ public class MarketTrendGenerationService {
         }
 
         // 8) 출처 메타 계산
-        //    - sourceClusterIds: AI가 insightCards에서 실제로 참조한 클러스터만 (중복 제거 + 입력 순서 유지).
-        //      프롬프트에 넘긴 15개 전부가 아니라 AI 동의한 것만 저장하여, 프론트의 "이 동향의 출처" 섹션이
-        //      본문과 실제로 관련된 카드만 노출하도록 보장
-        //    - sourceArticleCount: 전체 고유 기사 수. clusterArticleMap.values() 합산은 같은 기사가 복수
-        //      클러스터에 속할 때 중복 카운트되므로 allArticleIds.size()로 정확도 확보
-        java.util.LinkedHashSet<Long> referencedClusterIds = new java.util.LinkedHashSet<>();
-        for (InsightCard card : cards) {
-            referencedClusterIds.addAll(card.relatedClusterIds());
-        }
-        List<Long> sourceClusterIds = List.copyOf(referencedClusterIds);
+        //    - sourceClusterIds: AI가 insightCards에서 실제로 참조한 클러스터만 (중복 제거 + 입력 순서 유지)
+        //    - sourceArticleCount: 전체 고유 기사 수 (allArticleIds.size())
+        List<Long> sourceClusterIds = cardMapper.collectReferencedClusterIds(cards);
         int sourceArticleCount = allArticleIds.size();
 
         // 9) 저장 (upsert)
@@ -170,58 +160,6 @@ public class MarketTrendGenerationService {
         } catch (JsonProcessingException e) {
             log.warn("[MarketTrend] JSON 직렬화 실패 — 저장 스킵", e);
         }
-    }
-
-    /**
-     * 클러스터별 STOCK 태그를 flatten하여 상위 name을 반환한다.
-     */
-    private List<String> collectTopStockNames(Map<Long, List<StockInfo>> perCluster, int topN) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        Map<String, String> codeToName = new LinkedHashMap<>();
-        perCluster.values().forEach(list -> {
-            if (list == null) return;
-            list.forEach(info -> {
-                counts.merge(info.code(), 1, Integer::sum);
-                codeToName.putIfAbsent(info.code(), info.name());
-            });
-        });
-        return counts.entrySet().stream()
-                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
-                .limit(topN)
-                .map(e -> codeToName.get(e.getKey()))
-                .toList();
-    }
-
-    private List<String> collectTopTopicNames(Map<Long, List<String>> perCluster, int topN) {
-        Map<String, Integer> counts = new LinkedHashMap<>();
-        perCluster.values().forEach(list -> {
-            if (list == null) return;
-            list.forEach(name -> counts.merge(name, 1, Integer::sum));
-        });
-        return counts.entrySet().stream()
-                .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
-                .limit(topN)
-                .map(Map.Entry::getKey)
-                .toList();
-    }
-
-    /**
-     * AI가 반환한 relatedClusterIndices(1-based)를 실제 clusterId로 매핑한다.
-     */
-    private List<InsightCard> mapCards(List<ParsedCard> parsed, List<ClusterSummary> clusterSummaries) {
-        List<InsightCard> result = new ArrayList<>();
-        for (ParsedCard p : parsed) {
-            if (p == null || !p.isValid()) continue;
-            // AI가 동일 index를 복수 반환하는 경우가 있어 카드 단위에서 중복 제거 (LinkedHashSet로 순서 유지)
-            java.util.LinkedHashSet<Long> ids = new java.util.LinkedHashSet<>();
-            for (Integer idx : p.relatedClusterIndices()) {
-                if (idx == null) continue;
-                if (idx < 1 || idx > clusterSummaries.size()) continue;
-                ids.add(clusterSummaries.get(idx - 1).clusterId());
-            }
-            result.add(new InsightCard(p.headline(), p.body(), List.copyOf(ids)));
-        }
-        return List.copyOf(result);
     }
 
     private String toJson(Object value) throws JsonProcessingException {

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/MarketTrendQueryService.java
@@ -72,8 +72,11 @@ public class MarketTrendQueryService {
         List<SourceClusterInfo> sourceClusters = resolveSourceClusters(trend.getSourceClusterIdsJson());
         int sourceArticleCount = trend.getSourceArticleCount() != null ? trend.getSourceArticleCount() : 0;
 
+        // /overview 엔드포인트 응답은 personalized 개념이 적용되지 않으므로 mode=null.
+        // PersonalizedMarketTrendService가 폴백으로 재사용할 때 withMode(OVERVIEW_FALLBACK)로 갈아끼운다
         return new MarketTrendOverview(
                 true,
+                null,
                 trend.getTrendDate(),
                 trend.getTitle(),
                 trend.getSummary(),
@@ -91,7 +94,14 @@ public class MarketTrendQueryService {
      */
     private List<SourceClusterInfo> resolveSourceClusters(String json) {
         List<Long> ids = parseList(json, CLUSTER_IDS_TYPE);
-        if (ids.isEmpty()) {
+        return resolveSourceClusters(ids);
+    }
+
+    /**
+     * personalized 등 다른 서비스가 카드 union으로부터 직접 source cluster 메타를 만들 때 사용한다.
+     */
+    public List<SourceClusterInfo> resolveSourceClusters(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
             return List.of();
         }
 

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendService.java
@@ -1,0 +1,353 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.ClusterSummary;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.PersonalizedTrendRawResult;
+import com.solv.wefin.domain.market.trend.dto.InsightCard;
+import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.market.trend.dto.PersonalizationMode;
+import com.solv.wefin.domain.market.trend.dto.SourceClusterInfo;
+import com.solv.wefin.domain.market.trend.entity.UserMarketTrend;
+import com.solv.wefin.domain.market.trend.repository.UserMarketTrendRepository;
+import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.service.ClusterTagAggregator;
+import com.solv.wefin.domain.trading.watchlist.entity.InterestType;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 사용자 관심사 기반 맞춤 금융 동향 생성 서비스 (lazy: 호출 시점 기준 캐시 hit 또는 OpenAI 호출).
+ *
+ * 응답의 {@link PersonalizationMode}로 생성 방식을 명시한다.
+ *   {@code MATCHED} — 관심사와 매칭된 클러스터 기반 맞춤 분석
+ *   {@code ACTION_BRIEFING} — 매칭 0건이라 일반 24h 클러스터로 시장 액션 브리핑
+ *   {@code OVERVIEW_FALLBACK} — 관심사 0개·클러스터 0건·AI 실패·검증 실패 등으로 overview 콘텐츠 그대로
+ *
+ * 캐시: {@code user_market_trend} 테이블에 (user_id, trend_date) unique. TTL 30분.
+ * 관심사 변경 시 {@link UserMarketTrendCacheService#invalidateToday(UUID)}로 즉시 무효화
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PersonalizedMarketTrendService {
+
+    private static final int MAX_CLUSTERS = OpenAiMarketTrendClient.MAX_CLUSTERS_IN_PROMPT; // 프롬프트에 포함할 클러스터 최대 개수 (overview와 동일)
+    private static final int MAX_TAGS = OpenAiMarketTrendClient.MAX_TAGS_IN_PROMPT; // 떠오르는 종목/주제 태그 상한
+    private static final int REQUIRED_CARDS = OpenAiMarketTrendClient.REQUIRED_INSIGHT_CARDS; // 카드 개수 제약
+    private static final int MIN_KEYWORDS = 5;
+    private static final int MAX_KEYWORDS = 10;
+    private static final Duration LOOKBACK = Duration.ofHours(24); // 후보 클러스터의 최대 경과 시간
+    private static final List<SummaryStatus> VISIBLE_STATUSES =
+            List.of(SummaryStatus.GENERATED, SummaryStatus.STALE);
+    private static final List<String> EMPTY_SENTINEL = List.of(""); // JPQL IN 빈 컬렉션 회피용 sentinel
+    private static final Duration CACHE_TTL = Duration.ofMinutes(30); // 사용자 캐시 TTL — overview 배치(30분) 주기와 정렬
+
+
+    private final MarketSnapshotRepository marketSnapshotRepository;
+    private final UserInterestRepository userInterestRepository;
+    private final NewsClusterRepository newsClusterRepository;
+    private final NewsClusterArticleRepository clusterArticleRepository;
+    private final NewsArticleTagRepository newsArticleTagRepository;
+    private final ClusterTagAggregator tagAggregator;
+    private final OpenAiMarketTrendClient openAiClient;
+    private final MarketTrendQueryService marketTrendQueryService;
+    private final MarketTrendCardMapper cardMapper;
+    private final UserMarketTrendRepository userMarketTrendRepository;
+    private final UserMarketTrendCacheService userMarketTrendCacheService;
+    private final ObjectMapper objectMapper;
+
+
+    /**
+     * JSON을 List<InsightCard>로 역직렬화하기 위한 타입 정보 객체
+     */
+    private static final TypeReference<List<InsightCard>> CARDS_TYPE = new TypeReference<>() {
+    };
+    private static final TypeReference<List<String>> KEYWORDS_TYPE = new TypeReference<>() {
+    };
+    private static final TypeReference<List<Long>> CLUSTER_IDS_TYPE = new TypeReference<>() {
+    };
+
+    public MarketTrendOverview getForUser(UUID userId) {
+        // 0) 캐시 lookup — TTL(30분) 안이면 AI 호출 없이 즉시 반환
+        Optional<UserMarketTrend> cached = userMarketTrendRepository
+                .findByUserIdAndTrendDate(userId, LocalDate.now(UserMarketTrendCacheService.TREND_ZONE));
+        if (cached.isPresent()) {
+            OffsetDateTime cacheUpdatedAt = cached.get().getUpdatedAt();
+            boolean fresh = cacheUpdatedAt != null
+                    && cacheUpdatedAt.isAfter(OffsetDateTime.now().minus(CACHE_TTL));
+            if (fresh) {
+                log.info("[PersonalizedMarketTrend] 캐시 hit (fresh) — userId={}", userId);
+                return assembleFromCache(cached.get());
+            }
+            log.info("[PersonalizedMarketTrend] 캐시 stale — TTL 경과로 재생성 (userId={}, cacheUpdatedAt={})",
+                    userId, cacheUpdatedAt);
+        }
+
+        // AI 호출 시작 시점 기록 — 캐시 저장 직전 invalidate가 있었는지 비교하여 stale 스냅샷 저장 방지
+        Instant computeStartedAt = Instant.now();
+
+        // 1) 관심사 직접 조회
+        List<String> stockCodes = loadInterestCodes(userId, InterestType.STOCK);
+        List<String> sectorCodes = loadInterestCodes(userId, InterestType.SECTOR);
+        List<String> topicCodes = loadInterestCodes(userId, InterestType.TOPIC);
+
+        if (stockCodes.isEmpty() && sectorCodes.isEmpty() && topicCodes.isEmpty()) {
+            log.info("[PersonalizedMarketTrend] 관심사 없음 — overview 폴백 (userId={})", userId);
+            return overviewFallback();
+        }
+
+        // 2) 매칭 클러스터 조회
+        OffsetDateTime cutoff = OffsetDateTime.now().minus(LOOKBACK);
+        List<NewsCluster> clusters = newsClusterRepository.findPersonalizedClusters(
+                ClusterStatus.ACTIVE,
+                VISIBLE_STATUSES,
+                cutoff,
+                NewsArticleTag.TagType.STOCK, orSentinel(stockCodes),
+                NewsArticleTag.TagType.SECTOR, orSentinel(sectorCodes),
+                NewsArticleTag.TagType.TOPIC, orSentinel(topicCodes),
+                PageRequest.of(0, MAX_CLUSTERS));
+        log.info("[PersonalizedMarketTrend] 매칭 클러스터 조회 — userId={}, stocks={}, sectors={}, topics={}, matched={}",
+                userId, stockCodes, sectorCodes, topicCodes, clusters.size());
+
+        boolean matched = !clusters.isEmpty();
+        if (!matched) {
+            clusters = newsClusterRepository.findRecentActiveClusters(
+                    ClusterStatus.ACTIVE,
+                    VISIBLE_STATUSES,
+                    cutoff,
+                    PageRequest.of(0, MAX_CLUSTERS));
+            log.info("[PersonalizedMarketTrend] 직접 매칭 없음 — 시장 액션 브리핑으로 전환, 일반 클러스터 {}건 (userId={})",
+                    clusters.size(), userId);
+            if (clusters.isEmpty()) {
+                log.info("[PersonalizedMarketTrend] 일반 클러스터도 없음 — overview 폴백 (userId={})", userId);
+                return overviewFallback();
+            }
+        }
+
+        // 3) 태그 집계
+        List<Long> clusterIds = clusters.stream().map(NewsCluster::getId).toList();
+        Map<Long, List<Long>> clusterArticleMap = clusterArticleRepository.findByNewsClusterIdIn(clusterIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        NewsClusterArticle::getNewsClusterId,
+                        Collectors.mapping(NewsClusterArticle::getNewsArticleId, Collectors.toList())));
+        List<Long> allArticleIds = clusterArticleMap.values().stream()
+                .flatMap(List::stream).distinct().toList();
+
+        List<String> risingStocks = cardMapper.collectTopStockNames(
+                allArticleIds.isEmpty() ? Map.of() : tagAggregator.aggregateStocks(clusterArticleMap, allArticleIds),
+                MAX_TAGS);
+        List<String> risingTopics = cardMapper.collectTopTopicNames(
+                allArticleIds.isEmpty() ? Map.of() : tagAggregator.aggregateMarketTags(clusterArticleMap, allArticleIds),
+                MAX_TAGS);
+
+        // 4) 관심사 표시명 (matched 모드에서만 프롬프트에 사용)
+        List<String> stockNames = matched ? resolveTagNames(NewsArticleTag.TagType.STOCK, stockCodes) : List.of();
+        List<String> sectorNames = matched ? resolveTagNames(NewsArticleTag.TagType.SECTOR, sectorCodes) : List.of();
+        List<String> topicNames = matched ? resolveTagNames(NewsArticleTag.TagType.TOPIC, topicCodes) : List.of();
+
+        // 5) 프롬프트용 클러스터 경량 DTO
+        List<ClusterSummary> clusterSummaries = clusters.stream()
+                .map(c -> new ClusterSummary(c.getId(), c.getTitle(), c.getSummary()))
+                .toList();
+
+        // 6) AI 호출 분기
+        PersonalizedTrendRawResult raw;
+        try {
+            raw = matched
+                    ? openAiClient.generatePersonalizedTrend(
+                            marketSnapshotRepository.findAll(),
+                            clusterSummaries,
+                            risingStocks,
+                            risingTopics,
+                            stockNames,
+                            sectorNames,
+                            topicNames)
+                    : openAiClient.generateMarketActionBriefing(
+                            marketSnapshotRepository.findAll(),
+                            clusterSummaries,
+                            risingStocks,
+                            risingTopics);
+        } catch (OpenAiMarketTrendClient.MarketTrendAiException e) {
+            log.warn("[PersonalizedMarketTrend] AI 호출 실패 — overview 폴백 (userId={}, mode={})",
+                    userId, matched ? "matched" : "action", e);
+            return overviewFallback();
+        }
+
+        if (raw.isEmpty()) {
+            log.warn("[PersonalizedMarketTrend] summary 누락 — overview 폴백 (userId={})", userId);
+            return overviewFallback();
+        }
+
+        // 7) 카드 매핑 + 검증
+        List<InsightCard> cards = cardMapper.mapPersonalizedCards(raw.cards(), clusterSummaries);
+        if (cards.size() != REQUIRED_CARDS) {
+            log.warn("[PersonalizedMarketTrend] 카드 수 불일치 — overview 폴백 (expected={}, actual={})",
+                    REQUIRED_CARDS, cards.size());
+            return overviewFallback();
+        }
+        boolean hasEmptySource = cards.stream().anyMatch(c -> c.relatedClusterIds().isEmpty());
+        if (hasEmptySource) {
+            log.warn("[PersonalizedMarketTrend] 일부 카드에 출처 클러스터가 없음 — overview 폴백");
+            return overviewFallback();
+        }
+        boolean missingAdvice = cards.stream()
+                .anyMatch(c -> c.advice() == null || c.advice().isBlank()
+                        || c.adviceLabel() == null || c.adviceLabel().isBlank());
+        if (missingAdvice) {
+            log.warn("[PersonalizedMarketTrend] 일부 카드에 advice/adviceLabel 누락 — overview 폴백");
+            return overviewFallback();
+        }
+        int keywordCount = raw.relatedKeywords().size();
+        if (keywordCount < MIN_KEYWORDS || keywordCount > MAX_KEYWORDS) {
+            log.warn("[PersonalizedMarketTrend] 키워드 개수 범위 벗어남 — overview 폴백 (range={}~{}, actual={})",
+                    MIN_KEYWORDS, MAX_KEYWORDS, keywordCount);
+            return overviewFallback();
+        }
+
+        // 8) 응답 조립
+        List<Long> sourceClusterIds = cardMapper.collectReferencedClusterIds(cards);
+        List<SourceClusterInfo> sourceClusters = marketTrendQueryService.resolveSourceClusters(sourceClusterIds);
+        List<MarketSnapshot> snapshots = marketSnapshotRepository.findAll();
+        int sourceArticleCount = allArticleIds.size();
+        PersonalizationMode resultMode = matched ? PersonalizationMode.MATCHED : PersonalizationMode.ACTION_BRIEFING;
+
+        // 9) 캐시 저장 (matched/action briefing 모두). 직렬화 실패는 응답 영향 없게 처리
+        try {
+            userMarketTrendCacheService.cache(
+                    userId,
+                    computeStartedAt,
+                    raw.summary(),
+                    objectMapper.writeValueAsString(cards),
+                    objectMapper.writeValueAsString(raw.relatedKeywords()),
+                    objectMapper.writeValueAsString(sourceClusterIds),
+                    sourceArticleCount,
+                    resultMode);
+        } catch (JsonProcessingException e) {
+            log.warn("[PersonalizedMarketTrend] 캐시 직렬화 실패 — 응답은 정상 반환 (userId={})", userId, e);
+        }
+
+        return new MarketTrendOverview(
+                true,
+                resultMode,
+                LocalDate.now(UserMarketTrendCacheService.TREND_ZONE),
+                null,
+                raw.summary(),
+                cards,
+                raw.relatedKeywords(),
+                sourceClusters,
+                sourceArticleCount,
+                OffsetDateTime.now(),
+                snapshots
+        );
+    }
+
+    private List<String> loadInterestCodes(UUID userId, InterestType type) {
+        return userInterestRepository
+                .findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, type.name())
+                .stream().map(UserInterest::getInterestValue).toList();
+    }
+
+    private List<String> resolveTagNames(NewsArticleTag.TagType type, List<String> codes) {
+        if (codes.isEmpty()) return List.of();
+        Map<String, String> nameByCode = newsArticleTagRepository
+                .findTagNamesByTagTypeAndTagCodes(type.name(), codes)
+                .stream()
+                .collect(Collectors.toMap(
+                        NewsArticleTagRepository.TagNameProjection::getCode,
+                        NewsArticleTagRepository.TagNameProjection::getName));
+        return codes.stream().map(c -> nameByCode.getOrDefault(c, c)).toList();
+    }
+
+    /** 캐시 row를 응답 DTO로 풀어낸다. JSON 파싱 실패 시 빈 컬렉션으로 fallback */
+    private MarketTrendOverview assembleFromCache(UserMarketTrend cached) {
+        List<InsightCard> rawCards = parseList(cached.getInsightCardsJson(), CARDS_TYPE);
+        List<String> keywords = parseList(cached.getRelatedKeywordsJson(), KEYWORDS_TYPE);
+        List<Long> sourceClusterIds = parseList(cached.getSourceClusterIdsJson(), CLUSTER_IDS_TYPE);
+        List<SourceClusterInfo> sourceClusters = marketTrendQueryService.resolveSourceClusters(sourceClusterIds);
+        List<MarketSnapshot> snapshots = marketSnapshotRepository.findAll();
+        PersonalizationMode mode = cached.getMode() != null ? cached.getMode() : PersonalizationMode.MATCHED;
+
+        // 카드의 relatedClusterIds에서 현재 active(resolved)가 아닌 클러스터는 제외.
+        java.util.Set<Long> activeIds = sourceClusters.stream()
+                .map(SourceClusterInfo::clusterId)
+                .collect(java.util.stream.Collectors.toSet());
+        List<InsightCard> cards = rawCards.stream()
+                .map(c -> {
+                    List<Long> filtered = c.relatedClusterIds().stream()
+                            .filter(activeIds::contains)
+                            .toList();
+                    return new InsightCard(c.headline(), c.body(), c.advice(), c.adviceLabel(), filtered);
+                })
+                .toList();
+
+        return new MarketTrendOverview(
+                true,
+                mode,
+                cached.getTrendDate(),
+                null,
+                cached.getSummary(),
+                cards,
+                keywords,
+                sourceClusters,
+                cached.getSourceArticleCount(),
+                cached.getUpdatedAt(),
+                snapshots
+        );
+    }
+
+    /**
+     * 모든 폴백 경로에서 재사용하는 helper
+     *
+     * overview 응답(mode=null)을 PERSONALIZED 관점의 OVERVIEW_FALLBACK으로 표시해 프론트가
+     * "맞춤 분석이 불가하여 일반 시황으로 제공됨"으로 분기할 수 있게 한다
+     */
+    private MarketTrendOverview overviewFallback() {
+        return marketTrendQueryService.getOverview().withMode(PersonalizationMode.OVERVIEW_FALLBACK);
+    }
+
+    /**
+     * 빈 코드 리스트를 JPQL {@code IN ()} 에러 없이 OR 조건에 넣기 위한 sentinel wrapper.
+     * tag_code에 빈 문자열 row가 저장되지 않는다는 가정에 기반
+     */
+    private static List<String> orSentinel(List<String> codes) {
+        return codes.isEmpty() ? EMPTY_SENTINEL : codes;
+    }
+
+    private <T> List<T> parseList(String json, TypeReference<List<T>> type) {
+        if (json == null || json.isBlank()) return List.of();
+        try {
+            List<T> result = objectMapper.readValue(json, type);
+            return result != null ? result : List.of();
+        } catch (Exception e) {
+            log.warn("[PersonalizedMarketTrend] 캐시 JSON 파싱 실패 — 빈 리스트 fallback: {}", e.getMessage());
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendService.java
@@ -93,20 +93,55 @@ public class PersonalizedMarketTrendService {
     private static final TypeReference<List<Long>> CLUSTER_IDS_TYPE = new TypeReference<>() {
     };
 
-    public MarketTrendOverview getForUser(UUID userId) {
-        // 0) 캐시 lookup — TTL(30분) 안이면 AI 호출 없이 즉시 반환
+    /**
+     * TTL(30분) 내 캐시 row만 반환하고 AI 호출은 수행하지 않는다.
+     *
+     * 페이지 진입 시 "이전 분석 결과가 fresh면 자동 노출, stale/미생성이면 버튼 클릭 유도" 흐름에서 사용한다.
+     * 캐시 miss/stale은 모두 {@link Optional#empty()}로 반환되어 호출 측이 204 등으로 처리할 수 있다
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @return fresh 캐시가 있으면 화면 DTO, 아니면 empty
+     */
+    public Optional<MarketTrendOverview> getCachedForUser(UUID userId) {
+        return readFreshCache(userId).map(this::assembleFromCache);
+    }
+
+    /**
+     * TTL + invalidate CAS를 동시에 검사해 재사용 가능한 캐시 row를 반환한다.
+     *
+     * TTL 안이더라도 invalidate가 row의 updatedAt 이후에 발생했다면 afterCommit DELETE 이전의
+     * short window에서 stale row가 노출될 수 있으므로 miss로 취급한다.
+     * {@link #getCachedForUser(UUID)} 와 {@link #getForUser(UUID)} 가 공유하는 단일 게이트
+     */
+    private Optional<UserMarketTrend> readFreshCache(UUID userId) {
         Optional<UserMarketTrend> cached = userMarketTrendRepository
                 .findByUserIdAndTrendDate(userId, LocalDate.now(UserMarketTrendCacheService.TREND_ZONE));
-        if (cached.isPresent()) {
-            OffsetDateTime cacheUpdatedAt = cached.get().getUpdatedAt();
-            boolean fresh = cacheUpdatedAt != null
-                    && cacheUpdatedAt.isAfter(OffsetDateTime.now().minus(CACHE_TTL));
-            if (fresh) {
-                log.info("[PersonalizedMarketTrend] 캐시 hit (fresh) — userId={}", userId);
-                return assembleFromCache(cached.get());
-            }
-            log.info("[PersonalizedMarketTrend] 캐시 stale — TTL 경과로 재생성 (userId={}, cacheUpdatedAt={})",
+        if (cached.isEmpty()) return Optional.empty();
+
+        OffsetDateTime cacheUpdatedAt = cached.get().getUpdatedAt();
+        boolean fresh = cacheUpdatedAt != null
+                && cacheUpdatedAt.isAfter(OffsetDateTime.now().minus(CACHE_TTL));
+        if (!fresh) {
+            log.info("[PersonalizedMarketTrend] 캐시 stale (TTL 경과) — userId={}, cacheUpdatedAt={}",
                     userId, cacheUpdatedAt);
+            return Optional.empty();
+        }
+
+        Instant invalidatedAt = userMarketTrendCacheService.getLastInvalidatedAt(userId);
+        if (invalidatedAt != null && invalidatedAt.isAfter(cacheUpdatedAt.toInstant())) {
+            log.info("[PersonalizedMarketTrend] 캐시 stale (invalidate window) — userId={}, cacheUpdatedAt={}, invalidatedAt={}",
+                    userId, cacheUpdatedAt, invalidatedAt);
+            return Optional.empty();
+        }
+        return cached;
+    }
+
+    public MarketTrendOverview getForUser(UUID userId) {
+        // 0) 캐시 lookup — TTL(30분) 안 + invalidate 이후가 아니면 AI 호출 없이 즉시 반환
+        Optional<UserMarketTrend> cached = readFreshCache(userId);
+        if (cached.isPresent()) {
+            log.info("[PersonalizedMarketTrend] 캐시 hit (fresh) — userId={}", userId);
+            return assembleFromCache(cached.get());
         }
 
         // AI 호출 시작 시점 기록 — 캐시 저장 직전 invalidate가 있었는지 비교하여 stale 스냅샷 저장 방지

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendService.java
@@ -120,7 +120,7 @@ public class PersonalizedMarketTrendService {
 
         OffsetDateTime cacheUpdatedAt = cached.get().getUpdatedAt();
         boolean fresh = cacheUpdatedAt != null
-                && cacheUpdatedAt.isAfter(OffsetDateTime.now().minus(CACHE_TTL));
+                && cacheUpdatedAt.isAfter(OffsetDateTime.now(UserMarketTrendCacheService.TREND_ZONE).minus(CACHE_TTL));
         if (!fresh) {
             log.info("[PersonalizedMarketTrend] 캐시 stale (TTL 경과) — userId={}, cacheUpdatedAt={}",
                     userId, cacheUpdatedAt);

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
@@ -1,8 +1,9 @@
 package com.solv.wefin.domain.market.trend.service;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.solv.wefin.domain.market.trend.dto.PersonalizationMode;
 import com.solv.wefin.domain.market.trend.repository.UserMarketTrendRepository;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -10,32 +11,62 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * 사용자별 맞춤 동향 캐시 쓰기/무효화 전담 (트랜잭션 경계)
  *
- * <p>캐시 read는 {@link PersonalizedMarketTrendService} 내부에서 직접 수행하고,
+ * 캐시 read는 {@link PersonalizedMarketTrendService} 내부에서 직접 수행하고
  * 쓰기/삭제는 본 서비스를 통해 짧은 트랜잭션으로 처리한다 (AI 외부 호출과 분리)
+ *
+ * 단일 인스턴스 가정
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class UserMarketTrendCacheService {
 
     public static final ZoneId TREND_ZONE = ZoneId.of("Asia/Seoul"); // 캐시 TTL 기준 timezone
 
+    /** invalidate 타임스탬프 캐시의 최대 엔트리 수 — 활성 사용자 상한 근사치 */
+    private static final long INVALIDATION_CACHE_MAX_SIZE = 100_000L;
+    /** invalidate 엔트리 만료 — 오늘자 compute 창(24h)을 덮을 만큼이면 충분 */
+    private static final Duration INVALIDATION_CACHE_TTL = Duration.ofDays(1);
+
     private final UserMarketTrendRepository userMarketTrendRepository;
-    private final ConcurrentMap<UUID, Instant> lastInvalidatedAt = new ConcurrentHashMap<>(); // 사용자별 마지막 invalidate 시각
+    /**
+     * 사용자별 마지막 invalidate 시각. ConcurrentHashMap을 Caffeine으로 교체해 장기 운영 시
+     * heap 누수를 방지한다. expireAfterWrite는 오늘자 compute가 가능한 최대 구간(=1일)과 정렬
+     */
+    private final Cache<UUID, Instant> lastInvalidatedAt;
+
+    public UserMarketTrendCacheService(UserMarketTrendRepository userMarketTrendRepository) {
+        this.userMarketTrendRepository = userMarketTrendRepository;
+        this.lastInvalidatedAt = Caffeine.newBuilder()
+                .maximumSize(INVALIDATION_CACHE_MAX_SIZE)
+                .expireAfterWrite(INVALIDATION_CACHE_TTL)
+                .build();
+    }
 
     /**
-     * 관심사 등록/삭제 직전의 시점(호출 측이 전달)을 받아, compute 시작 이후 invalidate가 발생했다면 쓰기를 스킵한다.
-     * 쓰기 자체는 REQUIRES_NEW 트랜잭션으로 격리
+     * 사용자의 마지막 invalidate 시각을 반환한다 (없거나 만료되면 null).
+     *
+     * 캐시 read 경로에서 TTL 판정과 함께 CAS 비교를 수행하기 위한 getter.
+     * {@code invalidatedAt > cacheUpdatedAt}이면 row가 DELETE 되기 전 window 안에 있으므로
+     * 호출 측은 stale로 간주해야 한다
+     *
+     * @param userId 조회 대상 사용자 ID
+     * @return 마지막 invalidate 시각, 없으면 {@code null}
+     */
+    public Instant getLastInvalidatedAt(UUID userId) {
+        return lastInvalidatedAt.getIfPresent(userId);
+    }
+
+    /**
+     * 관심사 등록/삭제 직전의 시점(호출 측이 전달)을 받아,\ compute 시작 이후 invalidate가 발생했다면 쓰기를 스킵한다.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void cache(UUID userId,
@@ -46,7 +77,7 @@ public class UserMarketTrendCacheService {
                       String sourceClusterIdsJson,
                       int sourceArticleCount,
                       PersonalizationMode mode) {
-        Instant invalidatedAt = lastInvalidatedAt.get(userId);
+        Instant invalidatedAt = lastInvalidatedAt.getIfPresent(userId);
         if (invalidatedAt != null && invalidatedAt.isAfter(computeStartedAt)) {
             log.info("[UserMarketTrendCache] compute 이후 invalidate 발생 — 캐시 쓰기 스킵 (userId={}, started={}, invalidated={})",
                     userId, computeStartedAt, invalidatedAt);
@@ -63,12 +94,12 @@ public class UserMarketTrendCacheService {
     /**
      * 사용자의 오늘자 캐시를 무효화한다 (관심사 추가/삭제 시 호출).
      *
-     * <p>호출자가 트랜잭션 안에 있으면 afterCommit에서 실제 삭제를 수행하여:
-     * <ul>
-     *   <li>관심사 저장이 롤백될 경우 캐시 삭제도 일어나지 않음 (일관성 유지)</li>
-     *   <li>캐시 삭제 실패가 관심사 저장 트랜잭션을 말아먹지 않음 (best-effort)</li>
-     *   <li>self-invocation 문제 없이 Spring Data의 기본 @Transactional이 적용됨</li>
-     * </ul>
+     * 호출자가 트랜잭션 안에 있으면 afterCommit에서 실제 삭제를 수행하여:
+     *
+     *   관심사 저장이 롤백될 경우 캐시 삭제도 일어나지 않음 (일관성 유지)
+     *   캐시 삭제 실패가 관심사 저장 트랜잭션을 말아먹지 않음 (best-effort)
+     *   self-invocation 문제 없이 Spring Data의 기본 @Transactional이 적용됨
+     *
      * 타임스탬프({@code lastInvalidatedAt})는 호출 즉시 기록하여 진행 중인 compute가 stale 스냅샷을 저장하지 못하게 한다
      */
     public void invalidateToday(UUID userId) {

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
@@ -1,0 +1,79 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.solv.wefin.domain.market.trend.dto.PersonalizationMode;
+import com.solv.wefin.domain.market.trend.repository.UserMarketTrendRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * 사용자별 맞춤 동향 캐시 쓰기/무효화 전담 (트랜잭션 경계)
+ *
+ * 캐시 read는 {@link PersonalizedMarketTrendService} 내부에서 직접 수행하고,
+ * 쓰기/삭제는 본 서비스를 통해 짧은 트랜잭션으로 처리한다 (AI 외부 호출과 분리)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserMarketTrendCacheService {
+
+    public static final ZoneId TREND_ZONE = ZoneId.of("Asia/Seoul"); //캐시 TTL 기준 timezone
+
+    private final UserMarketTrendRepository userMarketTrendRepository;
+    private final ConcurrentMap<UUID, Instant> lastInvalidatedAt = new ConcurrentHashMap<>(); // 사용자별 마지막 invalidate 시각
+
+    /**
+     * 관심사 등록/삭제 직전의 시점(호출 측이 전달)을 받아, compute 시작 이후 invalidate가 발생했다면 쓰기를 스킵한다.
+     * 쓰기 자체는 REQUIRES_NEW 트랜잭션으로 격리
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void cache(UUID userId,
+                      Instant computeStartedAt,
+                      String summary,
+                      String insightCardsJson,
+                      String relatedKeywordsJson,
+                      String sourceClusterIdsJson,
+                      int sourceArticleCount,
+                      PersonalizationMode mode) {
+        Instant invalidatedAt = lastInvalidatedAt.get(userId);
+        if (invalidatedAt != null && invalidatedAt.isAfter(computeStartedAt)) {
+            log.info("[UserMarketTrendCache] compute 이후 invalidate 발생 — 캐시 쓰기 스킵 (userId={}, started={}, invalidated={})",
+                    userId, computeStartedAt, invalidatedAt);
+            return;
+        }
+        LocalDate today = LocalDate.now(TREND_ZONE);
+        userMarketTrendRepository.upsert(userId, today, mode.name(), summary,
+                insightCardsJson, relatedKeywordsJson, sourceClusterIdsJson,
+                sourceArticleCount);
+        log.info("[UserMarketTrendCache] 캐시 저장 — userId={}, trendDate={}, mode={}, articles={}",
+                userId, today, mode, sourceArticleCount);
+    }
+
+    /**
+     * 사용자의 오늘자 캐시를 삭제한다 (관심사 추가/삭제 시 호출)
+     */
+    public void invalidateToday(UUID userId) {
+        lastInvalidatedAt.put(userId, Instant.now());
+        try {
+            invalidateTodayInternal(userId);
+        } catch (Exception e) {
+            log.warn("[UserMarketTrendCache] 캐시 무효화 실패 — 관심사 등록은 정상 진행 (userId={})", userId, e);
+        }
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    protected void invalidateTodayInternal(UUID userId) {
+        LocalDate today = LocalDate.now(TREND_ZONE);
+        userMarketTrendRepository.deleteByUserIdAndTrendDate(userId, today);
+        log.info("[UserMarketTrendCache] 캐시 무효화 — userId={}, trendDate={}", userId, today);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
@@ -100,18 +100,22 @@ public class UserMarketTrendCacheService {
      *   캐시 삭제 실패가 관심사 저장 트랜잭션을 말아먹지 않음 (best-effort)
      *   self-invocation 문제 없이 Spring Data의 기본 @Transactional이 적용됨
      *
-     * 타임스탬프({@code lastInvalidatedAt})는 호출 즉시 기록하여 진행 중인 compute가 stale 스냅샷을 저장하지 못하게 한다
+     * 타임스탬프({@code lastInvalidatedAt})는 트랜잭션 활성 시 afterCommit에서 기록한다.
+     * 커밋 전에 먼저 기록하면, 아직 커밋되지 않은 관심사 변경을 다른 경로의 compute가 구 데이터로 읽은 뒤
+     * {@code invalidatedAt < computeStartedAt}으로 판정되어 stale 스냅샷을 캐시에 저장할 수 있기 때문이다.
+     * 비트랜잭션 경로에서는 즉시 기록한다.
      */
     public void invalidateToday(UUID userId) {
-        lastInvalidatedAt.put(userId, Instant.now());
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
+                    lastInvalidatedAt.put(userId, Instant.now());
                     deleteQuietly(userId);
                 }
             });
         } else {
+            lastInvalidatedAt.put(userId, Instant.now());
             deleteQuietly(userId);
         }
     }

--- a/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
+++ b/src/main/java/com/solv/wefin/domain/market/trend/service/UserMarketTrendCacheService.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -18,7 +20,7 @@ import java.util.concurrent.ConcurrentMap;
 /**
  * 사용자별 맞춤 동향 캐시 쓰기/무효화 전담 (트랜잭션 경계)
  *
- * 캐시 read는 {@link PersonalizedMarketTrendService} 내부에서 직접 수행하고,
+ * <p>캐시 read는 {@link PersonalizedMarketTrendService} 내부에서 직접 수행하고,
  * 쓰기/삭제는 본 서비스를 통해 짧은 트랜잭션으로 처리한다 (AI 외부 호출과 분리)
  */
 @Slf4j
@@ -26,7 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 @RequiredArgsConstructor
 public class UserMarketTrendCacheService {
 
-    public static final ZoneId TREND_ZONE = ZoneId.of("Asia/Seoul"); //캐시 TTL 기준 timezone
+    public static final ZoneId TREND_ZONE = ZoneId.of("Asia/Seoul"); // 캐시 TTL 기준 timezone
 
     private final UserMarketTrendRepository userMarketTrendRepository;
     private final ConcurrentMap<UUID, Instant> lastInvalidatedAt = new ConcurrentHashMap<>(); // 사용자별 마지막 invalidate 시각
@@ -59,21 +61,37 @@ public class UserMarketTrendCacheService {
     }
 
     /**
-     * 사용자의 오늘자 캐시를 삭제한다 (관심사 추가/삭제 시 호출)
+     * 사용자의 오늘자 캐시를 무효화한다 (관심사 추가/삭제 시 호출).
+     *
+     * <p>호출자가 트랜잭션 안에 있으면 afterCommit에서 실제 삭제를 수행하여:
+     * <ul>
+     *   <li>관심사 저장이 롤백될 경우 캐시 삭제도 일어나지 않음 (일관성 유지)</li>
+     *   <li>캐시 삭제 실패가 관심사 저장 트랜잭션을 말아먹지 않음 (best-effort)</li>
+     *   <li>self-invocation 문제 없이 Spring Data의 기본 @Transactional이 적용됨</li>
+     * </ul>
+     * 타임스탬프({@code lastInvalidatedAt})는 호출 즉시 기록하여 진행 중인 compute가 stale 스냅샷을 저장하지 못하게 한다
      */
     public void invalidateToday(UUID userId) {
         lastInvalidatedAt.put(userId, Instant.now());
-        try {
-            invalidateTodayInternal(userId);
-        } catch (Exception e) {
-            log.warn("[UserMarketTrendCache] 캐시 무효화 실패 — 관심사 등록은 정상 진행 (userId={})", userId, e);
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    deleteQuietly(userId);
+                }
+            });
+        } else {
+            deleteQuietly(userId);
         }
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    protected void invalidateTodayInternal(UUID userId) {
+    private void deleteQuietly(UUID userId) {
         LocalDate today = LocalDate.now(TREND_ZONE);
-        userMarketTrendRepository.deleteByUserIdAndTrendDate(userId, today);
-        log.info("[UserMarketTrendCache] 캐시 무효화 — userId={}, trendDate={}", userId, today);
+        try {
+            userMarketTrendRepository.deleteByUserIdAndTrendDate(userId, today);
+            log.info("[UserMarketTrendCache] 캐시 무효화 — userId={}, trendDate={}", userId, today);
+        } catch (Exception e) {
+            log.warn("[UserMarketTrendCache] 캐시 무효화 실패 — 본 요청은 정상 진행 (userId={})", userId, e);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -102,6 +102,43 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
             @Param("cutoff") OffsetDateTime cutoff,
             Pageable pageable);
 
+    /**
+     * 맞춤 금융 동향용 — 최근 특정 시각 이후 발행된 클러스터 중 사용자 관심사(STOCK/SECTOR/TOPIC) 와
+     * 하나라도 매칭되는 클러스터를 최신순으로 조회한다.
+     *
+     * 매칭 조건은 {@code NewsClusterArticle} → {@code NewsArticleTag} EXISTS 서브쿼리로 표현하며,
+     * 세 타입은 OR 결합. 빈 코드 리스트는 JPQL {@code IN ()} 에러를 내므로 호출 측에서 sentinel
+     * (실제로 매칭되지 않을 빈 문자열 등)을 넣어 조건을 비활성화해야 한다
+     */
+    @Query("SELECT DISTINCT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "AND c.publishedAt IS NOT NULL " +
+            "AND c.publishedAt >= :cutoff " +
+            "AND EXISTS (" +
+            "    SELECT 1 FROM NewsClusterArticle nca " +
+            "    JOIN NewsArticleTag t ON t.newsArticleId = nca.newsArticleId " +
+            "    WHERE nca.newsClusterId = c.id " +
+            "    AND (" +
+            "        (t.tagType = :stockType AND t.tagCode IN :stockCodes) " +
+            "     OR (t.tagType = :sectorType AND t.tagCode IN :sectorCodes) " +
+            "     OR (t.tagType = :topicType AND t.tagCode IN :topicCodes)" +
+            "    )" +
+            ") " +
+            "ORDER BY c.publishedAt DESC, c.id DESC")
+    List<NewsCluster> findPersonalizedClusters(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            @Param("cutoff") OffsetDateTime cutoff,
+            @Param("stockType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType stockType,
+            @Param("stockCodes") List<String> stockCodes,
+            @Param("sectorType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType sectorType,
+            @Param("sectorCodes") List<String> sectorCodes,
+            @Param("topicType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType topicType,
+            @Param("topicCodes") List<String> topicCodes,
+            Pageable pageable);
+
     // --- 피드 목록: updatedAt 정렬 ---
 
     @Query("SELECT c FROM NewsCluster c " +

--- a/src/main/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistService.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.trading.watchlist.service;
 
 import com.solv.wefin.domain.interest.service.ManualInterestLockService;
+import com.solv.wefin.domain.market.trend.service.UserMarketTrendCacheService;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import com.solv.wefin.domain.trading.stock.entity.Stock;
@@ -30,6 +31,7 @@ public class WatchlistService {
     private final UserInterestRepository userInterestRepository;
     private final StockRepository stockRepository;
     private final ManualInterestLockService manualInterestLockService;
+    private final UserMarketTrendCacheService userMarketTrendCacheService;
 
     public List<WatchlistInfo> getStockList(UUID userId) {
         List<UserInterest> interests = userInterestRepository
@@ -65,11 +67,14 @@ public class WatchlistService {
 
         userInterestRepository.save(UserInterest.createManual(
                 userId, InterestType.STOCK.name(), stockCode, ADD_WATCHLIST_WEIGHT));
+        // 관심사 변경 시 맞춤 동향 캐시 무효화 → 다음 personalized 호출이 새 watchlist로 AI 재호출
+        userMarketTrendCacheService.invalidateToday(userId);
     }
 
     @Transactional
     public void deleteUserInterest(UUID userId, String stockCode) {
         userInterestRepository.deleteByUserIdAndInterestTypeAndInterestValueAndManualRegisteredTrue(
                 userId, InterestType.STOCK.name(), stockCode);
+        userMarketTrendCacheService.invalidateToday(userId);
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**",
-                            "/api/market-trends/**",
+                            "/api/market-trends/overview",
                             "/api/stocks/**", "/api/ranking/**").permitAll()
                         .requestMatchers("/api/admin/**").permitAll() // 임시
                         .anyRequest().authenticated()

--- a/src/main/java/com/solv/wefin/web/market/trend/MarketTrendController.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/MarketTrendController.java
@@ -2,12 +2,16 @@ package com.solv.wefin.web.market.trend;
 
 import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
 import com.solv.wefin.domain.market.trend.service.MarketTrendQueryService;
+import com.solv.wefin.domain.market.trend.service.PersonalizedMarketTrendService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.market.trend.dto.MarketTrendOverviewResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 /**
  * 오늘의 금융 동향 API
@@ -18,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MarketTrendController {
 
     private final MarketTrendQueryService queryService;
+    private final PersonalizedMarketTrendService personalizedService;
 
     /**
      * 오늘 동향 조회 (비회원 가능)
@@ -25,6 +30,18 @@ public class MarketTrendController {
     @GetMapping("/overview")
     public ApiResponse<MarketTrendOverviewResponse> getOverview() {
         MarketTrendOverview overview = queryService.getOverview();
+        return ApiResponse.success(MarketTrendOverviewResponse.from(overview));
+    }
+
+    /**
+     * 사용자 관심사 기반 맞춤 동향 조회 (로그인 필요).
+     *
+     * 관심사 0개거나 매칭 클러스터가 없으면 overview와 동일한 페이로드를 {@code personalized=false}로 반환한다
+     */
+    @GetMapping("/personalized")
+    public ApiResponse<MarketTrendOverviewResponse> getPersonalized(
+            @AuthenticationPrincipal UUID userId) {
+        MarketTrendOverview overview = personalizedService.getForUser(userId);
         return ApiResponse.success(MarketTrendOverviewResponse.from(overview));
     }
 }

--- a/src/main/java/com/solv/wefin/web/market/trend/MarketTrendController.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/MarketTrendController.java
@@ -4,11 +4,14 @@ import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
 import com.solv.wefin.domain.market.trend.service.MarketTrendQueryService;
 import com.solv.wefin.domain.market.trend.service.PersonalizedMarketTrendService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.market.trend.dto.MarketTrendOverviewResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.UUID;
@@ -34,13 +37,24 @@ public class MarketTrendController {
     }
 
     /**
-     * 사용자 관심사 기반 맞춤 동향 조회 (로그인 필요).
+     * 사용자 관심사 기반 맞춤 동향 조회
      *
-     * 관심사 0개거나 매칭 클러스터가 없으면 overview와 동일한 페이로드를 {@code personalized=false}로 반환한다
+     * 관심사 0개거나 매칭 클러스터가 없으면 overview와 동일한 페이로드를 {@code personalized=false}로 반환한다.
+     * {@code cacheOnly=true}면 TTL(30분) 내 캐시만 반환하고 AI 호출은 수행하지 않는다.
      */
     @GetMapping("/personalized")
     public ApiResponse<MarketTrendOverviewResponse> getPersonalized(
-            @AuthenticationPrincipal UUID userId) {
+            @AuthenticationPrincipal UUID userId,
+            @RequestParam(name = "cacheOnly", defaultValue = "false") boolean cacheOnly) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+        if (cacheOnly) {
+            return personalizedService.getCachedForUser(userId)
+                    .map(MarketTrendOverviewResponse::from)
+                    .map(ApiResponse::success)
+                    .orElseGet(() -> ApiResponse.success(null));
+        }
         MarketTrendOverview overview = personalizedService.getForUser(userId);
         return ApiResponse.success(MarketTrendOverviewResponse.from(overview));
     }

--- a/src/main/java/com/solv/wefin/web/market/trend/dto/MarketTrendOverviewResponse.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/dto/MarketTrendOverviewResponse.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.market.trend.dto;
 import com.solv.wefin.domain.market.entity.MarketSnapshot;
 import com.solv.wefin.domain.market.trend.dto.InsightCard;
 import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.market.trend.dto.PersonalizationMode;
 import com.solv.wefin.domain.market.trend.dto.SourceClusterInfo;
 
 import java.math.BigDecimal;
@@ -17,6 +18,10 @@ import java.util.List;
  */
 public record MarketTrendOverviewResponse(
         boolean generated,
+        /** mode == MATCHED 와 동치. 호환용 derived field */
+        boolean personalized,
+        /** "MATCHED" / "ACTION_BRIEFING" / "OVERVIEW_FALLBACK" */
+        PersonalizationMode mode,
         LocalDate trendDate,
         String title,
         String summary,
@@ -41,6 +46,8 @@ public record MarketTrendOverviewResponse(
                 .toList();
         return new MarketTrendOverviewResponse(
                 overview.generated(),
+                overview.personalized(),
+                overview.mode(),
                 overview.trendDate(),
                 overview.title(),
                 overview.summary(),
@@ -64,13 +71,25 @@ public record MarketTrendOverviewResponse(
         }
     }
 
+    /**
+     * 인사이트 카드 응답
+     *
+     * {@code advice} / {@code adviceLabel}은 personalized 응답에서만 채워지며 overview에서는 항상 {@code null}
+     */
     public record InsightCardResponse(
             String headline,
             String body,
+            String advice,
+            String adviceLabel,
             List<Long> relatedClusterIds
     ) {
         public static InsightCardResponse from(InsightCard card) {
-            return new InsightCardResponse(card.headline(), card.body(), card.relatedClusterIds());
+            return new InsightCardResponse(
+                    card.headline(),
+                    card.body(),
+                    card.advice(),
+                    card.adviceLabel(),
+                    card.relatedClusterIds());
         }
     }
 

--- a/src/main/resources/db/migration/V32__add_order_reserved_avg_price.sql
+++ b/src/main/resources/db/migration/V32__add_order_reserved_avg_price.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN reserved_avg_price NUMERIC(15,2) NULL

--- a/src/main/resources/db/migration/V33__create_user_market_trend_cache.sql
+++ b/src/main/resources/db/migration/V33__create_user_market_trend_cache.sql
@@ -21,13 +21,3 @@ CREATE TABLE IF NOT EXISTS user_market_trend (
 );
 
 CREATE INDEX IF NOT EXISTS idx_user_market_trend_user_date ON user_market_trend (user_id, trend_date);
-
-ALTER TABLE user_market_trend
-    ADD COLUMN IF NOT EXISTS mode VARCHAR(30) NOT NULL DEFAULT 'MATCHED';
-
-ALTER TABLE user_market_trend
-    DROP CONSTRAINT IF EXISTS chk_user_market_trend_mode;
-
-ALTER TABLE user_market_trend
-    ADD CONSTRAINT chk_user_market_trend_mode
-        CHECK (mode IN ('MATCHED', 'ACTION_BRIEFING'));

--- a/src/main/resources/db/migration/V33__create_user_market_trend_cache.sql
+++ b/src/main/resources/db/migration/V33__create_user_market_trend_cache.sql
@@ -1,0 +1,33 @@
+-- /api/market-trends/personalized 응답을 사용자 단위로 하루 1회 캐싱한다.
+-- 다음 호출 시 cache hit이면 OpenAI 재호출 없이 즉시 반환하여 비용/지연을 줄인다.
+-- 관심사 변경 시(InterestService/WatchlistService add·delete) 해당 사용자의 오늘자 row를 삭제해 무효화한다.
+--
+-- 캐싱 대상: personalized=true 결과만 저장한다. personalized=false 폴백은 다음 호출 때 다시 시도하기 위해 저장하지 않는다
+
+CREATE TABLE IF NOT EXISTS user_market_trend (
+    user_market_trend_id BIGSERIAL PRIMARY KEY,
+    user_id              UUID         NOT NULL,
+    trend_date           DATE         NOT NULL,
+    mode                 VARCHAR(30)  NOT NULL DEFAULT 'MATCHED',
+    summary              TEXT         NOT NULL,
+    insight_cards        JSONB        NOT NULL,
+    related_keywords     JSONB        NOT NULL,
+    source_cluster_ids   JSONB        NOT NULL,
+    source_article_count INT          NOT NULL DEFAULT 0,
+    created_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at           TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT uk_user_market_trend_user_date UNIQUE (user_id, trend_date),
+    CONSTRAINT chk_user_market_trend_mode CHECK (mode IN ('MATCHED', 'ACTION_BRIEFING'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_market_trend_user_date ON user_market_trend (user_id, trend_date);
+
+ALTER TABLE user_market_trend
+    ADD COLUMN IF NOT EXISTS mode VARCHAR(30) NOT NULL DEFAULT 'MATCHED';
+
+ALTER TABLE user_market_trend
+    DROP CONSTRAINT IF EXISTS chk_user_market_trend_mode;
+
+ALTER TABLE user_market_trend
+    ADD CONSTRAINT chk_user_market_trend_mode
+        CHECK (mode IN ('MATCHED', 'ACTION_BRIEFING'));

--- a/src/test/java/com/solv/wefin/domain/interest/service/InterestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/interest/service/InterestServiceTest.java
@@ -34,6 +34,7 @@ class InterestServiceTest {
     @Mock private UserInterestRepository userInterestRepository;
     @Mock private NewsArticleTagRepository newsArticleTagRepository;
     @Mock private ManualInterestLockService manualInterestLockService;
+    @Mock private com.solv.wefin.domain.market.trend.service.UserMarketTrendCacheService userMarketTrendCacheService;
     @InjectMocks private InterestService interestService;
 
     private final UUID userId = UUID.randomUUID();

--- a/src/test/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/market/trend/service/PersonalizedMarketTrendServiceTest.java
@@ -1,0 +1,255 @@
+package com.solv.wefin.domain.market.trend.service;
+
+import com.solv.wefin.domain.market.entity.MarketSnapshot;
+import com.solv.wefin.domain.market.repository.MarketSnapshotRepository;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.MarketTrendAiException;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.PersonalizedParsedCard;
+import com.solv.wefin.domain.market.trend.client.OpenAiMarketTrendClient.PersonalizedTrendRawResult;
+import com.solv.wefin.domain.market.trend.dto.MarketTrendOverview;
+import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.cluster.service.ClusterTagAggregator;
+import com.solv.wefin.domain.user.entity.UserInterest;
+import com.solv.wefin.domain.user.repository.UserInterestRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PersonalizedMarketTrendServiceTest {
+
+    @Mock private MarketSnapshotRepository marketSnapshotRepository;
+    @Mock private UserInterestRepository userInterestRepository;
+    @Mock private NewsClusterRepository newsClusterRepository;
+    @Mock private NewsClusterArticleRepository clusterArticleRepository;
+    @Mock private NewsArticleTagRepository newsArticleTagRepository;
+    @Mock private ClusterTagAggregator tagAggregator;
+    @Mock private OpenAiMarketTrendClient openAiClient;
+    @Mock private MarketTrendQueryService marketTrendQueryService;
+    @Mock private com.solv.wefin.domain.market.trend.repository.UserMarketTrendRepository userMarketTrendRepository;
+    @Mock private UserMarketTrendCacheService userMarketTrendCacheService;
+    @Spy private MarketTrendCardMapper cardMapper = new MarketTrendCardMapper();
+    @Spy private com.fasterxml.jackson.databind.ObjectMapper objectMapper = new com.fasterxml.jackson.databind.ObjectMapper();
+    @InjectMocks private PersonalizedMarketTrendService service;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @Test
+    @DisplayName("관심사 0개 — overview 폴백 + personalized=false")
+    void noInterests_fallback() {
+        when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(any(), anyString()))
+                .thenReturn(List.of());
+        when(marketTrendQueryService.getOverview()).thenReturn(overview());
+
+        MarketTrendOverview result = service.getForUser(userId);
+
+        assertThat(result.personalized()).isFalse();
+        verify(openAiClient, never()).generatePersonalizedTrend(any(), any(), any(), any(), any(), any(), any());
+        verify(newsClusterRepository, never())
+                .findPersonalizedClusters(any(), any(), any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("매칭 클러스터 0건이지만 일반 24h 클러스터가 있으면 시장 액션 브리핑으로 생성")
+    void noMatchingClusters_butGeneralAvailable_marketActionBriefing() {
+        seedInterests(List.of("005930"), List.of(), List.of());
+        when(newsClusterRepository.findPersonalizedClusters(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+
+        NewsCluster general = mock(NewsCluster.class);
+        when(general.getId()).thenReturn(202L);
+        when(general.getTitle()).thenReturn("코스피 상승");
+        when(general.getSummary()).thenReturn("요약");
+        when(newsClusterRepository.findRecentActiveClusters(any(), any(), any(), any()))
+                .thenReturn(List.of(general));
+
+        NewsClusterArticle nca = mock(NewsClusterArticle.class);
+        when(nca.getNewsClusterId()).thenReturn(202L);
+        when(nca.getNewsArticleId()).thenReturn(8001L);
+        when(clusterArticleRepository.findByNewsClusterIdIn(anyList())).thenReturn(List.of(nca));
+
+        when(openAiClient.generateMarketActionBriefing(any(), any(), any(), any()))
+                .thenReturn(rawResult(List.of(
+                        validCard("c1"), validCard("c2"), validCard("c3"), validCard("c4"))));
+        when(marketTrendQueryService.resolveSourceClusters(anyList())).thenReturn(List.of());
+        when(marketSnapshotRepository.findAll()).thenReturn(List.of());
+
+        MarketTrendOverview result = service.getForUser(userId);
+
+        // ACTION_BRIEFING 모드: personalized()는 false (MATCHED만 true), mode 필드로 정확한 의미 전달
+        assertThat(result.personalized()).isFalse();
+        assertThat(result.mode())
+                .isEqualTo(com.solv.wefin.domain.market.trend.dto.PersonalizationMode.ACTION_BRIEFING);
+        verify(marketTrendQueryService, never()).getOverview();
+        verify(openAiClient, never()).generatePersonalizedTrend(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("매칭도 일반도 모두 0건 — overview 폴백")
+    void noClustersAtAll_fallback() {
+        seedInterests(List.of("005930"), List.of(), List.of());
+        when(newsClusterRepository.findPersonalizedClusters(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of());
+        when(newsClusterRepository.findRecentActiveClusters(any(), any(), any(), any()))
+                .thenReturn(List.of());
+        when(marketTrendQueryService.getOverview()).thenReturn(overview());
+
+        MarketTrendOverview result = service.getForUser(userId);
+
+        assertThat(result.personalized()).isFalse();
+        verify(openAiClient, never()).generatePersonalizedTrend(any(), any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("AI 호출 실패 — overview 폴백")
+    void aiException_fallback() {
+        seedInterests(List.of("005930"), List.of(), List.of());
+        seedMatchingClusters();
+        when(openAiClient.generatePersonalizedTrend(any(), any(), any(), any(), any(), any(), any()))
+                .thenThrow(new MarketTrendAiException("boom", null));
+        when(marketTrendQueryService.getOverview()).thenReturn(overview());
+
+        MarketTrendOverview result = service.getForUser(userId);
+
+        assertThat(result.personalized()).isFalse();
+    }
+
+    @Test
+    @DisplayName("AI 응답 카드 중 advice/adviceLabel 누락 — overview 폴백")
+    void missingAdvice_fallback() {
+        seedInterests(List.of("005930"), List.of(), List.of());
+        seedMatchingClusters();
+        when(openAiClient.generatePersonalizedTrend(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(rawResult(List.of(
+                        validCard("c1"),
+                        validCard("c2"),
+                        cardMissingAdvice(),
+                        validCard("c4"))));
+        when(marketTrendQueryService.getOverview()).thenReturn(overview());
+
+        MarketTrendOverview result = service.getForUser(userId);
+
+        // mapper가 invalid card를 걸러내 cards.size != 4 → 폴백
+        assertThat(result.personalized()).isFalse();
+    }
+
+    @Test
+    @DisplayName("정상 — personalized=true + 카드 4개 advice 모두 채워짐")
+    void success_personalized() {
+        seedInterests(List.of("005930"), List.of(), List.of());
+        seedMatchingClusters();
+        when(openAiClient.generatePersonalizedTrend(any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(rawResult(List.of(
+                        validCard("c1"), validCard("c2"), validCard("c3"), validCard("c4"))));
+        when(marketTrendQueryService.resolveSourceClusters(anyList())).thenReturn(List.of());
+        when(marketSnapshotRepository.findAll()).thenReturn(List.of());
+
+        MarketTrendOverview result = service.getForUser(userId);
+
+        assertThat(result.personalized()).isTrue();
+        assertThat(result.generated()).isTrue();
+        assertThat(result.summary()).isEqualTo("맞춤 시장 분석 본문");
+        assertThat(result.insightCards()).hasSize(4);
+        assertThat(result.insightCards()).allSatisfy(card -> {
+            assertThat(card.advice()).isNotBlank();
+            assertThat(card.adviceLabel()).isIn("오늘의 제안", "투자 힌트");
+            assertThat(card.relatedClusterIds()).isNotEmpty();
+        });
+        verify(marketTrendQueryService, never()).getOverview();
+    }
+
+    // ── helpers ───────────────────────────────────────────────
+
+    private void seedInterests(List<String> stocks, List<String> sectors, List<String> topics) {
+        when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "STOCK"))
+                .thenReturn(toInterests(stocks, "STOCK"));
+        when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "SECTOR"))
+                .thenReturn(toInterests(sectors, "SECTOR"));
+        when(userInterestRepository.findByUserIdAndInterestTypeAndManualRegisteredTrue(userId, "TOPIC"))
+                .thenReturn(toInterests(topics, "TOPIC"));
+    }
+
+    private List<UserInterest> toInterests(List<String> codes, String type) {
+        return codes.stream()
+                .map(code -> UserInterest.createManual(userId, type, code, BigDecimal.valueOf(5)))
+                .toList();
+    }
+
+    private void seedMatchingClusters() {
+        NewsCluster cluster = mock(NewsCluster.class);
+        when(cluster.getId()).thenReturn(101L);
+        when(cluster.getTitle()).thenReturn("삼성전자 실적 호조");
+        when(cluster.getSummary()).thenReturn("요약");
+        when(newsClusterRepository.findPersonalizedClusters(
+                any(), any(), any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(List.of(cluster));
+
+        NewsClusterArticle nca = mock(NewsClusterArticle.class);
+        when(nca.getNewsClusterId()).thenReturn(101L);
+        when(nca.getNewsArticleId()).thenReturn(9001L);
+        when(clusterArticleRepository.findByNewsClusterIdIn(anyList())).thenReturn(List.of(nca));
+    }
+
+    private PersonalizedTrendRawResult rawResult(List<PersonalizedParsedCard> cards) {
+        return new PersonalizedTrendRawResult(
+                "맞춤 시장 분석 본문",
+                cards,
+                List.of("반도체", "HBM", "AI", "기준금리", "엔비디아"));
+    }
+
+    private PersonalizedParsedCard validCard(String suffix) {
+        return new PersonalizedParsedCard(
+                "헤드라인 " + suffix,
+                "본문 " + suffix,
+                "조언 " + suffix,
+                "오늘의 제안",
+                List.of(1));
+    }
+
+    private PersonalizedParsedCard cardMissingAdvice() {
+        return new PersonalizedParsedCard(
+                "헤드라인",
+                "본문",
+                null,
+                "오늘의 제안",
+                List.of(1));
+    }
+
+    private MarketTrendOverview overview() {
+        return new MarketTrendOverview(
+                true,
+                com.solv.wefin.domain.market.trend.dto.PersonalizationMode.OVERVIEW_FALLBACK,
+                java.time.LocalDate.now(),
+                "overview title", "overview summary",
+                List.of(), List.of(), List.of(), 0,
+                OffsetDateTime.now(),
+                List.<MarketSnapshot>of());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/watchlist/service/WatchlistServiceTest.java
@@ -36,6 +36,7 @@ class WatchlistServiceTest {
     @Mock private StockRepository stockRepository;
     @Mock private MarketService marketService;
     @Mock private com.solv.wefin.domain.interest.service.ManualInterestLockService manualInterestLockService;
+    @Mock private com.solv.wefin.domain.market.trend.service.UserMarketTrendCacheService userMarketTrendCacheService;
     @InjectMocks private WatchlistService watchlistService;
 
     private final UUID userId = UUID.randomUUID();


### PR DESCRIPTION
## 📌 PR 설명
사용자 관심사를 기반으로 한 맞춤 금융 동향(`GET /api/market-trends/personalized`) 엔드포인트를 추가했습니다. 시장 개요 박스 + 인사이트 카드 4장 + 카드별 advice/adviceLabel("오늘의 제안" / "투자 힌트")까지 한 번의 OpenAI 호출로 생성하고, 사용자별 DB 캐시(30분 TTL)로 비용·지연을 통제합니다.

매칭되는 최근 24h 클러스터가 0건이면 일반 시장 클러스터를 컨텍스트로 시장 액션 브리핑으로 전환합니다. 관심사도 0건이거나 일반 클러스터도 0건인 극단 케이스만 overview로 폴백합니다.

<br>

### 🔄 데이터 흐름

```
[프론트 진입]
  ├─ overview API 호출 (모든 사용자)
  └─ localStorage에 personalizedOn=1 있으면(오늘 날짜) → personalized API 자동 호출

[버튼 클릭]
  ├─ 비로그인 → 로그인 모달
  ├─ 분석 결과 없음 → personalizedOn=true + localStorage 저장 → personalized API
  ├─ 결과 있고 30분 미만 → window.alert (호출 안 함)
  └─ 결과 있고 30분 경과 → invalidateQueries + refetch

[GET /api/market-trends/personalized]
  └─ PersonalizedMarketTrendService.getForUser(userId)
        ├─ 0. user_market_trend 캐시 lookup (오늘 + TTL 30분 안)
        │     hit → 즉시 반환 (AI 미호출)
        ├─ 1. 관심사 조회 (STOCK/SECTOR/TOPIC × 3) — manual_registered=true만
        │     0개 → overview 폴백 (personalized=false)
        ├─ 2. 매칭 클러스터 조회 (findPersonalizedClusters, 24h cutoff)
        │     ≥1 → matchedMode=true (사용자 관점 분석)
        │      0 → 일반 24h 클러스터로 폴백 (시장 액션 브리핑 모드)
        │            그조차 0 → overview 폴백
        ├─ 3. 태그 집계 (떠오르는 종목·주제) — overview와 동일 패턴
        ├─ 4. 관심사 표시명 lookup (NewsArticleTag.findTagNamesByTagTypeAndTagCodes)
        ├─ 5. AI 호출 분기:
        │     matchedMode  → openAi.generatePersonalizedTrend(..., interestNames)
        │     !matchedMode → openAi.generateMarketActionBriefing(...)
        ├─ 6. 검증 (카드 4 / 출처≥1 / advice·adviceLabel non-blank / 키워드 5~10)
        │     실패 → overview 폴백
        ├─ 7. 응답 조립 (personalized=true)
        └─ 8. user_market_trend upsert (다음 호출 cache hit 보장)

[관심사 변경 — InterestService.add/delete, WatchlistService.add/delete]
  └─ userMarketTrendCacheService.invalidateToday(userId)
        → 다음 personalized 호출이 새 관심사로 AI 재생성
```

<br>

## ✅ 완료한 기능 명세
### 신규 파일 (읽기 권장 순서)
1. **V33__create_user_market_trend_cache.sql** — 사용자별 캐시 테이블
2. **UserMarketTrend.java** — JSONB 컬럼 5종 + updated_at
3. **UserMarketTrendRepository.java** — `findByUserIdAndTrendDate`, native upsert(`ON CONFLICT DO UPDATE`), `deleteByUserIdAndTrendDate`
4. **UserMarketTrendCacheService.java** — `cache(userId, computeStartedAt, ...)` / `invalidateToday(userId)`. KST 기준 today 계산. 무효화는 `REQUIRES_NEW` + try/catch best-effort. in-memory `lastInvalidatedAt`으로 compute↔invalidate 레이싱 시 stale 쓰기 차단
5. **MarketTrendCardMapper.java** — overview/personalized 카드 매핑·출처 union·태그 집계 공유 유틸 (4단계 추출)
6. **PersonalizedMarketTrendService.java** — 8단계 흐름 오케스트레이션. 캐시 lookup(30분 TTL) + matchedMode 분기 + 폴백 + upsert
7. **MARKET_ACTION_SYSTEM_PROMPT** in `OpenAiMarketTrendClient.java` — 시장 액션 브리핑 system 프롬프트 + 매칭 0건 응답 스키마
8. **PersonalizedMarketTrendServiceTest.java** — 단위 테스트 6건 (관심사 0개 / 매칭 0건+일반 있음 / 매칭+일반 모두 0건 / advice 누락 / AI 실패 / 정상)

### 수정 파일
- **NewsClusterRepository.java** — `findPersonalizedClusters`(STOCK/SECTOR/TOPIC OR EXISTS, 24h cutoff)
- **OpenAiMarketTrendClient.java** — `generatePersonalizedTrend` + `generateMarketActionBriefing` 메서드 추가, `PERSONALIZED_SYSTEM_PROMPT` advice 구체성 강화, `PersonalizedTrendRawResult` / `PersonalizedParsedCard` 신규 record
- **InsightCard.java** — `advice` / `adviceLabel` (nullable) 필드 + `withoutAdvice(...)` 헬퍼
- **MarketTrendOverview.java** — `mode` 필드(nullable `PersonalizationMode`) + `withMode(...)` helper + `personalized()` 호환 accessor
- **MarketTrendOverviewResponse.java** — `mode` + `personalized` 응답 필드 (overview는 mode=null) + InsightCardResponse에 advice/adviceLabel 노출
- **MarketTrendQueryService.java** — overview 응답의 `mode=null` 명시 + `resolveSourceClusters(List<Long>)` public 오버로드 노출 (재사용)
- **PersonalizedMarketTrendService** 내부 정리 — `overviewFallback()` / `orSentinel(...)` 헬퍼로 폴백 6곳·sentinel 중복 일원화. `assembleFromCache`는 카드의 `relatedClusterIds`를 resolved된 ACTIVE 클러스터 id로 필터링해 캐시 저장 이후 클러스터 INACTIVE 처리 시 카드 클릭 404 방지
- **MarketTrendGenerationService.java** — 카드 매핑/출처 계산 로직을 `MarketTrendCardMapper`로 위임
- **MarketTrendController.java** — `/personalized` 엔드포인트 추가 (`@AuthenticationPrincipal UUID`)
- **SecurityConfig.java** — `/api/market-trends/**` → `/overview`로 좁혀 익명 허용, `/personalized`는 인증 필요
- **InterestService.java**, **WatchlistService.java** — 관심사 add/delete 시 `UserMarketTrendCacheService.invalidateToday(userId)` 호출
- 관련 단위 테스트(InterestServiceTest, WatchlistServiceTest) mock 추가

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
### 1. lazy vs eager — lazy 선택

처음엔 로그인 사용자에게 진입 시 자동 호출(eager)도 검토했지만 다음 이유로 버튼 클릭 시점에만 호출하는 lazy로 결정했습니다.

- AI 호출 비용이 가장 큰 자원. 자동 호출은 활성 사용자 × 페이지 진입 횟수만큼 누적
- 사용자가 명시적으로 "맞춤 분석"을 요청한 의도와 호출이 일치
- 로그인 사용자가 홈만 들렀다가 떠나는 경우의 비용 0

대신 백엔드 캐시(30분 TTL) + 프론트 localStorage 영속화로 두 번째 진입부터는 즉시 결과가 노출되도록 보강했습니다.

### 2. 한 번의 호출에 5개 텍스트 블록을 모두 생성

화면 구성상 다음 5개 텍스트가 필요합니다.

| 화면 요소 | 응답 필드 |
|---|---|
| 그라데이션 박스 본문 | `summary` |
| 인사이트 카드 4장 — 헤드라인 | `insightCards[].headline` |
| 인사이트 카드 4장 — 본문 | `insightCards[].body` (≤ 80자) |
| 카드 흰색 조언 박스 | `insightCards[].advice` (60~100자) |
| 조언 라벨 ("오늘의 제안" / "투자 힌트") | `insightCards[].adviceLabel` |

토글마다 5번 AI 호출은 비용·UX 모두 부담이라 **하나의 호출로 묶어** 프롬프트 system 메시지가 5개 텍스트를 모두 채우도록 강제했습니다. 카드별 검증(개수 4 / advice·adviceLabel non-blank / adviceLabel 화이트리스트 / 출처 클러스터 ≥1 / 키워드 5~10)을 통과하지 못하면 overview 폴백합니다.


### 3. 응답 의미 분리 — `mode` enum 도입 (리뷰 반영)

초기엔 `personalized: boolean` 단일 필드로 응답을 분류했지만, 매칭 0건일 때 생성되는 시장 액션 브리핑(generic 콘텐츠)이 `personalized=true`로 잘못 분류되는 의미 충돌이 발생했습니다.

`PersonalizationMode` enum 도입으로 정리:

| mode | 의미 | 어느 엔드포인트 | personalized() |
|---|---|---|---|
| `null` | personalized 분류 미적용 | `/overview` | false |
| `MATCHED` | 관심사 매칭 분석 | `/personalized` | true |
| `ACTION_BRIEFING` | 매칭 0건 → 일반 시장 액션 분석 | `/personalized` | false |
| `OVERVIEW_FALLBACK` | 관심사 0개·클러스터 0건·AI/검증 실패 등 | `/personalized` | false |

- 응답 DTO에 `mode` 필드 + `personalized` boolean 모두 노출 (`personalized()`는 `mode == MATCHED` 동치)
- `/overview` 엔드포인트 응답은 항상 `mode = null` — personalized 개념이 적용되지 않음
- 캐시 테이블에 `mode` 컬럼 + CHECK(`MATCHED`/`ACTION_BRIEFING`) 제약. OVERVIEW_FALLBACK은 캐시 X
- 프론트는 mode 값으로 분기 — MATCHED("내 관심 종목 맞춤 동향") / ACTION_BRIEFING("오늘의 시장 액션") / OVERVIEW_FALLBACK(노란 안내 배너) / null(overview 기본 렌더)

### 3-1. 매칭 클러스터 0건일 때 — 시장 액션 브리핑 별도 프롬프트

- 사용자 관심사 정보는 입력에 넣지 않음 — 일반 시장 분석가 톤(3인칭)
- "오늘 시장이 이러하니 일반 투자자가 어떤 액션을 고려할지" 형식으로 작성
- 카드 4장 = 액션 테마 (환율 대응 / 금리 시사점 / 호재 섹터 진입 / 위험 회피 등)

`PersonalizedMarketTrendService`가 매칭 결과 유무로 두 메서드를 분기:
- 매칭 ≥1: `generatePersonalizedTrend(...)`
- 매칭 0: `generateMarketActionBriefing(...)`
- 일반 클러스터도 0: overview 폴백

### 4. 캐싱 — 사용자별 DB 캐시 + 30분 TTL

매 호출 AI 호출은 비용 부담이 존재하고, 사용자가 새로고침/토글마다 다시 받는 UX도 좋지 않다고 판단하였습니다.

**선택: 사용자별 DB 캐시 (V33 `user_market_trend`)**

- 키: `(user_id, trend_date)` unique + `mode` 컬럼 (MATCHED / ACTION_BRIEFING만 저장, OVERVIEW_FALLBACK은 캐시 X)
- TTL: 30분 (overview 배치 주기와 정렬 — 시장 변동을 반영하면서 짧은 주기 반복 호출 방지)
- 무효화 트리거: 관심사 변경(`InterestService.add/delete`, `WatchlistService.add/delete`) → 사용자의 오늘자 row 삭제
- OVERVIEW_FALLBACK 폴백은 캐시하지 않음 (매칭 데이터가 새로 들어올 수 있어 다음 호출 때 다시 시도)

선택지 비교:
- A. 캐시 없음 — 비용 폭증
- B. **DB 캐시 + 30분 TTL** ✓
- C. in-memory Caffeine — 멀티 인스턴스 비호환
- D. overview 갱신 시점 동기화(`cache.updated_at < marketTrend.updated_at`) — TTL 30분과 사실상 동등하지만 구현이 복잡

### 4-1. 캐시 무효화 트랜잭션 분리 + invalidate↔compute 레이싱 방지

초안은 `InterestService.add/delete`가 호출되는 트랜잭션 안에서 `UserMarketTrendCacheService.invalidateToday(userId)`가 같이 실행되었는데, 두 가지 문제가 지적됨:

1. **invalidate 실패가 관심사 등록을 통째로 롤백** → 부가 캐시 장애로 핵심 기능이 깨짐
2. **invalidate ↔ compute 레이싱**: AI 호출 진행 중(T0~T2) T1에 invalidate가 끼어들면, 캐시 row가 없어 no-op 처리 후 T2의 AI 결과(= 구 관심사 스냅샷)가 덮어씀 → stale 캐시가 30분 유지

**반영**
- `invalidateToday()`를 외부 메서드로 두고 내부 `invalidateTodayInternal(userId)`는 `@Transactional(REQUIRES_NEW)` — 호출자 트랜잭션에서 독립
- 전체를 try/catch로 감싸 캐시 장애가 관심사 등록을 실패시키지 않도록 best-effort 보장 (WARN 로그만)
- in-memory `ConcurrentMap<UUID, Instant> lastInvalidatedAt`에 invalidate 시각 기록
- `PersonalizedMarketTrendService`가 AI 호출 직전 `computeStartedAt = Instant.now()`를 기록하고 `cache(...)` 호출 시 전달
- 캐시 쓰기 직전 `lastInvalidatedAt > computeStartedAt`이면 **쓰기 스킵** → stale 스냅샷이 새 invalidate를 덮지 않음
- 단일 JVM 전제. 멀티 인스턴스 확장 시 Redis 등 공유 스토리지로 이전 필요 (JavaDoc에 명시)

### 5. 프론트 새로고침 후 분석 결과 유지 — localStorage + 백엔드 캐시 이중 활용

토글 상태(`personalizedOn`)를 localStorage에 오늘 날짜 키로 저장(`market-trends:personalized-on:2026-04-15='1'`).

- 새로고침: useState 초기값으로 localStorage 읽음 → 자동 ON → personalized API 호출 → 백엔드 캐시 hit → 즉시 화면 복원
- 다음 날: 키가 날짜 포함이라 자동 무효 → OFF 상태로 fresh 시작
- 비용 영향 0 — 백엔드 캐시 덕분에 새로고침이 AI 재호출로 이어지지 않음

<br>

### 🔗 관련 이슈
Closes #135

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개인화된 시장 트렌드 조회 엔드포인트(/api/market-trends/personalized) 추가
  * 개인화 모드 및 카드별 투자 조언(advice, adviceLabel) 응답 필드 추가
  * 사용자별 일별 개인화 시장 트렌드 캐시 도입 및 캐시 쓰기/무효화 서비스 추가

* **개선 사항**
  * 관심사/워치리스트 변경 시 오늘치 개인화 캐시 자동 무효화
  * 매칭 실패 시 액션 브리핑 또는 개요(fallback) 제공

* **보안**
  * /api/market-trends/** 접근 규칙 제한 — 오픈 경로는 overview 하나로 축소
<!-- end of auto-generated comment: release notes by coderabbit.ai -->