### PR TITLE
[WEF-633] 게임 결과 조회 api 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/result/dto/GameResultInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/dto/GameResultInfo.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.domain.game.result.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 게임 결과 조회 응답용 Domain DTO.
+ * 본인이 FINISHED 상태일 때, 현 시점 game_result 기준 순위와 참가자별 결과를 묶어서 반환한다.
+ * 방이 아직 IN_PROGRESS여도 본인이 FINISHED이기만 하면 조회 가능하며,
+ * 이 경우 아직 종료하지 않은 참가자는 결과에 포함되지 않는다.
+ */
+public record GameResultInfo(
+        UUID roomId,
+        LocalDate startDate,
+        LocalDate endDate,
+        int totalTurns,
+        List<RankingEntry> rankings
+) {
+    public record RankingEntry(
+            int rank,
+            String userName,
+            BigDecimal seedMoney,
+            BigDecimal finalAsset,
+            BigDecimal profitRate,
+            int totalTrades
+    ) {}
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/dto/GameResultInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/dto/GameResultInfo.java
@@ -15,7 +15,6 @@ public record GameResultInfo(
         UUID roomId,
         LocalDate startDate,
         LocalDate endDate,
-        int totalTurns,
         List<RankingEntry> rankings
 ) {
     public record RankingEntry(

--- a/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
@@ -12,5 +12,7 @@ public interface GameResultRepository extends JpaRepository<GameResult, UUID> {
 
     List<GameResult> findByGameRoomOrderByFinalRankAsc(GameRoom gameRoom);
 
+    List<GameResult> findByGameRoomOrderByFinalAssetDescCreatedAtAsc(GameRoom gameRoom);
+
     boolean existsByGameRoomAndParticipant(GameRoom gameRoom, GameParticipant participant);
 }

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
@@ -1,0 +1,99 @@
+package com.solv.wefin.domain.game.result.service;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.GameResultInfo;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GameResultService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameResultRepository gameResultRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 게임 결과 조회.
+     * 본인이 FINISHED 상태여야 조회 가능.
+     * 순위는 매 요청마다 finalAsset DESC로 동적 계산(dense rank) —
+     * 방이 아직 IN_PROGRESS면 finalRank=0인 레코드가 섞일 수 있으므로 필드 값을 신뢰하지 않는다.
+     */
+    public GameResultInfo getGameResult(UUID roomId, UUID userId) {
+
+        // 1. 방 조회
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2. 참가자 검증 (FINISHED 전용)
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.FINISHED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
+
+        // 3. 결과 조회 (finalAsset 내림차순, 동률이면 먼저 종료한 순)
+        //    2차 정렬(createdAt ASC): 동률 시 DB 반환 순서 비결정성을 제거 —
+        //    같은 요청을 반복해도 동률 참가자들의 순서가 바뀌지 않도록 한다.
+        List<GameResult> results = gameResultRepository
+                .findByGameRoomOrderByFinalAssetDescCreatedAtAsc(gameRoom);
+
+        // 4. 닉네임 일괄 조회 (N+1 방지)
+        List<UUID> userIds = results.stream()
+                .map(r -> r.getParticipant().getUserId())
+                .toList();
+        Map<UUID, String> nicknameMap = buildNicknameMap(userIds);
+
+        // 5. dense rank 부여 (동률이면 같은 순위: 1, 1, 3)
+        List<GameResultInfo.RankingEntry> rankings = new ArrayList<>();
+        for (int i = 0; i < results.size(); i++) {
+            GameResult r = results.get(i);
+            int rank = (i == 0) ? 1
+                    : results.get(i - 1).getFinalAsset().compareTo(r.getFinalAsset()) == 0
+                            ? rankings.get(i - 1).rank()
+                            : i + 1;
+
+            rankings.add(new GameResultInfo.RankingEntry(
+                    rank,
+                    nicknameMap.getOrDefault(r.getParticipant().getUserId(), "알 수 없음"),
+                    r.getSeedMoney(),
+                    r.getFinalAsset(),
+                    r.getProfitRate(),
+                    r.getTotalTrades()));
+        }
+
+        // 6. 총 턴 수 — 실제 game_turn 행 수 (비거래일 보정 때문에 기간/moveDays 계산보다 정확)
+        int totalTurns = gameTurnRepository.countByGameRoom(gameRoom);
+
+        return new GameResultInfo(
+                gameRoom.getRoomId(),
+                gameRoom.getStartDate(),
+                gameRoom.getEndDate(),
+                totalTurns,
+                rankings);
+    }
+
+    private Map<UUID, String> buildNicknameMap(List<UUID> userIds) {
+        return userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(
+                        user -> user.getUserId(),
+                        user -> user.getNickname()));
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
@@ -8,7 +8,6 @@ import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.result.repository.GameResultRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
-import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -29,13 +28,12 @@ public class GameResultService {
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final GameResultRepository gameResultRepository;
-    private final GameTurnRepository gameTurnRepository;
     private final UserRepository userRepository;
 
     /**
      * 게임 결과 조회.
      * 본인이 FINISHED 상태여야 조회 가능.
-     * 순위는 매 요청마다 finalAsset DESC로 동적 계산(dense rank) —
+     * 순위는 매 요청마다 finalAsset DESC로 동적 계산(standard competition rank: 1, 1, 3) —
      * 방이 아직 IN_PROGRESS면 finalRank=0인 레코드가 섞일 수 있으므로 필드 값을 신뢰하지 않는다.
      */
     public GameResultInfo getGameResult(UUID roomId, UUID userId) {
@@ -49,9 +47,11 @@ public class GameResultService {
                 .filter(p -> p.getStatus() == ParticipantStatus.FINISHED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
 
-        // 3. 결과 조회 (finalAsset 내림차순, 동률이면 먼저 종료한 순)
+        // 3. 결과 조회 (finalAsset 내림차순)
         //    2차 정렬(createdAt ASC): 동률 시 DB 반환 순서 비결정성을 제거 —
-        //    같은 요청을 반복해도 동률 참가자들의 순서가 바뀌지 않도록 한다.
+        //    같은 요청을 반복해도 동률 참가자들의 순서가 바뀌지 않도록 정렬 결정성을 보장한다.
+        //    (강제 종료 경로에서는 같은 트랜잭션 내 일괄 저장이라 createdAt이 거의 동일하므로
+        //     "먼저 종료한 순" 의미보다는 결정성 보장 용도가 우선이다.)
         List<GameResult> results = gameResultRepository
                 .findByGameRoomOrderByFinalAssetDescCreatedAtAsc(gameRoom);
 
@@ -61,7 +61,7 @@ public class GameResultService {
                 .toList();
         Map<UUID, String> nicknameMap = buildNicknameMap(userIds);
 
-        // 5. dense rank 부여 (동률이면 같은 순위: 1, 1, 3)
+        // 5. standard competition rank 부여 (동률이면 같은 순위, 다음은 건너뜀: 1, 1, 3)
         List<GameResultInfo.RankingEntry> rankings = new ArrayList<>();
         for (int i = 0; i < results.size(); i++) {
             GameResult r = results.get(i);
@@ -79,14 +79,10 @@ public class GameResultService {
                     r.getTotalTrades()));
         }
 
-        // 6. 총 턴 수 — 실제 game_turn 행 수 (비거래일 보정 때문에 기간/moveDays 계산보다 정확)
-        int totalTurns = gameTurnRepository.countByGameRoom(gameRoom);
-
         return new GameResultInfo(
                 gameRoom.getRoomId(),
                 gameRoom.getStartDate(),
                 gameRoom.getEndDate(),
-                totalTurns,
                 rankings);
     }
 

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -15,4 +15,6 @@ public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
     Optional<GameTurn> findFirstByGameRoomAndStatusOrderByTurnNumberDesc(GameRoom gameRoom, TurnStatus status);
 
     int countByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
+
+    int countByGameRoom(GameRoom gameRoom);
 }

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -15,6 +15,4 @@ public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
     Optional<GameTurn> findFirstByGameRoomAndStatusOrderByTurnNumberDesc(GameRoom gameRoom, TurnStatus status);
 
     int countByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
-
-    int countByGameRoom(GameRoom gameRoom);
 }

--- a/src/main/java/com/solv/wefin/web/game/result/GameResultController.java
+++ b/src/main/java/com/solv/wefin/web/game/result/GameResultController.java
@@ -1,12 +1,16 @@
 package com.solv.wefin.web.game.result;
 
 import com.solv.wefin.domain.game.result.dto.GameEndInfo;
+import com.solv.wefin.domain.game.result.dto.GameResultInfo;
 import com.solv.wefin.domain.game.result.service.GameEndService;
+import com.solv.wefin.domain.game.result.service.GameResultService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.game.result.dto.response.GameEndResponse;
+import com.solv.wefin.web.game.result.dto.response.GameResultResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +24,7 @@ import java.util.UUID;
 public class GameResultController {
 
     private final GameEndService gameEndService;
+    private final GameResultService gameResultService;
 
     @PostMapping("/end")
     public ResponseEntity<ApiResponse<GameEndResponse>> endGame(
@@ -28,6 +33,17 @@ public class GameResultController {
 
         GameEndInfo info = gameEndService.endGame(roomId, userId);
         GameEndResponse response = GameEndResponse.from(info);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/result")
+    public ResponseEntity<ApiResponse<GameResultResponse>> getGameResult(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        GameResultInfo info = gameResultService.getGameResult(roomId, userId);
+        GameResultResponse response = GameResultResponse.from(info);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/GameResultResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/GameResultResponse.java
@@ -1,0 +1,33 @@
+package com.solv.wefin.web.game.result.dto.response;
+
+import com.solv.wefin.domain.game.result.dto.GameResultInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class GameResultResponse {
+
+    private UUID roomId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private int totalTurns;
+    private List<RankingEntryDto> rankings;
+
+    public static GameResultResponse from(GameResultInfo info) {
+        List<RankingEntryDto> rankings = info.rankings().stream()
+                .map(RankingEntryDto::from)
+                .toList();
+
+        return new GameResultResponse(
+                info.roomId(),
+                info.startDate(),
+                info.endDate(),
+                info.totalTurns(),
+                rankings);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/GameResultResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/GameResultResponse.java
@@ -15,7 +15,6 @@ public class GameResultResponse {
     private UUID roomId;
     private LocalDate startDate;
     private LocalDate endDate;
-    private int totalTurns;
     private List<RankingEntryDto> rankings;
 
     public static GameResultResponse from(GameResultInfo info) {
@@ -27,7 +26,6 @@ public class GameResultResponse {
                 info.roomId(),
                 info.startDate(),
                 info.endDate(),
-                info.totalTurns(),
                 rankings);
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/RankingEntryDto.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/RankingEntryDto.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.web.game.result.dto.response;
+
+import com.solv.wefin.domain.game.result.dto.GameResultInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@AllArgsConstructor
+public class RankingEntryDto {
+
+    private int rank;
+    private String userName;
+    private BigDecimal seedMoney;
+    private BigDecimal finalAsset;
+    private BigDecimal profitRate;
+    private int totalTrades;
+
+    public static RankingEntryDto from(GameResultInfo.RankingEntry entry) {
+        return new RankingEntryDto(
+                entry.rank(),
+                entry.userName(),
+                entry.seedMoney(),
+                entry.finalAsset(),
+                entry.profitRate(),
+                entry.totalTrades());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
@@ -10,7 +10,6 @@ import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.result.repository.GameResultRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
-import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -45,8 +44,6 @@ class GameResultServiceTest {
     private GameParticipantRepository gameParticipantRepository;
     @Mock
     private GameResultRepository gameResultRepository;
-    @Mock
-    private GameTurnRepository gameTurnRepository;
     @Mock
     private UserRepository userRepository;
 
@@ -90,7 +87,6 @@ class GameResultServiceTest {
                     .willReturn(Optional.of(participantA));
             given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
                     .willReturn(List.of(resultB, resultC, resultA));
-            given(gameTurnRepository.countByGameRoom(room)).willReturn(26);
 
             User userA = mockUser(USER_A, "재훈");
             User userB = mockUser(USER_B, "길동");
@@ -104,7 +100,6 @@ class GameResultServiceTest {
             // Then
             assertThat(info.startDate()).isEqualTo(START_DATE);
             assertThat(info.endDate()).isEqualTo(END_DATE);
-            assertThat(info.totalTurns()).isEqualTo(26);
             assertThat(info.rankings()).hasSize(3);
 
             // 1위: B
@@ -148,7 +143,6 @@ class GameResultServiceTest {
                     .willReturn(Optional.of(participantA));
             given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
                     .willReturn(List.of(resultA, resultB, resultC));
-            given(gameTurnRepository.countByGameRoom(room)).willReturn(26);
 
             User userA = mockUser(USER_A, "재훈");
             User userB = mockUser(USER_B, "길동");
@@ -182,7 +176,6 @@ class GameResultServiceTest {
                     .willReturn(Optional.of(participantA));
             given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
                     .willReturn(List.of(resultA));
-            given(gameTurnRepository.countByGameRoom(room)).willReturn(8);
 
             User userA = mockUser(USER_A, "재훈");
             given(userRepository.findAllById(any())).willReturn(List.of(userA));
@@ -194,7 +187,6 @@ class GameResultServiceTest {
             assertThat(info.rankings()).hasSize(1);
             assertThat(info.rankings().get(0).rank()).isEqualTo(1);
             assertThat(info.rankings().get(0).userName()).isEqualTo("재훈");
-            assertThat(info.totalTurns()).isEqualTo(8);
         }
 
         @Test
@@ -217,7 +209,6 @@ class GameResultServiceTest {
                     .willReturn(Optional.of(participantA));
             given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
                     .willReturn(List.of(resultA, resultB));
-            given(gameTurnRepository.countByGameRoom(room)).willReturn(26);
 
             // USER_A만 user 테이블에 존재, USER_B는 누락
             User userA = mockUser(USER_A, "재훈");

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
@@ -1,0 +1,320 @@
+package com.solv.wefin.domain.game.result.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.GameResultInfo;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class GameResultServiceTest {
+
+    @InjectMocks
+    private GameResultService gameResultService;
+
+    @Mock
+    private GameRoomRepository gameRoomRepository;
+    @Mock
+    private GameParticipantRepository gameParticipantRepository;
+    @Mock
+    private GameResultRepository gameResultRepository;
+    @Mock
+    private GameTurnRepository gameTurnRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    private static final UUID ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID USER_A = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final UUID USER_B = UUID.fromString("00000000-0000-4000-a000-000000000003");
+    private static final UUID USER_C = UUID.fromString("00000000-0000-4000-a000-000000000004");
+    private static final Long GROUP_ID = 1L;
+    private static final LocalDate START_DATE = LocalDate.of(2022, 3, 2);
+    private static final LocalDate END_DATE = LocalDate.of(2022, 9, 2);
+    private static final BigDecimal SEED = new BigDecimal("10000000");
+
+    // === 성공 테스트 ===
+
+    @Nested
+    @DisplayName("게임 결과 조회 성공")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("FINISHED 참가자 조회 — finalAsset DESC 순서로 순위 부여")
+        void getResult_sortedByFinalAssetDesc() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+            GameParticipant participantC = GameParticipant.createMember(room, USER_C);
+            participantA.finish();
+            participantB.finish();
+            participantC.finish();
+
+            // DB는 finalAsset DESC로 정렬된 리스트를 반환 (B > C > A)
+            GameResult resultB = GameResult.create(room, participantB, 0, SEED,
+                    new BigDecimal("12500000"), new BigDecimal("25.00"), 42);
+            GameResult resultC = GameResult.create(room, participantC, 0, SEED,
+                    new BigDecimal("10500000"), new BigDecimal("5.00"), 15);
+            GameResult resultA = GameResult.create(room, participantA, 0, SEED,
+                    new BigDecimal("9000000"), new BigDecimal("-10.00"), 8);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
+                    .willReturn(List.of(resultB, resultC, resultA));
+            given(gameTurnRepository.countByGameRoom(room)).willReturn(26);
+
+            User userA = mockUser(USER_A, "재훈");
+            User userB = mockUser(USER_B, "길동");
+            User userC = mockUser(USER_C, "철수");
+            given(userRepository.findAllById(any()))
+                    .willReturn(List.of(userA, userB, userC));
+
+            // When
+            GameResultInfo info = gameResultService.getGameResult(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(info.startDate()).isEqualTo(START_DATE);
+            assertThat(info.endDate()).isEqualTo(END_DATE);
+            assertThat(info.totalTurns()).isEqualTo(26);
+            assertThat(info.rankings()).hasSize(3);
+
+            // 1위: B
+            assertThat(info.rankings().get(0).rank()).isEqualTo(1);
+            assertThat(info.rankings().get(0).userName()).isEqualTo("길동");
+            assertThat(info.rankings().get(0).finalAsset()).isEqualByComparingTo("12500000");
+            assertThat(info.rankings().get(0).profitRate()).isEqualByComparingTo("25.00");
+            assertThat(info.rankings().get(0).totalTrades()).isEqualTo(42);
+
+            // 2위: C
+            assertThat(info.rankings().get(1).rank()).isEqualTo(2);
+            assertThat(info.rankings().get(1).userName()).isEqualTo("철수");
+
+            // 3위: A
+            assertThat(info.rankings().get(2).rank()).isEqualTo(3);
+            assertThat(info.rankings().get(2).userName()).isEqualTo("재훈");
+        }
+
+        @Test
+        @DisplayName("동률 처리 — 같은 finalAsset이면 같은 순위 (1위, 1위, 3위)")
+        void tieBreaking_sameFinalAsset_sameRank() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+            GameParticipant participantC = GameParticipant.createMember(room, USER_C);
+            participantA.finish();
+            participantB.finish();
+            participantC.finish();
+
+            // A, B 동률 / C 낮음
+            GameResult resultA = GameResult.create(room, participantA, 0, SEED,
+                    new BigDecimal("11000000"), new BigDecimal("10.00"), 20);
+            GameResult resultB = GameResult.create(room, participantB, 0, SEED,
+                    new BigDecimal("11000000"), new BigDecimal("10.00"), 18);
+            GameResult resultC = GameResult.create(room, participantC, 0, SEED,
+                    new BigDecimal("8000000"), new BigDecimal("-20.00"), 5);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
+                    .willReturn(List.of(resultA, resultB, resultC));
+            given(gameTurnRepository.countByGameRoom(room)).willReturn(26);
+
+            User userA = mockUser(USER_A, "재훈");
+            User userB = mockUser(USER_B, "길동");
+            User userC = mockUser(USER_C, "철수");
+            given(userRepository.findAllById(any()))
+                    .willReturn(List.of(userA, userB, userC));
+
+            // When
+            GameResultInfo info = gameResultService.getGameResult(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(info.rankings()).hasSize(3);
+            assertThat(info.rankings().get(0).rank()).isEqualTo(1);
+            assertThat(info.rankings().get(1).rank()).isEqualTo(1);  // 동률
+            assertThat(info.rankings().get(2).rank()).isEqualTo(3);  // 1위가 2명 → 다음은 3위
+        }
+
+        @Test
+        @DisplayName("방이 아직 IN_PROGRESS여도 본인 FINISHED면 조회 가능")
+        void inProgressRoom_finishedParticipant_canQuery() {
+            // Given — 방은 IN_PROGRESS, A만 FINISHED
+            GameRoom room = createStartedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            participantA.finish();
+
+            GameResult resultA = GameResult.create(room, participantA, 0, SEED,
+                    new BigDecimal("11000000"), new BigDecimal("10.00"), 12);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
+                    .willReturn(List.of(resultA));
+            given(gameTurnRepository.countByGameRoom(room)).willReturn(8);
+
+            User userA = mockUser(USER_A, "재훈");
+            given(userRepository.findAllById(any())).willReturn(List.of(userA));
+
+            // When
+            GameResultInfo info = gameResultService.getGameResult(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(info.rankings()).hasSize(1);
+            assertThat(info.rankings().get(0).rank()).isEqualTo(1);
+            assertThat(info.rankings().get(0).userName()).isEqualTo("재훈");
+            assertThat(info.totalTurns()).isEqualTo(8);
+        }
+
+        @Test
+        @DisplayName("닉네임 조회 누락 — 탈퇴 등으로 user 레코드 없으면 '알 수 없음' fallback")
+        void missingNickname_fallsBackToUnknown() {
+            // Given — game_result에는 USER_B 결과가 있지만 user 테이블에서 USER_B 누락 (탈퇴 가정)
+            GameRoom room = createFinishedRoom();
+            GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
+            GameParticipant participantB = GameParticipant.createMember(room, USER_B);
+            participantA.finish();
+            participantB.finish();
+
+            GameResult resultA = GameResult.create(room, participantA, 0, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 10);
+            GameResult resultB = GameResult.create(room, participantB, 0, SEED,
+                    new BigDecimal("9000000"), new BigDecimal("-10.00"), 5);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participantA));
+            given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
+                    .willReturn(List.of(resultA, resultB));
+            given(gameTurnRepository.countByGameRoom(room)).willReturn(26);
+
+            // USER_A만 user 테이블에 존재, USER_B는 누락
+            User userA = mockUser(USER_A, "재훈");
+            given(userRepository.findAllById(any())).willReturn(List.of(userA));
+
+            // When
+            GameResultInfo info = gameResultService.getGameResult(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(info.rankings()).hasSize(2);
+            assertThat(info.rankings().get(0).userName()).isEqualTo("재훈");
+            assertThat(info.rankings().get(1).userName()).isEqualTo("알 수 없음");
+        }
+    }
+
+    // === 실패 테스트 ===
+
+    @Nested
+    @DisplayName("게임 결과 조회 실패")
+    class FailTests {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void roomNotFound() {
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameResultService.getGameResult(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("참가자가 아니면 PARTICIPANT_NOT_FINISHED")
+        void notParticipant() {
+            GameRoom room = createFinishedRoom();
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameResultService.getGameResult(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("참가자가 ACTIVE면 PARTICIPANT_NOT_FINISHED")
+        void participantActive() {
+            GameRoom room = createStartedRoom();
+            GameParticipant participant = GameParticipant.createLeader(room, USER_A);
+            // status 그대로 ACTIVE
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participant));
+
+            assertThat(participant.getStatus()).isEqualTo(ParticipantStatus.ACTIVE);
+            assertThatThrownBy(() -> gameResultService.getGameResult(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("참가자가 LEFT면 PARTICIPANT_NOT_FINISHED")
+        void participantLeft() {
+            GameRoom room = createStartedRoom();
+            GameParticipant participant = GameParticipant.createLeader(room, USER_A);
+            participant.leave();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(participant));
+
+            assertThatThrownBy(() -> gameResultService.getGameResult(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createStartedRoom() {
+        GameRoom room = GameRoom.create(GROUP_ID, USER_A, SEED,
+                6, 7, START_DATE, END_DATE);
+        room.start();
+        return room;
+    }
+
+    private GameRoom createFinishedRoom() {
+        GameRoom room = createStartedRoom();
+        room.finish();
+        return room;
+    }
+
+    private User mockUser(UUID userId, String nickname) {
+        User user = mock(User.class);
+        given(user.getUserId()).willReturn(userId);
+        given(user.getNickname()).willReturn(nickname);
+        return user;
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
<br>본인이 게임을 종료(FINISHED)한 상태일 때 방의 최종 순위, 각 참가자의 시드머니·최종자산·수익률·총거래수, 그리고 게임 기간과 총 턴 수를 한 번에 조회할 수 있게 하는 API이며, 방이 아직 IN_PROGRESS여도 본인만 FINISHED이면 조회를 허용하여 먼저 끝낸 참가자가 대기 중에도 자신의 결과와 현 시점까지의 잠정 순위를 확인할 수 있도록 했습니다.

 방 안의 모든 사람이 게임을 마치면 자연스럽게 1등, 2등, 3등이 정해집니다. 
 그러나 먼저 끝낸 유저가 있는 경우 시스템이 일단 이 유저의 자산을 기록해두고, 순위는 일단 비워둡니다. 마지막 유저까지 다 끝나면, 그 때 자산 금액들을 비교해서 1등, 2등, 3등을 한 번에 계산합니다.
 

## ✅ 완료한 기능 명세

- [x] 엔드포인트 구현
- [x] finished 조회 허용 
- [x] 내림차순 순위 정렬
- [x] 동률 처리
- [x] 테스트 코드

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #259 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게임 결과 조회 기능 추가: 사용자는 게임 종료 후 순위, 초기자본, 최종자산, 수익률, 총 거래 횟수를 포함한 상세한 결과를 확인할 수 있습니다. 동일한 자산을 보유한 참가자들은 같은 순위로 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->