### PR TITLE
[WEF-640] 실시간 거래 랭킹 API 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/indices/client/YahooChartClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/client/YahooChartClient.java
@@ -1,0 +1,262 @@
+package com.solv.wefin.domain.trading.indices.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.trading.indices.dto.ChangeDirection;
+import com.solv.wefin.domain.trading.indices.dto.IndexCode;
+import com.solv.wefin.domain.trading.indices.dto.IndexQuote;
+import com.solv.wefin.domain.trading.indices.dto.MarketStatus;
+import com.solv.wefin.domain.trading.indices.dto.SparklineInterval;
+import com.solv.wefin.domain.trading.indices.dto.SparklinePoint;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Yahoo Finance chart API 클라이언트.
+ *
+ * <p>{@code interval=1m&range=1d} 로 호출하여 meta(현재값/전일종가/장상태) + close 분봉 배열을 함께 받아
+ * {@link IndexQuote} 로 조립한다.</p>
+ */
+@Slf4j
+@Component
+public class YahooChartClient {
+
+    private static final String BASE_URL = "https://query1.finance.yahoo.com/v8/finance/chart";
+    private static final String USER_AGENT = "Mozilla/5.0 (compatible; WefinBot/1.0)";
+    private static final int RATE_SCALE = 4;
+    private static final BigDecimal PERCENT_MULTIPLIER = new BigDecimal("100");
+    private static final long SESSION_GAP_MULTIPLIER = 3L;
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    public YahooChartClient(@Qualifier("marketRestTemplate") RestTemplate restTemplate,
+                            ObjectMapper objectMapper) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * 단일 지수의 현재값 + 스파크라인 배열을 조회한다.
+     *
+     * @param code             지수 코드
+     * @param interval         분봉 간격 (1m / 5m / 15m)
+     * @param sparklinePoints  스파크라인 포인트 개수 (최근 N개)
+     * @return IndexQuote
+     */
+    public IndexQuote fetchQuote(IndexCode code, SparklineInterval interval, int sparklinePoints) {
+        URI uri = buildUri(code, interval);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("User-Agent", USER_AGENT);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    uri, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+
+            String body = response.getBody();
+            if (body == null || body.isBlank()) {
+                throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+            }
+
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode result = root.path("chart").path("result").path(0);
+            if (result.isMissingNode()) {
+                log.warn("Yahoo {} 응답에 result 없음", code);
+                throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+            }
+
+            JsonNode meta = result.path("meta");
+            if (!meta.has("regularMarketPrice")) {
+                log.warn("Yahoo {} meta 필수 필드 누락: {}", code, meta);
+                throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+            }
+
+            BigDecimal currentValue = BigDecimal.valueOf(meta.get("regularMarketPrice").asDouble());
+            BigDecimal previousClose = resolvePreviousClose(meta);
+            BigDecimal changeValue = currentValue.subtract(previousClose);
+            BigDecimal changeRate = calculateChangeRate(changeValue, previousClose);
+            ChangeDirection direction = resolveDirection(changeValue);
+            MarketStatus marketStatus = resolveMarketStatus(meta.path("marketState").asText(""));
+
+            List<SparklinePoint> sparkline = extractSparkline(result, interval, sparklinePoints);
+
+            return new IndexQuote(
+                    code,
+                    code.getLabel(),
+                    currentValue,
+                    changeValue,
+                    changeRate,
+                    direction,
+                    code.isDelayed(),
+                    marketStatus,
+                    sparkline
+            );
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (RestClientException | JsonProcessingException e) {
+            log.error("Yahoo {} 조회 실패", code, e);
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+    }
+
+    /**
+     * Yahoo chart API URI 를 조립한다. 심볼(^GSPC, ^IXIC 등) 의 특수문자가 안전하게 인코딩되도록
+     * {@link UriComponentsBuilder} 로 구성한 뒤 {@link URI} 로 반환한다.
+     * <p>{@code String} 이 아닌 {@code URI} 로 넘겨야 RestTemplate 의 자동 인코딩으로 인한 이중 인코딩을 피할 수 있다.</p>
+     */
+    private URI buildUri(IndexCode code, SparklineInterval interval) {
+        return UriComponentsBuilder.fromUriString(BASE_URL)
+                .pathSegment(code.getYahooSymbol())
+                .queryParam("interval", interval.getLabel())
+                .queryParam("range", resolveRange(interval))
+                .build()
+                .toUri();
+    }
+
+    /**
+     * result.timestamp[] + indicators.quote[0].close[] 를 엮어 최근 N개 SparklinePoint 리스트를 만든다.
+     * <p>파이프라인:
+     * <ol>
+     *   <li>close 가 null 인 포인트 제외 (장 시작 전/마감 후 빈 슬롯)</li>
+     *   <li>세션 경계 감지 — interval 3배 넘는 시간 간격이 있으면 split, 가장 최신 세션만 유지</li>
+     *   <li>최신 sparklinePoints 개수만큼 꼬리 잘라 반환</li>
+     * </ol>
+     * </p>
+     */
+    private List<SparklinePoint> extractSparkline(JsonNode result, SparklineInterval interval, int sparklinePoints) {
+        JsonNode timestamps = result.path("timestamp");
+        JsonNode quoteArr = result.path("indicators").path("quote");
+        if (!timestamps.isArray() || !quoteArr.isArray() || quoteArr.isEmpty()) {
+            return List.of();
+        }
+        JsonNode closes = quoteArr.path(0).path("close");
+        if (!closes.isArray()) {
+            return List.of();
+        }
+
+        int size = Math.min(timestamps.size(), closes.size());
+        List<SparklinePoint> points = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            JsonNode closeNode = closes.get(i);
+            if (closeNode == null || closeNode.isNull()) continue;
+
+            long epochSec = timestamps.get(i).asLong();
+            BigDecimal value = BigDecimal.valueOf(closeNode.asDouble());
+            points.add(new SparklinePoint(Instant.ofEpochSecond(epochSec), value));
+        }
+
+        List<SparklinePoint> latestSession = filterLatestSession(points, interval);
+
+        if (latestSession.size() <= sparklinePoints) {
+            return List.copyOf(latestSession);
+        }
+        // subList 는 원본 view 라 외부 변경에 노출됨 → copyOf 로 불변 리스트 반환
+        return List.copyOf(latestSession.subList(latestSession.size() - sparklinePoints, latestSession.size()));
+    }
+
+    /**
+     * 타임스탬프 간격이 interval 의 3배를 초과하는 지점(세션 경계)을 찾아,
+     * 가장 최근 세션의 포인트만 반환한다.
+     * <p>예: 5분봉에서 15분 이상 gap 이면 점심시간 or 장마감/다음날로 간주하고 그 뒤부터만 유지.</p>
+     */
+    private List<SparklinePoint> filterLatestSession(List<SparklinePoint> points, SparklineInterval interval) {
+        if (points.size() < 2) return points;
+
+        long gapThresholdSec = interval.getIntervalSeconds() * SESSION_GAP_MULTIPLIER;
+        int sessionStart = 0;
+        for (int i = 1; i < points.size(); i++) {
+            long gap = points.get(i).t().getEpochSecond() - points.get(i - 1).t().getEpochSecond();
+            if (gap > gapThresholdSec) {
+                sessionStart = i;
+            }
+        }
+        // 중간 가공 단계 — caller(extractSparkline) 가 최종 copyOf 로 감싼다
+        return points.subList(sessionStart, points.size());
+    }
+
+    /**
+     * 진짜 전일 종가를 결정한다.
+     * <p>Yahoo meta 에는 2개의 유사 필드가 있는데 의미가 다름:
+     * <ul>
+     *   <li>{@code previousClose} / {@code regularMarketPreviousClose}: 실제 직전 영업일 종가</li>
+     *   <li>{@code chartPreviousClose}: 요청한 {@code range} 시작 이전의 종가 — {@code range=2d} 면 2일 전 종가</li>
+     * </ul>
+     * {@code range=2d} 로 호출하므로 {@code chartPreviousClose} 를 쓰면 이틀 전 값이 되어 변동률 왜곡.
+     * 실제 전일 종가인 {@code previousClose} 를 우선 사용하고, 누락 시에만 fallback.
+     * </p>
+     */
+    private BigDecimal resolvePreviousClose(JsonNode meta) {
+        if (meta.has("previousClose") && !meta.get("previousClose").isNull()) {
+            return BigDecimal.valueOf(meta.get("previousClose").asDouble());
+        }
+        if (meta.has("regularMarketPreviousClose") && !meta.get("regularMarketPreviousClose").isNull()) {
+            return BigDecimal.valueOf(meta.get("regularMarketPreviousClose").asDouble());
+        }
+        if (meta.has("chartPreviousClose") && !meta.get("chartPreviousClose").isNull()) {
+            log.warn("Yahoo meta 에 previousClose 없음 — chartPreviousClose fallback (range 이전 종가라 부정확할 수 있음)");
+            return BigDecimal.valueOf(meta.get("chartPreviousClose").asDouble());
+        }
+        throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+    }
+
+    private BigDecimal calculateChangeRate(BigDecimal changeValue, BigDecimal previousClose) {
+        if (previousClose.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return changeValue.divide(previousClose, RATE_SCALE, RoundingMode.HALF_UP)
+                .multiply(PERCENT_MULTIPLIER)
+                .setScale(2, RoundingMode.HALF_UP);
+    }
+
+    private ChangeDirection resolveDirection(BigDecimal changeValue) {
+        int cmp = changeValue.compareTo(BigDecimal.ZERO);
+        if (cmp > 0) return ChangeDirection.UP;
+        if (cmp < 0) return ChangeDirection.DOWN;
+        return ChangeDirection.FLAT;
+    }
+
+    /**
+     * Yahoo meta.marketState 매핑.
+     * REGULAR → OPEN, PRE → PRE_OPEN, 나머지(POST/POSTPOST/CLOSED/빈값) → CLOSED
+     */
+    private MarketStatus resolveMarketStatus(String raw) {
+        if (raw == null || raw.isBlank()) return MarketStatus.CLOSED;
+        return switch (raw.toUpperCase()) {
+            case "REGULAR" -> MarketStatus.OPEN;
+            case "PRE" -> MarketStatus.PRE_OPEN;
+            default -> MarketStatus.CLOSED;
+        };
+    }
+
+    /**
+     * interval 에 맞는 range 를 결정한다.
+     * Yahoo 제약상 1m 은 7일까지, 5m/15m 은 60일까지 허용.
+     * 정규장 하루치(1d) 면 1m 에서 충분, 5m/15m 은 2d 로 넉넉히 받아 세션 필터로 오늘치만 추림.
+     */
+    private String resolveRange(SparklineInterval interval) {
+        return switch (interval) {
+            case ONE_MIN -> "1d";
+            case FIVE_MIN, FIFTEEN_MIN -> "2d";
+        };
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/dto/ChangeDirection.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/dto/ChangeDirection.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.trading.indices.dto;
+
+/**
+ * 지수 변동 방향.
+ * <p>{@code domain/market/entity/MarketSnapshot.ChangeDirection} 과 값은 같지만,
+ * 타 팀 도메인(기사쪽) 의존을 피하기 위해 자체 정의한다.</p>
+ */
+public enum ChangeDirection {
+    UP, DOWN, FLAT
+}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/dto/IndexCode.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/dto/IndexCode.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.trading.indices.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 홈 상단 주요 지수 4종 정의.
+ * Yahoo Finance 심볼과 지연 여부를 함께 보관한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public enum IndexCode {
+    KOSPI("^KS11", "코스피", false),
+    KOSDAQ("^KQ11", "코스닥", false),
+    NASDAQ("^IXIC", "나스닥", true),
+    SP500("^GSPC", "S&P 500", true);
+
+    private final String yahooSymbol;
+    private final String label;
+    private final boolean delayed;
+}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/dto/IndexQuote.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/dto/IndexQuote.java
@@ -1,0 +1,19 @@
+package com.solv.wefin.domain.trading.indices.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 지수 현재값 + 스파크라인 묶음 (도메인 DTO)
+ */
+public record IndexQuote(
+    IndexCode code,
+    String label,
+    BigDecimal currentValue,
+    BigDecimal changeValue,
+    BigDecimal changeRate,
+    ChangeDirection changeDirection,
+    boolean isDelayed,
+    MarketStatus marketStatus,
+    List<SparklinePoint> sparkline
+) {}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/dto/MarketStatus.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/dto/MarketStatus.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.trading.indices.dto;
+
+/**
+ * 시장 개장 상태. Yahoo Finance meta.marketState 기준으로 매핑한다.
+ */
+public enum MarketStatus {
+    OPEN,
+    PRE_OPEN,
+    CLOSED
+}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/dto/SparklineInterval.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/dto/SparklineInterval.java
@@ -1,0 +1,33 @@
+package com.solv.wefin.domain.trading.indices.dto;
+
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+
+/**
+ * 스파크라인 분봉 간격. Yahoo chart API 가 지원하는 값만 허용한다.
+ * <p>Yahoo 는 10m 을 지원하지 않으므로 1m / 5m / 15m 중 선택.</p>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SparklineInterval {
+    ONE_MIN("1m", 60L),
+    FIVE_MIN("5m", 300L),
+    FIFTEEN_MIN("15m", 900L);
+
+    private final String label;
+    private final long intervalSeconds;
+
+    public static SparklineInterval fromLabel(String label) {
+        if (label == null || label.isBlank()) {
+            return ONE_MIN;
+        }
+        return Arrays.stream(values())
+            .filter(v -> v.label.equalsIgnoreCase(label))
+            .findFirst()
+            .orElseThrow(() -> new BusinessException(ErrorCode.MARKET_INVALID_INTERVAL));
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/dto/SparklinePoint.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/dto/SparklinePoint.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.trading.indices.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/**
+ * 스파크라인 단일 포인트.
+ *
+ * @param t 시점 (UTC Instant, 프론트에서 KST 변환)
+ * @param v 해당 시점 지수 값
+ */
+public record SparklinePoint(Instant t, BigDecimal v) {}

--- a/src/main/java/com/solv/wefin/domain/trading/indices/service/MarketIndicesService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/indices/service/MarketIndicesService.java
@@ -1,0 +1,78 @@
+package com.solv.wefin.domain.trading.indices.service;
+
+import com.solv.wefin.domain.trading.indices.client.YahooChartClient;
+import com.solv.wefin.domain.trading.indices.dto.IndexCode;
+import com.solv.wefin.domain.trading.indices.dto.IndexQuote;
+import com.solv.wefin.domain.trading.indices.dto.SparklineInterval;
+import com.solv.wefin.global.error.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 주요 지수 4종 조회 서비스.
+ *
+ * <p>Yahoo Finance chart API 를 on-demand 호출하고, 60초 TTL 인메모리 캐시로 외부 호출을 줄인다.
+ * 4개 지수 중 일부 조회 실패 시에도 성공한 지수만 반환한다(부분 성공 허용).</p>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MarketIndicesService {
+
+    private static final long CACHE_TTL_MS = 60_000L;
+
+    private final YahooChartClient yahooChartClient;
+
+    // cacheKey = "CODE:interval:sparklinePoints" 로 분기
+    private final ConcurrentHashMap<String, IndexQuote> quoteCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> quoteCacheTimestamp = new ConcurrentHashMap<>();
+
+    /**
+     * 4개 지수 전체를 조회한다.
+     *
+     * @param interval         분봉 간격
+     * @param sparklinePoints  지수별 스파크라인 포인트 개수
+     */
+    public List<IndexQuote> getAllIndices(SparklineInterval interval, int sparklinePoints) {
+        List<IndexQuote> result = new ArrayList<>();
+        for (IndexCode code : IndexCode.values()) {
+            try {
+                result.add(getOne(code, interval, sparklinePoints));
+            } catch (BusinessException e) {
+                log.warn("지수 {} 조회 실패 — 스킵", code, e);
+            }
+        }
+        return result;
+    }
+
+    private IndexQuote getOne(IndexCode code, SparklineInterval interval, int sparklinePoints) {
+        String cacheKey = code.name() + ":" + interval.getLabel() + ":" + sparklinePoints;
+
+        IndexQuote cached = getCached(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        IndexQuote quote = yahooChartClient.fetchQuote(code, interval, sparklinePoints);
+        quoteCache.put(cacheKey, quote);
+        quoteCacheTimestamp.put(cacheKey, System.currentTimeMillis());
+        return quote;
+    }
+
+    private IndexQuote getCached(String cacheKey) {
+        Long ts = quoteCacheTimestamp.get(cacheKey);
+        if (ts != null && System.currentTimeMillis() - ts < CACHE_TTL_MS) {
+            return quoteCache.get(cacheKey);
+        }
+        if (ts != null) {
+            quoteCache.remove(cacheKey);
+            quoteCacheTimestamp.remove(cacheKey);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -130,4 +130,90 @@ public class HantuMarketClient {
                 .header("custtype", "P")
                 .retrieve().body(HantuMinuteCandleApiResponse.class);
     }
+
+    /**
+     * 국내 주식 거래량 순위를 조회
+     */
+    public HantuRankingApiResponse fetchVolumeRanking() {
+        return hantuRestClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path("/uapi/domestic-stock/v1/quotations/volume-rank")
+                .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                .queryParam("FID_COND_SCR_DIV_CODE", "20171")
+                .queryParam("FID_INPUT_ISCD", "0000")
+                .queryParam("FID_DIV_CLS_CODE", "0")
+                .queryParam("FID_BLNG_CLS_CODE", "0")
+                .queryParam("FID_TRGT_CLS_CODE", "111111111")
+                .queryParam("FID_TRGT_EXLS_CLS_CODE", "000000")
+                .queryParam("FID_INPUT_PRICE_1", "0")
+                .queryParam("FID_INPUT_PRICE_2", "0")
+                .queryParam("FID_VOL_CNT", "0")
+                .queryParam("FID_INPUT_DATE_1", "")
+                .build())
+            .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+            .header("appkey", appKey)
+            .header("appsecret", appSecret)
+            .header("tr_id", "FHPST01710000")
+            .header("custtype", "P")
+            .retrieve().body(HantuRankingApiResponse.class);
+    }
+
+    /**
+     * 국내 주식 거래대금 순위를 조회
+     */
+    public HantuRankingApiResponse fetchTradingAmountRanking() {
+        return hantuRestClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path("/uapi/domestic-stock/v1/quotations/volume-rank")
+                .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                .queryParam("FID_COND_SCR_DIV_CODE", "20171")
+                .queryParam("FID_INPUT_ISCD", "0000")
+                .queryParam("FID_DIV_CLS_CODE", "0")
+                .queryParam("FID_BLNG_CLS_CODE", "3")       // 3: 거래금액순 (공식 문서)
+                .queryParam("FID_TRGT_CLS_CODE", "111111111")
+                .queryParam("FID_TRGT_EXLS_CLS_CODE", "000000")
+                .queryParam("FID_INPUT_PRICE_1", "0")
+                .queryParam("FID_INPUT_PRICE_2", "0")
+                .queryParam("FID_VOL_CNT", "0")
+                .queryParam("FID_INPUT_DATE_1", "")
+                .build())
+            .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+            .header("appkey", appKey)
+            .header("appsecret", appSecret)
+            .header("tr_id", "FHPST01710000")  // 거래량과 동일 API, DIV_CLS_CODE로 구분
+            .header("custtype", "P")
+            .retrieve().body(HantuRankingApiResponse.class);
+    }
+
+    /**
+     * 구갠 주식 등략률 순위를 조회
+     * @param isRising true: 급등 (상승률 상위), false: 급락 (하락률 상위)
+     */
+    public HantuRankingApiResponse fetchChangeRateRanking(boolean isRising) {
+        return hantuRestClient.get()
+            .uri(uriBuilder -> uriBuilder
+                .path("/uapi/domestic-stock/v1/ranking/fluctuation")
+                .queryParam("fid_cond_mrkt_div_code", "J")
+                .queryParam("fid_cond_scr_div_code", "20170")
+                .queryParam("fid_input_iscd", "0000")
+                .queryParam("fid_rank_sort_cls_code", isRising ? "0" : "1")
+                .queryParam("fid_input_cnt_1", "0")
+                .queryParam("fid_prc_cls_code", "0")
+                .queryParam("fid_input_price_1", "0")
+                .queryParam("fid_input_price_2", "0")
+                .queryParam("fid_vol_cnt", "0")
+                .queryParam("fid_trgt_cls_code", "0")
+                .queryParam("fid_trgt_exls_cls_code", "0")
+                .queryParam("fid_div_cls_code", "0")
+                .queryParam("fid_rsfl_rate1", "")
+                .queryParam("fid_rsfl_rate2", "")
+                .build())
+            .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+            .header("appkey", appKey)
+            .header("appsecret", appSecret)
+            .header("tr_id", "FHPST01720000")
+            .header("custtype", "P")
+            .retrieve().body(HantuRankingApiResponse.class);
+    }
+
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -186,7 +186,7 @@ public class HantuMarketClient {
     }
 
     /**
-     * 구갠 주식 등략률 순위를 조회
+     * 국내 주식 등락률 순위를 조회
      * @param isRising true: 급등 (상승률 상위), false: 급락 (하락률 상위)
      */
     public HantuRankingApiResponse fetchChangeRateRanking(boolean isRising) {

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuTokenManager.java
@@ -24,14 +24,14 @@ public class HantuTokenManager {
     private String appSecret;
 
     private final RestClient hantuRestClient;
-    private String accessToken;
-    private LocalDateTime tokenExpiresAt;
+    private volatile String accessToken;
+    private volatile LocalDateTime tokenExpiresAt;
 
     /**
      * 토큰을 반환합니다. (만료됐거나 만료 5분 이내이면 자동 갱신)
      * @return 액세스 토큰 문자열
      */
-    public String getAccessToken() {
+    public synchronized String getAccessToken() {
         if (accessToken == null || tokenExpiresAt == null || tokenExpiresAt.isBefore(LocalDateTime.now().plusMinutes(5))) {
             fetchToken();
         }
@@ -74,7 +74,11 @@ public class HantuTokenManager {
      * 6시간 주기로 토큰을 갱신합니다.
      */
     @Scheduled(fixedRate = 1000 * 60 * 60 * 6)
-    public void refreshToken() {
-        fetchToken();
+    public synchronized void refreshToken() {
+        try {
+            fetchToken();
+        } catch (Exception e) {
+            log.error("한투 토큰 정기 갱신 실패", e);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuRankingApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuRankingApiResponse.java
@@ -1,0 +1,17 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import java.util.List;
+
+public record HantuRankingApiResponse(List<Output> output) {
+	public record Output(
+		String data_rank, // 순위
+		String mksc_shrn_iscd, // 종목코드 (6자리)
+		String hts_kor_isnm, // 종목명 (한글)
+		String stck_prpr, // 현재가
+		String prdy_vrss, // 전일 대비
+		String prdy_vrss_sign, // 부호 (1:상한 2:상승 3:보합 4:하한 5:하락
+		String prdy_ctrt, // 전일대비율 (%)
+		String acml_vol, // 누적 거래량
+		String acml_tr_pbmn // 누적 거래대금
+	) {}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/RankingType.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/RankingType.java
@@ -1,0 +1,5 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+public enum RankingType {
+	VOLUME, AMOUNT, RISING, FALLING
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/StockRankingItem.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/StockRankingItem.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import java.math.BigDecimal;
+
+public record StockRankingItem(
+	int rank,
+	String stockCode,
+	String stockName,
+	BigDecimal currentPrice,
+	BigDecimal changeRate,
+	BigDecimal changeAmount,
+	String changeSign,
+	Long volume,
+	Long tradingAmount  // 누적 거래대금
+) {
+	public static StockRankingItem from(HantuRankingApiResponse.Output output) {
+		return new StockRankingItem(
+			Integer.parseInt(output.data_rank()),
+			output.mksc_shrn_iscd(),
+			output.hts_kor_isnm(),
+			new BigDecimal(output.stck_prpr()),
+			new BigDecimal(output.prdy_ctrt()),
+			new BigDecimal(output.prdy_vrss()),
+			output.prdy_vrss_sign(),
+			Long.parseLong(output.acml_vol()),
+			(output.acml_tr_pbmn() != null && !output.acml_tr_pbmn().isBlank())
+				? Long.parseLong(output.acml_tr_pbmn()) : 0L
+		);
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/StockRankingResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/StockRankingResponse.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import java.util.List;
+
+public record StockRankingResponse(List<StockRankingItem> items) {
+	public static StockRankingResponse from(List<StockRankingItem> items) {
+		return new StockRankingResponse(items);
+	}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -49,6 +49,7 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private final ConcurrentHashMap<String, Long> rankingCacheTimestamp = new ConcurrentHashMap<>();
 
     private static final long RANKING_CACHE_TTL_MS = 10000;
+    private static final long STALE_RANKING_TTL_MS = 3000; // 외부 API 실패 시 stale 캐시 유지 시간
     private static final long CACHE_TTL_MS = 5000; // 5초
     private static final Set<String> VALID_PERIOD_CODES = Set.of("D", "W", "M", "Y");
     private static final Set<String> MINUTE_PERIOD_CODES = Set.of("1", "5", "15", "30", "60");
@@ -151,10 +152,16 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
                 ? response.output().stream().map(StockRankingItem::from).toList()
                 : List.of();
 
-            // FALLING: 등락률 오름차순 재정렬 (가장 큰 하락이 1위)
+            // FALLING: 한투 API 가 급락 데이터를 정렬 없이 반환 — 서버에서 재정렬 후 순위 재부여
+            // 동률 시 tie-break: 거래량 내림차순(큰 거래 우선) → 종목코드 오름차순(deterministic)
             if (!items.isEmpty() && type == RankingType.FALLING) {
-                var sorted = new java.util.ArrayList<>(items);
-                sorted.sort((a, b) -> a.changeRate().compareTo(b.changeRate()));
+                Comparator<StockRankingItem> fallingOrder = Comparator
+                    .comparing(StockRankingItem::changeRate)
+                    .thenComparing(StockRankingItem::volume, Comparator.reverseOrder())
+                    .thenComparing(StockRankingItem::stockCode);
+
+                var sorted = new ArrayList<>(items);
+                sorted.sort(fallingOrder);
                 items = java.util.stream.IntStream.range(0, sorted.size())
                     .mapToObj(i -> new StockRankingItem(
                         i + 1, sorted.get(i).stockCode(), sorted.get(i).stockName(),
@@ -169,6 +176,15 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
 
             return items;
         } catch (Exception e) {
+            // 실패 시 stale 캐시 있으면 반환 — 네거티브 캐시 효과로 rate limit 폭주 방지
+            // TTL 을 짧게 조정해 장애 복구 시 빠르게 재시도
+            List<StockRankingItem> stale = rankingCache.get(cacheKey);
+            if (stale != null) {
+                log.warn("랭킹 조회 실패 — stale 캐시 반환: type={}", type, e);
+                rankingCacheTimestamp.put(cacheKey,
+                    System.currentTimeMillis() - RANKING_CACHE_TTL_MS + STALE_RANKING_TTL_MS);
+                return stale;
+            }
             if (e instanceof BusinessException) throw (BusinessException) e;
             log.error("랭킹 조회 실패: type={}", type, e);
             throw new BusinessException(ErrorCode.MARKET_API_FAILED);
@@ -180,10 +196,9 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         if (cachedTime != null && System.currentTimeMillis() - cachedTime < RANKING_CACHE_TTL_MS) {
             return rankingCache.get(type);
         }
-        if (cachedTime != null) {
-            rankingCache.remove(type);
-            rankingCacheTimestamp.remove(type);
-        }
+        // TTL 만료 시 캐시는 유지 (stale fallback 용).
+        // 성공 호출이 덮어쓰거나, 실패 시 catch 블록에서 stale 로 반환된다.
+        // 랭킹 타입이 4개뿐이라 메모리 누적 부담 없음.
         return null;
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -6,7 +6,10 @@ import com.solv.wefin.domain.trading.market.client.dto.HantuCandleApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuMinuteCandleApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuOrderbookApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuRankingApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.RankingType;
+import com.solv.wefin.domain.trading.market.client.dto.StockRankingItem;
 import com.solv.wefin.domain.trading.market.dto.CandleResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
@@ -42,6 +45,10 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private final ConcurrentHashMap<String, CompletableFuture<PriceResponse>> ongoingRequests = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, PriceResponse> priceCache = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Long> priceCacheTimestamp = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, List<StockRankingItem>> rankingCache = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Long> rankingCacheTimestamp = new ConcurrentHashMap<>();
+
+    private static final long RANKING_CACHE_TTL_MS = 10000;
     private static final long CACHE_TTL_MS = 5000; // 5초
     private static final Set<String> VALID_PERIOD_CODES = Set.of("D", "W", "M", "Y");
     private static final Set<String> MINUTE_PERIOD_CODES = Set.of("1", "5", "15", "30", "60");
@@ -121,6 +128,56 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             priceCacheTimestamp.remove(stockCode);
         }
 
+        return null;
+    }
+
+    public List<StockRankingItem> getStockRanking(RankingType type) {
+
+        String cacheKey = type.name();
+        List<StockRankingItem> cached = getCachedRanking(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+
+        HantuRankingApiResponse response = switch (type) {
+            case VOLUME -> hantuMarketClient.fetchVolumeRanking();
+            case AMOUNT -> hantuMarketClient.fetchTradingAmountRanking();
+            case RISING -> hantuMarketClient.fetchChangeRateRanking(true);
+            case FALLING -> hantuMarketClient.fetchChangeRateRanking(false);
+        };
+
+        List<StockRankingItem> items = (response.output() != null)
+            ? response.output().stream().map(StockRankingItem::from).toList()
+            : List.of();
+
+        // FALLING: 등락률 오름차순 재정렬 (가장 큰 하락이 1위)
+        if (!items.isEmpty() && type == RankingType.FALLING) {
+            var sorted = new java.util.ArrayList<>(items);
+            sorted.sort((a, b) -> a.changeRate().compareTo(b.changeRate()));
+            items = java.util.stream.IntStream.range(0, sorted.size())
+                .mapToObj(i -> new StockRankingItem(
+                    i + 1, sorted.get(i).stockCode(), sorted.get(i).stockName(),
+                    sorted.get(i).currentPrice(), sorted.get(i).changeRate(),
+                    sorted.get(i).changeAmount(), sorted.get(i).changeSign(),
+                    sorted.get(i).volume(), sorted.get(i).tradingAmount()))
+                .toList();
+        }
+
+        rankingCache.put(cacheKey, items);
+        rankingCacheTimestamp.put(cacheKey, System.currentTimeMillis());
+
+        return items;
+    }
+
+    private List<StockRankingItem> getCachedRanking(String type) {
+        Long cachedTime = rankingCacheTimestamp.get(type);
+        if (cachedTime != null && System.currentTimeMillis() - cachedTime < RANKING_CACHE_TTL_MS) {
+            return rankingCache.get(type);
+        }
+        if (cachedTime != null) {
+            rankingCache.remove(type);
+            rankingCacheTimestamp.remove(type);
+        }
         return null;
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -139,34 +139,40 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             return cached;
         }
 
-        HantuRankingApiResponse response = switch (type) {
-            case VOLUME -> hantuMarketClient.fetchVolumeRanking();
-            case AMOUNT -> hantuMarketClient.fetchTradingAmountRanking();
-            case RISING -> hantuMarketClient.fetchChangeRateRanking(true);
-            case FALLING -> hantuMarketClient.fetchChangeRateRanking(false);
-        };
+        try {
+            HantuRankingApiResponse response = switch (type) {
+                case VOLUME -> hantuMarketClient.fetchVolumeRanking();
+                case AMOUNT -> hantuMarketClient.fetchTradingAmountRanking();
+                case RISING -> hantuMarketClient.fetchChangeRateRanking(true);
+                case FALLING -> hantuMarketClient.fetchChangeRateRanking(false);
+            };
 
-        List<StockRankingItem> items = (response.output() != null)
-            ? response.output().stream().map(StockRankingItem::from).toList()
-            : List.of();
+            List<StockRankingItem> items = (response.output() != null)
+                ? response.output().stream().map(StockRankingItem::from).toList()
+                : List.of();
 
-        // FALLING: 등락률 오름차순 재정렬 (가장 큰 하락이 1위)
-        if (!items.isEmpty() && type == RankingType.FALLING) {
-            var sorted = new java.util.ArrayList<>(items);
-            sorted.sort((a, b) -> a.changeRate().compareTo(b.changeRate()));
-            items = java.util.stream.IntStream.range(0, sorted.size())
-                .mapToObj(i -> new StockRankingItem(
-                    i + 1, sorted.get(i).stockCode(), sorted.get(i).stockName(),
-                    sorted.get(i).currentPrice(), sorted.get(i).changeRate(),
-                    sorted.get(i).changeAmount(), sorted.get(i).changeSign(),
-                    sorted.get(i).volume(), sorted.get(i).tradingAmount()))
-                .toList();
+            // FALLING: 등락률 오름차순 재정렬 (가장 큰 하락이 1위)
+            if (!items.isEmpty() && type == RankingType.FALLING) {
+                var sorted = new java.util.ArrayList<>(items);
+                sorted.sort((a, b) -> a.changeRate().compareTo(b.changeRate()));
+                items = java.util.stream.IntStream.range(0, sorted.size())
+                    .mapToObj(i -> new StockRankingItem(
+                        i + 1, sorted.get(i).stockCode(), sorted.get(i).stockName(),
+                        sorted.get(i).currentPrice(), sorted.get(i).changeRate(),
+                        sorted.get(i).changeAmount(), sorted.get(i).changeSign(),
+                        sorted.get(i).volume(), sorted.get(i).tradingAmount()))
+                    .toList();
+            }
+
+            rankingCache.put(cacheKey, items);
+            rankingCacheTimestamp.put(cacheKey, System.currentTimeMillis());
+
+            return items;
+        } catch (Exception e) {
+            if (e instanceof BusinessException) throw (BusinessException) e;
+            log.error("랭킹 조회 실패: type={}", type, e);
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
         }
-
-        rankingCache.put(cacheKey, items);
-        rankingCacheTimestamp.put(cacheKey, System.currentTimeMillis());
-
-        return items;
     }
 
     private List<StockRankingItem> getCachedRanking(String type) {

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -104,7 +104,7 @@ public enum ErrorCode {
     MARKET_INVALID_PERIOD_CODE(400, "유효하지 않은 기간 옵션입니다."),
     MARKET_INVALID_DATE(400, "조회 시작일자는 종료일자 이전이어야 합니다."),
     MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 20개까지 가능합니다."),
-    MARKET_INVALID_REQUEST(400, "유효하지 안흥ㄴ 랭킹 유형입니다."),
+    MARKET_INVALID_REQUEST(400, "유효하지 않은 랭킹 유형입니다."),
 
     // Interest
     INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심사입니다."),

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -104,6 +104,7 @@ public enum ErrorCode {
     MARKET_INVALID_PERIOD_CODE(400, "유효하지 않은 기간 옵션입니다."),
     MARKET_INVALID_DATE(400, "조회 시작일자는 종료일자 이전이어야 합니다."),
     MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 20개까지 가능합니다."),
+    MARKET_INVALID_REQUEST(400, "유효하지 안흥ㄴ 랭킹 유형입니다."),
 
     // Interest
     INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심사입니다."),

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -105,6 +105,7 @@ public enum ErrorCode {
     MARKET_INVALID_DATE(400, "조회 시작일자는 종료일자 이전이어야 합니다."),
     MARKET_SUBSCRIPTION_LIMIT_EXCEEDED(400, "실시간 구독 종목은 최대 20개까지 가능합니다."),
     MARKET_INVALID_REQUEST(400, "유효하지 않은 랭킹 유형입니다."),
+    MARKET_INVALID_INTERVAL(400, "유효하지 않은 분봉 간격입니다. (1m, 5m, 15m 만 지원)"),
 
     // Interest
     INTEREST_ALREADY_EXISTS(400, "이미 등록된 관심사입니다."),

--- a/src/main/java/com/solv/wefin/web/trading/indices/MarketIndicesController.java
+++ b/src/main/java/com/solv/wefin/web/trading/indices/MarketIndicesController.java
@@ -1,0 +1,38 @@
+package com.solv.wefin.web.trading.indices;
+
+import com.solv.wefin.domain.trading.indices.dto.IndexQuote;
+import com.solv.wefin.domain.trading.indices.dto.SparklineInterval;
+import com.solv.wefin.domain.trading.indices.service.MarketIndicesService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.trading.indices.dto.MarketIndicesResponse;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Validated
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/market/indices")
+public class MarketIndicesController {
+
+    private final MarketIndicesService marketIndicesService;
+
+    @GetMapping
+    public ApiResponse<MarketIndicesResponse> getIndices(
+        @RequestParam(defaultValue = "1m") String interval,
+        @RequestParam(defaultValue = "30") @Min(1) @Max(80) int sparklinePoints
+    ) {
+        SparklineInterval parsedInterval = SparklineInterval.fromLabel(interval);
+        List<IndexQuote> quotes = marketIndicesService.getAllIndices(parsedInterval, sparklinePoints);
+        return ApiResponse.success(MarketIndicesResponse.from(quotes));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/indices/dto/MarketIndicesResponse.java
+++ b/src/main/java/com/solv/wefin/web/trading/indices/dto/MarketIndicesResponse.java
@@ -1,0 +1,52 @@
+package com.solv.wefin.web.trading.indices.dto;
+
+import com.solv.wefin.domain.trading.indices.dto.ChangeDirection;
+import com.solv.wefin.domain.trading.indices.dto.IndexCode;
+import com.solv.wefin.domain.trading.indices.dto.IndexQuote;
+import com.solv.wefin.domain.trading.indices.dto.MarketStatus;
+import com.solv.wefin.domain.trading.indices.dto.SparklinePoint;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+public record MarketIndicesResponse(Instant updatedAt, List<Item> indices) {
+
+    public static MarketIndicesResponse from(List<IndexQuote> quotes) {
+        List<Item> items = quotes.stream().map(Item::from).toList();
+        return new MarketIndicesResponse(Instant.now(), items);
+    }
+
+    public record Item(
+        IndexCode code,
+        String name,
+        BigDecimal currentValue,
+        BigDecimal changeValue,
+        BigDecimal changeRate,
+        ChangeDirection changeDirection,
+        boolean isDelayed,
+        MarketStatus marketStatus,
+        List<Point> sparkline
+    ) {
+        public static Item from(IndexQuote q) {
+            List<Point> points = q.sparkline().stream().map(Point::from).toList();
+            return new Item(
+                q.code(),
+                q.label(),
+                q.currentValue(),
+                q.changeValue(),
+                q.changeRate(),
+                q.changeDirection(),
+                q.isDelayed(),
+                q.marketStatus(),
+                points
+            );
+        }
+    }
+
+    public record Point(Instant t, BigDecimal v) {
+        public static Point from(SparklinePoint p) {
+            return new Point(p.t(), p.v());
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
+++ b/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
@@ -1,5 +1,8 @@
 package com.solv.wefin.web.trading.market;
 
+import com.solv.wefin.domain.trading.market.client.dto.RankingType;
+import com.solv.wefin.domain.trading.market.client.dto.StockRankingItem;
+import com.solv.wefin.domain.trading.market.client.dto.StockRankingResponse;
 import com.solv.wefin.domain.trading.market.dto.CandleResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
@@ -8,13 +11,18 @@ import com.solv.wefin.domain.trading.market.service.MarketService;
 import com.solv.wefin.domain.trading.stock.dto.StockSearchResponse;
 import com.solv.wefin.domain.trading.stock.service.StockService;
 import com.solv.wefin.global.common.ApiResponse;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
 
-
+@Validated
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/stocks")
@@ -52,6 +60,15 @@ public class MarketController {
     @GetMapping("/{code}/trades/recent")
     public ApiResponse<List<RecentTradeResponse>> getRecentTrades(@PathVariable String code) {
         return ApiResponse.success(marketService.getRecentTrades(code));
+    }
+
+    @GetMapping("/ranking")
+    public ApiResponse<StockRankingResponse> getStockRanking(@RequestParam RankingType type,
+                                                             @RequestParam(defaultValue = "30") @Min(1) @Max(50) int limit) {
+        List<StockRankingItem> items = marketService.getStockRanking(type);
+        List<StockRankingItem> limited = items.size() > limit
+            ? items.subList(0, limit) : items;
+        return ApiResponse.success(StockRankingResponse.from(limited));
     }
 
 }

--- a/src/test/java/com/solv/wefin/domain/trading/indices/client/YahooChartClientTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/indices/client/YahooChartClientTest.java
@@ -1,0 +1,270 @@
+package com.solv.wefin.domain.trading.indices.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.trading.indices.dto.ChangeDirection;
+import com.solv.wefin.domain.trading.indices.dto.IndexCode;
+import com.solv.wefin.domain.trading.indices.dto.IndexQuote;
+import com.solv.wefin.domain.trading.indices.dto.MarketStatus;
+import com.solv.wefin.domain.trading.indices.dto.SparklineInterval;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+class YahooChartClientTest {
+
+    private RestTemplate restTemplate;
+    private MockRestServiceServer mockServer;
+    private YahooChartClient client;
+
+    @BeforeEach
+    void setUp() {
+        restTemplate = new RestTemplate();
+        mockServer = MockRestServiceServer.createServer(restTemplate);
+        client = new YahooChartClient(restTemplate, new ObjectMapper());
+    }
+
+    @Test
+    void 정상_응답_파싱() {
+        String body = """
+            {
+              "chart": {
+                "result": [{
+                  "meta": {
+                    "regularMarketPrice": 6226.05,
+                    "previousClose": 6091.39,
+                    "chartPreviousClose": 5967.75,
+                    "marketState": "REGULAR"
+                  },
+                  "timestamp": [1713254400, 1713254460, 1713254520],
+                  "indicators": {
+                    "quote": [{
+                      "close": [6150.0, 6170.5, 6226.05]
+                    }]
+                  }
+                }]
+              }
+            }
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+
+        assertThat(quote.code()).isEqualTo(IndexCode.KOSPI);
+        assertThat(quote.currentValue()).isEqualByComparingTo("6226.05");
+        assertThat(quote.changeValue()).isEqualByComparingTo("134.66");
+        assertThat(quote.changeRate()).isEqualByComparingTo("2.21");
+        assertThat(quote.changeDirection()).isEqualTo(ChangeDirection.UP);
+        assertThat(quote.marketStatus()).isEqualTo(MarketStatus.OPEN);
+        assertThat(quote.sparkline()).hasSize(3);
+
+        mockServer.verify();
+    }
+
+    @Test
+    void previousClose_우선_사용_chartPreviousClose_무시() {
+        String body = """
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":6226.05,"previousClose":6091.39,"chartPreviousClose":5967.75,"marketState":"CLOSED"},
+              "timestamp":[1713254400],"indicators":{"quote":[{"close":[6226.05]}]}
+            }]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+
+        // chartPreviousClose(5967.75) 썼으면 +4.33%, previousClose(6091.39) 썼으면 +2.21%
+        assertThat(quote.changeRate()).isEqualByComparingTo("2.21");
+    }
+
+    @Test
+    void previousClose_없을때_chartPreviousClose_fallback() {
+        String body = """
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":6226.05,"chartPreviousClose":5967.75,"marketState":"CLOSED"},
+              "timestamp":[1713254400],"indicators":{"quote":[{"close":[6226.05]}]}
+            }]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+
+        assertThat(quote.changeRate()).isEqualByComparingTo("4.33");
+    }
+
+    @Test
+    void 세션_경계_감지_최근_세션만_유지() {
+        long t1 = 1713168000L;
+        long t2 = t1 + 60;
+        long t3 = t2 + 60;
+        long t4 = t3 + 60 * 60 * 18;
+        long t5 = t4 + 60;
+        long t6 = t5 + 60;
+        String body = String.format("""
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":6226.05,"previousClose":6091.39,"marketState":"REGULAR"},
+              "timestamp":[%d,%d,%d,%d,%d,%d],
+              "indicators":{"quote":[{"close":[6000.0,6010.0,6020.0,6200.0,6210.0,6226.05]}]}
+            }]}}
+            """, t1, t2, t3, t4, t5, t6);
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+
+        assertThat(quote.sparkline()).hasSize(3);
+        assertThat(quote.sparkline().get(0).t()).isEqualTo(Instant.ofEpochSecond(t4));
+        assertThat(quote.sparkline().get(2).t()).isEqualTo(Instant.ofEpochSecond(t6));
+    }
+
+    @Test
+    void null_close_포인트는_스킵() {
+        String body = """
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":6226.05,"previousClose":6091.39,"marketState":"CLOSED"},
+              "timestamp":[1713254400,1713254460,1713254520],
+              "indicators":{"quote":[{"close":[6150.0,null,6226.05]}]}
+            }]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+
+        assertThat(quote.sparkline()).hasSize(2);
+        assertThat(quote.sparkline()).extracting(p -> p.v())
+            .containsExactly(new BigDecimal("6150.0"), new BigDecimal("6226.05"));
+    }
+
+    @Test
+    void sparklinePoints_보다_많으면_최근_N개만_반환() {
+        String body = """
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":6226.05,"previousClose":6091.39,"marketState":"CLOSED"},
+              "timestamp":[1713254400,1713254460,1713254520,1713254580,1713254640],
+              "indicators":{"quote":[{"close":[100.0,200.0,300.0,400.0,500.0]}]}
+            }]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 3);
+
+        assertThat(quote.sparkline()).hasSize(3);
+        assertThat(quote.sparkline()).extracting(p -> p.v())
+            .containsExactly(new BigDecimal("300.0"), new BigDecimal("400.0"), new BigDecimal("500.0"));
+    }
+
+    @Test
+    void marketState_매핑() {
+        assertMarketStateMapping("REGULAR", MarketStatus.OPEN);
+        assertMarketStateMapping("PRE", MarketStatus.PRE_OPEN);
+        assertMarketStateMapping("POST", MarketStatus.CLOSED);
+        assertMarketStateMapping("POSTPOST", MarketStatus.CLOSED);
+        assertMarketStateMapping("CLOSED", MarketStatus.CLOSED);
+    }
+
+    private void assertMarketStateMapping(String rawState, MarketStatus expected) {
+        RestTemplate local = new RestTemplate();
+        MockRestServiceServer server = MockRestServiceServer.createServer(local);
+        YahooChartClient localClient = new YahooChartClient(local, new ObjectMapper());
+
+        String body = String.format("""
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":6226.05,"previousClose":6091.39,"marketState":"%s"},
+              "timestamp":[1713254400],"indicators":{"quote":[{"close":[6226.05]}]}
+            }]}}
+            """, rawState);
+        server.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = localClient.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+        assertThat(quote.marketStatus()).as("state=%s", rawState).isEqualTo(expected);
+    }
+
+    @Test
+    void regularMarketPrice_없으면_MARKET_API_FAILED() {
+        String body = """
+            {"chart":{"result":[{
+              "meta":{"previousClose":6091.39,"marketState":"CLOSED"},
+              "timestamp":[1713254400],"indicators":{"quote":[{"close":[6226.05]}]}
+            }]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() ->
+            client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30))
+            .isInstanceOf(BusinessException.class)
+            .extracting(e -> ((BusinessException) e).getErrorCode())
+            .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void result_없으면_MARKET_API_FAILED() {
+        String body = """
+            {"chart":{"result":[]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        assertThatThrownBy(() ->
+            client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30))
+            .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    void HTTP_5xx_에러시_MARKET_API_FAILED() {
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EKS11?interval=1m&range=1d"))
+            .andRespond(withServerError());
+
+        assertThatThrownBy(() ->
+            client.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30))
+            .isInstanceOf(BusinessException.class)
+            .extracting(e -> ((BusinessException) e).getErrorCode())
+            .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void 해외지수_심볼_URL_인코딩_검증() {
+        String body = """
+            {"chart":{"result":[{
+              "meta":{"regularMarketPrice":7022.95,"previousClose":6886.24,"marketState":"CLOSED"},
+              "timestamp":[1713254400],"indicators":{"quote":[{"close":[7022.95]}]}
+            }]}}
+            """;
+        mockServer.expect(requestTo(
+                "https://query1.finance.yahoo.com/v8/finance/chart/%5EGSPC?interval=5m&range=2d"))
+            .andRespond(withSuccess(body, MediaType.APPLICATION_JSON));
+
+        IndexQuote quote = client.fetchQuote(IndexCode.SP500, SparklineInterval.FIVE_MIN, 30);
+
+        assertThat(quote.code()).isEqualTo(IndexCode.SP500);
+        assertThat(quote.isDelayed()).isTrue();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/indices/service/MarketIndicesServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/indices/service/MarketIndicesServiceTest.java
@@ -1,0 +1,135 @@
+package com.solv.wefin.domain.trading.indices.service;
+
+import com.solv.wefin.domain.trading.indices.client.YahooChartClient;
+import com.solv.wefin.domain.trading.indices.dto.ChangeDirection;
+import com.solv.wefin.domain.trading.indices.dto.IndexCode;
+import com.solv.wefin.domain.trading.indices.dto.IndexQuote;
+import com.solv.wefin.domain.trading.indices.dto.MarketStatus;
+import com.solv.wefin.domain.trading.indices.dto.SparklineInterval;
+import com.solv.wefin.domain.trading.indices.dto.SparklinePoint;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class MarketIndicesServiceTest {
+
+    @Mock
+    private YahooChartClient yahooChartClient;
+
+    @InjectMocks
+    private MarketIndicesService marketIndicesService;
+
+    @Test
+    void 지수_4종_전체_정상조회() {
+        // given
+        for (IndexCode code : IndexCode.values()) {
+            given(yahooChartClient.fetchQuote(code, SparklineInterval.ONE_MIN, 30))
+                .willReturn(buildQuote(code));
+        }
+
+        // when
+        List<IndexQuote> result = marketIndicesService.getAllIndices(SparklineInterval.ONE_MIN, 30);
+
+        // then
+        assertThat(result).hasSize(4);
+        assertThat(result).extracting(IndexQuote::code)
+            .containsExactly(IndexCode.KOSPI, IndexCode.KOSDAQ, IndexCode.NASDAQ, IndexCode.SP500);
+    }
+
+    @Test
+    void 두번째_호출은_캐시히트로_외부_API_호출_안함() {
+        // given
+        for (IndexCode code : IndexCode.values()) {
+            given(yahooChartClient.fetchQuote(code, SparklineInterval.ONE_MIN, 30))
+                .willReturn(buildQuote(code));
+        }
+
+        // when
+        marketIndicesService.getAllIndices(SparklineInterval.ONE_MIN, 30); // 첫 호출
+        marketIndicesService.getAllIndices(SparklineInterval.ONE_MIN, 30); // 두 번째 — 캐시 히트
+
+        // then — 각 지수당 1번만 호출
+        for (IndexCode code : IndexCode.values()) {
+            verify(yahooChartClient, times(1)).fetchQuote(code, SparklineInterval.ONE_MIN, 30);
+        }
+    }
+
+    @Test
+    void 일부_지수_조회_실패해도_성공한_것만_반환() {
+        // given — KOSPI 성공, KOSDAQ 실패, NASDAQ 성공, SP500 실패
+        given(yahooChartClient.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30))
+            .willReturn(buildQuote(IndexCode.KOSPI));
+        willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED))
+            .given(yahooChartClient).fetchQuote(IndexCode.KOSDAQ, SparklineInterval.ONE_MIN, 30);
+        given(yahooChartClient.fetchQuote(IndexCode.NASDAQ, SparklineInterval.ONE_MIN, 30))
+            .willReturn(buildQuote(IndexCode.NASDAQ));
+        willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED))
+            .given(yahooChartClient).fetchQuote(IndexCode.SP500, SparklineInterval.ONE_MIN, 30);
+
+        // when
+        List<IndexQuote> result = marketIndicesService.getAllIndices(SparklineInterval.ONE_MIN, 30);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(IndexQuote::code)
+            .containsExactly(IndexCode.KOSPI, IndexCode.NASDAQ);
+    }
+
+    @Test
+    void interval_또는_포인트수_다르면_캐시키_분리되어_별도_호출() {
+        // given
+        given(yahooChartClient.fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30))
+            .willReturn(buildQuote(IndexCode.KOSPI));
+        given(yahooChartClient.fetchQuote(IndexCode.KOSPI, SparklineInterval.FIVE_MIN, 80))
+            .willReturn(buildQuote(IndexCode.KOSPI));
+        // 나머지 3개 지수는 실패 처리해서 테스트 단순화
+        for (IndexCode code : IndexCode.values()) {
+            if (code != IndexCode.KOSPI) {
+                willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED))
+                    .given(yahooChartClient).fetchQuote(code, SparklineInterval.ONE_MIN, 30);
+                willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED))
+                    .given(yahooChartClient).fetchQuote(code, SparklineInterval.FIVE_MIN, 80);
+            }
+        }
+
+        // when
+        marketIndicesService.getAllIndices(SparklineInterval.ONE_MIN, 30);
+        marketIndicesService.getAllIndices(SparklineInterval.FIVE_MIN, 80);
+
+        // then
+        verify(yahooChartClient, times(1)).fetchQuote(IndexCode.KOSPI, SparklineInterval.ONE_MIN, 30);
+        verify(yahooChartClient, times(1)).fetchQuote(IndexCode.KOSPI, SparklineInterval.FIVE_MIN, 80);
+    }
+
+    private IndexQuote buildQuote(IndexCode code) {
+        return new IndexQuote(
+            code,
+            code.getLabel(),
+            new BigDecimal("2560.23"),
+            new BigDecimal("12.45"),
+            new BigDecimal("0.49"),
+            ChangeDirection.UP,
+            code.isDelayed(),
+            MarketStatus.OPEN,
+            List.of(
+                new SparklinePoint(Instant.ofEpochSecond(1713254400L), new BigDecimal("2548.10")),
+                new SparklinePoint(Instant.ofEpochSecond(1713254460L), new BigDecimal("2550.32"))
+            )
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/MarketServiceTest.java
@@ -2,7 +2,10 @@ package com.solv.wefin.domain.trading.market.service;
 
 import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
 import com.solv.wefin.domain.trading.market.client.dto.HantuPriceApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.HantuRankingApiResponse;
 import com.solv.wefin.domain.trading.market.client.dto.HantuRecentTradeApiResponse;
+import com.solv.wefin.domain.trading.market.client.dto.RankingType;
+import com.solv.wefin.domain.trading.market.client.dto.StockRankingItem;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.dto.RecentTradeResponse;
 import com.solv.wefin.domain.trading.stock.service.StockService;
@@ -205,5 +208,111 @@ class MarketServiceTest {
         // when & then
         assertThatThrownBy(() -> marketService.getRecentTrades("005930"))
                 .isInstanceOf(BusinessException.class);
+    }
+
+
+
+    // === getStockRanking FALLING 재정렬 테스트 ===
+
+    /**
+     * FALLING 재부여 시 같은 changeRate 면 거래량 큰 쪽이 먼저 오고,
+     * 거래량도 같으면 stockCode 오름차순으로 안정화된다.
+     */
+    @Test
+    void 급락_랭킹_동률시_거래량_내림차순_종목코드_오름차순으로_tie_break() {
+        // given — 같은 등락률 -3.00 (종목 A, B) + 다른 등락률 -5.00 (종목 C)
+        // 종목 A: volume=100, B: volume=500 → B 가 먼저 와야 함
+        List<HantuRankingApiResponse.Output> output = List.of(
+            rankingOutput("1", "A0000001", "종목A", "1000", "-3.00", "100"),
+            rankingOutput("2", "B0000002", "종목B", "1000", "-3.00", "500"),
+            rankingOutput("3", "C0000003", "종목C", "1000", "-5.00", "300")
+        );
+        given(hantuMarketClient.fetchChangeRateRanking(false))
+            .willReturn(new HantuRankingApiResponse(output));
+
+        // when
+        List<StockRankingItem> result = marketService.getStockRanking(RankingType.FALLING);
+
+        // then
+        // 가장 큰 하락(-5.00) 이 1위, 그 다음 -3.00 두 개 중 거래량 큰 B 가 2위
+        assertThat(result).extracting(StockRankingItem::stockCode)
+            .containsExactly("C0000003", "B0000002", "A0000001");
+        assertThat(result).extracting(StockRankingItem::rank)
+            .containsExactly(1, 2, 3);
+    }
+
+    // === getStockRanking 네거티브 캐시 테스트 ===
+
+    /**
+     * 외부 API 실패 시 stale 캐시가 있으면 예외 대신 stale 데이터를 반환한다.
+     * 프론트 5초 polling 상황에서 KIS rate limit 폭주 방지.
+     */
+    @Test
+    void 랭킹_조회_실패시_직전_캐시를_stale로_반환() {
+        // given — 첫 호출은 성공해서 캐시에 저장됨
+        List<HantuRankingApiResponse.Output> firstOutput = List.of(
+            rankingOutput("1", "A0000001", "종목A", "1000", "+5.00", "100")
+        );
+        given(hantuMarketClient.fetchVolumeRanking())
+            .willReturn(new HantuRankingApiResponse(firstOutput))
+            .willThrow(new RuntimeException("KIS API 장애"));
+
+        // when — 첫 호출 (성공 → 캐시 저장)
+        List<StockRankingItem> firstResult = marketService.getStockRanking(RankingType.VOLUME);
+        assertThat(firstResult).hasSize(1);
+
+        // 캐시 만료시키기 위해 TTL 경과 대기 대신 내부 강제 만료하지 않고,
+        // 새 쿼리가 미스로 판정되도록 직접 캐시 제거 후 stale 복원 시나리오를 재현.
+        // 실제로는 TTL 만료 후 API 호출 → 실패 → 이전 값 유지.
+        // 여기서는 두 번째 호출이 예외를 던지도록 stub 했으므로
+        // 캐시가 만료된 상태를 시뮬레이션하기 위해 timestamp 만 과거로 돌림
+        forceCacheExpire("VOLUME");
+
+        // when — 두 번째 호출 (TTL 만료 + API 실패 → stale 반환)
+        List<StockRankingItem> staleResult = marketService.getStockRanking(RankingType.VOLUME);
+
+        // then — 예외 대신 직전 값이 반환됨
+        assertThat(staleResult).isEqualTo(firstResult);
+    }
+
+    /**
+     * 실패 + 이전 캐시도 없음 → 기존처럼 BusinessException 전파.
+     */
+    @Test
+    void 랭킹_조회_실패시_이전캐시_없으면_예외_전파() {
+        // given
+        given(hantuMarketClient.fetchVolumeRanking())
+            .willThrow(new RuntimeException("KIS API 장애"));
+
+        // when & then
+        assertThatThrownBy(() -> marketService.getStockRanking(RankingType.VOLUME))
+            .isInstanceOf(BusinessException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    // === 헬퍼 ===
+
+    private HantuRankingApiResponse.Output rankingOutput(String rank, String code, String name,
+                                                         String price, String changeRate, String volume) {
+        return new HantuRankingApiResponse.Output(
+            rank, code, name, price, "0", "2", changeRate, volume, "0"
+        );
+    }
+
+    /**
+     * 캐시 TTL 이 만료된 상태를 시뮬레이션하기 위해 내부 timestamp 를 과거로 돌린다.
+     * 리플렉션으로 private 맵 접근.
+     */
+    private void forceCacheExpire(String cacheKey) {
+        try {
+            var field = MarketService.class.getDeclaredField("rankingCacheTimestamp");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            var map = (java.util.concurrent.ConcurrentHashMap<String, Long>) field.get(marketService);
+            map.put(cacheKey, 0L); // 아주 과거 — 무조건 만료
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
 ## 📌 PR 설명
  홈 화면 실시간 거래 랭킹 (거래량 TOP / 거래대금 TOP / 급등 / 급락) API 구현.
  한투 KIS 랭킹 API 프록시 방식. 프론트에서 5초 polling으로 실시간 갱신.

  <br>

  ## ✅ 완료한 기능 명세

  - [x] `GET /api/stocks/ranking?type=VOLUME` — 거래량 TOP 30
  - [x] `GET /api/stocks/ranking?type=AMOUNT` — 거래대금 TOP 30
  - [x] `GET /api/stocks/ranking?type=RISING` — 급등 TOP 30
  - [x] `GET /api/stocks/ranking?type=FALLING` — 급락 TOP 30
  - [x] 10초 캐싱 (ConcurrentHashMap + TTL)
  - [x] HantuTokenManager synchronized 토큰 관리 (rate limit 방지)
  - [x] size 파라미터 검증 (@Min(1) @Max(50))

<br>

  ## 💭 고민과 해결과정

  ### 1. 한투 KIS API 파라미터 탐색
  공식 문서 기반으로 정확한 파라미터 확인. 거래대금은 `FID_BLNG_CLS_CODE=3`, 급등/급락은 `FHPST01720000` (등락률 순위 API), 거래량/거래대금은
  `FHPST01710000` (거래량 순위 API)의 정렬 옵션으로 구분.

  ### 2. 종목코드 필드명 불일치
  KIS 거래량 순위 API는 종목코드를 `mksc_shrn_iscd`로 반환 (다른 API의 `stck_shrn_iscd`와 다름). RAW JSON 확인 후 수정.

  ### 3. 급락 정렬 문제
  KIS API가 급락 데이터를 정렬 없이 반환. 서비스에서 등락률 오름차순 재정렬 처리.

  ### 4. 토큰 rate limit 방지
  HantuTokenManager에 synchronized + volatile 적용. 서버 시작 시 동시 토큰 발급 요청으로 1분당 1회 rate limit 걸리는 문제 해결. 기존
  KisTokenManager 패턴 참고.

  <br>

  ### 🔗 관련 이슈
  Closes #250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 주식 랭킹 조회 API 추가(거래량/거래대금/상승률/하락률) 및 지수 조회 API(스파크라인 포함)
* **개선**
  * 랭킹 및 지수 조회 결과 캐싱 도입으로 응답 속도 향상
  * 토큰 관리의 멀티스레드 안정성 및 정기 갱신 실패 처리 개선
* **오류 처리**
  * 유효하지 않은 랭킹 유형·스파크라인 간격에 대한 명확한 오류 응답
* **테스트**
  * 외부 API 파싱·캐싱·부분실패 케이스에 대한 단위/통합 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->