### PR TITLE
[WEF-632] 게임 종료 api 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/order/repository/GameOrderRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/repository/GameOrderRepository.java
@@ -1,9 +1,12 @@
 package com.solv.wefin.domain.game.order.repository;
 
 import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface GameOrderRepository extends JpaRepository<GameOrder, UUID> {
+
+    int countByParticipant(GameParticipant participant);
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/GameParticipant.java
@@ -107,8 +107,14 @@ public class GameParticipant {
     }
 
     public void leave() {
-
         this.status = LEFT;
+    }
+
+    public void finish() {
+        if (this.status != ACTIVE) {
+            throw new IllegalStateException("ACTIVE 상태의 참가자만 종료할 수 있습니다. 현재 상태: " + this.status);
+        }
+        this.status = ParticipantStatus.FINISHED;
     }
 
     //방장 퇴장 시
@@ -121,7 +127,9 @@ public class GameParticipant {
     }
 
     public void rejoin() {
-
+        if (this.status != LEFT) {
+            throw new IllegalStateException("LEFT 상태의 참가자만 재입장할 수 있습니다. 현재 상태: " + this.status);
+        }
         this.status = ACTIVE;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/entity/ParticipantStatus.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/entity/ParticipantStatus.java
@@ -2,5 +2,6 @@ package com.solv.wefin.domain.game.participant.entity;
 
 public enum ParticipantStatus {
     ACTIVE,
-    LEFT
+    LEFT,
+    FINISHED
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/repository/GameParticipantRepository.java
@@ -28,6 +28,9 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
     //방장 위임 - 참가자 중 랜덤 선택
     List<GameParticipant> findByGameRoomAndStatus(GameRoom gameRoom, ParticipantStatus status);
 
+    // 복수 상태 조회 (랭킹 등에서 ACTIVE + FINISHED 조회)
+    List<GameParticipant> findByGameRoomAndStatusIn(GameRoom gameRoom, List<ParticipantStatus> statuses);
+
     // 매수/매도 시 참가자 잔액 비관적 락 (SELECT FOR UPDATE)
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT p FROM GameParticipant p WHERE p.gameRoom = :gameRoom AND p.userId = :userId")

--- a/src/main/java/com/solv/wefin/domain/game/result/dto/GameEndInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/dto/GameEndInfo.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.game.result.dto;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record GameEndInfo(
+        UUID participantId,
+        BigDecimal finalAsset,
+        BigDecimal profitRate,
+        int totalTrades,
+        boolean roomFinished
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/entity/GameResult.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/entity/GameResult.java
@@ -1,0 +1,89 @@
+package com.solv.wefin.domain.game.result.entity;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "game_result",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "participant_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "result_id")
+    private UUID resultId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private GameRoom gameRoom;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    private GameParticipant participant;
+
+    @Column(name = "final_rank", nullable = false)
+    private int finalRank;
+
+    @Column(name = "seed_money", nullable = false, precision = 18, scale = 2)
+    private BigDecimal seedMoney;
+
+    @Column(name = "final_asset", nullable = false, precision = 18, scale = 2)
+    private BigDecimal finalAsset;
+
+    @Column(name = "profit_rate", nullable = false, precision = 8, scale = 2)
+    private BigDecimal profitRate;
+
+    @Column(name = "total_trades", nullable = false)
+    private int totalTrades;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private GameResult(GameRoom gameRoom, GameParticipant participant,
+                       int finalRank, BigDecimal seedMoney, BigDecimal finalAsset,
+                       BigDecimal profitRate, int totalTrades) {
+        this.gameRoom = gameRoom;
+        this.participant = participant;
+        this.finalRank = finalRank;
+        this.seedMoney = seedMoney;
+        this.finalAsset = finalAsset;
+        this.profitRate = profitRate;
+        this.totalTrades = totalTrades;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    public static GameResult create(GameRoom gameRoom, GameParticipant participant,
+                                     int finalRank, BigDecimal seedMoney,
+                                     BigDecimal finalAsset, BigDecimal profitRate,
+                                     int totalTrades) {
+        return GameResult.builder()
+                .gameRoom(gameRoom)
+                .participant(participant)
+                .finalRank(finalRank)
+                .seedMoney(seedMoney)
+                .finalAsset(finalAsset)
+                .profitRate(profitRate)
+                .totalTrades(totalTrades)
+                .build();
+    }
+
+    public void updateFinalRank(int rank) {
+        this.finalRank = rank;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
@@ -1,0 +1,16 @@
+package com.solv.wefin.domain.game.result.repository;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface GameResultRepository extends JpaRepository<GameResult, UUID> {
+
+    List<GameResult> findByGameRoomOrderByFinalRankAsc(GameRoom gameRoom);
+
+    boolean existsByGameRoomAndParticipant(GameRoom gameRoom, GameParticipant participant);
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameEndService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameEndService.java
@@ -92,32 +92,41 @@ public class GameEndService {
                     gameRoom.getSeed(), finalAsset, profitRate, totalTrades));
         }
 
-        // 6. 방장이면 위임
+        // 6. 본인을 제외한 ACTIVE 참가자 목록 조회 (finish() 전에 조회 — JPA flush 타이밍 의존 회피)
+        //    한 번 조회해서 ① 방 종료 판단 ② 방장 위임 후보 양쪽에 재사용 (DB 조회 절약)
+        List<GameParticipant> otherActive = gameParticipantRepository
+                .findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE)
+                .stream()
+                .filter(p -> !p.getUserId().equals(participant.getUserId()))
+                .toList();
+
+        // 7. 방장이면 위임 해제
         boolean wasLeader = participant.getIsLeader();
         if (wasLeader) {
             participant.resignLeader();
         }
 
-        // 7. 참가자 상태 FINISHED 전환
+        // 8. 참가자 상태 FINISHED 전환
         participant.finish();
 
-        // 8. 남은 ACTIVE 참가자 확인 → 없으면 방 종료 + 순위 확정
-        boolean roomFinished = checkAndFinishRoom(gameRoom);
+        // 9. 본인 외 ACTIVE 참가자가 없으면 방 종료 + 순위 확정
+        boolean roomFinished = false;
+        if (otherActive.isEmpty()) {
+            gameRoom.finish();
+            finalizeRanks(gameRoom);
+            roomFinished = true;
+        }
 
-        // 9. 방장 위임 (방이 아직 진행 중이고, 종료한 참가자가 방장이었으면)
+        // 10. 방이 아직 진행 중이고 종료한 참가자가 방장이었으면 랜덤 위임
         if (!roomFinished && wasLeader) {
-            List<GameParticipant> remainingActive =
-                    gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
-            if (!remainingActive.isEmpty()) {
-                int randomIndex = ThreadLocalRandom.current().nextInt(remainingActive.size());
-                remainingActive.get(randomIndex).assignLeader();
-            }
+            int randomIndex = ThreadLocalRandom.current().nextInt(otherActive.size());
+            otherActive.get(randomIndex).assignLeader();
         }
 
         log.info("[게임 종료] userId={}, roomId={}, finalAsset={}, roomFinished={}",
                 userId, roomId, finalAsset, roomFinished);
 
-        // 10. WebSocket 이벤트 발행 (커밋 후 브로드캐스트)
+        // 11. WebSocket 이벤트 발행 (커밋 후 브로드캐스트)
         eventPublisher.publishEvent(
                 new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_FINISHED));
 
@@ -127,23 +136,6 @@ public class GameEndService {
                 profitRate,
                 totalTrades,
                 roomFinished);
-    }
-
-    /**
-     * 모든 ACTIVE 참가자가 FINISHED → 방 FINISHED + 순위 확정.
-     * @return 방이 종료되었으면 true
-     */
-    private boolean checkAndFinishRoom(GameRoom gameRoom) {
-        List<GameParticipant> activeParticipants =
-                gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
-
-        if (!activeParticipants.isEmpty()) {
-            return false;
-        }
-
-        gameRoom.finish();
-        finalizeRanks(gameRoom);
-        return true;
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameEndService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameEndService.java
@@ -1,0 +1,177 @@
+package com.solv.wefin.domain.game.result.service;
+
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.GameEndInfo;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.room.event.GameRoomEvent;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameEndService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameResultRepository gameResultRepository;
+    private final GameOrderRepository gameOrderRepository;
+    private final GamePortfolioSnapshotRepository snapshotRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public GameEndInfo endGame(UUID roomId, UUID userId) {
+
+        // 1. 방 조회 + IN_PROGRESS 검증
+        GameRoom gameRoom = gameRoomRepository.findByIdForUpdate(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        if (gameRoom.getStatus() != RoomStatus.IN_PROGRESS) {
+            if (gameRoom.getStatus() == RoomStatus.FINISHED) {
+                throw new BusinessException(ErrorCode.GAME_ALREADY_FINISHED);
+            }
+            throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
+        }
+
+        // 2. 참가자 조회 + ACTIVE 검증
+        GameParticipant participant = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        if (participant.getStatus() == ParticipantStatus.FINISHED) {
+            throw new BusinessException(ErrorCode.PARTICIPANT_ALREADY_FINISHED);
+        }
+        if (participant.getStatus() != ParticipantStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        // 3. 최신 스냅샷에서 최종 자산/수익률 조회
+        GamePortfolioSnapshot latestSnapshot = snapshotRepository
+                .findLatestByParticipant(participant)
+                .orElse(null);
+
+        BigDecimal finalAsset;
+        BigDecimal profitRate;
+        if (latestSnapshot != null) {
+            finalAsset = latestSnapshot.getTotalAsset();
+            profitRate = latestSnapshot.getProfitRate();
+        } else {
+            // 스냅샷 없음 = 첫 턴에서 바로 종료 → 시드머니 그대로
+            finalAsset = gameRoom.getSeed();
+            profitRate = BigDecimal.ZERO;
+        }
+
+        // 4. 거래 횟수
+        int totalTrades = gameOrderRepository.countByParticipant(participant);
+
+        // 5. game_result 저장 (이미 존재하면 스킵 — 턴 자동종료로 먼저 생성된 경우)
+        if (!gameResultRepository.existsByGameRoomAndParticipant(gameRoom, participant)) {
+            gameResultRepository.save(GameResult.create(
+                    gameRoom, participant, 0,
+                    gameRoom.getSeed(), finalAsset, profitRate, totalTrades));
+        }
+
+        // 6. 방장이면 위임
+        boolean wasLeader = participant.getIsLeader();
+        if (wasLeader) {
+            participant.resignLeader();
+        }
+
+        // 7. 참가자 상태 FINISHED 전환
+        participant.finish();
+
+        // 8. 남은 ACTIVE 참가자 확인 → 없으면 방 종료 + 순위 확정
+        boolean roomFinished = checkAndFinishRoom(gameRoom);
+
+        // 9. 방장 위임 (방이 아직 진행 중이고, 종료한 참가자가 방장이었으면)
+        if (!roomFinished && wasLeader) {
+            List<GameParticipant> remainingActive =
+                    gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+            if (!remainingActive.isEmpty()) {
+                int randomIndex = ThreadLocalRandom.current().nextInt(remainingActive.size());
+                remainingActive.get(randomIndex).assignLeader();
+            }
+        }
+
+        log.info("[게임 종료] userId={}, roomId={}, finalAsset={}, roomFinished={}",
+                userId, roomId, finalAsset, roomFinished);
+
+        // 10. WebSocket 이벤트 발행 (커밋 후 브로드캐스트)
+        eventPublisher.publishEvent(
+                new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_FINISHED));
+
+        return new GameEndInfo(
+                participant.getParticipantId(),
+                finalAsset,
+                profitRate,
+                totalTrades,
+                roomFinished);
+    }
+
+    /**
+     * 모든 ACTIVE 참가자가 FINISHED → 방 FINISHED + 순위 확정.
+     * @return 방이 종료되었으면 true
+     */
+    private boolean checkAndFinishRoom(GameRoom gameRoom) {
+        List<GameParticipant> activeParticipants =
+                gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+
+        if (!activeParticipants.isEmpty()) {
+            return false;
+        }
+
+        gameRoom.finish();
+        finalizeRanks(gameRoom);
+        return true;
+    }
+
+    /**
+     * 방 전체 종료 시 game_result의 finalRank를 확정한다.
+     * finalAsset DESC 기준, 동률이면 같은 순위 (1위, 1위, 3위).
+     */
+    public void finalizeRanks(GameRoom gameRoom) {
+        List<GameResult> results = new ArrayList<>(
+                gameResultRepository.findByGameRoomOrderByFinalRankAsc(gameRoom));
+
+        // finalAsset DESC 재정렬
+        results.sort(Comparator.comparing(GameResult::getFinalAsset).reversed());
+
+        int prevRank = 1;
+        for (int i = 0; i < results.size(); i++) {
+            GameResult r = results.get(i);
+
+            int rank;
+            if (i == 0) {
+                rank = 1;
+            } else if (results.get(i - 1).getFinalAsset().compareTo(r.getFinalAsset()) == 0) {
+                rank = prevRank;
+            } else {
+                rank = i + 1;
+            }
+            prevRank = rank;
+
+            r.updateFinalRank(rank);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/room/event/GameRoomEvent.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/event/GameRoomEvent.java
@@ -6,6 +6,7 @@ public record GameRoomEvent(UUID roomId, EventType type) {
     public enum EventType {
         PARTICIPANT_JOINED,
         PARTICIPANT_LEFT,
+        PARTICIPANT_FINISHED,
         GAME_STARTED
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -151,6 +151,9 @@ public class GameRoomService {
             if (participant.getStatus() == ParticipantStatus.ACTIVE) {
                 throw new BusinessException(ErrorCode.ROOM_ALREADY_JOINED);
             }
+            if (participant.getStatus() == ParticipantStatus.FINISHED) {
+                throw new BusinessException(ErrorCode.PARTICIPANT_ALREADY_FINISHED);
+            }
             int currentPlayers = gameParticipantRepository.countByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
             if (currentPlayers >= 6) {
                 throw new BusinessException(ErrorCode.ROOM_FULL);

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/dto/SnapshotInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/dto/SnapshotInfo.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.game.snapshot.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record SnapshotInfo(
+        int turnNumber,
+        LocalDate turnDate,
+        BigDecimal totalAsset,
+        BigDecimal cash,
+        BigDecimal stockValue,
+        BigDecimal profitRate
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/repository/GamePortfolioSnapshotRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/repository/GamePortfolioSnapshotRepository.java
@@ -1,13 +1,32 @@
 package com.solv.wefin.domain.game.snapshot.repository;
 
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface GamePortfolioSnapshotRepository extends JpaRepository<GamePortfolioSnapshot, UUID> {
 
     List<GamePortfolioSnapshot> findByTurnOrderByTotalAssetDesc(GameTurn turn);
+
+    @Query("SELECT s FROM GamePortfolioSnapshot s " +
+            "JOIN FETCH s.turn t " +
+            "WHERE s.participant = :participant " +
+            "ORDER BY t.turnNumber ASC")
+    List<GamePortfolioSnapshot> findByParticipantOrderByTurnNumber(
+            @Param("participant") GameParticipant participant);
+
+    @Query("SELECT s FROM GamePortfolioSnapshot s " +
+            "JOIN s.turn t " +
+            "WHERE s.participant = :participant " +
+            "ORDER BY t.turnNumber DESC " +
+            "LIMIT 1")
+    Optional<GamePortfolioSnapshot> findLatestByParticipant(
+            @Param("participant") GameParticipant participant);
 }

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/service/GameRankingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/service/GameRankingService.java
@@ -46,9 +46,10 @@ public class GameRankingService {
             throw new BusinessException(ErrorCode.GAME_NOT_STARTED);
         }
 
-        // 2. 참가자 검증
+        // 2. 참가자 검증 (ACTIVE 또는 FINISHED 참가자만 랭킹 조회 가능)
         gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
-                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE
+                        || p.getStatus() == ParticipantStatus.FINISHED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
 
         // 3. 최신 완료 턴의 스냅샷 조회
@@ -96,7 +97,7 @@ public class GameRankingService {
      */
     private List<RankingInfo> buildInitialRankings(GameRoom gameRoom) {
         List<GameParticipant> participants = gameParticipantRepository
-                .findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+                .findByGameRoomAndStatusIn(gameRoom, List.of(ParticipantStatus.ACTIVE, ParticipantStatus.FINISHED));
 
         List<UUID> userIds = participants.stream()
                 .map(GameParticipant::getUserId)

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -13,4 +13,6 @@ public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
     Optional<GameTurn> findByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
 
     Optional<GameTurn> findFirstByGameRoomAndStatusOrderByTurnNumberDesc(GameRoom gameRoom, TurnStatus status);
+
+    int countByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
 }

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -3,9 +3,13 @@ package com.solv.wefin.domain.game.turn.service;
 import com.solv.wefin.domain.game.holding.entity.GameHolding;
 import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
 import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.result.service.GameEndService;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
@@ -47,6 +51,9 @@ public class TurnAdvanceService {
     private final GameHoldingRepository gameHoldingRepository;
     private final StockDailyRepository stockDailyRepository;
     private final GamePortfolioSnapshotRepository snapshotRepository;
+    private final GameOrderRepository gameOrderRepository;
+    private final GameResultRepository gameResultRepository;
+    private final GameEndService gameEndService;
     private final BriefingCacheRepository briefingCacheRepository;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -93,8 +100,9 @@ public class TurnAdvanceService {
         // 6. 현재 턴 완료 처리
         currentTurn.complete();
 
-        // 7. 종료 판단
+        // 7. 종료 판단 — 기간 만료 시 남은 ACTIVE 전원 강제 종료
         if (isGameOver) {
+            forceEndAllActive(gameRoom, snapshots);
             gameRoom.finish();
             log.info("[턴 전환] 게임 종료: roomId={}, 마지막 턴={}", roomId, currentTurn.getTurnNumber());
             return null;
@@ -194,6 +202,42 @@ public class TurnAdvanceService {
                 .flatMap(tradeDate -> stockDailyRepository.findByStockInfoAndTradeDate(stockInfo, tradeDate))
                 .map(StockDaily::getClosePrice)
                 .orElse(BigDecimal.ZERO);
+    }
+
+    /**
+     * 기간 만료 시 남은 ACTIVE 참가자 전원을 강제 종료한다.
+     * 스냅샷 기반으로 game_result 저장 + FINISHED 전환 + 순위 확정.
+     * 이미 개별 종료한(FINISHED) 참가자의 결과도 함께 순위 확정한다.
+     */
+    private void forceEndAllActive(GameRoom gameRoom, List<GamePortfolioSnapshot> snapshots) {
+        BigDecimal seedMoney = gameRoom.getSeed();
+
+        // 스냅샷 → participant 매핑
+        Map<UUID, GamePortfolioSnapshot> snapshotMap = snapshots.stream()
+                .collect(Collectors.toMap(
+                        s -> s.getParticipant().getParticipantId(),
+                        Function.identity()));
+
+        // ACTIVE 참가자 전원 → game_result 저장 + FINISHED
+        List<GameParticipant> activeParticipants =
+                gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
+
+        for (GameParticipant participant : activeParticipants) {
+            GamePortfolioSnapshot snapshot = snapshotMap.get(participant.getParticipantId());
+
+            BigDecimal finalAsset = snapshot != null ? snapshot.getTotalAsset() : seedMoney;
+            BigDecimal profitRate = snapshot != null ? snapshot.getProfitRate() : BigDecimal.ZERO;
+            int totalTrades = gameOrderRepository.countByParticipant(participant);
+
+            gameResultRepository.save(GameResult.create(
+                    gameRoom, participant, 0,
+                    seedMoney, finalAsset, profitRate, totalTrades));
+
+            participant.finish();
+        }
+
+        // 전원(기존 FINISHED + 방금 FINISHED) 순위 확정
+        gameEndService.finalizeRanks(gameRoom);
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -223,6 +223,13 @@ public class TurnAdvanceService {
                 gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
 
         for (GameParticipant participant : activeParticipants) {
+            if (gameResultRepository.existsByGameRoomAndParticipant(gameRoom, participant)) {
+                log.warn("[강제 종료] game_result 이미 존재 — 참가자 {} 중복 저장 생략",
+                        participant.getParticipantId());
+                participant.finish();
+                continue;
+            }
+
             GamePortfolioSnapshot snapshot = snapshotMap.get(participant.getParticipantId());
 
             BigDecimal finalAsset = snapshot != null ? snapshot.getTotalAsset() : seedMoney;

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -159,6 +159,11 @@ public enum ErrorCode {
     // GameTurn
     GAME_NOT_STARTED(400, "게임이 시작되지 않았습니다."),
     GAME_ALREADY_FINISHED(400, "이미 종료된 게임입니다."),
+    GAME_NOT_FINISHED(400, "게임이 아직 종료되지 않았습니다."),
+
+    // GameParticipant - 개별 종료
+    PARTICIPANT_ALREADY_FINISHED(400, "이미 게임을 종료한 참가자입니다."),
+    PARTICIPANT_NOT_FINISHED(400, "아직 게임을 종료하지 않은 참가자입니다."),
 
     // GameStock
     GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다."),

--- a/src/main/java/com/solv/wefin/web/game/result/GameResultController.java
+++ b/src/main/java/com/solv/wefin/web/game/result/GameResultController.java
@@ -1,0 +1,34 @@
+package com.solv.wefin.web.game.result;
+
+import com.solv.wefin.domain.game.result.dto.GameEndInfo;
+import com.solv.wefin.domain.game.result.service.GameEndService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.result.dto.response.GameEndResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/rooms/{roomId}")
+@RequiredArgsConstructor
+public class GameResultController {
+
+    private final GameEndService gameEndService;
+
+    @PostMapping("/end")
+    public ResponseEntity<ApiResponse<GameEndResponse>> endGame(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        GameEndInfo info = gameEndService.endGame(roomId, userId);
+        GameEndResponse response = GameEndResponse.from(info);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/GameEndResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/GameEndResponse.java
@@ -1,0 +1,28 @@
+package com.solv.wefin.web.game.result.dto.response;
+
+import com.solv.wefin.domain.game.result.dto.GameEndInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class GameEndResponse {
+
+    private UUID participantId;
+    private BigDecimal finalAsset;
+    private BigDecimal profitRate;
+    private int totalTrades;
+    private boolean roomFinished;
+
+    public static GameEndResponse from(GameEndInfo info) {
+        return new GameEndResponse(
+                info.participantId(),
+                info.finalAsset(),
+                info.profitRate(),
+                info.totalTrades(),
+                info.roomFinished());
+    }
+}

--- a/src/main/resources/db/migration/V35__create_table_result.sql
+++ b/src/main/resources/db/migration/V35__create_table_result.sql
@@ -1,0 +1,13 @@
+CREATE TABLE game_result (
+                             result_id       UUID            PRIMARY KEY DEFAULT gen_random_uuid(),
+                             room_id         UUID            NOT NULL REFERENCES game_room(room_id),
+                             participant_id  UUID            NOT NULL REFERENCES game_participant(participant_id),
+                             final_rank      INT             NOT NULL,
+                             seed_money      DECIMAL(18,2)   NOT NULL,
+                             final_asset     DECIMAL(18,2)   NOT NULL,
+                             profit_rate     DECIMAL(8,2)    NOT NULL,
+                             total_trades    INT             NOT NULL DEFAULT 0,
+                             created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+                             CONSTRAINT uk_game_result_room_participant UNIQUE (room_id, participant_id)
+);

--- a/src/main/resources/db/migration/V36__add_check_participant.sql
+++ b/src/main/resources/db/migration/V36__add_check_participant.sql
@@ -1,0 +1,6 @@
+ALTER TABLE game_participant
+DROP CONSTRAINT chk_participant_status;
+
+ALTER TABLE game_participant
+    ADD CONSTRAINT chk_participant_status
+        CHECK (status IN ('ACTIVE', 'LEFT', 'FINISHED'));

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameEndServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameEndServiceTest.java
@@ -88,9 +88,9 @@ class GameEndServiceTest {
             given(gameOrderRepository.countByParticipant(participantA)).willReturn(5);
             given(gameResultRepository.save(any(GameResult.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
-            // 다른 ACTIVE 참가자가 남아있음
+            // finish() 이전 ACTIVE 조회 → 본인 포함 전원 ACTIVE
             given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
-                    .willReturn(List.of(participantB));
+                    .willReturn(List.of(participantA, participantB));
 
             // When
             GameEndInfo result = gameEndService.endGame(ROOM_ID, USER_A);
@@ -124,9 +124,9 @@ class GameEndServiceTest {
             given(gameOrderRepository.countByParticipant(participantA)).willReturn(10);
             given(gameResultRepository.save(any(GameResult.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
-            // ACTIVE 참가자 없음 (본인이 방금 FINISHED됨)
+            // finish() 이전 ACTIVE 조회 → 본인만 ACTIVE (본인 제외하면 빈 리스트 → 방 종료)
             given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
-                    .willReturn(List.of());
+                    .willReturn(List.of(participantA));
             given(gameResultRepository.findByGameRoomOrderByFinalRankAsc(room))
                     .willReturn(List.of(GameResult.create(
                             room, participantA, 0, SEED,
@@ -166,9 +166,9 @@ class GameEndServiceTest {
             given(gameOrderRepository.countByParticipant(participantA)).willReturn(7);
             given(gameResultRepository.save(any(GameResult.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
-            // A가 FINISHED되면 ACTIVE 없음
+            // finish() 이전 ACTIVE 조회 → A만 ACTIVE (B는 이미 FINISHED)
             given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
-                    .willReturn(List.of());
+                    .willReturn(List.of(participantA));
             // 순위 확정 시 A + B 결과 모두 조회
             GameResult resultA = GameResult.create(room, participantA, 0, SEED,
                     new BigDecimal("12000000"), new BigDecimal("20.00"), 7);
@@ -201,8 +201,9 @@ class GameEndServiceTest {
             given(gameOrderRepository.countByParticipant(participantA)).willReturn(0);
             given(gameResultRepository.save(any(GameResult.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
+            // finish() 이전 ACTIVE 조회 → 본인 + B 둘 다 ACTIVE
             given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
-                    .willReturn(List.of(GameParticipant.createMember(room, USER_B)));
+                    .willReturn(List.of(participantA, GameParticipant.createMember(room, USER_B)));
 
             // When
             GameEndInfo result = gameEndService.endGame(ROOM_ID, USER_A);

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameEndServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameEndServiceTest.java
@@ -1,0 +1,369 @@
+package com.solv.wefin.domain.game.result.service;
+
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.GameEndInfo;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameEndServiceTest {
+
+    @InjectMocks
+    private GameEndService gameEndService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private GameResultRepository gameResultRepository;
+    @Mock
+    private GameOrderRepository gameOrderRepository;
+    @Mock
+    private GamePortfolioSnapshotRepository snapshotRepository;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private static final UUID ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID USER_A = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final UUID USER_B = UUID.fromString("00000000-0000-4000-a000-000000000003");
+    private static final Long GROUP_ID = 1L;
+    private static final LocalDate START_DATE = LocalDate.of(2022, 3, 2);
+    private static final BigDecimal SEED = new BigDecimal("10000000");
+
+    @Nested
+    @DisplayName("개별 게임 종료 성공")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("스냅샷 있는 참가자 종료 — 최종 자산/수익률 반환, 다른 참가자 남아있으면 방은 유지")
+        void endGame_withSnapshot_roomNotFinished() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+
+            GameTurn turn = GameTurn.createFirst(room);
+            GamePortfolioSnapshot snapshot = GamePortfolioSnapshot.create(
+                    turn, participantA, new BigDecimal("5000000"),
+                    new BigDecimal("6500000"), SEED);  // total = 11,500,000
+
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(snapshotRepository.findLatestByParticipant(participantA))
+                    .willReturn(Optional.of(snapshot));
+            given(gameOrderRepository.countByParticipant(participantA)).willReturn(5);
+            given(gameResultRepository.save(any(GameResult.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            // 다른 ACTIVE 참가자가 남아있음
+            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                    .willReturn(List.of(participantB));
+
+            // When
+            GameEndInfo result = gameEndService.endGame(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(result.finalAsset()).isEqualByComparingTo(new BigDecimal("11500000"));
+            assertThat(result.profitRate()).isEqualByComparingTo(new BigDecimal("15.00"));
+            assertThat(result.totalTrades()).isEqualTo(5);
+            assertThat(result.roomFinished()).isFalse();
+            assertThat(participantA.getStatus()).isEqualTo(ParticipantStatus.FINISHED);
+            assertThat(room.getStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
+        }
+
+        @Test
+        @DisplayName("마지막 참가자 종료 — 방도 FINISHED + 순위 확정")
+        void endGame_lastParticipant_roomFinished() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+
+            GameTurn turn = GameTurn.createFirst(room);
+            GamePortfolioSnapshot snapshot = GamePortfolioSnapshot.create(
+                    turn, participantA, new BigDecimal("8000000"),
+                    new BigDecimal("4000000"), SEED);  // total = 12,000,000
+
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(snapshotRepository.findLatestByParticipant(participantA))
+                    .willReturn(Optional.of(snapshot));
+            given(gameOrderRepository.countByParticipant(participantA)).willReturn(10);
+            given(gameResultRepository.save(any(GameResult.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            // ACTIVE 참가자 없음 (본인이 방금 FINISHED됨)
+            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                    .willReturn(List.of());
+            given(gameResultRepository.findByGameRoomOrderByFinalRankAsc(room))
+                    .willReturn(List.of(GameResult.create(
+                            room, participantA, 0, SEED,
+                            new BigDecimal("12000000"), new BigDecimal("20.00"), 10)));
+
+            // When
+            GameEndInfo result = gameEndService.endGame(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(result.roomFinished()).isTrue();
+            assertThat(room.getStatus()).isEqualTo(RoomStatus.FINISHED);
+        }
+
+        @Test
+        @DisplayName("2명 중 1명 이미 FINISHED → 마지막 ACTIVE 종료 시 방 FINISHED + 순위 2명 확정")
+        void endGame_secondParticipant_roomFinished_ranksBothConfirmed() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+            participantB.finish(); // B는 이미 종료
+
+            GameTurn turn = GameTurn.createFirst(room);
+            GamePortfolioSnapshot snapshotA = GamePortfolioSnapshot.create(
+                    turn, participantA, new BigDecimal("7000000"),
+                    new BigDecimal("5000000"), SEED);  // A total = 12,000,000
+
+            // B의 기존 결과 (개별 종료 시 저장됨, rank=0)
+            GameResult resultB = GameResult.create(room, participantB, 0, SEED,
+                    new BigDecimal("9000000"), new BigDecimal("-10.00"), 3);
+
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(snapshotRepository.findLatestByParticipant(participantA))
+                    .willReturn(Optional.of(snapshotA));
+            given(gameOrderRepository.countByParticipant(participantA)).willReturn(7);
+            given(gameResultRepository.save(any(GameResult.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            // A가 FINISHED되면 ACTIVE 없음
+            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                    .willReturn(List.of());
+            // 순위 확정 시 A + B 결과 모두 조회
+            GameResult resultA = GameResult.create(room, participantA, 0, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 7);
+            given(gameResultRepository.findByGameRoomOrderByFinalRankAsc(room))
+                    .willReturn(List.of(resultA, resultB));
+
+            // When
+            GameEndInfo result = gameEndService.endGame(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(result.roomFinished()).isTrue();
+            assertThat(room.getStatus()).isEqualTo(RoomStatus.FINISHED);
+            // A: 12,000,000 > B: 9,000,000 → A가 1위, B가 2위
+            assertThat(resultA.getFinalRank()).isEqualTo(1);
+            assertThat(resultB.getFinalRank()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("스냅샷 없이 종료 — 시드머니 그대로")
+        void endGame_noSnapshot_seedMoney() {
+            // Given
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(snapshotRepository.findLatestByParticipant(participantA))
+                    .willReturn(Optional.empty());
+            given(gameOrderRepository.countByParticipant(participantA)).willReturn(0);
+            given(gameResultRepository.save(any(GameResult.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+                    .willReturn(List.of(GameParticipant.createMember(room, USER_B)));
+
+            // When
+            GameEndInfo result = gameEndService.endGame(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(result.finalAsset()).isEqualByComparingTo(SEED);
+            assertThat(result.profitRate()).isEqualByComparingTo(BigDecimal.ZERO);
+            assertThat(result.totalTrades()).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("개별 게임 종료 실패")
+    class FailTests {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void roomNotFound() {
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameEndService.endGame(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("이미 종료된 방이면 GAME_ALREADY_FINISHED")
+        void gameAlreadyFinished() {
+            GameRoom room = createStartedRoom();
+            room.finish();
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> gameEndService.endGame(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_ALREADY_FINISHED);
+        }
+
+        @Test
+        @DisplayName("게임 미시작이면 GAME_NOT_STARTED")
+        void gameNotStarted() {
+            GameRoom room = createWaitingRoom();
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+
+            assertThatThrownBy(() -> gameEndService.endGame(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GAME_NOT_STARTED);
+        }
+
+        @Test
+        @DisplayName("참가자가 아니면 ROOM_NOT_PARTICIPANT")
+        void notParticipant() {
+            GameRoom room = createStartedRoom();
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameEndService.endGame(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+        }
+
+        @Test
+        @DisplayName("이미 FINISHED면 PARTICIPANT_ALREADY_FINISHED")
+        void alreadyFinished() {
+            GameRoom room = createStartedRoom();
+            GameParticipant participant = GameParticipant.createLeader(room, USER_A);
+            participant.finish();
+
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participant));
+
+            assertThatThrownBy(() -> gameEndService.endGame(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_ALREADY_FINISHED);
+
+            verify(gameResultRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("LEFT 상태 참가자가 종료 시도하면 ROOM_NOT_PARTICIPANT")
+        void leftParticipantCannotEnd() {
+            GameRoom room = createStartedRoom();
+            GameParticipant participant = GameParticipant.createLeader(room, USER_A);
+            participant.leave();
+
+            given(gameRoomRepository.findByIdForUpdate(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participant));
+
+            assertThatThrownBy(() -> gameEndService.endGame(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_PARTICIPANT);
+
+            verify(gameResultRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("순위 확정 (finalizeRanks)")
+    class FinalizeRanksTests {
+
+        @Test
+        @DisplayName("3명 중 2명 동률 → 1위, 1위, 3위")
+        void tieBreaking() {
+            GameRoom room = createStartedRoom();
+            GameParticipant pA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant pB = GameParticipant.createMember(room, USER_B);
+            UUID userC = UUID.fromString("00000000-0000-4000-a000-000000000004");
+            GameParticipant pC = GameParticipant.createMember(room, userC);
+
+            GameResult rA = GameResult.create(room, pA, 0, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 5);
+            GameResult rB = GameResult.create(room, pB, 0, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 3);
+            GameResult rC = GameResult.create(room, pC, 0, SEED,
+                    new BigDecimal("9000000"), new BigDecimal("-10.00"), 2);
+
+            given(gameResultRepository.findByGameRoomOrderByFinalRankAsc(room))
+                    .willReturn(List.of(rA, rB, rC));
+
+            gameEndService.finalizeRanks(room);
+
+            assertThat(rA.getFinalRank()).isEqualTo(1);
+            assertThat(rB.getFinalRank()).isEqualTo(1);
+            assertThat(rC.getFinalRank()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("전원 동률 → 모두 1위")
+        void allTied() {
+            GameRoom room = createStartedRoom();
+            GameParticipant pA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant pB = GameParticipant.createMember(room, USER_B);
+
+            GameResult rA = GameResult.create(room, pA, 0, SEED,
+                    new BigDecimal("10000000"), BigDecimal.ZERO, 0);
+            GameResult rB = GameResult.create(room, pB, 0, SEED,
+                    new BigDecimal("10000000"), BigDecimal.ZERO, 0);
+
+            given(gameResultRepository.findByGameRoomOrderByFinalRankAsc(room))
+                    .willReturn(List.of(rA, rB));
+
+            gameEndService.finalizeRanks(room);
+
+            assertThat(rA.getFinalRank()).isEqualTo(1);
+            assertThat(rB.getFinalRank()).isEqualTo(1);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createStartedRoom() {
+        GameRoom room = GameRoom.create(GROUP_ID, USER_A, SEED,
+                6, 7, START_DATE, START_DATE.plusMonths(6));
+        room.start();
+        return room;
+    }
+
+    private GameRoom createWaitingRoom() {
+        return GameRoom.create(GROUP_ID, USER_A, SEED,
+                6, 7, START_DATE, START_DATE.plusMonths(6));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/snapshot/service/GameRankingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/snapshot/service/GameRankingServiceTest.java
@@ -81,7 +81,7 @@ class GameRankingServiceTest {
                     .willReturn(Optional.of(participantA));
             given(gameTurnRepository.findFirstByGameRoomAndStatusOrderByTurnNumberDesc(room, TurnStatus.COMPLETED))
                     .willReturn(Optional.empty());
-            given(gameParticipantRepository.findByGameRoomAndStatus(room, ParticipantStatus.ACTIVE))
+            given(gameParticipantRepository.findByGameRoomAndStatusIn(room, List.of(ParticipantStatus.ACTIVE, ParticipantStatus.FINISHED)))
                     .willReturn(List.of(participantA, participantB));
 
             User userA = mockUser(USER_A, "재훈");

--- a/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceServiceTest.java
@@ -4,6 +4,9 @@ import com.solv.wefin.domain.game.holding.entity.GameHolding;
 import com.solv.wefin.domain.game.holding.repository.GameHoldingRepository;
 import com.solv.wefin.domain.game.news.entity.BriefingCache;
 import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.result.service.GameEndService;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
@@ -61,6 +64,12 @@ class TurnAdvanceServiceTest {
     private StockDailyRepository stockDailyRepository;
     @Mock
     private GamePortfolioSnapshotRepository snapshotRepository;
+    @Mock
+    private GameOrderRepository gameOrderRepository;
+    @Mock
+    private GameResultRepository gameResultRepository;
+    @Mock
+    private GameEndService gameEndService;
     @Mock
     private BriefingCacheRepository briefingCacheRepository;
     @Mock
@@ -217,6 +226,11 @@ class TurnAdvanceServiceTest {
                     .willReturn(List.of());
             given(stockDailyRepository.findLatestTradeDateOnOrBefore(START_DATE.plusDays(7)))
                     .willReturn(Optional.of(nextTradeDate));
+            given(snapshotRepository.save(any(GamePortfolioSnapshot.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(gameOrderRepository.countByParticipant(participant)).willReturn(0);
+            given(gameResultRepository.save(any()))
+                    .willAnswer(invocation -> invocation.getArgument(0));
 
             // When
             GameTurn result = turnAdvanceService.advanceTurn(TEST_ROOM_ID, TEST_USER_ID);
@@ -227,6 +241,7 @@ class TurnAdvanceServiceTest {
             assertThat(currentTurn.getStatus()).isEqualTo(TurnStatus.COMPLETED);
             verify(gameTurnRepository, never()).save(any(GameTurn.class));
             verify(eventPublisher, never()).publishEvent(any(TurnChangeEvent.class));
+            verify(gameEndService).finalizeRanks(room);
         }
     }
 


### PR DESCRIPTION
## 📌 PR 설명
<br> 게임 종료 api를 추가했습니다. 방 나가기와 게임 종료 차이 : 방 나가기는 게임 재입장 가능하지만 결과 받지 못하고 게임 종료는 재입장이 불가능 하지만 투자 변동 그래프 ai 투자 분석 등을 제공하는 결과 페이지로 이동됩니다.

## ✅ 완료한 기능 명세

- [x] 게임 종료 api
- [x] 재입장 방어
- [x] 방장 위임
- [x] 테스트코드
- [x] 에러코드
<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #249 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 종료 기능 추가: 게임을 종료하면 최종 자산, 수익률, 거래 횟수가 기록되고 순위가 자동으로 확정됩니다.
  * 게임 결과 조회 API 엔드포인트 추가
  * 게임 기간 만료 시 활성 참가자의 게임이 자동으로 종료됩니다.

* **버그 수정**
  * 게임을 종료한 참가자의 재입장 방지

<!-- end of auto-generated comment: release notes by coderabbit.ai -->