### PR TITLE
[WEF-653] 인증 제한 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailVerification.java
@@ -58,6 +58,13 @@ public class EmailVerification extends BaseEntity {
     @Column(name = "last_sent_at")
     private OffsetDateTime lastSentAt;
 
+    @Column(name = "resend_window_started_at")
+    private OffsetDateTime resendWindowStartedAt;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @Builder
     public EmailVerification(String email,
                              VerificationPurpose purpose,
@@ -72,6 +79,7 @@ public class EmailVerification extends BaseEntity {
         this.resendCount = 0;
         this.lockedUntil = null;
         this.lastSentAt = null;
+        this.resendWindowStartedAt = null;
     }
 
     public void renew(String verificationCode, OffsetDateTime expiresAt) {
@@ -81,7 +89,6 @@ public class EmailVerification extends BaseEntity {
 
         this.attemptCount = 0;
         this.lockedUntil = null;
-        this.lastSentAt = null;
     }
 
     public void verify() {
@@ -119,15 +126,22 @@ public class EmailVerification extends BaseEntity {
         return lockedUntil != null && now.isBefore(lockedUntil);
     }
 
-    public void increaseResend() {
+    public boolean isResendWindowExpired(OffsetDateTime now, long windowSeconds) {
+        return resendWindowStartedAt == null
+                || !resendWindowStartedAt.plusSeconds(windowSeconds).isAfter(now);
+    }
+
+    public void resetResendWindow(OffsetDateTime now) {
+        this.resendWindowStartedAt = now;
+        this.resendCount = 0;
+    }
+
+    public void recordResend(OffsetDateTime now) {
+        this.lastSentAt = now;
         this.resendCount++;
     }
 
     public boolean isResendTooSoon(OffsetDateTime now, long cooldownSeconds) {
         return lastSentAt != null && lastSentAt.plusSeconds(cooldownSeconds).isAfter(now);
-    }
-
-    public void updateLastSentAt(OffsetDateTime now) {
-        this.lastSentAt = now;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailVerification.java
@@ -93,6 +93,8 @@ public class EmailVerification extends BaseEntity {
 
     public void verify() {
         this.verified = true;
+        this.resendCount = 0;
+        this.resendWindowStartedAt = null;
     }
 
     public void consume() {

--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailVerification.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailVerification.java
@@ -46,6 +46,18 @@ public class EmailVerification extends BaseEntity {
     @Column(name = "expires_at", nullable = false)
     private OffsetDateTime expiresAt;
 
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "resend_count", nullable = false)
+    private int resendCount;
+
+    @Column(name = "locked_until")
+    private OffsetDateTime lockedUntil;
+
+    @Column(name = "last_sent_at")
+    private OffsetDateTime lastSentAt;
+
     @Builder
     public EmailVerification(String email,
                              VerificationPurpose purpose,
@@ -56,12 +68,20 @@ public class EmailVerification extends BaseEntity {
         this.verificationCode = verificationCode;
         this.expiresAt = expiresAt;
         this.verified = false;
+        this.attemptCount = 0;
+        this.resendCount = 0;
+        this.lockedUntil = null;
+        this.lastSentAt = null;
     }
 
     public void renew(String verificationCode, OffsetDateTime expiresAt) {
         this.verificationCode = verificationCode;
         this.expiresAt = expiresAt;
         this.verified = false;
+
+        this.attemptCount = 0;
+        this.lockedUntil = null;
+        this.lastSentAt = null;
     }
 
     public void verify() {
@@ -81,5 +101,33 @@ public class EmailVerification extends BaseEntity {
                 this.verificationCode.getBytes(StandardCharsets.UTF_8),
                 code.getBytes(StandardCharsets.UTF_8)
         );
+    }
+
+    public void increaseAttempt() {
+        this.attemptCount++;
+    }
+
+    public void resetAttempt() {
+        this.attemptCount = 0;
+    }
+
+    public void lock(OffsetDateTime until) {
+        this.lockedUntil = until;
+    }
+
+    public boolean isLocked(OffsetDateTime now) {
+        return lockedUntil != null && now.isBefore(lockedUntil);
+    }
+
+    public void increaseResend() {
+        this.resendCount++;
+    }
+
+    public boolean isResendTooSoon(OffsetDateTime now, long cooldownSeconds) {
+        return lastSentAt != null && lastSentAt.plusSeconds(cooldownSeconds).isAfter(now);
+    }
+
+    public void updateLastSentAt(OffsetDateTime now) {
+        this.lastSentAt = now;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.auth.repository.EmailVerificationRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,45 +26,53 @@ public class EmailVerificationService {
     private static final int MAX_RESEND = 5;
     private static final long LOCK_MINUTES = 10L;
     private static final long RESEND_COOLDOWN_SECONDS = 60L;
+    private static final long RESEND_WINDOW_SECONDS = 600L;
 
     private final EmailVerificationRepository emailVerificationRepository;
     private final MailService mailService;
 
     @Transactional
     public void sendVerificationCode(String email, VerificationPurpose purpose) {
-        String normalizedEmail = normalizeEmail(email);
-        String code = generateCode();
-        OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(EXPIRE_MINUTES);
-        OffsetDateTime now = OffsetDateTime.now();
+        try {
+            String normalizedEmail = normalizeEmail(email);
+            String code = generateCode();
+            OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(EXPIRE_MINUTES);
+            OffsetDateTime now = OffsetDateTime.now();
 
-        EmailVerification verification = emailVerificationRepository
-                .findByEmailAndPurpose(normalizedEmail, purpose)
-                .orElse(null);
+            EmailVerification verification = emailVerificationRepository
+                    .findByEmailAndPurpose(normalizedEmail, purpose)
+                    .orElse(null);
 
-        if (verification != null) {
-            if (verification.isResendTooSoon(now, RESEND_COOLDOWN_SECONDS)) {
-                throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
+            if (verification != null) {
+                if (verification.isResendTooSoon(now, RESEND_COOLDOWN_SECONDS)) {
+                    throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
+                }
+
+                if (verification.isResendWindowExpired(now, RESEND_WINDOW_SECONDS)) {
+                    verification.resetResendWindow(now);
+                } else if (verification.getResendCount() >= MAX_RESEND) {
+                    throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_MANY_REQUESTS);
+                }
+
+                verification.renew(code, expiresAt);
+            } else {
+                verification = EmailVerification.builder()
+                        .email(normalizedEmail)
+                        .purpose(purpose)
+                        .verificationCode(code)
+                        .expiresAt(expiresAt)
+                        .build();
+
+                verification.resetResendWindow(now);
             }
 
-            if (verification.getResendCount() >= MAX_RESEND) {
-                throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_MANY_REQUESTS);
-            }
+            verification.recordResend(now);
+            emailVerificationRepository.saveAndFlush(verification);
+            mailService.sendVerificationCode(normalizedEmail, code);
 
-            verification.renew(code, expiresAt);
-        } else {
-            verification = EmailVerification.builder()
-                    .email(normalizedEmail)
-                    .purpose(purpose)
-                    .verificationCode(code)
-                    .expiresAt(expiresAt)
-                    .build();
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new BusinessException(ErrorCode.AUTH_VERIFICATION_CONCURRENT_REQUEST);
         }
-
-        emailVerificationRepository.save(verification);
-        mailService.sendVerificationCode(normalizedEmail, code);
-
-        verification.increaseResend();
-        verification.updateLastSentAt(now);
     }
 
     @Transactional

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
@@ -101,11 +101,14 @@ public class EmailVerificationService {
                 verification.lock(now.plusMinutes(LOCK_MINUTES));
             }
 
+            emailVerificationRepository.saveAndFlush(verification);
+
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_CODE_INVALID);
         }
 
         verification.resetAttempt();
         verification.verify();
+        emailVerificationRepository.saveAndFlush(verification);
     }
 
     public void validateVerifiedEmail(String email, VerificationPurpose purpose) {

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
@@ -21,34 +21,51 @@ public class EmailVerificationService {
 
     private static final long EXPIRE_MINUTES = 5L;
 
+    private static final int MAX_ATTEMPTS = 5;
+    private static final int MAX_RESEND = 5;
+    private static final long LOCK_MINUTES = 10L;
+    private static final long RESEND_COOLDOWN_SECONDS = 60L;
+
     private final EmailVerificationRepository emailVerificationRepository;
     private final MailService mailService;
 
-    // 인증코드 발송
     @Transactional
     public void sendVerificationCode(String email, VerificationPurpose purpose) {
         String normalizedEmail = normalizeEmail(email);
         String code = generateCode();
         OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(EXPIRE_MINUTES);
+        OffsetDateTime now = OffsetDateTime.now();
 
         EmailVerification verification = emailVerificationRepository
                 .findByEmailAndPurpose(normalizedEmail, purpose)
-                .map(saved -> {
-                    saved.renew(code, expiresAt);
-                    return saved;
-                })
-                .orElseGet(() -> EmailVerification.builder()
-                        .email(normalizedEmail)
-                        .purpose(purpose)
-                        .verificationCode(code)
-                        .expiresAt(expiresAt)
-                        .build());
+                .orElse(null);
+
+        if (verification != null) {
+            if (verification.isResendTooSoon(now, RESEND_COOLDOWN_SECONDS)) {
+                throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
+            }
+
+            if (verification.getResendCount() >= MAX_RESEND) {
+                throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_MANY_REQUESTS);
+            }
+
+            verification.renew(code, expiresAt);
+        } else {
+            verification = EmailVerification.builder()
+                    .email(normalizedEmail)
+                    .purpose(purpose)
+                    .verificationCode(code)
+                    .expiresAt(expiresAt)
+                    .build();
+        }
 
         emailVerificationRepository.save(verification);
         mailService.sendVerificationCode(normalizedEmail, code);
+
+        verification.increaseResend();
+        verification.updateLastSentAt(now);
     }
 
-    // 인증코드 확인
     @Transactional
     public void confirmVerificationCode(String email, String code, VerificationPurpose purpose) {
         String normalizedEmail = normalizeEmail(email);
@@ -58,18 +75,30 @@ public class EmailVerificationService {
                 .findByEmailAndPurpose(normalizedEmail, purpose)
                 .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_VERIFICATION_CODE_INVALID));
 
-        if (verification.isExpired(OffsetDateTime.now())) {
+        OffsetDateTime now = OffsetDateTime.now();
+
+        if (verification.isLocked(now)) {
+            throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
+        }
+
+        if (verification.isExpired(now)) {
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_CODE_EXPIRED);
         }
 
         if (!verification.matchesCode(normalizedCode)) {
+            verification.increaseAttempt();
+
+            if (verification.getAttemptCount() >= MAX_ATTEMPTS) {
+                verification.lock(now.plusMinutes(LOCK_MINUTES));
+            }
+
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_CODE_INVALID);
         }
 
+        verification.resetAttempt();
         verification.verify();
     }
 
-    // 인증 완료 여부 확인 (signup, resetPassword에서 사용)
     public void validateVerifiedEmail(String email, VerificationPurpose purpose) {
         String normalizedEmail = normalizeEmail(email);
 
@@ -86,7 +115,6 @@ public class EmailVerificationService {
         }
     }
 
-    // 인증 소모 (한 번 쓰고 끝)
     @Transactional
     public void consumeVerifiedEmail(String email, VerificationPurpose purpose) {
         String normalizedEmail = normalizeEmail(email);
@@ -96,8 +124,6 @@ public class EmailVerificationService {
 
         optionalVerification.ifPresent(EmailVerification::consume);
     }
-
-    // ===== 내부 유틸 =====
 
     private String normalizeEmail(String email) {
         if (email == null) {

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
@@ -36,14 +36,19 @@ public class EmailVerificationService {
         try {
             String normalizedEmail = normalizeEmail(email);
             String code = generateCode();
-            OffsetDateTime expiresAt = OffsetDateTime.now().plusMinutes(EXPIRE_MINUTES);
             OffsetDateTime now = OffsetDateTime.now();
+            OffsetDateTime expiresAt = now.plusMinutes(EXPIRE_MINUTES);
 
             EmailVerification verification = emailVerificationRepository
                     .findByEmailAndPurpose(normalizedEmail, purpose)
                     .orElse(null);
 
             if (verification != null) {
+
+                if (verification.isLocked(now)) {
+                    throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
+                }
+
                 if (verification.isResendTooSoon(now, RESEND_COOLDOWN_SECONDS)) {
                     throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
                 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -53,7 +53,6 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
 
     // Auth - SIGNUP
-    // Auth - SIGNUP
     AUTH_EMAIL_DUPLICATED(409, "이미 사용 중인 이메일입니다."),
     AUTH_NICKNAME_DUPLICATED(409, "이미 사용 중인 닉네임입니다."),
     AUTH_VALIDATION_FAILED(400, "잘못된 입력입니다."),
@@ -61,6 +60,10 @@ public enum ErrorCode {
     AUTH_VERIFICATION_CODE_INVALID(400, "인증코드가 올바르지 않습니다."),
     AUTH_VERIFICATION_CODE_EXPIRED(400, "인증코드가 만료되었습니다."),
     AUTH_EMAIL_SEND_FAILED(500, "인증 메일 발송에 실패했습니다."),
+    AUTH_VERIFICATION_TOO_FAST_REQUEST(400, "인증코드 재발송 요청이 너무 빠릅니다."),
+    AUTH_VERIFICATION_TOO_MANY_REQUESTS(400, "인증코드 재발송 횟수를 초과했습니다."),
+    AUTH_VERIFICATION_TOO_MANY_ATTEMPTS(400, "인증 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
+
     // Auth - LOGIN
     AUTH_LOGIN_FAILED(401, "이메일 또는 비밀번호가 올바르지 않습니다."),
     ACCOUNT_LOCKED(423, "계정이 잠금 상태입니다."),

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode {
     AUTH_VERIFICATION_TOO_FAST_REQUEST(400, "인증코드 재발송 요청이 너무 빠릅니다."),
     AUTH_VERIFICATION_TOO_MANY_REQUESTS(400, "인증코드 재발송 횟수를 초과했습니다."),
     AUTH_VERIFICATION_TOO_MANY_ATTEMPTS(400, "인증 시도 횟수를 초과했습니다. 잠시 후 다시 시도해주세요."),
+    AUTH_VERIFICATION_CONCURRENT_REQUEST(409, "동시에 여러 인증 요청이 처리되어 다시 시도해주세요."),
 
     // Auth - LOGIN
     AUTH_LOGIN_FAILED(401, "이메일 또는 비밀번호가 올바르지 않습니다."),

--- a/src/main/resources/db/migration/V41__add_email_verification_limits.sql
+++ b/src/main/resources/db/migration/V41__add_email_verification_limits.sql
@@ -1,0 +1,11 @@
+ALTER TABLE email_verification
+    ADD COLUMN attempt_count INT NOT NULL DEFAULT 0;
+
+ALTER TABLE email_verification
+    ADD COLUMN resend_count INT NOT NULL DEFAULT 0;
+
+ALTER TABLE email_verification
+    ADD COLUMN locked_until TIMESTAMPTZ;
+
+ALTER TABLE email_verification
+    ADD COLUMN last_sent_at TIMESTAMPTZ;

--- a/src/main/resources/db/migration/V42__add_resend_window_started_at.sql
+++ b/src/main/resources/db/migration/V42__add_resend_window_started_at.sql
@@ -1,0 +1,5 @@
+ALTER TABLE email_verification
+    ADD COLUMN resend_window_started_at TIMESTAMPTZ;
+
+ALTER TABLE email_verification
+    ADD COLUMN version BIGINT DEFAULT 0;

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
@@ -64,6 +64,8 @@ class EmailVerificationServiceTest {
 
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
+
+        verify(repository, atLeastOnce()).saveAndFlush(verification);
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
@@ -1,0 +1,130 @@
+package com.solv.wefin.domain.auth.service;
+
+import com.solv.wefin.domain.auth.entity.EmailVerification;
+import com.solv.wefin.domain.auth.entity.VerificationPurpose;
+import com.solv.wefin.domain.auth.repository.EmailVerificationRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceTest {
+
+    @Mock
+    private EmailVerificationRepository repository;
+
+    @Mock
+    private MailService mailService;
+
+    @InjectMocks
+    private EmailVerificationService service;
+
+    private static final VerificationPurpose PURPOSE = VerificationPurpose.SIGNUP;
+
+    private EmailVerification createVerification(String email, String code) {
+        return EmailVerification.builder()
+                .email(email)
+                .purpose(PURPOSE)
+                .verificationCode(code)
+                .expiresAt(OffsetDateTime.now().plusMinutes(5))
+                .build();
+    }
+
+    @Test
+    @DisplayName("인증코드 5회 틀리면 잠금된다")
+    void lock_after_max_attempts() {
+        String email = "test@example.com";
+        EmailVerification verification = createVerification(email, "123456");
+
+        when(repository.findByEmailAndPurpose(email, PURPOSE))
+                .thenReturn(Optional.of(verification));
+
+        for (int i = 0; i < 5; i++) {
+            assertThrows(BusinessException.class,
+                    () -> service.confirmVerificationCode(email, "wrong", PURPOSE));
+        }
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.confirmVerificationCode(email, "wrong", PURPOSE));
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
+    }
+
+    @Test
+    @DisplayName("잠금 상태에서는 인증이 차단된다")
+    void blocked_when_locked() {
+        String email = "test@example.com";
+        EmailVerification verification = createVerification(email, "123456");
+
+        verification.lock(OffsetDateTime.now().plusMinutes(10));
+
+        when(repository.findByEmailAndPurpose(email, PURPOSE))
+                .thenReturn(Optional.of(verification));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.confirmVerificationCode(email, "123456", PURPOSE));
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
+    }
+
+    @Test
+    @DisplayName("재발송 쿨타임이 적용된다")
+    void resend_cooldown() {
+        String email = "test@example.com";
+        EmailVerification verification = createVerification(email, "123456");
+
+        verification.increaseResend();
+        verification.updateLastSentAt(OffsetDateTime.now());
+
+        when(repository.findByEmailAndPurpose(email, PURPOSE))
+                .thenReturn(Optional.of(verification));
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> service.sendVerificationCode(email, PURPOSE)
+        );
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
+
+        verify(mailService, never()).sendVerificationCode(anyString(), anyString());
+        verify(repository, never()).save(any(EmailVerification.class));
+    }
+
+    @Test
+    @DisplayName("재발송 횟수 초과 시 예외가 발생한다")
+    void resend_limit_exceeded() {
+        String email = "test@example.com";
+        EmailVerification verification = createVerification(email, "123456");
+
+        for (int i = 0; i < 5; i++) {
+            verification.increaseResend();
+        }
+
+        when(repository.findByEmailAndPurpose(email, PURPOSE))
+                .thenReturn(Optional.of(verification));
+
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> service.sendVerificationCode(email, PURPOSE));
+
+        assertThat(exception.getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_REQUESTS);
+
+        verify(mailService, never()).sendVerificationCode(anyString(), anyString());
+        verify(repository, never()).save(any(EmailVerification.class));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
@@ -16,7 +16,10 @@ import java.time.OffsetDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,9 +89,10 @@ class EmailVerificationServiceTest {
     void resend_cooldown() {
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
+        OffsetDateTime now = OffsetDateTime.now();
 
-        verification.increaseResend();
-        verification.updateLastSentAt(OffsetDateTime.now());
+        verification.resetResendWindow(now.minusSeconds(30));
+        verification.recordResend(now);
 
         when(repository.findByEmailAndPurpose(email, PURPOSE))
                 .thenReturn(Optional.of(verification));
@@ -102,29 +106,56 @@ class EmailVerificationServiceTest {
                 .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
 
         verify(mailService, never()).sendVerificationCode(anyString(), anyString());
-        verify(repository, never()).save(any(EmailVerification.class));
+        verify(repository, never()).saveAndFlush(any(EmailVerification.class));
     }
 
     @Test
-    @DisplayName("재발송 횟수 초과 시 예외가 발생한다")
-    void resend_limit_exceeded() {
+    @DisplayName("10분 내 재발송 횟수 초과 시 예외가 발생한다")
+    void resend_limit_exceeded_within_window() {
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
+        OffsetDateTime now = OffsetDateTime.now();
 
+        verification.resetResendWindow(now.minusMinutes(5));
         for (int i = 0; i < 5; i++) {
-            verification.increaseResend();
+            verification.recordResend(now.minusSeconds(61 + i));
         }
 
         when(repository.findByEmailAndPurpose(email, PURPOSE))
                 .thenReturn(Optional.of(verification));
 
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> service.sendVerificationCode(email, PURPOSE));
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> service.sendVerificationCode(email, PURPOSE)
+        );
 
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_REQUESTS);
 
         verify(mailService, never()).sendVerificationCode(anyString(), anyString());
-        verify(repository, never()).save(any(EmailVerification.class));
+        verify(repository, never()).saveAndFlush(any(EmailVerification.class));
+    }
+
+    @Test
+    @DisplayName("재발송 윈도우가 만료되면 다시 요청할 수 있다")
+    void resend_allowed_when_window_expired() {
+        String email = "test@example.com";
+        EmailVerification verification = createVerification(email, "123456");
+        OffsetDateTime now = OffsetDateTime.now();
+
+        verification.resetResendWindow(now.minusMinutes(11));
+        for (int i = 0; i < 5; i++) {
+            verification.recordResend(now.minusMinutes(11).plusSeconds(i));
+        }
+
+        when(repository.findByEmailAndPurpose(email, PURPOSE))
+                .thenReturn(Optional.of(verification));
+        when(repository.saveAndFlush(any(EmailVerification.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.sendVerificationCode(email, PURPOSE));
+
+        verify(repository).saveAndFlush(verification);
+        verify(mailService).sendVerificationCode(eq(email), anyString());
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
이메일 인증 기능에 대한 보안 강화를 위해 인증 시도 횟수 제한, 재발송 쿨타임 및 횟수 제한, 잠금 처리 로직을 추가.
<br>

## ✅ 완료한 기능 명세

- [x] 이메일 인증코드 시도 횟수 제한 (5회 초과 시 잠금)
- [x] 인증 실패 누적 및 일정 시간 잠금 처리 구현
- [x] 인증 성공 시 시도 횟수 초기화
- [x] 인증코드 재발송 쿨타임 제한 (60초)
- [x] 인증코드 재발송 횟수 제한 (최대 5회)
- [x] EmailVerification 엔티티 상태 필드 확장 (attemptCount, resendCount, lockedUntil, lastSentAt)
- [x] 인증 제한 관련 ErrorCode 추가
- [x] 인증 제한 관련 테스트 코드 작성 (EmailVerificationServiceTest)
- [x] consumeVerifiedEmail 트랜잭션 보완
- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
- 테스트 코드 작성 시 Mockito의 동일 객체 반환으로 인해 상태가 초기화되는 문제
-> 기존 상태를 직접 세팅하는 방식으로 테스트를 구성
<br>

### 🔗 관련 이슈
Closes #260 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이메일 인증에 재발송 쿨다운, 재발송 창(window), 재발송/시도 카운트 및 잠금 상태 관리가 도입되었습니다.
  * 인증 시도 초기화 및 잠금 설정/해제, 재발송 기록 및 창 초기화 기능 추가.
* **버그 픽스 / 안정성**
  * 동시 요청 충돌을 감지해 명확한 오류로 응답하도록 개선.
  * 재발송 과도 및 쿨다운 위반 시 차단 및 명확한 오류 반환.
* **데이터베이스**
  * 이메일 인증 관련 컬럼(카운트·타임스탬프·버전) 추가 마이그레이션 포함.
* **테스트**
  * 인증 확인 및 재발송 흐름에 대한 단위 테스트 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->