### PR TITLE
[WEF-639] Flyway 마이그레이션 순서 비순차 실행 허용 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+    out-of-order: true
 
 openai:
   api-key: ${OPENAI_API_KEY:}


### PR DESCRIPTION
## 📌 PR 설명
Flyway의 `out-of-order` 마이그레이션 설정을 활성화하여 브랜치 간 충돌을 최소화합니다.
<br>

### 🔗 관련 이슈
Closes #246

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데이터베이스 마이그레이션 설정을 업데이트하여 순서가 맞지 않는 마이그레이션을 처리할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->