### PR TITLE
[WEF-368] 지정가/부분체결 엔진 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/account/service/VirtualAccountService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/account/service/VirtualAccountService.java
@@ -130,4 +130,12 @@ public class VirtualAccountService {
 	public VirtualAccount getAccountWithLock(Long virtualAccountId) {
 		return getAccountForUpdate(virtualAccountId);
 	}
+
+	/**
+	 * 단건 조회 (락 없음)
+	 */
+	public VirtualAccount getAccount(Long virtualAccountId) {
+		return accountRepository.findById(virtualAccountId)
+				.orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/common/StockInfoProvider.java
+++ b/src/main/java/com/solv/wefin/domain/trading/common/StockInfoProvider.java
@@ -7,4 +7,5 @@ public interface StockInfoProvider {
     Stock getStock(Long stockId);
     String getStockName(String stockCode);
     String getMarket(String stockCode);
+    Stock getStockByCode(String stockCode);
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClient.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
 import com.solv.wefin.domain.trading.market.service.CandleGenerator;
 import com.solv.wefin.domain.trading.market.service.MarketService;
+import com.solv.wefin.domain.trading.matching.service.LimitOrderMatchingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,6 +51,7 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
     private final MarketService marketService;
     private final Set<String> subscribedStocks = ConcurrentHashMap.newKeySet();
     private final CandleGenerator candleGenerator;
+    private final LimitOrderMatchingService limitOrderMatchingService;
 
     // 한투 WS에 연결
     @EventListener(ApplicationReadyEvent.class)
@@ -204,6 +206,13 @@ public class HantuWebSocketClient extends TextWebSocketHandler {
                         new BigDecimal(fields[offset + 9])
                 );
                 marketService.updatePriceCache(fields[offset], priceResponse);
+
+                // 지정가 주문 매칭
+                try {
+                    limitOrderMatchingService.matchLimitOrders(response.stockCode(), response.currentPrice());
+                } catch (Exception e) {
+                    log.error("지정가 매칭 실패: stockCode={}", response.stockCode(), e);
+                }
             } catch (Exception e) {
                 log.warn("체결 레코드 파싱 스킵: index={}, offset={}", i, offset, e);
             }

--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
@@ -19,18 +19,18 @@ public record OrderMatchedEvent(
 	BigDecimal realizedProfit,
 	BigDecimal balance
 ) {
-	public static OrderMatchedEvent ofBuy(UUID orderNo, String stockCode,
+	public static OrderMatchedEvent ofBuy(OrderType orderType, UUID orderNo, String stockCode,
 										  String stockName, Integer quantity,
 										  BigDecimal price, BigDecimal fee, BigDecimal balance) {
-		return new OrderMatchedEvent(OrderType.MARKET, orderNo, stockCode, stockName,
+		return new OrderMatchedEvent(orderType, orderNo, stockCode, stockName,
 			OrderSide.BUY, quantity, price, fee, BigDecimal.ZERO, BigDecimal.ZERO, balance);
 	}
 
-	public static OrderMatchedEvent ofSell(UUID orderNo, String stockCode,
+	public static OrderMatchedEvent ofSell(OrderType orderType, UUID orderNo, String stockCode,
 										   String stockName, Integer quantity,
 										   BigDecimal price, BigDecimal fee, BigDecimal tax,
 										   BigDecimal realizedProfit, BigDecimal balance) {
-		return new OrderMatchedEvent(OrderType.MARKET, orderNo, stockCode, stockName,
+		return new OrderMatchedEvent(orderType, orderNo, stockCode, stockName,
 			OrderSide.SELL, quantity, price, fee, tax, realizedProfit, balance);
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
@@ -1,0 +1,169 @@
+package com.solv.wefin.domain.trading.matching.service;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.common.TradingConstants;
+import com.solv.wefin.domain.trading.matching.event.OrderMatchedEvent;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderStatus;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.domain.trading.trade.service.TradeService;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class LimitOrderMatchingService {
+
+    private final StockInfoProvider stockInfoProvider;
+    private final OrderRepository orderRepository;
+    private final TradeService tradeService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final VirtualAccountService virtualAccountService;
+    private final PortfolioService portfolioService;
+
+    /**
+     * 지정가 주문을 체결 처리한다.
+     */
+    @Transactional
+    public void matchLimitOrders(String stockCode, BigDecimal currentPrice) {
+        Stock stock = stockInfoProvider.getStockByCode(stockCode);
+        List<Order> orders = getFilteredLimitOrderList(stock.getId(), currentPrice);
+
+        for (Order order : orders) {
+            if (order.getSide().equals(OrderSide.BUY)) {
+                matchBuyOrder(order, stock, currentPrice);
+            } else if (order.getSide().equals(OrderSide.SELL)) {
+                matchSellOrder(order, stock, currentPrice);
+            }
+        }
+    }
+
+    private void matchBuyOrder(Order order, Stock stock, BigDecimal currentPrice) {
+        int matchedQuantity = order.getQuantity() - order.getFilledQuantity();
+
+        // 실제 거래 금액/수수료 (체결가 기준)
+        BigDecimal actualCost = currentPrice.multiply(BigDecimal.valueOf(matchedQuantity));
+        BigDecimal actualFee = actualCost
+                .multiply(TradingConstants.FEE_RATE)
+                .setScale(0, RoundingMode.DOWN);
+
+        // 묶여있던 해당 몫 (주문가 기준)
+        BigDecimal reservedCost = order.getRequestPrice()
+                .multiply(BigDecimal.valueOf(matchedQuantity));
+        BigDecimal reservedFee = reservedCost
+                .multiply(TradingConstants.FEE_RATE)
+                .setScale(0, RoundingMode.DOWN);
+
+        // 차액 환급 (requestPrice ≥ currentPrice 이므로 항상 ≥ 0)
+        BigDecimal refund = reservedCost.add(reservedFee)
+                .subtract(actualCost).subtract(actualFee);
+
+        VirtualAccount account = virtualAccountService.getAccountWithLock(
+                order.getVirtualAccountId());
+        if (refund.compareTo(BigDecimal.ZERO) > 0) {
+            account.deposit(refund);
+        }
+
+        // 포트폴리오에 실제 보유 증가 (체결가가 새 매입 단가)
+        portfolioService.addHolding(
+                order.getVirtualAccountId(), stock.getId(), matchedQuantity,
+                currentPrice, order.getCurrency()
+        );
+
+        // Trade 생성 (actualFee 사용)
+        tradeService.createBuyTrade(
+                order.getOrderId(), order.getVirtualAccountId(), stock.getId(),
+                matchedQuantity, currentPrice, actualCost, actualFee,
+                order.getCurrency(), order.getExchangeRate()
+        );
+
+        order.fillPartially(matchedQuantity);
+
+        eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
+                OrderType.LIMIT, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
+                matchedQuantity, currentPrice, actualFee, account.getBalance()
+        ));
+    }
+
+    private void matchSellOrder(Order order, Stock stock, BigDecimal currentPrice) {
+        int matchedQuantity = order.getQuantity() - order.getFilledQuantity();
+
+        // 실제 거래 금액/수수료/세금 (체결가 기준)
+        BigDecimal actualAmount = currentPrice.multiply(BigDecimal.valueOf(matchedQuantity));
+        BigDecimal actualFee = actualAmount
+                .multiply(TradingConstants.FEE_RATE)
+                .setScale(0, RoundingMode.DOWN);
+        BigDecimal actualTax = actualAmount
+                .multiply(TradingConstants.TAX_RATE)
+                .setScale(0, RoundingMode.DOWN);
+
+        // 실현손익 = (체결가 - 주문 생성 시점의 avgPrice 스냅샷) × 수량
+        BigDecimal realizedProfit = currentPrice
+                .subtract(order.getReservedAvgPrice())
+                .multiply(BigDecimal.valueOf(matchedQuantity));
+
+        // 매도 대금에서 수수료/세금 차감 후 계좌 입금
+        BigDecimal netDeposit = actualAmount.subtract(actualFee).subtract(actualTax);
+
+        VirtualAccount account = virtualAccountService.getAccountWithLock(
+                order.getVirtualAccountId());
+        account.deposit(netDeposit);
+
+        // 포트폴리오는 건드리지 않음 (생성 시점에 이미 deductQuantity 완료)
+
+        tradeService.createSellTrade(
+                order.getOrderId(), order.getVirtualAccountId(), stock.getId(),
+                matchedQuantity, currentPrice, actualAmount, actualFee, actualTax,
+                realizedProfit, order.getCurrency(), order.getExchangeRate()
+        );
+
+        order.fillPartially(matchedQuantity);
+
+        eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
+                OrderType.LIMIT, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
+                matchedQuantity, currentPrice, actualFee, actualTax,
+                realizedProfit, account.getBalance()
+        ));
+    }
+
+    /**
+     * 매수/매도 조건에 맞는 주문을 필터링한다.
+     */
+    private List<Order> getFilteredLimitOrderList(Long stockId, BigDecimal currentPrice) {
+        List<Order> orders = getLimitOrderList(stockId);
+
+        return orders.stream()
+                .filter(order -> {
+                    if (order.getSide() == OrderSide.BUY) {
+                        return currentPrice.compareTo(order.getRequestPrice()) <= 0;
+                    } else {
+                        return currentPrice.compareTo(order.getRequestPrice()) >= 0;
+                    }
+                })
+                .toList();
+    }
+
+    /**
+     * PENDING/PARTIAL 지정가 주문을 조회한다.
+     */
+    private List<Order> getLimitOrderList(Long stockId) {
+        return orderRepository.findAllByStatusInAndOrderTypeAndStockId(List.of(OrderStatus.PENDING, OrderStatus.PARTIAL), OrderType.LIMIT, stockId);
+    }
+
+
+
+}

--- a/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
@@ -159,10 +159,18 @@ public class LimitOrderMatchingService {
     }
 
     /**
-     * PENDING/PARTIAL 지정가 주문을 조회한다.
+     * PENDING/PARTIAL 지정가 주문을 비관적 쓰기 락으로 조회한다.
+     *
+     * <p>동시 WebSocket 틱에서 같은 주문을 이중 체결하는 TOCTOU 경쟁과,
+     * 매칭 도중 유저의 취소/수정 경로(findByOrderNoForUpdate)가 개입하는
+     * race condition을 차단하기 위해 FOR UPDATE 조회를 사용한다.
      */
     private List<Order> getLimitOrderList(Long stockId) {
-        return orderRepository.findAllByStatusInAndOrderTypeAndStockId(List.of(OrderStatus.PENDING, OrderStatus.PARTIAL), OrderType.LIMIT, stockId);
+        return orderRepository.findAllByStatusInAndOrderTypeAndStockIdForUpdate(
+                List.of(OrderStatus.PENDING, OrderStatus.PARTIAL),
+                OrderType.LIMIT,
+                stockId
+        );
     }
 
 

--- a/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
@@ -122,6 +122,7 @@ public class LimitOrderMatchingService {
         VirtualAccount account = virtualAccountService.getAccountWithLock(
                 order.getVirtualAccountId());
         account.deposit(netDeposit);
+        account.addProfit(realizedProfit);
 
         // 포트폴리오는 건드리지 않음 (생성 시점에 이미 deductQuantity 완료)
 

--- a/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
@@ -167,4 +167,8 @@ public class Order extends BaseEntity {
 			throw new BusinessException(ErrorCode.ORDER_ALREADY_CANCELLED);
 		}
 	}
+
+	public void updateReservedAvgPrice(BigDecimal newValue) {
+		this.reservedAvgPrice = newValue;
+	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/entity/Order.java
@@ -74,6 +74,8 @@ public class Order extends BaseEntity {
 	@Column(nullable = false)
 	private BigDecimal tax;
 
+	private BigDecimal reservedAvgPrice;
+
 	private OffsetDateTime cancelledAt;
 
 	public Order(Long virtualAccountId, Long stockId, OrderType orderType, OrderSide side, Integer quantity,
@@ -92,6 +94,15 @@ public class Order extends BaseEntity {
 		this.tax = tax;
 	}
 
+	public Order(Long virtualAccountId, Long stockId, OrderType orderType, OrderSide side, Integer quantity,
+				 BigDecimal requestPrice, Currency currency,
+				 BigDecimal exchangeRate, BigDecimal fee, BigDecimal tax,
+				 BigDecimal reservedAvgPrice) {
+		this(virtualAccountId, stockId, orderType, side, quantity, requestPrice, currency,
+				exchangeRate, fee, tax);
+		this.reservedAvgPrice = reservedAvgPrice;
+	}
+
 	// == 비즈니스 메서드 ==
 	public void fill(Integer filledQuantity) {
 		validatePending();
@@ -100,6 +111,21 @@ public class Order extends BaseEntity {
 		}
 		this.status = OrderStatus.FILLED;
 		this.filledQuantity = filledQuantity;
+	}
+
+	public void fillPartially(Integer matchedQuantity) {
+		validatePending();
+
+		if (matchedQuantity == null || matchedQuantity > this.quantity - this.filledQuantity || matchedQuantity <= 0) {
+			throw new BusinessException(ErrorCode.ORDER_INVALID_QUANTITY);
+		}
+		this.filledQuantity = this.filledQuantity + matchedQuantity;
+
+		if (this.filledQuantity.equals(this.quantity)) {
+			this.status = OrderStatus.FILLED;
+		} else {
+			this.status = OrderStatus.PARTIAL;
+		}
 	}
 
 	public void cancel() {

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepository.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.solv.wefin.domain.trading.order.entity.OrderStatus;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +26,6 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
 	Optional<Order> findByOrderNoForUpdate(@Param("orderNo") UUID orderNo);
 
 	List<Order> findAllByVirtualAccountIdOrderByCreatedAtDesc(Long virtualAccountId);
+
+	List<Order> findAllByStatusInAndOrderTypeAndStockId(List<OrderStatus> statuses, OrderType orderType, Long stockId);
 }

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepository.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepository.java
@@ -27,5 +27,24 @@ public interface OrderRepository extends JpaRepository<Order, Long>, OrderReposi
 
 	List<Order> findAllByVirtualAccountIdOrderByCreatedAtDesc(Long virtualAccountId);
 
-	List<Order> findAllByStatusInAndOrderTypeAndStockId(List<OrderStatus> statuses, OrderType orderType, Long stockId);
+	/**
+	 * 매칭 엔진 전용: PENDING/PARTIAL 상태의 지정가 주문을 비관적 쓰기 락으로 조회한다.
+	 *
+	 * <p>동시 WebSocket 틱에서 같은 주문을 이중 체결하는 TOCTOU 경쟁을 차단하기 위해 사용한다.
+	 * 같은 종목에 대한 matchLimitOrders 호출이 여러 트랜잭션에서 동시에 일어나면 첫 번째가
+	 * 락을 잡고 나머지는 대기하게 되어 체결 순서가 직렬화된다.
+	 *
+	 * <p>취소/수정 경로(findByOrderNoForUpdate)와도 같은 row에 대해 경쟁하므로
+	 * cancel-vs-match race condition도 함께 해소된다.
+	 */
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("SELECT o FROM Order o " +
+			"WHERE o.status IN :statuses " +
+			"AND o.orderType = :orderType " +
+			"AND o.stockId = :stockId")
+	List<Order> findAllByStatusInAndOrderTypeAndStockIdForUpdate(
+			@Param("statuses") List<OrderStatus> statuses,
+			@Param("orderType") OrderType orderType,
+			@Param("stockId") Long stockId
+	);
 }

--- a/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/repository/OrderRepositoryImpl.java
@@ -52,6 +52,16 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 			.fetch();
 	}
 
+	/*
+	 * 오늘 최종 체결된 주문을 조회한다.
+	 *
+	 * FILLED 상태의 주문은 validatePending()이 모든 변경(fill, fillPartially,
+	 * cancel, modify)을 차단하므로, 최종 체결 이후에는 엔티티 mutation이 발생하지 않는다.
+	 * 따라서 FILLED 주문에 한해 updatedAt이 사실상 체결 시각과 동일하다.
+	 *
+	 * 주의: "FILLED 주문 불변" 가정이 깨지면 이 쿼리도 깨진다. 향후 FILLED 주문을
+	 * 변경하는 로직이 도입되면 별도 filledAt 컬럼 도입을 검토해야 한다.
+	 */
 	@Override
 	public List<Order> findTodayFilledOrders(Long virtualAccountId, LocalDate today) {
 		OffsetDateTime startOfDay = today.atStartOfDay(KST).toOffsetDateTime();
@@ -61,10 +71,10 @@ public class OrderRepositoryImpl implements OrderRepositoryCustom {
 		return queryFactory
 			.selectFrom(order)
 			.where(
-				accountEq(virtualAccountId),
-				order.status.eq(OrderStatus.FILLED),
-				order.createdAt.goe(startOfDay),
-				order.createdAt.lt(startOfNextDay)
+					accountEq(virtualAccountId),
+					order.status.eq(OrderStatus.FILLED),
+					order.updatedAt.goe(startOfDay),
+					order.updatedAt.lt(startOfNextDay)
 			)
 			.orderBy(order.orderId.desc())
 			.fetch();

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/LimitOrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/LimitOrderService.java
@@ -1,0 +1,115 @@
+package com.solv.wefin.domain.trading.order.service;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.common.TradingConstants;
+import com.solv.wefin.domain.trading.order.dto.OrderInfo;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.portfolio.entity.Currency;
+import com.solv.wefin.domain.trading.portfolio.entity.Portfolio;
+import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.springframework.transaction.annotation.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Service
+@RequiredArgsConstructor
+public class LimitOrderService {
+
+    private final StockInfoProvider stockInfoProvider;
+    private final VirtualAccountService virtualAccountService;
+    private final PortfolioService portfolioService;
+    private final OrderRepository orderRepository;
+
+    @Transactional
+    public OrderInfo buyLimit(Long virtualAccountId, Long stockId, Integer quantity, BigDecimal requestPrice) {
+        // 1. 검증
+        validateQuantity(quantity);
+        if (requestPrice == null || requestPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException(ErrorCode.ORDER_INVALID_AMOUNT);
+        }
+
+        // 2. 종목 조회
+        Stock stock = stockInfoProvider.getStock(stockId);
+
+        // 3. 금액 계산
+        BigDecimal totalAmount = requestPrice.multiply(BigDecimal.valueOf(quantity));
+        BigDecimal fee = totalAmount.multiply(TradingConstants.FEE_RATE).setScale(0, RoundingMode.DOWN);
+
+        // 4. 예수금 차감
+        VirtualAccount account = virtualAccountService.deductBalance(virtualAccountId, totalAmount.add(fee));
+
+        // 5. Order 저장
+        Order order = new Order(
+                virtualAccountId, stockId, OrderType.LIMIT, OrderSide.BUY, quantity,
+                requestPrice, Currency.KRW, null, fee, BigDecimal.ZERO
+        );
+        orderRepository.save(order);
+
+        // 6. OrderInfo 반환
+        return new OrderInfo(
+                order, stock.getStockCode(), stock.getStockName(),
+                requestPrice,
+                totalAmount, BigDecimal.ZERO, BigDecimal.ZERO, account.getBalance()
+        );
+    }
+
+    @Transactional
+    public OrderInfo sellLimit(Long virtualAccountId, Long stockId, Integer quantity, BigDecimal requestPrice) {
+        // 1. 검증
+        validateQuantity(quantity);
+        if (requestPrice == null || requestPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException(ErrorCode.ORDER_INVALID_AMOUNT);
+        }
+
+        // 2. 종목 조회
+        Stock stock = stockInfoProvider.getStock(stockId);
+
+        // 3. 포트폴리오 락 + avgPrice 스냅샷
+        Portfolio portfolio = portfolioService.getPortfolioForUpdate(virtualAccountId, stockId);
+        if (portfolio.getQuantity() < quantity) {
+            throw new BusinessException(ErrorCode.ORDER_INSUFFICIENT_HOLDINGS);
+        }
+        BigDecimal reservedAvgPrice = portfolio.getAvgPrice();
+
+        // 4. 금액 계산
+        BigDecimal totalAmount = requestPrice.multiply(BigDecimal.valueOf(quantity));
+        BigDecimal fee = totalAmount.multiply(TradingConstants.FEE_RATE).setScale(0, RoundingMode.DOWN);
+        BigDecimal tax = totalAmount.multiply(TradingConstants.TAX_RATE).setScale(0, RoundingMode.DOWN);
+
+        // 5. 에스크로 (주식 차감)
+        portfolioService.deductQuantity(virtualAccountId, stockId, quantity);
+
+        // 6. Order 저장
+        Order order = new Order(
+                virtualAccountId, stockId, OrderType.LIMIT, OrderSide.SELL, quantity,
+                requestPrice, Currency.KRW, null, fee, tax, reservedAvgPrice
+        );
+        orderRepository.save(order);
+
+        // 7. 락 없이 조회
+        VirtualAccount account = virtualAccountService.getAccount(virtualAccountId);
+
+        // 8. OrderInfo 반환
+        return new OrderInfo(
+                order, stock.getStockCode(), stock.getStockName(),
+                requestPrice, totalAmount, tax, BigDecimal.ZERO, account.getBalance()
+        );
+    }
+
+    private static void validateQuantity(Integer quantity) {
+        if (quantity == null || quantity <= 0) {
+            throw new BusinessException(ErrorCode.ORDER_INVALID_QUANTITY);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -247,10 +247,26 @@ public class OrderService {
 		} else if (order.getSide() == OrderSide.SELL) {
 			int diffQuantity = Math.abs(newQuantity - oldQuantity);
 			if (newQuantity > oldQuantity) {
+				// 현재 포트폴리오 avgPrice 조회 (deductQuantity는 락 보유 상태)
+				Portfolio portfolio = portfolioService.getPortfolioForUpdate(
+						virtualAccountId, order.getStockId());
+				BigDecimal currentAvgPrice = portfolio.getAvgPrice();
+
+				// 가중평균으로 reservedAvgPrice 갱신
+				// newReservedAvg = (oldQty × oldReservedAvg + diffQty × currentAvg) / newQty
+				BigDecimal oldReservedAvg = order.getReservedAvgPrice();
+				BigDecimal weightedSum = oldReservedAvg
+						.multiply(BigDecimal.valueOf(oldQuantity))
+						.add(currentAvgPrice.multiply(BigDecimal.valueOf(diffQuantity)));
+				BigDecimal newReservedAvg = weightedSum
+						.divide(BigDecimal.valueOf(newQuantity), 2, RoundingMode.HALF_UP);
+				order.updateReservedAvgPrice(newReservedAvg);
+
 				portfolioService.deductQuantity(virtualAccountId, order.getStockId(), diffQuantity);
 			} else if (newQuantity < oldQuantity) {
 				portfolioService.addHolding(virtualAccountId, order.getStockId(), diffQuantity,
-					order.getReservedAvgPrice(), order.getCurrency());
+						order.getReservedAvgPrice(), order.getCurrency());
+				// reservedAvgPrice 그대로 (수량 감소는 기존 스냅샷 유지)
 			}
 		}
 		Stock stock = stockInfoProvider.getStock(order.getStockId());

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -88,7 +88,7 @@ public class OrderService {
 
 		// 9. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
-			order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
+			OrderType.MARKET, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
 			quantity, currentPrice, fee, account.getBalance()
 		));
 
@@ -157,7 +157,7 @@ public class OrderService {
 
 		// 15. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
-			order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
+			OrderType.MARKET, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
 			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance()
 		));
 

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 
 import com.solv.wefin.domain.quest.entity.QuestEventType;
 import com.solv.wefin.domain.quest.service.QuestProgressService;
+import com.solv.wefin.domain.trading.common.TradingConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -189,16 +190,18 @@ public class OrderService {
 
 		BigDecimal refundedAmount = BigDecimal.ZERO;
 		if (order.getSide() == OrderSide.BUY) {
-			refundedAmount = order.getRequestPrice()
-				.multiply(BigDecimal.valueOf(order.getQuantity()))
-				.add(order.getFee());
+			int remainingQuantity = order.getQuantity() - order.getFilledQuantity();
+			BigDecimal remainingCost = order.getRequestPrice()
+					.multiply(BigDecimal.valueOf(remainingQuantity));
+			BigDecimal remainingFee = remainingCost
+					.multiply(TradingConstants.FEE_RATE)
+					.setScale(0, RoundingMode.DOWN);
+			refundedAmount = remainingCost.add(remainingFee);
 			account.deposit(refundedAmount);
 		} else if (order.getSide() == OrderSide.SELL) {
-			// TODO: addHolding은 avgPrice를 재계산함
-			// 취소 시 원래 avgPrice를 유지하는 returnHolding 메서드가 필요
-			// 지정가 매도 구현 후 팀원 협의 필요
-			portfolioService.addHolding(virtualAccountId, order.getStockId(), order.getQuantity(),
-				order.getRequestPrice(), order.getCurrency());
+			int remainingQuantity = order.getQuantity() - order.getFilledQuantity();
+			portfolioService.addHolding(virtualAccountId, order.getStockId(), remainingQuantity,
+				order.getReservedAvgPrice(), order.getCurrency());
 		}
 
 		order.cancel();
@@ -217,6 +220,9 @@ public class OrderService {
 			.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
 		if (order.getOrderType() == OrderType.MARKET) {
 			throw new BusinessException(ErrorCode.ORDER_NOT_MODIFIABLE);
+		}
+		if (order.getFilledQuantity() > 0) {
+			throw new BusinessException(ErrorCode.ORDER_PARTIAL_NOT_MODIFIABLE);
 		}
 
 		order.validateOwnership(virtualAccountId);
@@ -239,15 +245,12 @@ public class OrderService {
 				account.deposit(diff.abs());
 			}
 		} else if (order.getSide() == OrderSide.SELL) {
-			// TODO: addHolding은 avgPrice를 재계산함
-			// 취소 시 원래 avgPrice를 유지하는 returnHolding 메서드가 필요
-			// 지정가 매도 구현 후 팀원 협의 필요
 			int diffQuantity = Math.abs(newQuantity - oldQuantity);
 			if (newQuantity > oldQuantity) {
 				portfolioService.deductQuantity(virtualAccountId, order.getStockId(), diffQuantity);
 			} else if (newQuantity < oldQuantity) {
 				portfolioService.addHolding(virtualAccountId, order.getStockId(), diffQuantity,
-					order.getRequestPrice(), order.getCurrency());
+					order.getReservedAvgPrice(), order.getCurrency());
 			}
 		}
 		Stock stock = stockInfoProvider.getStock(order.getStockId());

--- a/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/service/StockService.java
@@ -19,6 +19,11 @@ public class StockService implements StockInfoProvider {
     private final StockRepository stockRepository;
 
     @Override
+    public Stock getStockByCode(String stockCode) {
+        return findByCodeOrThrow(stockCode);
+    }
+
+    @Override
     public boolean existsByCode(String stockCode) {
         return stockRepository.existsByStockCode(stockCode);
     }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -90,6 +90,7 @@ public enum ErrorCode {
     ORDER_NOT_FOUND(404, "주문을 찾을 수 없습니다."),
     ORDER_ALREADY_CANCELLED(400, "이미 취소된 주문입니다."),
     ORDER_NOT_MODIFIABLE(400, "수정 가능한 상태가 아닙니다."),
+    ORDER_PARTIAL_NOT_MODIFIABLE(400, "부분 체결된 주문은 수정할 수 없습니다. 취소 후 재주문해주세요."),
     ORDER_OWNERSHIP_MISMATCH(403, "소유권이 일치하지 않습니다."),
     ORDER_NOT_CANCELLABLE(400, "주문을 취소할 수 없습니다."),
 

--- a/src/main/java/com/solv/wefin/web/trading/order/LimitOrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/LimitOrderController.java
@@ -1,0 +1,58 @@
+package com.solv.wefin.web.trading.order;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.order.dto.OrderInfo;
+import com.solv.wefin.domain.trading.order.service.LimitOrderService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.trading.order.dto.request.LimitOrderBuyRequest;
+import com.solv.wefin.web.trading.order.dto.request.LimitOrderSellRequest;
+import com.solv.wefin.web.trading.order.dto.response.OrderResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/order/limit")
+@RequiredArgsConstructor
+public class LimitOrderController {
+
+    private final LimitOrderService limitOrderService;
+    private final VirtualAccountService accountService;
+
+    @PostMapping("/buy")
+    public ApiResponse<OrderResponse> buy(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody LimitOrderBuyRequest request
+    ) {
+        VirtualAccount account = accountService.getAccountByUserId(userId);
+        OrderInfo orderInfo = limitOrderService.buyLimit(
+                account.getVirtualAccountId(),
+                request.stockId(),
+                request.quantity(),
+                request.requestPrice()
+        );
+        return ApiResponse.success(OrderResponse.from(orderInfo));
+    }
+
+    @PostMapping("/sell")
+    public ApiResponse<OrderResponse> sell(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody LimitOrderSellRequest request
+    ) {
+        VirtualAccount account = accountService.getAccountByUserId(userId);
+        OrderInfo orderInfo = limitOrderService.sellLimit(
+                account.getVirtualAccountId(),
+                request.stockId(),
+                request.quantity(),
+                request.requestPrice()
+        );
+        return ApiResponse.success(OrderResponse.from(orderInfo));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderBuyRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderBuyRequest.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.web.trading.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public record LimitOrderBuyRequest(
+        @NotNull Long stockId,
+        @NotNull @Min(1) Integer quantity,
+        @NotNull @Positive BigDecimal requestPrice
+) {
+}

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderSellRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderSellRequest.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.trading.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+
+public record LimitOrderSellRequest(
+        @NotNull Long stockId,
+        @NotNull @Min(1) Integer quantity,
+        @NotNull @Positive BigDecimal requestPrice
+) {
+}
+

--- a/src/main/resources/db/migration/V32__add_order_reserved_avg_price.sql
+++ b/src/main/resources/db/migration/V32__add_order_reserved_avg_price.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orders ADD COLUMN reserved_avg_price NUMERIC(15,2) NULL;

--- a/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/client/HantuWebSocketClientTest.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.trading.market.dto.TradeResponse;
 import com.solv.wefin.domain.trading.market.dto.WebSocketMessageType;
 import com.solv.wefin.domain.trading.market.service.CandleGenerator;
 import com.solv.wefin.domain.trading.market.service.MarketService;
+import com.solv.wefin.domain.trading.matching.service.LimitOrderMatchingService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,6 +41,8 @@ class HantuWebSocketClientTest {
     private WebSocketSession session;
     @Mock
     private CandleGenerator candleGenerator;
+    @Mock
+    private LimitOrderMatchingService limitOrderMatchingService;
 
     private HantuWebSocketClient client;
 
@@ -51,7 +54,8 @@ class HantuWebSocketClientTest {
                 objectMapper,
                 messagingTemplate,
                 marketService,
-                candleGenerator
+                candleGenerator,
+                limitOrderMatchingService
         );
     }
 

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/LimitOrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/LimitOrderServiceTest.java
@@ -1,0 +1,198 @@
+package com.solv.wefin.domain.trading.order.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.order.dto.OrderInfo;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.portfolio.entity.Portfolio;
+import com.solv.wefin.domain.trading.portfolio.service.PortfolioService;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class LimitOrderServiceTest {
+
+    @Mock
+    private StockInfoProvider stockInfoProvider;
+    @Mock
+    private VirtualAccountService virtualAccountService;
+    @Mock
+    private PortfolioService portfolioService;
+    @Mock
+    private OrderRepository orderRepository;
+
+    @InjectMocks
+    private LimitOrderService limitOrderService;
+
+    @Nested
+    class BuyLimitTest {
+
+        @Test
+        void 매수_성공_에스크로_차감() {
+            // given
+            Long accountId = 1L;
+            Long stockId = 1L;
+            Stock mockStock = mock(Stock.class);
+            given(stockInfoProvider.getStock(stockId)).willReturn(mockStock);
+            given(mockStock.getStockCode()).willReturn("005930");
+            given(mockStock.getStockName()).willReturn("삼성전자");
+
+            VirtualAccount mockAccount = mock(VirtualAccount.class);
+            given(virtualAccountService.deductBalance(eq(accountId), any(BigDecimal.class)))
+                    .willReturn(mockAccount);
+            given(mockAccount.getBalance()).willReturn(BigDecimal.valueOf(9499925));
+
+            // when
+            OrderInfo result = limitOrderService.buyLimit(
+                    accountId, stockId, 10, BigDecimal.valueOf(50000));
+
+            // then
+            // totalAmount = 50000 * 10 = 500000, fee = 75, escrow = 500075
+            verify(virtualAccountService).deductBalance(accountId, BigDecimal.valueOf(500075));
+
+            ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+            verify(orderRepository).save(captor.capture());
+            Order saved = captor.getValue();
+            assertThat(saved.getOrderType()).isEqualTo(OrderType.LIMIT);
+            assertThat(saved.getSide()).isEqualTo(OrderSide.BUY);
+            assertThat(saved.getQuantity()).isEqualTo(10);
+            assertThat(saved.getRequestPrice()).isEqualByComparingTo(BigDecimal.valueOf(50000));
+            assertThat(saved.getFee()).isEqualByComparingTo(BigDecimal.valueOf(75));
+            assertThat(saved.getReservedAvgPrice()).isNull();
+
+            assertThat(result.price()).isEqualByComparingTo(BigDecimal.valueOf(50000));
+            assertThat(result.totalAmount()).isEqualByComparingTo(BigDecimal.valueOf(500000));
+        }
+
+        @Test
+        void 매수_실패_수량_0이하() {
+            assertThatThrownBy(() ->
+                    limitOrderService.buyLimit(1L, 1L, 0, BigDecimal.valueOf(50000)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_INVALID_QUANTITY.getMessage());
+        }
+
+        @Test
+        void 매수_실패_가격_null() {
+            assertThatThrownBy(() ->
+                    limitOrderService.buyLimit(1L, 1L, 10, null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_INVALID_AMOUNT.getMessage());
+        }
+
+        @Test
+        void 매수_실패_가격_0이하() {
+            assertThatThrownBy(() ->
+                    limitOrderService.buyLimit(1L, 1L, 10, BigDecimal.ZERO))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_INVALID_AMOUNT.getMessage());
+        }
+    }
+
+    @Nested
+    class SellLimitTest {
+
+        @Test
+        void 매도_성공_reservedAvgPrice_스냅샷_저장() {
+            // given
+            Long accountId = 1L;
+            Long stockId = 1L;
+            BigDecimal avgPrice = BigDecimal.valueOf(45000);
+
+            Stock mockStock = mock(Stock.class);
+            given(stockInfoProvider.getStock(stockId)).willReturn(mockStock);
+            given(mockStock.getStockCode()).willReturn("005930");
+            given(mockStock.getStockName()).willReturn("삼성전자");
+
+            Portfolio mockPortfolio = mock(Portfolio.class);
+            given(portfolioService.getPortfolioForUpdate(accountId, stockId))
+                    .willReturn(mockPortfolio);
+            given(mockPortfolio.getQuantity()).willReturn(100);
+            given(mockPortfolio.getAvgPrice()).willReturn(avgPrice);
+
+            VirtualAccount mockAccount = mock(VirtualAccount.class);
+            given(virtualAccountService.getAccount(accountId)).willReturn(mockAccount);
+            given(mockAccount.getBalance()).willReturn(BigDecimal.valueOf(1000000));
+
+            // when
+            OrderInfo result = limitOrderService.sellLimit(
+                    accountId, stockId, 10, BigDecimal.valueOf(50000));
+
+            // then
+            verify(portfolioService).deductQuantity(accountId, stockId, 10);
+
+            ArgumentCaptor<Order> captor = ArgumentCaptor.forClass(Order.class);
+            verify(orderRepository).save(captor.capture());
+            Order saved = captor.getValue();
+            assertThat(saved.getOrderType()).isEqualTo(OrderType.LIMIT);
+            assertThat(saved.getSide()).isEqualTo(OrderSide.SELL);
+            // fee = 500000 * 0.00015 = 75
+            assertThat(saved.getFee()).isEqualByComparingTo(BigDecimal.valueOf(75));
+            // tax = 500000 * 0.0018 = 900
+            assertThat(saved.getTax()).isEqualByComparingTo(BigDecimal.valueOf(900));
+            // 핵심: reservedAvgPrice 스냅샷
+            assertThat(saved.getReservedAvgPrice()).isEqualByComparingTo(avgPrice);
+
+            assertThat(result.price()).isEqualByComparingTo(BigDecimal.valueOf(50000));
+            assertThat(result.tax()).isEqualByComparingTo(BigDecimal.valueOf(900));
+        }
+
+        @Test
+        void 매도_실패_보유부족() {
+            // given
+            Long accountId = 1L;
+            Long stockId = 1L;
+
+            Stock mockStock = mock(Stock.class);
+            given(stockInfoProvider.getStock(stockId)).willReturn(mockStock);
+
+            Portfolio mockPortfolio = mock(Portfolio.class);
+            given(portfolioService.getPortfolioForUpdate(accountId, stockId))
+                    .willReturn(mockPortfolio);
+            given(mockPortfolio.getQuantity()).willReturn(5);
+
+            // when & then
+            assertThatThrownBy(() ->
+                    limitOrderService.sellLimit(accountId, stockId, 10, BigDecimal.valueOf(50000)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_INSUFFICIENT_HOLDINGS.getMessage());
+
+            verify(portfolioService, never()).deductQuantity(anyLong(), anyLong(), anyInt());
+            verify(orderRepository, never()).save(any());
+        }
+
+        @Test
+        void 매도_실패_수량_0이하() {
+            assertThatThrownBy(() ->
+                    limitOrderService.sellLimit(1L, 1L, 0, BigDecimal.valueOf(50000)))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_INVALID_QUANTITY.getMessage());
+        }
+
+        @Test
+        void 매도_실패_가격_null() {
+            assertThatThrownBy(() ->
+                    limitOrderService.sellLimit(1L, 1L, 10, null))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessage(ErrorCode.ORDER_INVALID_AMOUNT.getMessage());
+        }
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/order/service/OrderServiceTest.java
@@ -204,9 +204,10 @@ class OrderServiceTest {
 		@Test
 		void 취소_성공_매도주문() {
 			// given
+			BigDecimal reservedAvgPrice = BigDecimal.valueOf(4500);  // 포트폴리오 avgPrice 스냅샷
 			Order order = new Order(1L, 1L, OrderType.LIMIT, OrderSide.SELL, 10,
 				BigDecimal.valueOf(5000), Currency.KRW, null,
-				BigDecimal.valueOf(75), BigDecimal.ZERO);
+				BigDecimal.valueOf(75), BigDecimal.ZERO, reservedAvgPrice);
 			VirtualAccount mockAccount = mock(VirtualAccount.class);
 			given(orderRepository.findByOrderNoForUpdate(order.getOrderNo())).willReturn(Optional.of(order));
 			given(virtualAccountService.getAccountWithLock(1L)).willReturn(mockAccount);
@@ -215,7 +216,53 @@ class OrderServiceTest {
 			orderService.cancelOrder(1L, order.getOrderNo());
 
 			// then
-			verify(portfolioService).addHolding(1L, 1L, 10, BigDecimal.valueOf(5000), Currency.KRW);
+			verify(portfolioService).addHolding(1L, 1L, 10, reservedAvgPrice, Currency.KRW);
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+		}
+
+		@Test
+		void 취소_성공_매수주문_부분체결() {
+			// given
+			Order order = new Order(1L, 1L, OrderType.LIMIT, OrderSide.BUY, 10,
+					BigDecimal.valueOf(50000), Currency.KRW, null,
+					BigDecimal.valueOf(75), BigDecimal.ZERO);
+			order.fillPartially(3);  // 3주 체결된 상태 → remainingQty = 7
+
+			VirtualAccount mockAccount = mock(VirtualAccount.class);
+			given(orderRepository.findByOrderNoForUpdate(any())).willReturn(Optional.of(order));
+			given(virtualAccountService.getAccountWithLock(1L)).willReturn(mockAccount);
+
+			// when
+			orderService.cancelOrder(1L, order.getOrderNo());
+
+			// then
+			// remainingCost = 50000 × 7 = 350000
+			// remainingFee = 350000 × 0.00015 = 52.5 → 52 (DOWN)
+			// refund = 350052
+			verify(mockAccount).deposit(BigDecimal.valueOf(350052));
+			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+		}
+
+		@Test
+		void 취소_성공_매도주문_부분체결() {
+			// given
+			BigDecimal reservedAvgPrice = BigDecimal.valueOf(45000);
+			Order order = new Order(1L, 1L, OrderType.LIMIT, OrderSide.SELL, 10,
+					BigDecimal.valueOf(50000), Currency.KRW, null,
+					BigDecimal.valueOf(75), BigDecimal.valueOf(900),
+					reservedAvgPrice);
+			order.fillPartially(4);  // 4주 체결 → remainingQty = 6
+
+			VirtualAccount mockAccount = mock(VirtualAccount.class);
+			given(orderRepository.findByOrderNoForUpdate(any())).willReturn(Optional.of(order));
+			given(virtualAccountService.getAccountWithLock(1L)).willReturn(mockAccount);
+
+			// when
+			orderService.cancelOrder(1L, order.getOrderNo());
+
+			// then
+			// 남은 6주를 reservedAvgPrice(45000) 기준으로 복원
+			verify(portfolioService).addHolding(1L, 1L, 6, reservedAvgPrice, Currency.KRW);
 			assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
 		}
 
@@ -283,6 +330,24 @@ class OrderServiceTest {
 			assertThatThrownBy(() -> orderService.modifyOrder(1L, order.getOrderNo(), BigDecimal.valueOf(60000), 10))
 				.isInstanceOf(BusinessException.class)
 				.hasMessage(ErrorCode.ORDER_NOT_MODIFIABLE.getMessage());
+		}
+
+		@Test
+		void 정정_실패_부분체결된_주문() {
+			// given
+			Order order = new Order(1L, 1L, OrderType.LIMIT, OrderSide.BUY, 10,
+					BigDecimal.valueOf(50000), Currency.KRW, null,
+					BigDecimal.valueOf(75), BigDecimal.ZERO);
+			order.fillPartially(2);  // 부분체결 상태
+
+			given(orderRepository.findByOrderNoForUpdate(order.getOrderNo()))
+					.willReturn(Optional.of(order));
+
+			// when & then
+			assertThatThrownBy(() ->
+					orderService.modifyOrder(1L, order.getOrderNo(), BigDecimal.valueOf(60000), 10))
+					.isInstanceOf(BusinessException.class)
+					.hasMessage(ErrorCode.ORDER_PARTIAL_NOT_MODIFIABLE.getMessage());
 		}
 
 		@Test


### PR DESCRIPTION
## 📌 PR 설명
한투 WebSocket 실시간 체결가 기반 지정가 주문 매칭 엔진을 구현했습니다. 
에스크로 모델을 도입하여 주문 생성 시점에 현금(매수)/주식(매도)을 선차감하고, 매칭 시점에 차액 환급 및 포트폴리오 반영을 수행합니다.
부분 체결과 취소 흐름도 함께 처리했습니다.
<br>

## ✅ 완료한 기능 명세
**지정가 주문 생성**
  - [x] `POST /api/order/limit/buy` - 지정가 매수 (현금 에스크로)
  - [x] `POST /api/order/limit/sell` - 지정가 매도 (주식 에스크로 + `reservedAvgPrice` 스냅샷)
  - [x] 수량/가격 검증 및 보유 수량 검증

  **매칭 엔진**
  - [x] `LimitOrderMatchingService` - 체결가 수신 시 PENDING/PARTIAL 지정가 주문 매칭
  - [x] 매수: 체결가 ≤ 주문가 조건, 차액 환급 로직
  - [x] 매도: 체결가 ≥ 주문가 조건, `reservedAvgPrice` 기반 실현손익 계산
  - [x] `matchBuyOrder`/`matchSellOrder` 메서드 분리로 가독성 확보

  **주문 취소/수정 (기존 엔드포인트 재사용)**
  - [x] `cancelOrder` 부분 체결 반영 — 남은 수량 기준 환급
  - [x] `cancelOrder` SELL 복원 시 `reservedAvgPrice`로 포트폴리오 정확히 복원 (기존 TODO 해소)
  - [x] `modifyOrder` 부분 체결된 주문은 `ORDER_PARTIAL_NOT_MODIFIABLE` 로 거부

  **WebSocket 연동**
  - [x] `HantuWebSocketClient.parseAndSendTrade()`에서 틱 수신 시 매칭 트리거
  - [x] 매칭 실패가 전체 파싱을 오염시키지 않도록 별도 try-catch 격리

  **테스트**
  - [x] `LimitOrderServiceTest` 신규 8 케이스 (happy path + 검증 실패)
  - [x] `OrderServiceTest` 부분 체결 취소 2 케이스 + PARTIAL modify 거부 1 케이스
  - [x] `OrderServiceTest.취소_성공_매도주문` `reservedAvgPrice` 반영해 회귀 수정

  **스키마**
  - [x] `V32__add_order_reserved_avg_price.sql` — `orders.reserved_avg_price NUMERIC(15,2) NULL`

<br>

## 📸 스크린샷
해당 없음 (백엔드 API)

<br>

## 💭 고민과 해결과정
### 1. 에스크로 모델 채택

  지정가 주문은 **주문 생성 시점에 현금/주식을 선차감**하는 에스크로 모델로 구현했습니다. 대안(체결 시점 차감)은 구현이 단순하지만, "지정가 걸어두고 안심"이라는 UX가 보장되지 않습니다(걸어둔 주문이 체결될 때
  잔고 부족으로 실패 가능). 실제 증권사 모델과도 일치합니다.

  결과적으로 매칭 서비스의 역할이 "잔고/포트폴리오 직접 차감"에서 **"에스크로에서 잔여 정산"** 으로 바뀌었고, 매수 매칭 시 차액 환급 로직이 추가되었습니다:
  refund = (requestPrice - currentPrice) × matchedQty × (1 + FEE_RATE)

  ### 2. `Order.reservedAvgPrice` 도입 (기존 TODO 해소)

  A가 `cancelOrder`/`modifyOrder`에서 SELL 주문 복원 시 `addHolding(..., requestPrice, ...)`로 처리하고, 주석으로 *"취소 시 원래 avgPrice를 유지하는 returnHolding 메서드가 필요"* TODO를 남겨두었습니다.

  지정가 매도 주문 생성 시점의 포트폴리오 `avgPrice`를 `Order.reservedAvgPrice`에 스냅샷으로 저장하는 방식으로 해결했습니다. 이렇게 하면:

  - **매칭 시점**: 포트폴리오 조회 없이 `order.getReservedAvgPrice()`로 실현손익 정확히 계산 가능 (포트폴리오가 전량 매도로 삭제된 엣지 케이스에서도 안전)
  - **취소 시점**: 원래 `avgPrice`로 복원되어 포트폴리오 평균단가 왜곡 없음
  - `PortfolioService.deductQuantity`의 zero-quantity-delete 로직을 건드리지 않음

  ### 3. 팀원(@ochanhyeok) 코드 수정 범위

  Shared code ownership 관점에서 불가피한 동료의 코드 수정을 최소화하며 진행했습니다:

  - `OrderMatchedEvent.ofBuy/ofSell`: 하드코딩된 `MARKET` 제거, `OrderType` 파라미터 추가 (시장가 호출부 2곳도 같이 업데이트)
  - `OrderService.cancelOrder`: 부분 체결된 주문의 환급액을 `remainingQuantity` 기준으로 재계산, SELL 복원 가격을 `reservedAvgPrice`로 교체
  - `OrderService.modifyOrder`: 동일 패턴 + `ORDER_PARTIAL_NOT_MODIFIABLE` 거부 추가
  - `VirtualAccountService.getAccount`, `StockInfoProvider.getStockByCode`, `OrderRepository.findAllByStatusInAndOrderTypeAndStockId`: @cl-o-lc의 매칭 서비스용 확장 포인트 (메서드 추가만, 기존 무수정)

  ### 4. `modifyOrder` PARTIAL 거부 결정

  부분 체결된 주문의 가격/수량 수정은 복잡도가 급증합니다 (체결된 몫은 이미 확정, 남은 몫만 수정 대상, 수량 증가 시 `reservedAvgPrice` 드리프트 처리 등). 실제 증권사도 "취소 후 재주문" UX가 일반적이라
  `ORDER_PARTIAL_NOT_MODIFIABLE`로 명시적 거부했습니다.

  ### 5. 매칭 엔진 메서드 분리

  초기 구현에서 `matchLimitOrders`가 단일 메서드에 BUY/SELL 로직을 모두 포함해 길이가 길어졌습니다. `matchBuyOrder`/`matchSellOrder` private 메서드로 분리해 디스패처 패턴으로 리팩터했습니다. `@Transactional`은
   public 디스패처에만 걸어 프록시 동작 보장.

  ### 6. 이벤트 WEF-376 부분 커버

WEF-376(이벤트 발행 연동)의 **이벤트 발행** 부분이 본 PR로 자연스럽게 구현됩니다. 
**WebSocket push 부분은 #242 예정**이라 본 PR 스코프 외 — 리스너(`OrderMatchedEventListener`)에 TODO 주석이 그대로 남아있습니다.

<br>

### 🔗 관련 이슈
Closes #221 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

**새로운 기능**
- 특정 가격으로 매수/매도 주문을 설정할 수 있는 지정가 주문 기능 추가
- 시장 가격이 지정된 수준에 도달하면 자동으로 지정가 주문을 체결하는 매칭 시스템 구현

**버그 수정**
- 부분 체결된 주문의 취소 처리 로직 개선
- 부분 체결된 주문의 수정을 방지하는 검증 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->