### PR TITLE
[WEF-415] DART 기업 개요 + 재무제표 조회 (2/4)

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartCompanyClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartCompanyClient.java
@@ -25,8 +25,9 @@ public class DartCompanyClient {
     }
 
     public DartCompanyApiResponse fetch(String corpCode) {
+        DartCompanyApiResponse body;
         try {
-            return dartRestClient.get()
+            body = dartRestClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path(COMPANY_PATH)
                             .queryParam("crtfc_key", dartProperties.getKey())
@@ -38,5 +39,10 @@ public class DartCompanyClient {
             log.error("DART company.json 호출 실패: type={}", e.getClass().getSimpleName());
             throw new BusinessException(ErrorCode.DART_COMPANY_FETCH_FAILED);
         }
+        if (body == null) {
+            log.error("DART company.json 응답 body가 null");
+            throw new BusinessException(ErrorCode.DART_COMPANY_FETCH_FAILED);
+        }
+        return body;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartCompanyClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartCompanyClient.java
@@ -1,0 +1,42 @@
+package com.solv.wefin.domain.trading.dart.client;
+
+import com.solv.wefin.domain.trading.dart.client.dto.DartCompanyApiResponse;
+import com.solv.wefin.domain.trading.dart.config.DartProperties;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class DartCompanyClient {
+
+    private static final String COMPANY_PATH = "/api/company.json";
+
+    private final RestClient dartRestClient;
+    private final DartProperties dartProperties;
+
+    public DartCompanyClient(@Qualifier("dartRestClient") RestClient dartRestClient,
+                             DartProperties dartProperties) {
+        this.dartRestClient = dartRestClient;
+        this.dartProperties = dartProperties;
+    }
+
+    public DartCompanyApiResponse fetch(String corpCode) {
+        try {
+            return dartRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(COMPANY_PATH)
+                            .queryParam("crtfc_key", dartProperties.getKey())
+                            .queryParam("corp_code", corpCode)
+                            .build())
+                    .retrieve()
+                    .body(DartCompanyApiResponse.class);
+        } catch (Exception e) {
+            log.error("DART company.json 호출 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.DART_COMPANY_FETCH_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartFinancialClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartFinancialClient.java
@@ -1,0 +1,48 @@
+package com.solv.wefin.domain.trading.dart.client;
+
+import com.solv.wefin.domain.trading.dart.client.dto.DartFinancialApiResponse;
+import com.solv.wefin.domain.trading.dart.config.DartProperties;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class DartFinancialClient {
+
+    private static final String FINANCIAL_PATH = "/api/fnlttSinglAcntAll.json";
+
+    private final RestClient dartRestClient;
+    private final DartProperties dartProperties;
+
+    public DartFinancialClient(@Qualifier("dartRestClient") RestClient dartRestClient,
+                               DartProperties dartProperties) {
+        this.dartRestClient = dartRestClient;
+        this.dartProperties = dartProperties;
+    }
+
+    public DartFinancialApiResponse fetch(String corpCode,
+                                          String businessYear,
+                                          String reportCode,
+                                          String fsDiv) {
+        try {
+            return dartRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(FINANCIAL_PATH)
+                            .queryParam("crtfc_key", dartProperties.getKey())
+                            .queryParam("corp_code", corpCode)
+                            .queryParam("bsns_year", businessYear)
+                            .queryParam("reprt_code", reportCode)
+                            .queryParam("fs_div", fsDiv)
+                            .build())
+                    .retrieve()
+                    .body(DartFinancialApiResponse.class);
+        } catch (Exception e) {
+            log.error("DART fnlttSinglAcntAll.json 호출 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartFinancialClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartFinancialClient.java
@@ -28,8 +28,9 @@ public class DartFinancialClient {
                                           String businessYear,
                                           String reportCode,
                                           String fsDiv) {
+        DartFinancialApiResponse body;
         try {
-            return dartRestClient.get()
+            body = dartRestClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path(FINANCIAL_PATH)
                             .queryParam("crtfc_key", dartProperties.getKey())
@@ -44,5 +45,10 @@ public class DartFinancialClient {
             log.error("DART fnlttSinglAcntAll.json 호출 실패: type={}", e.getClass().getSimpleName());
             throw new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
         }
+        if (body == null) {
+            log.error("DART fnlttSinglAcntAll.json 응답 body가 null");
+            throw new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
+        }
+        return body;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartCompanyApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartCompanyApiResponse.java
@@ -1,0 +1,38 @@
+package com.solv.wefin.domain.trading.dart.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DART OpenAPI /api/company.json 응답 원본 DTO.
+ * 필드는 DART 스펙(snake_case) 그대로 매핑.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DartCompanyApiResponse(
+        String status,
+        String message,
+        @JsonProperty("corp_name") String corpName,
+        @JsonProperty("corp_name_eng") String corpNameEng,
+        @JsonProperty("stock_name") String stockName,
+        @JsonProperty("stock_code") String stockCode,
+        @JsonProperty("ceo_nm") String ceoName,
+        @JsonProperty("corp_cls") String corpCls,
+        @JsonProperty("jurir_no") String jurirNo,
+        @JsonProperty("bizr_no") String bizrNo,
+        @JsonProperty("adres") String address,
+        @JsonProperty("hm_url") String homepageUrl,
+        @JsonProperty("ir_url") String irUrl,
+        @JsonProperty("phn_no") String phoneNo,
+        @JsonProperty("fax_no") String faxNo,
+        @JsonProperty("induty_code") String indutyCode,
+        @JsonProperty("est_dt") String establishedDate,
+        @JsonProperty("acc_mt") String accountingMonth
+) {
+    public boolean isSuccess() {
+        return "000".equals(status);
+    }
+
+    public boolean isNoData() {
+        return "013".equals(status);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartFinancialApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartFinancialApiResponse.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.domain.trading.dart.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * DART /api/fnlttSinglAcntAll.json 응답 원본.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DartFinancialApiResponse(
+        String status,
+        String message,
+        List<DartFinancialItem> list
+) {
+    public boolean isSuccess() {
+        return "000".equals(status);
+    }
+
+    public boolean isNoData() {
+        return "013".equals(status);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartFinancialItem.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartFinancialItem.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.domain.trading.dart.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DART /api/fnlttSinglAcntAll.json 응답 list[] 내부 항목.
+ * 필요한 필드만 매핑 (전체 스펙은 수십 개).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DartFinancialItem(
+        @JsonProperty("sj_div") String statementDiv,
+        @JsonProperty("account_id") String accountId,
+        @JsonProperty("account_nm") String accountName,
+        @JsonProperty("thstrm_nm") String currentPeriodName,
+        @JsonProperty("thstrm_amount") String currentAmount,
+        @JsonProperty("frmtrm_nm") String previousPeriodName,
+        @JsonProperty("frmtrm_amount") String previousAmount,
+        @JsonProperty("bfefrmtrm_nm") String prePreviousPeriodName,
+        @JsonProperty("bfefrmtrm_amount") String prePreviousAmount,
+        @JsonProperty("currency") String currency
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartCompanyInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartCompanyInfo.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.trading.dart.dto;
+
+import com.solv.wefin.domain.trading.dart.client.dto.DartCompanyApiResponse;
+
+public record DartCompanyInfo(
+        String corpName,
+        String corpNameEng,
+        String stockName,
+        String stockCode,
+        String ceoName,
+        String address,
+        String homepageUrl,
+        String irUrl,
+        String phoneNo,
+        String faxNo,
+        String indutyCode,
+        String establishedDate,
+        String accountingMonth
+) {
+    public static DartCompanyInfo from(DartCompanyApiResponse response) {
+        return new DartCompanyInfo(
+                response.corpName(),
+                response.corpNameEng(),
+                response.stockName(),
+                response.stockCode(),
+                response.ceoName(),
+                response.address(),
+                response.homepageUrl(),
+                response.irUrl(),
+                response.phoneNo(),
+                response.faxNo(),
+                response.indutyCode(),
+                response.establishedDate(),
+                response.accountingMonth()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartCompanyInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartCompanyInfo.java
@@ -2,6 +2,8 @@ package com.solv.wefin.domain.trading.dart.dto;
 
 import com.solv.wefin.domain.trading.dart.client.dto.DartCompanyApiResponse;
 
+import java.util.Objects;
+
 public record DartCompanyInfo(
         String corpName,
         String corpNameEng,
@@ -18,6 +20,7 @@ public record DartCompanyInfo(
         String accountingMonth
 ) {
     public static DartCompanyInfo from(DartCompanyApiResponse response) {
+        Objects.requireNonNull(response, "DartCompanyApiResponse must not be null");
         return new DartCompanyInfo(
                 response.corpName(),
                 response.corpNameEng(),

--- a/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartFinancialPeriod.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartFinancialPeriod.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.trading.dart.dto;
+
+import java.math.BigDecimal;
+
+public record DartFinancialPeriod(
+        String periodName,
+        BigDecimal totalAssets,
+        BigDecimal totalLiabilities,
+        BigDecimal totalEquity,
+        BigDecimal revenue,
+        BigDecimal operatingIncome,
+        BigDecimal netIncome
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartFinancialSummary.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartFinancialSummary.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.trading.dart.dto;
+
+public record DartFinancialSummary(
+        String businessYear,
+        String reportCode,
+        String currency,
+        DartFinancialPeriod currentPeriod,
+        DartFinancialPeriod previousPeriod,
+        DartFinancialPeriod prePreviousPeriod
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartCompanyService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartCompanyService.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartCompanyClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartCompanyApiResponse;
+import com.solv.wefin.domain.trading.dart.dto.DartCompanyInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DartCompanyService {
+
+    private final DartCorpCodeService dartCorpCodeService;
+    private final DartCompanyClient dartCompanyClient;
+
+    @Cacheable(cacheNames = "dartCompany", key = "#stockCode")
+    public DartCompanyInfo getCompany(String stockCode) {
+        String corpCode = dartCorpCodeService.getCorpCode(stockCode);
+        DartCompanyApiResponse response = dartCompanyClient.fetch(corpCode);
+
+        if (response == null) {
+            throw new BusinessException(ErrorCode.DART_COMPANY_FETCH_FAILED);
+        }
+        if (response.isNoData()) {
+            throw new BusinessException(ErrorCode.DART_COMPANY_NOT_FOUND);
+        }
+        if (!response.isSuccess()) {
+            log.error("DART company.json 에러 응답: status={}, message={}",
+                    response.status(), response.message());
+            throw new BusinessException(ErrorCode.DART_COMPANY_FETCH_FAILED);
+        }
+
+        return DartCompanyInfo.from(response);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
@@ -36,7 +36,7 @@ public class DartFinancialService {
     private final DartFinancialClient dartFinancialClient;
 
     @Cacheable(cacheNames = "dartFinancial", key = "#stockCode")
-    public DartFinancialSummary getDartFinancialSummary(String stockCode) {
+    public DartFinancialSummary getFinancialSummary(String stockCode) {
         String corpCode = dartCorpCodeService.getCorpCode(stockCode);
 
         int currentYear = LocalDate.now().getYear();

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
@@ -1,0 +1,168 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartFinancialClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartFinancialApiResponse;
+import com.solv.wefin.domain.trading.dart.client.dto.DartFinancialItem;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialPeriod;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DartFinancialService {
+
+    private static final String DEFAULT_REPORT_CODE = "11011"; // 사업보고서
+    private static final String DEFAULT_FS_DIV = "CFS";        // 연결재무제표
+
+    private static final String ACCOUNT_ASSETS = "ifrs-full_Assets";
+    private static final String ACCOUNT_LIABILITIES = "ifrs-full_Liabilities";
+    private static final String ACCOUNT_EQUITY = "ifrs-full_Equity";
+    private static final String ACCOUNT_REVENUE = "ifrs-full_Revenue";
+    private static final String ACCOUNT_OPERATING_INCOME = "dart_OperatingIncomeLoss";
+    private static final String ACCOUNT_NET_INCOME = "ifrs-full_ProfitLoss";
+
+    private final DartCorpCodeService dartCorpCodeService;
+    private final DartFinancialClient dartFinancialClient;
+
+    @Cacheable(cacheNames = "dartFinancial", key = "#stockCode")
+    public DartFinancialSummary getDartFinancialSummary(String stockCode) {
+        String corpCode = dartCorpCodeService.getCorpCode(stockCode);
+
+        int currentYear = LocalDate.now().getYear();
+        YearlyResponse yearly = fetchWithYearFallback(corpCode, currentYear);
+
+        return buildSummary(yearly.response(), yearly.businessYear());
+    }
+
+    private YearlyResponse fetchWithYearFallback(String corpCode, int currentYear) {
+        for (int yearOffset = 1; yearOffset <= 2; yearOffset++) {
+            String year = String.valueOf(currentYear - yearOffset);
+            DartFinancialApiResponse response =
+                    dartFinancialClient.fetch(corpCode, year, DEFAULT_REPORT_CODE, DEFAULT_FS_DIV);
+
+            if (response == null) {
+                throw new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
+            }
+            if (response.isSuccess()) {
+                log.debug("DART 재무제표 조회 성공: corp_code={}, year={}", corpCode, year);
+                return new YearlyResponse(response, year);
+            }
+            if (!response.isNoData()) {
+                log.error("DART 재무제표 에러 응답: status={}, message={}",
+                        response.status(), response.message());
+                throw new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
+            }
+            log.debug("DART 재무제표 미존재, 연도 fallback: corp_code={}, year={}", corpCode, year);
+        }
+        throw new BusinessException(ErrorCode.DART_FINANCIAL_NOT_FOUND);
+    }
+
+    private record YearlyResponse(DartFinancialApiResponse response, String businessYear) {
+    }
+
+    private DartFinancialSummary buildSummary(DartFinancialApiResponse response, String businessYear) {
+        List<DartFinancialItem> items = response.list();
+        if (items == null || items.isEmpty()) {
+            throw new BusinessException(ErrorCode.DART_FINANCIAL_NOT_FOUND);
+        }
+
+        Map<String, DartFinancialItem> byAccountId = items.stream()
+                .filter(item -> item.accountId() != null)
+                .collect(java.util.stream.Collectors.toMap(
+                        DartFinancialItem::accountId,
+                        item -> item,
+                        (existing, duplicate) -> existing
+                ));
+
+        DartFinancialItem assets = byAccountId.get(ACCOUNT_ASSETS);
+        DartFinancialItem liabilities = byAccountId.get(ACCOUNT_LIABILITIES);
+        DartFinancialItem equity = byAccountId.get(ACCOUNT_EQUITY);
+        DartFinancialItem revenue = byAccountId.get(ACCOUNT_REVENUE);
+        DartFinancialItem operatingIncome = byAccountId.get(ACCOUNT_OPERATING_INCOME);
+        DartFinancialItem netIncome = byAccountId.get(ACCOUNT_NET_INCOME);
+
+        String currency = firstNonNull(
+                assets, liabilities, equity, revenue, operatingIncome, netIncome,
+                DartFinancialItem::currency, "KRW");
+
+        DartFinancialPeriod current = buildPeriod(
+                firstPeriodName(items, DartFinancialItem::currentPeriodName),
+                assets, liabilities, equity, revenue, operatingIncome, netIncome,
+                DartFinancialItem::currentAmount);
+        DartFinancialPeriod previous = buildPeriod(
+                firstPeriodName(items, DartFinancialItem::previousPeriodName),
+                assets, liabilities, equity, revenue, operatingIncome, netIncome,
+                DartFinancialItem::previousAmount);
+        DartFinancialPeriod prePrevious = buildPeriod(
+                firstPeriodName(items, DartFinancialItem::prePreviousPeriodName),
+                assets, liabilities, equity, revenue, operatingIncome, netIncome,
+                DartFinancialItem::prePreviousAmount);
+
+        return new DartFinancialSummary(businessYear, DEFAULT_REPORT_CODE, currency,
+                current, previous, prePrevious);
+    }
+
+    private DartFinancialPeriod buildPeriod(String periodName,
+                                        DartFinancialItem assets,
+                                        DartFinancialItem liabilities,
+                                        DartFinancialItem equity,
+                                        DartFinancialItem revenue,
+                                        DartFinancialItem operatingIncome,
+                                        DartFinancialItem netIncome,
+                                        java.util.function.Function<DartFinancialItem, String> amountExtractor) {
+        return new DartFinancialPeriod(
+                periodName,
+                parseAmount(assets, amountExtractor),
+                parseAmount(liabilities, amountExtractor),
+                parseAmount(equity, amountExtractor),
+                parseAmount(revenue, amountExtractor),
+                parseAmount(operatingIncome, amountExtractor),
+                parseAmount(netIncome, amountExtractor)
+        );
+    }
+
+    private BigDecimal parseAmount(DartFinancialItem item,
+                                   java.util.function.Function<DartFinancialItem, String> extractor) {
+        if (item == null) return null;
+        String raw = extractor.apply(item);
+        if (raw == null || raw.isBlank() || "-".equals(raw.trim())) return null;
+        try {
+            return new BigDecimal(raw.replace(",", "").trim());
+        } catch (NumberFormatException e) {
+            log.warn("DART 재무 금액 파싱 실패: account={}, raw={}", item.accountId(), raw);
+            return null;
+        }
+    }
+
+    private String firstPeriodName(List<DartFinancialItem> items,
+                                   java.util.function.Function<DartFinancialItem, String> extractor) {
+        return items.stream()
+                .map(extractor)
+                .filter(name -> name != null && !name.isBlank())
+                .findFirst()
+                .orElse(null);
+    }
+
+    private String firstNonNull(DartFinancialItem a, DartFinancialItem b, DartFinancialItem c,
+                                DartFinancialItem d, DartFinancialItem e, DartFinancialItem f,
+                                java.util.function.Function<DartFinancialItem, String> extractor,
+                                String fallback) {
+        return java.util.stream.Stream.of(a, b, c, d, e, f)
+                .filter(java.util.Objects::nonNull)
+                .map(extractor)
+                .filter(s -> s != null && !s.isBlank())
+                .findFirst()
+                .orElse(fallback);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
@@ -92,6 +92,12 @@ public class DartFinancialService {
         DartFinancialItem operatingIncome = byAccountId.get(ACCOUNT_OPERATING_INCOME);
         DartFinancialItem netIncome = byAccountId.get(ACCOUNT_NET_INCOME);
 
+        if (java.util.stream.Stream.of(assets, liabilities, equity, revenue, operatingIncome, netIncome)
+                .allMatch(java.util.Objects::isNull)) {
+            log.error("DART 재무제표 응답에 핵심 account_id 6개 모두 없음 (IFRS 체계 불일치 가능)");
+            throw new BusinessException(ErrorCode.DART_FINANCIAL_NOT_FOUND);
+        }
+
         String currency = firstNonNull(
                 assets, liabilities, equity, revenue, operatingIncome, netIncome,
                 DartFinancialItem::currency, "KRW");

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -27,6 +27,16 @@ public class CacheConfig {
                 .maximumSize(5000)
                 .build());
 
+        manager.registerCustomCache("dartCompany", Caffeine.newBuilder()
+                .expireAfterWrite(6, TimeUnit.HOURS)
+                .maximumSize(5000)
+                .build());
+
+        manager.registerCustomCache("dartFinancial", Caffeine.newBuilder()
+                .expireAfterWrite(12, TimeUnit.HOURS)
+                .maximumSize(5000)
+                .build());
+
         return manager;
     }
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -191,7 +191,11 @@ public enum ErrorCode {
 
     // DART
     DART_CORP_CODE_NOT_FOUND(404, "DART 고유번호를 찾을 수 없습니다."),
-    DART_CORP_CODE_FETCH_FAILED(503, "DART 고유번호 조회에 실패했습니다.");
+    DART_CORP_CODE_FETCH_FAILED(503, "DART 고유번호 조회에 실패했습니다."),
+    DART_COMPANY_NOT_FOUND(404, "DART 기업 정보가 존재하지 않습니다."),
+    DART_COMPANY_FETCH_FAILED(503, "DART 기업 정보 조회에 실패했습니다."),
+    DART_FINANCIAL_NOT_FOUND(404, "DART 재무제표가 존재하지 않습니다."),
+    DART_FINANCIAL_FETCH_FAILED(503, "DART 재무제표 조회에 실패했습니다.");
 
     private final int status;
     private final String message;

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartCompanyServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartCompanyServiceTest.java
@@ -1,0 +1,109 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartCompanyClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartCompanyApiResponse;
+import com.solv.wefin.domain.trading.dart.dto.DartCompanyInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DartCompanyServiceTest {
+
+    @Mock
+    private DartCorpCodeService dartCorpCodeService;
+
+    @Mock
+    private DartCompanyClient dartCompanyClient;
+
+    @InjectMocks
+    private DartCompanyService dartCompanyService;
+
+    private DartCompanyApiResponse okResponse(String status) {
+        return new DartCompanyApiResponse(
+                status, status.equals("000") ? "정상" : "에러",
+                "삼성전자", "SAMSUNG ELECTRONICS CO,.LTD",
+                "삼성전자", "005930", "한종희", "Y",
+                "1301110006246", "1248100998",
+                "경기도 수원시 영통구 삼성로 129", "www.samsung.com/sec", "",
+                "02-2255-0114", "031-200-7538",
+                "264", "19690113", "12"
+        );
+    }
+
+    @Test
+    void stockCode로_기업정보_정상조회() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartCompanyClient.fetch("00126380")).willReturn(okResponse("000"));
+
+        // when
+        DartCompanyInfo result = dartCompanyService.getCompany("005930");
+
+        // then
+        assertThat(result.corpName()).isEqualTo("삼성전자");
+        assertThat(result.stockCode()).isEqualTo("005930");
+        assertThat(result.ceoName()).isEqualTo("한종희");
+        assertThat(result.homepageUrl()).isEqualTo("www.samsung.com/sec");
+    }
+
+    @Test
+    void corpCode_미존재시_DART_CORP_CODE_NOT_FOUND_전파() {
+        // given
+        given(dartCorpCodeService.getCorpCode("999999"))
+                .willThrow(new BusinessException(ErrorCode.DART_CORP_CODE_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> dartCompanyService.getCompany("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_CORP_CODE_NOT_FOUND);
+    }
+
+    @Test
+    void DART_응답이_null이면_FETCH_FAILED() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartCompanyClient.fetch("00126380")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> dartCompanyService.getCompany("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_COMPANY_FETCH_FAILED);
+    }
+
+    @Test
+    void DART_status_013이면_COMPANY_NOT_FOUND() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartCompanyClient.fetch("00126380")).willReturn(okResponse("013"));
+
+        // when & then
+        assertThatThrownBy(() -> dartCompanyService.getCompany("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_COMPANY_NOT_FOUND);
+    }
+
+    @Test
+    void DART_status가_000도_013도_아니면_FETCH_FAILED() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartCompanyClient.fetch("00126380")).willReturn(okResponse("020"));
+
+        // when & then
+        assertThatThrownBy(() -> dartCompanyService.getCompany("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_COMPANY_FETCH_FAILED);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
@@ -103,7 +103,8 @@ class DartFinancialServiceTest {
 
         // then
         assertThat(result.businessYear()).isEqualTo(secondYear);
-        verify(dartFinancialClient, times(2)).fetch(anyString(), anyString(), anyString(), anyString());
+        verify(dartFinancialClient).fetch("00126380", firstYear, "11011", "CFS");
+        verify(dartFinancialClient).fetch("00126380", secondYear, "11011", "CFS");
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
@@ -1,0 +1,205 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartFinancialClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartFinancialApiResponse;
+import com.solv.wefin.domain.trading.dart.client.dto.DartFinancialItem;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DartFinancialServiceTest {
+
+    @Mock
+    private DartCorpCodeService dartCorpCodeService;
+
+    @Mock
+    private DartFinancialClient dartFinancialClient;
+
+    @InjectMocks
+    private DartFinancialService dartFinancialService;
+
+    private DartFinancialItem item(String accountId, String thstrm, String frmtrm, String bfe) {
+        return new DartFinancialItem(
+                accountIdToSjDiv(accountId), accountId, accountId, // sj/account_id/account_nm
+                "제 55 기", thstrm,
+                "제 54 기", frmtrm,
+                "제 53 기", bfe,
+                "KRW"
+        );
+    }
+
+    private String accountIdToSjDiv(String accountId) {
+        if (accountId.contains("Assets") || accountId.contains("Liabilities") || accountId.contains("Equity")) return "BS";
+        return "IS";
+    }
+
+    private DartFinancialApiResponse successResponse() {
+        return new DartFinancialApiResponse("000", "정상", List.of(
+                item("ifrs-full_Assets", "448234000000000", "447000000000000", "415000000000000"),
+                item("ifrs-full_Liabilities", "92000000000000", "91000000000000", "85000000000000"),
+                item("ifrs-full_Equity", "356000000000000", "356000000000000", "330000000000000"),
+                item("ifrs-full_Revenue", "258000000000000", "302000000000000", "279000000000000"),
+                item("dart_OperatingIncomeLoss", "6566000000000", "43300000000000", "51600000000000"),
+                item("ifrs-full_ProfitLoss", "15500000000000", "55600000000000", "39200000000000")
+        ));
+    }
+
+    @Test
+    void 재무제표_정상_추출_당기_전기_전전기() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(successResponse());
+
+        // when
+        DartFinancialSummary result = dartFinancialService.getDartFinancialSummary("005930");
+
+        // then
+        assertThat(result.currency()).isEqualTo("KRW");
+        assertThat(result.currentPeriod().totalAssets())
+                .isEqualByComparingTo(new BigDecimal("448234000000000"));
+        assertThat(result.currentPeriod().revenue())
+                .isEqualByComparingTo(new BigDecimal("258000000000000"));
+        assertThat(result.currentPeriod().operatingIncome())
+                .isEqualByComparingTo(new BigDecimal("6566000000000"));
+        assertThat(result.previousPeriod().netIncome())
+                .isEqualByComparingTo(new BigDecimal("55600000000000"));
+        assertThat(result.prePreviousPeriod().totalEquity())
+                .isEqualByComparingTo(new BigDecimal("330000000000000"));
+    }
+
+    @Test
+    void status_013이면_이전연도로_fallback() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        int currentYear = LocalDate.now().getYear();
+        String firstYear = String.valueOf(currentYear - 1);
+        String secondYear = String.valueOf(currentYear - 2);
+
+        DartFinancialApiResponse noData = new DartFinancialApiResponse("013", "조회된 데이타가 없습니다.", null);
+        given(dartFinancialClient.fetch("00126380", firstYear, "11011", "CFS")).willReturn(noData);
+        given(dartFinancialClient.fetch("00126380", secondYear, "11011", "CFS")).willReturn(successResponse());
+
+        // when
+        DartFinancialSummary result = dartFinancialService.getDartFinancialSummary("005930");
+
+        // then
+        assertThat(result.businessYear()).isEqualTo(secondYear);
+        verify(dartFinancialClient, times(2)).fetch(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void 연도_2회_fallback_모두_실패시_NOT_FOUND() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartFinancialApiResponse noData = new DartFinancialApiResponse("013", "조회된 데이타가 없습니다.", null);
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(noData);
+
+        // when & then
+        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_FINANCIAL_NOT_FOUND);
+    }
+
+    @Test
+    void status가_000도_013도_아니면_FETCH_FAILED() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartFinancialApiResponse error = new DartFinancialApiResponse("020", "요청 제한 초과", null);
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(error);
+
+        // when & then
+        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
+    }
+
+    @Test
+    void 응답이_null이면_FETCH_FAILED() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
+    }
+
+    @Test
+    void 금액이_대시_또는_null인_계정은_null로_파싱() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartFinancialApiResponse response = new DartFinancialApiResponse("000", "정상", List.of(
+                item("ifrs-full_Assets", "448234000000000", "447000000000000", "415000000000000"),
+                item("ifrs-full_Revenue", "-", null, ""),
+                item("dart_OperatingIncomeLoss", "NOT_A_NUMBER", "43300000000000", "51600000000000")
+        ));
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(response);
+
+        // when
+        DartFinancialSummary result = dartFinancialService.getDartFinancialSummary("005930");
+
+        // then
+        assertThat(result.currentPeriod().totalAssets()).isNotNull();
+        assertThat(result.currentPeriod().revenue()).isNull();      // "-"
+        assertThat(result.previousPeriod().revenue()).isNull();     // null
+        assertThat(result.prePreviousPeriod().revenue()).isNull();  // ""
+        assertThat(result.currentPeriod().operatingIncome()).isNull(); // NumberFormatException
+        assertThat(result.previousPeriod().operatingIncome())
+                .isEqualByComparingTo(new BigDecimal("43300000000000"));
+    }
+
+    @Test
+    void list이_비어있으면_NOT_FOUND() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartFinancialApiResponse empty = new DartFinancialApiResponse("000", "정상", List.of());
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(empty);
+
+        // when & then
+        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_FINANCIAL_NOT_FOUND);
+    }
+
+    @Test
+    void corpCode_미존재시_예외_전파() {
+        // given
+        given(dartCorpCodeService.getCorpCode("999999"))
+                .willThrow(new BusinessException(ErrorCode.DART_CORP_CODE_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_CORP_CODE_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
@@ -70,7 +70,7 @@ class DartFinancialServiceTest {
                 .willReturn(successResponse());
 
         // when
-        DartFinancialSummary result = dartFinancialService.getDartFinancialSummary("005930");
+        DartFinancialSummary result = dartFinancialService.getFinancialSummary("005930");
 
         // then
         assertThat(result.currency()).isEqualTo("KRW");
@@ -99,7 +99,7 @@ class DartFinancialServiceTest {
         given(dartFinancialClient.fetch("00126380", secondYear, "11011", "CFS")).willReturn(successResponse());
 
         // when
-        DartFinancialSummary result = dartFinancialService.getDartFinancialSummary("005930");
+        DartFinancialSummary result = dartFinancialService.getFinancialSummary("005930");
 
         // then
         assertThat(result.businessYear()).isEqualTo(secondYear);
@@ -115,7 +115,7 @@ class DartFinancialServiceTest {
                 .willReturn(noData);
 
         // when & then
-        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+        assertThatThrownBy(() -> dartFinancialService.getFinancialSummary("005930"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.DART_FINANCIAL_NOT_FOUND);
@@ -130,7 +130,7 @@ class DartFinancialServiceTest {
                 .willReturn(error);
 
         // when & then
-        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+        assertThatThrownBy(() -> dartFinancialService.getFinancialSummary("005930"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
@@ -144,7 +144,7 @@ class DartFinancialServiceTest {
                 .willReturn(null);
 
         // when & then
-        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+        assertThatThrownBy(() -> dartFinancialService.getFinancialSummary("005930"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
@@ -163,7 +163,7 @@ class DartFinancialServiceTest {
                 .willReturn(response);
 
         // when
-        DartFinancialSummary result = dartFinancialService.getDartFinancialSummary("005930");
+        DartFinancialSummary result = dartFinancialService.getFinancialSummary("005930");
 
         // then
         assertThat(result.currentPeriod().totalAssets()).isNotNull();
@@ -176,6 +176,24 @@ class DartFinancialServiceTest {
     }
 
     @Test
+    void 핵심_6개_계정이_하나도_매칭안되면_NOT_FOUND() {
+        // given — list는 비어있지 않지만 6개 account_id 중 하나도 매칭 안 됨
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartFinancialApiResponse response = new DartFinancialApiResponse("000", "정상", List.of(
+                item("ifrs-full_UnknownAccount", "100", "100", "100"),
+                item("dart_SomethingElse", "200", "200", "200")
+        ));
+        given(dartFinancialClient.fetch(eq("00126380"), anyString(), anyString(), anyString()))
+                .willReturn(response);
+
+        // when & then
+        assertThatThrownBy(() -> dartFinancialService.getFinancialSummary("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_FINANCIAL_NOT_FOUND);
+    }
+
+    @Test
     void list이_비어있으면_NOT_FOUND() {
         // given
         given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
@@ -184,7 +202,7 @@ class DartFinancialServiceTest {
                 .willReturn(empty);
 
         // when & then
-        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("005930"))
+        assertThatThrownBy(() -> dartFinancialService.getFinancialSummary("005930"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.DART_FINANCIAL_NOT_FOUND);
@@ -197,7 +215,7 @@ class DartFinancialServiceTest {
                 .willThrow(new BusinessException(ErrorCode.DART_CORP_CODE_NOT_FOUND));
 
         // when & then
-        assertThatThrownBy(() -> dartFinancialService.getDartFinancialSummary("999999"))
+        assertThatThrownBy(() -> dartFinancialService.getFinancialSummary("999999"))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.DART_CORP_CODE_NOT_FOUND);


### PR DESCRIPTION
## 📌 PR 설명
WEF-415 종목정보 탭의 2차 PR입니다. 
WEF-647(corpCode 매핑) 기반 위에 **기업 개요(WEF-416)**와 **재무제표 요약(WEF-419)** 조회 Service 계층을 추가했습니다.

  - WEF-416: `DART /api/company.json` → 기업명/대표자/주소/홈페이지 등
  - WEF-419: `DART /api/fnlttSinglAcntAll.json` → 당기/전기/전전기 3개년 재무제표 (자산·부채·자본·매출·영업이익·순이익)
<br>

## ✅ 완료한 기능 명세

### **WEF-416 기업 개요**
  - [x] `DartCompanyApiResponse` — DART JSON 원본 매핑 + `isSuccess()`/`isNoData()`
  - [x] `DartCompanyInfo` — 도메인 DTO (`from(response)` factory)
  - [x] `DartCompanyClient` — `/api/company.json?corp_code=...` 호출
  - [x] `DartCompanyService.getCompany(stockCode)` — corpCode 조회 → client 호출 → status 분기 → `@Cacheable("dartCompany", TTL 6h)`
  - [x] 에러 코드: `DART_COMPANY_NOT_FOUND(404)`,
  `DART_COMPANY_FETCH_FAILED(503)`

###  **WEF-419 재무제표 요약**
  - [x] `DartFinancialApiResponse` + `DartFinancialItem` — DART JSON 원본 + list row
  - [x] `DartFinancialSummary` + `DartFinancialPeriod` — 도메인 DTO (3개년 nested)
  - [x] `DartFinancialClient` — `/api/fnlttSinglAcntAll.json` (bsns_year/reprt_code/fs_div)
  - [x] `DartFinancialService.getFinancialSummary(stockCode)`:
    - 현재 연도-1 → status 013 시 현재 연도-2로 **연도 fallback**
    - IFRS `account_id` 기반 **핵심 6개 계정 추출** (자산/부채/자본/매출/영업이익/순이익)
    - 금액 파싱 방어 (`-`, null, 빈 문자열, `NumberFormatException` → `null`)
    - `@Cacheable("dartFinancial", TTL 12h)`
  - [x] 에러 코드: `DART_FINANCIAL_NOT_FOUND(404)`, `DART_FINANCIAL_FETCH_FAILED(503)`

###  **공통**
  - [x] `CacheConfig` — `dartCompany`, `dartFinancial` 캐시 등록
  - [x] DTO 네이밍 일관화 — `Dart` prefix, Info(일반)/Summary(집계)/ApiResponse/Item 구분
  - [x] 단위 테스트 13건 (Company 5 + Financial 8) — 정상/에러/fallback/파싱 실패 커버

<br>

## 📸 스크린샷

본 PR에는 Controller가 없어 end-to-end 응답 스크린샷 생략. 
실제 DART 응답 매핑 검증은 WEF-645 통합 PR에서 수행 예정.

  로컬 단위 테스트 결과 (Service 계층):
  DartCompanyServiceTest    : 5/5 passed
  DartFinancialServiceTest  : 8/8 passed

<br>

## 💭 고민과 해결과정

 - **연도 fallback**: DART 사업보고서 공시 시점(3월 말) 이후에도 일부 기업 지연 공시 가능 → `N-1` 실패 시 `N-2`로 1회 fallback. 3회 이상은 오래된 정보 반환 리스크라 의도적으로 2회만.
  - **핵심 6개 계정만 추출**: DART 응답은 재무상태표/손익/현금흐름 수십~수백 row. "요약" 스펙에 맞춰 FE 표시에 필요한 계정만 IFRS `account_id` 기반 필터링. 회사별 계정 ID 편차(`ifrs-full_Revenue` vs `dart_OperatingIncomeLoss` 등)는 현재 스코프 외 — WEF-645 스모크 시점에 확인.
  - **금액 파싱 방어**: 일부 row에 `-`, 빈 문자열, 포맷 깨짐. 모든 파싱 실패를 `null`로 수렴 → FE에서 "정보 없음" 표시 가능.
  - **DTO 네이밍 일괄화**: 초기 `CompanyInfo`/`FinancialSummary`로 시작했으나 `Dart*ApiResponse`와 prefix 불일치 → 전체 `Dart*` prefix 적용. Info(일반 객체)와 Summary(집계형) 의미는 유지.
  - **Cache TTL 차등**: Company 6h(대표자/주소 정도 변동), Financial 12h(분기/반기 공시 시점 외엔 고정). DART 쿼터(일 10,000건) 보호 + 응답 속도 균형.

<br>

### 🔗 관련 이슈
  Part of #258

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **DART 기업 정보 조회**
  * 기업명, 주식코드, 대표자, 연락처 등 기업 정보 조회 기능 추가

* **DART 재무제표 조회**
  * 총자산, 부채, 자본, 매출, 영업이익, 순이익 등 재무 정보 조회 기능 추가
  * 데이터 미존재 시 이전 연도 자동 조회

* **성능 개선**
  * 기업 정보 및 재무제표 조회 결과 캐싱으로 응답 속도 향상

## 오류 처리

* 기업 정보 및 재무제표 미존재 시 명확한 오류 메시지 제공
* API 조회 실패 시 적절한 예외 처리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->