### PR TITLE
[WEF-376] 체결 이벤트 WebSocket push 연동

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/matching/dev/OrderMatchedEventSimulator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/dev/OrderMatchedEventSimulator.java
@@ -1,0 +1,102 @@
+package com.solv.wefin.domain.trading.matching.dev;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
+import com.solv.wefin.domain.trading.matching.event.OrderMatchedEvent;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 로컬 개발 환경에서 OrderMatchedEvent를 수동으로 발행하기 위한 헬퍼.
+ *
+ * <p>장외 시간이나 한투 WebSocket 틱 없이 리스너 → WebSocket push 경로를
+ * E2E로 검증할 때 사용한다. local profile에서만 활성화되므로 prod/dev/staging에는 노출되지 않는다.
+ *
+ * <p>사용 방법:
+ * <ol>
+ *   <li>실제로 주문(시장가/지정가 무관)을 생성해 orderNo 확보</li>
+ *   <li>해당 orderNo를 이 simulator에 전달</li>
+ *   <li>리스너가 이벤트를 수신 → WebSocket으로 해당 사용자의 /user/queue/orders 에 push</li>
+ *   <li>프론트에서 구독 중이면 알림 수신</li>
+ * </ol>
+ */
+@Service
+@Profile("local")
+@RequiredArgsConstructor
+@Slf4j
+public class OrderMatchedEventSimulator {
+
+	private static final BigDecimal FALLBACK_PRICE = new BigDecimal("70000");
+
+	private final ApplicationEventPublisher eventPublisher;
+	private final OrderRepository orderRepository;
+	private final StockInfoProvider stockInfoProvider;
+	private final VirtualAccountService virtualAccountService;
+
+	/**
+	 * 주어진 orderNo를 기반으로 OrderMatchedEvent를 구성해 발행한다.
+	 *
+	 * <p>@Transactional 블록 안에서 발행해야 AFTER_COMMIT phase의 리스너가 호출된다.
+	 */
+	@Transactional
+	public void simulate(UUID orderNo) {
+		Order order = orderRepository.findByOrderNo(orderNo)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+		Stock stock = stockInfoProvider.getStock(order.getStockId());
+		VirtualAccount account = virtualAccountService.getAccount(order.getVirtualAccountId());
+
+		OrderMatchedEvent event = buildEvent(order, stock, account);
+		eventPublisher.publishEvent(event);
+
+		log.info("[DEV] OrderMatchedEvent 시뮬레이션 발행 - orderNo: {}, side: {}, userId: {}",
+			orderNo, order.getSide(), account.getUserId());
+	}
+
+	private OrderMatchedEvent buildEvent(Order order, Stock stock, VirtualAccount account) {
+		BigDecimal price = order.getRequestPrice() != null
+			? order.getRequestPrice()
+			: FALLBACK_PRICE;
+
+		if (order.getSide() == OrderSide.BUY) {
+			return OrderMatchedEvent.ofBuy(
+				order.getOrderType(),
+				order.getOrderNo(),
+				stock.getStockCode(),
+				stock.getStockName(),
+				order.getQuantity(),
+				price,
+				order.getFee(),
+				account.getBalance()
+			);
+		}
+
+		return OrderMatchedEvent.ofSell(
+			order.getOrderType(),
+			order.getOrderNo(),
+			stock.getStockCode(),
+			stock.getStockName(),
+			order.getQuantity(),
+			price,
+			order.getFee(),
+			order.getTax(),
+			BigDecimal.ZERO,
+			account.getBalance()
+		);
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/matching/dev/OrderMatchedEventSimulator.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/dev/OrderMatchedEventSimulator.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.trading.matching.dev;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -72,6 +73,7 @@ public class OrderMatchedEventSimulator {
 		BigDecimal price = order.getRequestPrice() != null
 			? order.getRequestPrice()
 			: FALLBACK_PRICE;
+		OffsetDateTime matchedAt = OffsetDateTime.now();
 
 		if (order.getSide() == OrderSide.BUY) {
 			return OrderMatchedEvent.ofBuy(
@@ -82,7 +84,8 @@ public class OrderMatchedEventSimulator {
 				order.getQuantity(),
 				price,
 				order.getFee(),
-				account.getBalance()
+				account.getBalance(),
+				matchedAt
 			);
 		}
 
@@ -96,7 +99,8 @@ public class OrderMatchedEventSimulator {
 			order.getFee(),
 			order.getTax(),
 			BigDecimal.ZERO,
-			account.getBalance()
+			account.getBalance(),
+			matchedAt
 		);
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEvent.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.trading.matching.event;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 import com.solv.wefin.domain.trading.order.entity.OrderSide;
@@ -17,20 +18,23 @@ public record OrderMatchedEvent(
 	BigDecimal fee,
 	BigDecimal tax,
 	BigDecimal realizedProfit,
-	BigDecimal balance
+	BigDecimal balance,
+	OffsetDateTime matchedAt
 ) {
 	public static OrderMatchedEvent ofBuy(OrderType orderType, UUID orderNo, String stockCode,
 										  String stockName, Integer quantity,
-										  BigDecimal price, BigDecimal fee, BigDecimal balance) {
+										  BigDecimal price, BigDecimal fee, BigDecimal balance,
+										  OffsetDateTime matchedAt) {
 		return new OrderMatchedEvent(orderType, orderNo, stockCode, stockName,
-			OrderSide.BUY, quantity, price, fee, BigDecimal.ZERO, BigDecimal.ZERO, balance);
+			OrderSide.BUY, quantity, price, fee, BigDecimal.ZERO, BigDecimal.ZERO, balance, matchedAt);
 	}
 
 	public static OrderMatchedEvent ofSell(OrderType orderType, UUID orderNo, String stockCode,
 										   String stockName, Integer quantity,
 										   BigDecimal price, BigDecimal fee, BigDecimal tax,
-										   BigDecimal realizedProfit, BigDecimal balance) {
+										   BigDecimal realizedProfit, BigDecimal balance,
+										   OffsetDateTime matchedAt) {
 		return new OrderMatchedEvent(orderType, orderNo, stockCode, stockName,
-			OrderSide.SELL, quantity, price, fee, tax, realizedProfit, balance);
+			OrderSide.SELL, quantity, price, fee, tax, realizedProfit, balance, matchedAt);
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListener.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.trading.matching.event;
 
 import java.util.UUID;
 
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -42,6 +43,13 @@ public class OrderMatchedEventListener {
 	 *
 	 * <p>실패 시 예외를 전파하지 않고 로그만 남긴다. 후속 리스너(채팅 알림 등)나
 	 * 원 트랜잭션의 관점에서 push 실패는 치명적이지 않기 때문이다.
+	 *
+	 * <p>예외 타입별로 로그 레벨을 분리한다:
+	 * <ul>
+	 *   <li>{@link BusinessException}: 이벤트는 커밋되었는데 주문/계좌 조회 실패 → 데이터 정합성 이슈, ERROR 레벨 + 경보 대상</li>
+	 *   <li>{@link MessagingException}: 브로커 일시 장애 → WARN 레벨, 재시도 전략은 후속 이슈로 분리</li>
+	 *   <li>그 외: 예상치 못한 에러 → ERROR 레벨</li>
+	 * </ul>
 	 */
 	private void pushOrderMatchedNotification(OrderMatchedEvent event) {
 		try {
@@ -52,8 +60,13 @@ public class OrderMatchedEventListener {
 				"/queue/orders",
 				notification
 			);
+		} catch (BusinessException e) {
+			log.error("체결 알림 전송 실패 (데이터 정합성): orderNo={}, code={}",
+				event.orderNo(), e.getErrorCode(), e);
+		} catch (MessagingException e) {
+			log.warn("체결 알림 전송 실패 (메시징 장애): orderNo={}", event.orderNo(), e);
 		} catch (Exception e) {
-			log.error("체결 알림 전송 실패: orderNo={}", event.orderNo(), e);
+			log.error("체결 알림 전송 실패 (예상치 못함): orderNo={}", event.orderNo(), e);
 		}
 	}
 

--- a/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListener.java
@@ -1,21 +1,70 @@
 package com.solv.wefin.domain.trading.matching.event;
 
+import java.util.UUID;
+
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.trading.order.dto.response.OrderMatchedNotification;
+
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
 @Slf4j
+@RequiredArgsConstructor
 public class OrderMatchedEventListener {
+
+	private final SimpMessagingTemplate messagingTemplate;
+	private final OrderRepository orderRepository;
+	private final VirtualAccountService virtualAccountService;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void handleOrderMatchedEvent(OrderMatchedEvent event) {
 		log.info("체결 완료 - orderNo: {}, side: {}, stockCode: {}, quantity: {}, price: {}",
 			event.orderNo(), event.side(), event.stockCode(), event.quantity(), event.price());
 
-		// TODO: WebSocket 체결 알림 (스프린트 5)
-		// TODO: 채팅 알림 - 수익금 +-50만원 이상 매도 시 (스프린트 5)
+		pushOrderMatchedNotification(event);
+
+		// TODO: 채팅 알림 - 수익금 ±50만원 이상 매도 시 (별도 티켓)
+	}
+
+	/**
+	 * 체결 알림을 해당 사용자의 WebSocket 큐로 push 한다.
+	 *
+	 * <p>실패 시 예외를 전파하지 않고 로그만 남긴다. 후속 리스너(채팅 알림 등)나
+	 * 원 트랜잭션의 관점에서 push 실패는 치명적이지 않기 때문이다.
+	 */
+	private void pushOrderMatchedNotification(OrderMatchedEvent event) {
+		try {
+			UUID userId = resolveUserId(event.orderNo());
+			OrderMatchedNotification notification = OrderMatchedNotification.from(event);
+			messagingTemplate.convertAndSendToUser(
+				userId.toString(),
+				"/queue/orders",
+				notification
+			);
+		} catch (Exception e) {
+			log.error("체결 알림 전송 실패: orderNo={}", event.orderNo(), e);
+		}
+	}
+
+	/**
+	 * 주문번호로부터 사용자 ID를 조회한다.
+	 * orderNo → Order → virtualAccountId → VirtualAccount → userId
+	 */
+	private UUID resolveUserId(UUID orderNo) {
+		Order order = orderRepository.findByOrderNo(orderNo)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+		VirtualAccount account = virtualAccountService.getAccount(order.getVirtualAccountId());
+		return account.getUserId();
 	}
 }

--- a/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
@@ -21,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 
@@ -95,7 +96,7 @@ public class LimitOrderMatchingService {
 
         eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
                 OrderType.LIMIT, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
-                matchedQuantity, currentPrice, actualFee, account.getBalance()
+                matchedQuantity, currentPrice, actualFee, account.getBalance(), OffsetDateTime.now()
         ));
     }
 
@@ -137,7 +138,7 @@ public class LimitOrderMatchingService {
         eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
                 OrderType.LIMIT, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
                 matchedQuantity, currentPrice, actualFee, actualTax,
-                realizedProfit, account.getBalance()
+                realizedProfit, account.getBalance(), OffsetDateTime.now()
         ));
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/matching/service/LimitOrderMatchingService.java
@@ -93,10 +93,11 @@ public class LimitOrderMatchingService {
         );
 
         order.fillPartially(matchedQuantity);
+        OffsetDateTime matchedAt = OffsetDateTime.now();
 
         eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
                 OrderType.LIMIT, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
-                matchedQuantity, currentPrice, actualFee, account.getBalance(), OffsetDateTime.now()
+                matchedQuantity, currentPrice, actualFee, account.getBalance(), matchedAt
         ));
     }
 
@@ -134,11 +135,12 @@ public class LimitOrderMatchingService {
         );
 
         order.fillPartially(matchedQuantity);
+        OffsetDateTime matchedAt = OffsetDateTime.now();
 
         eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
                 OrderType.LIMIT, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
                 matchedQuantity, currentPrice, actualFee, actualTax,
-                realizedProfit, account.getBalance(), OffsetDateTime.now()
+                realizedProfit, account.getBalance(), matchedAt
         ));
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -5,6 +5,7 @@ import static com.solv.wefin.domain.trading.common.TradingConstants.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
@@ -90,7 +91,7 @@ public class OrderService {
 		// 9. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
 			OrderType.MARKET, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
-			quantity, currentPrice, fee, account.getBalance()
+			quantity, currentPrice, fee, account.getBalance(), OffsetDateTime.now()
 		));
 
 		questProgressService.handleEvent(account.getUserId(), QuestEventType.BUY_STOCK);
@@ -159,7 +160,7 @@ public class OrderService {
 		// 15. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
 			OrderType.MARKET, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
-			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance()
+			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance(), OffsetDateTime.now()
 		));
 
 		try {

--- a/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/order/service/OrderService.java
@@ -84,6 +84,7 @@ public class OrderService {
 		tradeService.createBuyTrade(order.getOrderId(), virtualAccountId, stockId,
 			quantity, currentPrice, totalAmount, fee, Currency.KRW, null);
 		order.fill(quantity);
+		OffsetDateTime matchedAt = OffsetDateTime.now();
 
 		// 8. 포트폴리오 갱신
 		portfolioService.addHolding(virtualAccountId, stockId, quantity, currentPrice, Currency.KRW);
@@ -91,7 +92,7 @@ public class OrderService {
 		// 9. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofBuy(
 			OrderType.MARKET, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
-			quantity, currentPrice, fee, account.getBalance(), OffsetDateTime.now()
+			quantity, currentPrice, fee, account.getBalance(), matchedAt
 		));
 
 		questProgressService.handleEvent(account.getUserId(), QuestEventType.BUY_STOCK);
@@ -147,6 +148,7 @@ public class OrderService {
 
 		// 11. Order 상태 변경
 		order.fill(quantity);
+		OffsetDateTime matchedAt = OffsetDateTime.now();
 
 		// 12. 포트폴리오 수량 차감
 		portfolioService.deductQuantity(virtualAccountId, stockId, quantity);
@@ -160,7 +162,7 @@ public class OrderService {
 		// 15. 이벤트 발행
 		eventPublisher.publishEvent(OrderMatchedEvent.ofSell(
 			OrderType.MARKET, order.getOrderNo(), stock.getStockCode(), stock.getStockName(),
-			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance(), OffsetDateTime.now()
+			quantity, currentPrice, fee, tax, realizedAmount, account.getBalance(), matchedAt
 		));
 
 		try {

--- a/src/main/java/com/solv/wefin/web/trading/order/dev/OrderMatchedEventDevController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dev/OrderMatchedEventDevController.java
@@ -1,0 +1,39 @@
+package com.solv.wefin.web.trading.order.dev;
+
+import java.util.UUID;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.solv.wefin.domain.trading.matching.dev.OrderMatchedEventSimulator;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 로컬 개발 환경 전용: OrderMatchedEvent 수동 발행 엔드포인트.
+ *
+ * <p>{@code @Profile("local")} 로만 활성화되어 prod/dev/staging 환경에서는 빈 등록되지 않는다.
+ *
+ * <p>사용 예:
+ * <pre>
+ * POST /api/dev/order-matched/simulate/{orderNo}
+ * </pre>
+ */
+@RestController
+@Profile("local")
+@RequestMapping("/api/dev/order-matched")
+@RequiredArgsConstructor
+public class OrderMatchedEventDevController {
+
+	private final OrderMatchedEventSimulator simulator;
+
+	@PostMapping("/simulate/{orderNo}")
+	public ResponseEntity<Void> simulate(@PathVariable UUID orderNo) {
+		simulator.simulate(orderNo);
+		return ResponseEntity.ok().build();
+	}
+}

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/response/OrderMatchedNotification.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/response/OrderMatchedNotification.java
@@ -35,7 +35,7 @@ public record OrderMatchedNotification(
 			event.tax(),
 			event.realizedProfit(),
 			event.balance(),
-			OffsetDateTime.now()
+			event.matchedAt()
 		);
 	}
 }

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/response/OrderMatchedNotification.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/response/OrderMatchedNotification.java
@@ -1,0 +1,41 @@
+package com.solv.wefin.web.trading.order.dto.response;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import com.solv.wefin.domain.trading.matching.event.OrderMatchedEvent;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+
+public record OrderMatchedNotification(
+	UUID orderNo,
+	String stockCode,
+	String stockName,
+	OrderSide side,
+	OrderType orderType,
+	Integer quantity,
+	BigDecimal price,
+	BigDecimal fee,
+	BigDecimal tax,
+	BigDecimal realizedProfit,
+	BigDecimal balance,
+	OffsetDateTime matchedAt
+) {
+	public static OrderMatchedNotification from(OrderMatchedEvent event) {
+		return new OrderMatchedNotification(
+			event.orderNo(),
+			event.stockCode(),
+			event.stockName(),
+			event.side(),
+			event.orderType(),
+			event.quantity(),
+			event.price(),
+			event.fee(),
+			event.tax(),
+			event.realizedProfit(),
+			event.balance(),
+			OffsetDateTime.now()
+		);
+	}
+}

--- a/src/test/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListenerTest.java
@@ -15,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
@@ -126,7 +127,7 @@ class OrderMatchedEventListenerTest {
 			given(mockAccount.getUserId()).willReturn(userId);
 			given(virtualAccountService.getAccount(virtualAccountId)).willReturn(mockAccount);
 
-			doThrow(new RuntimeException("broker down"))
+			doThrow(new MessagingException("broker down"))
 				.when(messagingTemplate)
 				.convertAndSendToUser(anyString(), anyString(), any());
 

--- a/src/test/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListenerTest.java
@@ -1,0 +1,136 @@
+package com.solv.wefin.domain.trading.matching.event;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
+import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.order.entity.Order;
+import com.solv.wefin.domain.trading.order.entity.OrderSide;
+import com.solv.wefin.domain.trading.order.entity.OrderType;
+import com.solv.wefin.domain.trading.order.repository.OrderRepository;
+import com.solv.wefin.web.trading.order.dto.response.OrderMatchedNotification;
+
+@ExtendWith(MockitoExtension.class)
+class OrderMatchedEventListenerTest {
+
+	@Mock
+	private SimpMessagingTemplate messagingTemplate;
+	@Mock
+	private OrderRepository orderRepository;
+	@Mock
+	private VirtualAccountService virtualAccountService;
+
+	@InjectMocks
+	private OrderMatchedEventListener listener;
+
+	private OrderMatchedEvent sampleEvent(UUID orderNo) {
+		return OrderMatchedEvent.ofBuy(
+			OrderType.LIMIT,
+			orderNo,
+			"005930",
+			"삼성전자",
+			10,
+			BigDecimal.valueOf(50000),
+			BigDecimal.valueOf(75),
+			BigDecimal.valueOf(9499925)
+		);
+	}
+
+	@Nested
+	class HandleOrderMatchedEventTest {
+
+		@Test
+		void 체결_알림을_사용자_큐로_전송한다() {
+			// given
+			UUID orderNo = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Long virtualAccountId = 1L;
+
+			OrderMatchedEvent event = sampleEvent(orderNo);
+
+			Order mockOrder = mock(Order.class);
+			given(mockOrder.getVirtualAccountId()).willReturn(virtualAccountId);
+			given(orderRepository.findByOrderNo(orderNo)).willReturn(Optional.of(mockOrder));
+
+			VirtualAccount mockAccount = mock(VirtualAccount.class);
+			given(mockAccount.getUserId()).willReturn(userId);
+			given(virtualAccountService.getAccount(virtualAccountId)).willReturn(mockAccount);
+
+			// when
+			listener.handleOrderMatchedEvent(event);
+
+			// then
+			ArgumentCaptor<OrderMatchedNotification> captor =
+				ArgumentCaptor.forClass(OrderMatchedNotification.class);
+			verify(messagingTemplate).convertAndSendToUser(
+				eq(userId.toString()),
+				eq("/queue/orders"),
+				captor.capture()
+			);
+
+			OrderMatchedNotification sent = captor.getValue();
+			assertThat(sent.orderNo()).isEqualTo(orderNo);
+			assertThat(sent.stockCode()).isEqualTo("005930");
+			assertThat(sent.side()).isEqualTo(OrderSide.BUY);
+			assertThat(sent.orderType()).isEqualTo(OrderType.LIMIT);
+			assertThat(sent.quantity()).isEqualTo(10);
+			assertThat(sent.price()).isEqualByComparingTo(BigDecimal.valueOf(50000));
+			assertThat(sent.matchedAt()).isNotNull();
+		}
+
+		@Test
+		void 주문을_찾지_못하면_전송없이_예외를_삼킨다() {
+			// given
+			UUID orderNo = UUID.randomUUID();
+			OrderMatchedEvent event = sampleEvent(orderNo);
+
+			given(orderRepository.findByOrderNo(orderNo)).willReturn(Optional.empty());
+
+			// when & then — 예외 전파 없이 정상 complete
+			assertThatCode(() -> listener.handleOrderMatchedEvent(event))
+				.doesNotThrowAnyException();
+
+			verify(messagingTemplate, never()).convertAndSendToUser(anyString(), anyString(), any());
+		}
+
+		@Test
+		void 메시징_전송_실패해도_예외를_삼킨다() {
+			// given
+			UUID orderNo = UUID.randomUUID();
+			UUID userId = UUID.randomUUID();
+			Long virtualAccountId = 1L;
+
+			OrderMatchedEvent event = sampleEvent(orderNo);
+
+			Order mockOrder = mock(Order.class);
+			given(mockOrder.getVirtualAccountId()).willReturn(virtualAccountId);
+			given(orderRepository.findByOrderNo(orderNo)).willReturn(Optional.of(mockOrder));
+
+			VirtualAccount mockAccount = mock(VirtualAccount.class);
+			given(mockAccount.getUserId()).willReturn(userId);
+			given(virtualAccountService.getAccount(virtualAccountId)).willReturn(mockAccount);
+
+			doThrow(new RuntimeException("broker down"))
+				.when(messagingTemplate)
+				.convertAndSendToUser(anyString(), anyString(), any());
+
+			// when & then — 예외 전파 없이 정상 complete
+			assertThatCode(() -> listener.handleOrderMatchedEvent(event))
+				.doesNotThrowAnyException();
+		}
+	}
+}

--- a/src/test/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/matching/event/OrderMatchedEventListenerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -46,7 +47,8 @@ class OrderMatchedEventListenerTest {
 			10,
 			BigDecimal.valueOf(50000),
 			BigDecimal.valueOf(75),
-			BigDecimal.valueOf(9499925)
+			BigDecimal.valueOf(9499925),
+			OffsetDateTime.now()
 		);
 	}
 


### PR DESCRIPTION
## 📌 PR 설명
`OrderMatchedEvent`를 WebSocket `/user/{userId}/queue/orders`로 push하는 리스너를 구현했습니다. 
AFTER_COMMIT phase에서 이벤트 수신 후 해당 주문의 소유자를 조회해 사용자별 큐로 알림을 전송합니다. 
로컬 환경에서 수동 E2E 검증용 이벤트 시뮬레이터도 함께 추가했습니다.
<br>

## ✅ 완료한 기능 명세

  - [x] \`OrderMatchedNotification\` 응답 DTO 추가 — 프론트 계약을 내부 이벤트 스키마와 분리
  - [x] \`OrderMatchedEventListener\`에 WebSocket push 로직 구현
    - \`orderNo → Order → virtualAccountId → VirtualAccount → userId\` 순서로 수신자 resolve
    - \`SimpMessagingTemplate.convertAndSendToUser\`로 \`/queue/orders\` destination 전송
    - push 실패 시 예외를 전파하지 않고 로그만 남김 (후속 리스너 보호)
  - [x] 단위 테스트 3건 — happy path / order not found / messaging exception
  - [x] 로컬 전용 이벤트 시뮬레이터 \`OrderMatchedEventSimulator\` + \`POST /api/dev/order-matched/simulate/{orderNo}\` 엔드포인트
    - \`@Profile("local")\` 로 prod/dev/staging 환경에선 bean 등록 안 됨

<br>

## 📸 스크린샷
해당 없음 (백엔드 API).

 **E2E 검증 상태**: 프론트엔드 \`/user/queue/orders\` 구독 코드가 아직 미구현이라 브라우저 toast 단계까지의 수동 E2E는 보류. 동일 프로젝트 내 \`/user/queue/errors\`(채팅 에러 알림)가 같은 메커니즘으로 이미 동작 중이라 Spring user destination 라우팅은 신뢰 가능한 상태입니다. 프론트 구독 추가 후 로컬 환경에서 \`POST /api/dev/order-matched/simulate/{orderNo}\`로 즉시 E2E 가능합니다.

<br>

## 💭 고민과 해결과정
### 사용자 식별 방법

  \`OrderMatchedEvent\`엔 \`userId\`가 없어 destination 라우팅 대상을 결정할 방법이 필요했습니다. 두 가지 옵션이 있었습니다:

  1. **이벤트에 \`userId\` 필드 추가** — 모든 publisher 수정 필요, \`OrderMatchedEvent\` 팩토리 시그니처 변경 → 머지 충돌 가능성
  2. **리스너에서 DB 조회로 resolve** — 이벤트 스키마 불변, 리스너 내부에 쿼리 2개 추가

  **옵션 2를 선택**했습니다. AFTER_COMMIT 단계의 read-only 조회 2개는 성능 부담이 낮고, 이벤트 스키마와 push 로직을 느슨하게 결합할 수 있습니다. WEF-368에서 이미 추가된
  \`VirtualAccountService.getAccount(Long)\`과 기존 \`OrderRepository.findByOrderNo\`를 재사용했습니다.

  ### push 실패 격리

  리스너 내부에 별도 try-catch로 push 로직을 감싸 예외가 호출자(Spring 이벤트 인프라)로 전파되지 않도록 했습니다. push 실패는 체결 자체에 영향 없으며, 향후 채팅 알림 등 후속 리스너도 독립적으로 실행되어야 하기 때문입니다.

  ### 로컬 E2E용 시뮬레이터

  장외 시간이거나 한투 WebSocket 틱이 없는 환경에서도 리스너 → push 경로를 검증할 수 있도록 \`@Profile("local")\` 기반 시뮬레이터를 추가했습니다. 실제 주문(시장가/지정가 무관) 생성 후 \`orderNo\`만 있으면 이벤트 발행 → 리스너 → WebSocket push 전체 체인을 수동으로 트리거할 수 있습니다. prod/dev/staging에는 bean 등록되지 않습니다.

  ### 스코프 분리

  리스너 내 \`// TODO: 채팅 알림 - 수익금 ±50만원 이상 매도 시\` 는 본 PR 스코프 외로 남겼습니다. 해당 기능은 별도 티켓으로 분리 예정입니다.

<br>

 ## 🧭 알려진 후속 과제

 **체결 알림 push 실패 observability** — 현재 `OrderMatchedEventListener.pushOrderMatchedNotification`은 실패를 로그로만 남기고 재시도/복구 경로가 없습니다. AFTER_COMMIT 이후라 일시적 broker 장애 시에도
  알림이 영구 유실될 수 있습니다. 후속 이슈로 분리 예정:
      - 실패 카운터 metric (Micrometer) — 가장 가벼운 observability
      - `@Retryable` 기반 동기 재시도 — 일시적 장애 대응
      - Outbox 패턴 — 가장 견고하지만 스키마/스케줄러 도입 필요

<br>

### 🔗 관련 이슈
Closes #242 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주문 체결 시 실시간 WebSocket 알림이 전송됩니다. 사용자는 종목 정보, 체결가, 수량, 수수료, 세금, 실현 손익 등 상세 정보를 즉시 수신합니다.
  * 로컬 개발용 시뮬레이터 엔드포인트가 추가되어 특정 주문의 체결 이벤트를 수동으로 트리거할 수 있습니다.

* **변경**
  * 체결 이벤트 및 알림에 체결 시각(matchedAt) 타임스탬프가 추가되었습니다.

* **테스트**
  * 주문 체결 알림 발송 로직에 대한 단위 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->