### PR TITLE
[WEF-415] 종목 기본정보 + 투자지표 + 배당 조회 (3/4)

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartDividendClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartDividendClient.java
@@ -1,0 +1,50 @@
+package com.solv.wefin.domain.trading.dart.client;
+
+import com.solv.wefin.domain.trading.dart.client.dto.DartDividendApiResponse;
+import com.solv.wefin.domain.trading.dart.config.DartProperties;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class DartDividendClient {
+
+    private static final String DIVIDEND_PATH = "/api/alotMatter.json";
+
+    private final RestClient dartRestClient;
+    private final DartProperties dartProperties;
+
+    public DartDividendClient(@Qualifier("dartRestClient") RestClient dartRestClient,
+                              DartProperties dartProperties) {
+        this.dartRestClient = dartRestClient;
+        this.dartProperties = dartProperties;
+    }
+
+    public DartDividendApiResponse fetch(String corpCode, String businessYear, String reportCode) {
+        DartDividendApiResponse body;
+        try {
+            body = dartRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(DIVIDEND_PATH)
+                            .queryParam("crtfc_key", dartProperties.getKey())
+                            .queryParam("corp_code", corpCode)
+                            .queryParam("bsns_year", businessYear)
+                            .queryParam("reprt_code", reportCode)
+                            .build())
+                    .retrieve()
+                    .body(DartDividendApiResponse.class);
+        } catch (Exception e) {
+            log.error("DART alotMatter.json 호출 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.DART_DIVIDEND_FETCH_FAILED);
+        }
+        if (body == null) {
+            log.error("DART alotMatter.json 응답 body가 null");
+            throw new BusinessException(ErrorCode.DART_DIVIDEND_FETCH_FAILED);
+        }
+        return body;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartDividendApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartDividendApiResponse.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.domain.trading.dart.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DartDividendApiResponse(
+        String status,
+        String message,
+        List<DartDividendItem> list
+) {
+    public boolean isSuccess() {
+        return "000".equals(status);
+    }
+
+    public boolean isNoData() {
+        return "013".equals(status);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartDividendItem.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartDividendItem.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.domain.trading.dart.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DART /api/alotMatter.json 응답 list[] 항목.
+ * 필요한 필드만 매핑.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DartDividendItem(
+        @JsonProperty("se") String category,          // 구분명 (예: "주당 현금배당금(원)", "현금배당수익률(%)")
+        @JsonProperty("stock_knd") String stockKind,  // 주식 종류 (보통주/우선주 등)
+        @JsonProperty("thstrm") String currentAmount,
+        @JsonProperty("frmtrm") String previousAmount,
+        @JsonProperty("bfefrmtrm") String prePreviousAmount
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/config/DartRestClientConfig.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/config/DartRestClientConfig.java
@@ -19,6 +19,7 @@ public class DartRestClientConfig {
     @Bean("dartRestClient")
     public RestClient dartRestClient() {
         JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory();
+        factory.setConnectTimeout(Duration.ofSeconds(5));
         factory.setReadTimeout(Duration.ofSeconds(30));
 
         return RestClient.builder()

--- a/src/main/java/com/solv/wefin/domain/trading/dart/config/DartRestClientConfig.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/config/DartRestClientConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
+import java.net.http.HttpClient;
 import java.time.Duration;
 
 @Configuration
@@ -18,8 +19,11 @@ public class DartRestClientConfig {
 
     @Bean("dartRestClient")
     public RestClient dartRestClient() {
-        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory();
-        factory.setConnectTimeout(Duration.ofSeconds(5));
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
         factory.setReadTimeout(Duration.ofSeconds(30));
 
         return RestClient.builder()

--- a/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartDividendInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartDividendInfo.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.trading.dart.dto;
+
+import java.math.BigDecimal;
+
+public record DartDividendInfo(
+        String businessYear,                  // 조회 사업연도
+        BigDecimal dividendPerShare,          // 주당 현금배당금 (원, 보통주 당기)
+        BigDecimal dividendYieldRate,         // 현금배당수익률 (%, 당기)
+        BigDecimal payoutRatio                // 현금배당성향 (%, 당기)
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,10 +24,11 @@ public class DartDividendService {
 
     private static final String DEFAULT_REPORT_CODE = "11011"; // 사업보고서
     private static final String COMMON_STOCK = "보통주";
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
-    private static final String CATEGORY_DIVIDEND_PER_SHARE = "주당 현금배당금";
-    private static final String CATEGORY_YIELD_RATE = "현금배당수익률";
-    private static final String CATEGORY_PAYOUT_RATIO = "현금배당성향";
+    private static final String CATEGORY_DIVIDEND_PER_SHARE = "주당 현금배당금(원)";
+    private static final String CATEGORY_YIELD_RATE = "현금배당수익률(%)";
+    private static final String CATEGORY_PAYOUT_RATIO = "현금배당성향(%)";
 
     private final DartCorpCodeService dartCorpCodeService;
     private final DartDividendClient dartDividendClient;
@@ -35,7 +37,7 @@ public class DartDividendService {
     public DartDividendInfo getDividend(String stockCode) {
         String corpCode = dartCorpCodeService.getCorpCode(stockCode);
 
-        int currentYear = LocalDate.now().getYear();
+        int currentYear = LocalDate.now(KST).getYear();
         YearlyResponse yearly = fetchWithYearFallback(corpCode, currentYear);
 
         return buildDividendInfo(yearly.response().list(), yearly.businessYear());
@@ -78,9 +80,9 @@ public class DartDividendService {
         return new DartDividendInfo(businessYear, dividendPerShare, yieldRate, payoutRatio);
     }
 
-    private BigDecimal pickCurrent(List<DartDividendItem> items, String categoryKeyword) {
+    private BigDecimal pickCurrent(List<DartDividendItem> items, String category) {
         Optional<DartDividendItem> item = items.stream()
-                .filter(i -> i.category() != null && i.category().contains(categoryKeyword))
+                .filter(i -> category.equals(i.category()))
                 .filter(i -> COMMON_STOCK.equals(i.stockKind()))
                 .findFirst();
         return item.map(i -> parseAmount(i.currentAmount())).orElse(null);

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
@@ -1,0 +1,101 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartDividendClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartDividendApiResponse;
+import com.solv.wefin.domain.trading.dart.client.dto.DartDividendItem;
+import com.solv.wefin.domain.trading.dart.dto.DartDividendInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DartDividendService {
+
+    private static final String DEFAULT_REPORT_CODE = "11011"; // 사업보고서
+    private static final String COMMON_STOCK = "보통주";
+
+    private static final String CATEGORY_DIVIDEND_PER_SHARE = "주당 현금배당금";
+    private static final String CATEGORY_YIELD_RATE = "현금배당수익률";
+    private static final String CATEGORY_PAYOUT_RATIO = "현금배당성향";
+
+    private final DartCorpCodeService dartCorpCodeService;
+    private final DartDividendClient dartDividendClient;
+
+    @Cacheable(cacheNames = "dartDividend", key = "#stockCode")
+    public DartDividendInfo getDividend(String stockCode) {
+        String corpCode = dartCorpCodeService.getCorpCode(stockCode);
+
+        int currentYear = LocalDate.now().getYear();
+        YearlyResponse yearly = fetchWithYearFallback(corpCode, currentYear);
+
+        return buildDividendInfo(yearly.response().list(), yearly.businessYear());
+    }
+
+    private YearlyResponse fetchWithYearFallback(String corpCode, int currentYear) {
+        for (int yearOffset = 1; yearOffset <= 2; yearOffset++) {
+            String year = String.valueOf(currentYear - yearOffset);
+            DartDividendApiResponse response =
+                    dartDividendClient.fetch(corpCode, year, DEFAULT_REPORT_CODE);
+
+            if (response.isSuccess()) {
+                log.debug("DART 배당 조회 성공: corp_code={}, year={}", corpCode, year);
+                return new YearlyResponse(response, year);
+            }
+            if (!response.isNoData()) {
+                log.error("DART 배당 에러 응답: status={}, message={}",
+                        response.status(), response.message());
+                throw new BusinessException(ErrorCode.DART_DIVIDEND_FETCH_FAILED);
+            }
+            log.debug("DART 배당 미존재, 연도 fallback: corp_code={}, year={}", corpCode, year);
+        }
+        throw new BusinessException(ErrorCode.DART_DIVIDEND_NOT_FOUND);
+    }
+
+    private DartDividendInfo buildDividendInfo(List<DartDividendItem> items, String businessYear) {
+        if (items == null || items.isEmpty()) {
+            throw new BusinessException(ErrorCode.DART_DIVIDEND_NOT_FOUND);
+        }
+
+        BigDecimal dividendPerShare = pickCurrent(items, CATEGORY_DIVIDEND_PER_SHARE);
+        BigDecimal yieldRate = pickCurrent(items, CATEGORY_YIELD_RATE);
+        BigDecimal payoutRatio = pickCurrent(items, CATEGORY_PAYOUT_RATIO);
+
+        if (dividendPerShare == null && yieldRate == null && payoutRatio == null) {
+            log.error("DART 배당 응답에 핵심 항목 3개 모두 없음 (보통주 기준)");
+            throw new BusinessException(ErrorCode.DART_DIVIDEND_NOT_FOUND);
+        }
+
+        return new DartDividendInfo(businessYear, dividendPerShare, yieldRate, payoutRatio);
+    }
+
+    private BigDecimal pickCurrent(List<DartDividendItem> items, String categoryKeyword) {
+        Optional<DartDividendItem> item = items.stream()
+                .filter(i -> i.category() != null && i.category().contains(categoryKeyword))
+                .filter(i -> COMMON_STOCK.equals(i.stockKind()))
+                .findFirst();
+        return item.map(i -> parseAmount(i.currentAmount())).orElse(null);
+    }
+
+    private BigDecimal parseAmount(String raw) {
+        if (raw == null || raw.isBlank() || "-".equals(raw.trim())) return null;
+        try {
+            return new BigDecimal(raw.replace(",", "").trim());
+        } catch (NumberFormatException e) {
+            log.warn("DART 배당 금액 파싱 실패: raw={}", raw);
+            return null;
+        }
+    }
+
+    private record YearlyResponse(DartDividendApiResponse response, String businessYear) {
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ public class DartFinancialService {
 
     private static final String DEFAULT_REPORT_CODE = "11011"; // 사업보고서
     private static final String DEFAULT_FS_DIV = "CFS";        // 연결재무제표
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private static final String ACCOUNT_ASSETS = "ifrs-full_Assets";
     private static final String ACCOUNT_LIABILITIES = "ifrs-full_Liabilities";
@@ -39,7 +41,7 @@ public class DartFinancialService {
     public DartFinancialSummary getFinancialSummary(String stockCode) {
         String corpCode = dartCorpCodeService.getCorpCode(stockCode);
 
-        int currentYear = LocalDate.now().getYear();
+        int currentYear = LocalDate.now(KST).getYear();
         YearlyResponse yearly = fetchWithYearFallback(corpCode, currentYear);
 
         return buildSummary(yearly.response(), yearly.businessYear());

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -46,6 +46,27 @@ public class HantuMarketClient {
     }
 
     /**
+     * 국내 주식 기본정보(시가총액/상장주식수/외국인소진율)를 조회합니다.
+     * fetchCurrentPrice와 동일한 endpoint 호출이지만 다른 필드 subset을 매핑한 DTO로 받습니다.
+     * @param stockCode 종목코드
+     * @return 기본정보 응답
+     */
+    public HantuStockInfoApiResponse fetchStockInfo(String stockCode) {
+        return hantuRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-price")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .build())
+                .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST01010100")
+                .header("custtype", "P")
+                .retrieve().body(HantuStockInfoApiResponse.class);
+    }
+
+    /**
      * 국내 주식 호가를 조회합니다.
      * @param stockCode 종목코드
      * @return 호가 응답

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuStockInfoApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuStockInfoApiResponse.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * 한투 Open API /uapi/domestic-stock/v1/quotations/inquire-price (TR_ID: FHKST01010100) 응답 중
+ * 종목 기본정보(시가총액/상장주식수/외국인소진율)에 필요한 필드만 매핑.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HantuStockInfoApiResponse(Output output) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output(
+            String hts_avls,        // 시가총액 (단위: 억원)
+            String lstn_stcn,       // 상장주식수 (주)
+            String hts_frgn_ehrt,   // 외국인소진율 (%)
+            String per,             // PER
+            String pbr,             // PBR
+            String eps              // EPS
+    ) {
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/StockBasicInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/StockBasicInfo.java
@@ -1,0 +1,43 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+import com.solv.wefin.domain.trading.market.client.dto.HantuStockInfoApiResponse;
+
+import java.math.BigDecimal;
+
+public record StockBasicInfo(
+        Long marketCapInHundredMillionKrw,  // 시가총액 (단위: 억원, 한투 원본 단위 유지)
+        Long listedShares,                  // 상장주식수
+        BigDecimal foreignRatio             // 외국인 소진율 (%)
+) {
+
+    /**
+     * 한투 응답 → 도메인 DTO 매핑.
+     * 시가총액은 한투가 제공하는 억원 단위를 그대로 유지 (FE 포맷팅 편의 + 원본 단위 투명성).
+     * 파싱 실패/빈 문자열은 null.
+     */
+    public static StockBasicInfo from(HantuStockInfoApiResponse.Output output) {
+        return new StockBasicInfo(
+                parseLong(output.hts_avls()),
+                parseLong(output.lstn_stcn()),
+                parseBigDecimal(output.hts_frgn_ehrt())
+        );
+    }
+
+    private static BigDecimal parseBigDecimal(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return new BigDecimal(raw.replace(",", "").trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static Long parseLong(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return Long.parseLong(raw.replace(",", "").trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/StockIndicatorInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/StockIndicatorInfo.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+import java.math.BigDecimal;
+
+public record StockIndicatorInfo(
+        BigDecimal per,      // 주가수익비율
+        BigDecimal pbr,      // 주가순자산비율
+        BigDecimal eps,      // 주당순이익
+        BigDecimal roe       // 자기자본이익률 (%) — DART 기반 계산
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoService.java
@@ -1,0 +1,42 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuStockInfoApiResponse;
+import com.solv.wefin.domain.trading.market.dto.StockBasicInfo;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockBasicInfoService {
+
+    private final StockService stockService;
+    private final HantuMarketClient hantuMarketClient;
+
+    @Cacheable(cacheNames = "stockBasicInfo", key = "#stockCode")
+    public StockBasicInfo getBasicInfo(String stockCode) {
+        if (!stockService.existsByCode(stockCode)) {
+            throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
+        }
+
+        HantuStockInfoApiResponse response;
+        try {
+            response = hantuMarketClient.fetchStockInfo(stockCode);
+        } catch (Exception e) {
+            log.error("한투 기본정보 조회 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+
+        if (response == null || response.output() == null) {
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+
+        return StockBasicInfo.from(response.output());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @Service
@@ -28,7 +29,7 @@ public class StockBasicInfoService {
         HantuStockInfoApiResponse response;
         try {
             response = hantuMarketClient.fetchStockInfo(stockCode);
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("한투 기본정보 조회 실패: type={}", e.getClass().getSimpleName());
             throw new BusinessException(ErrorCode.MARKET_API_FAILED);
         }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/StockIndicatorService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/StockIndicatorService.java
@@ -1,0 +1,93 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialPeriod;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.domain.trading.dart.service.DartFinancialService;
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuStockInfoApiResponse;
+import com.solv.wefin.domain.trading.market.dto.StockIndicatorInfo;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockIndicatorService {
+
+    private static final int ROE_SCALE = 2;
+    private static final BigDecimal ONE_HUNDRED = new BigDecimal("100");
+
+    private final StockService stockService;
+    private final HantuMarketClient hantuMarketClient;
+    private final DartFinancialService dartFinancialService;
+
+    @Cacheable(cacheNames = "stockIndicator", key = "#stockCode")
+    public StockIndicatorInfo getIndicator(String stockCode) {
+        if (!stockService.existsByCode(stockCode)) {
+            throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
+        }
+
+        HantuStockInfoApiResponse response;
+        try {
+            response = hantuMarketClient.fetchStockInfo(stockCode);
+        } catch (Exception e) {
+            log.error("한투 투자지표 조회 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+
+        if (response == null || response.output() == null) {
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+
+        HantuStockInfoApiResponse.Output output = response.output();
+        return new StockIndicatorInfo(
+                parseBigDecimal(output.per()),
+                parseBigDecimal(output.pbr()),
+                parseBigDecimal(output.eps()),
+                calculateRoe(stockCode)
+        );
+    }
+
+    /**
+     * ROE = 당기순이익 / 자본총계 × 100 (%)
+     * DART 재무제표 기반. DART 실패 시 null 반환 (다른 지표는 영향 없이 제공).
+     */
+    private BigDecimal calculateRoe(String stockCode) {
+        try {
+            DartFinancialSummary summary = dartFinancialService.getFinancialSummary(stockCode);
+            DartFinancialPeriod current = summary.currentPeriod();
+            if (current == null) return null;
+
+            BigDecimal netIncome = current.netIncome();
+            BigDecimal totalEquity = current.totalEquity();
+            if (netIncome == null || totalEquity == null
+                    || totalEquity.compareTo(BigDecimal.ZERO) == 0) {
+                return null;
+            }
+
+            return netIncome.multiply(ONE_HUNDRED)
+                    .divide(totalEquity, ROE_SCALE, RoundingMode.HALF_UP);
+        } catch (BusinessException e) {
+            log.warn("ROE 계산 실패 (DART 재무제표 미존재/실패): stockCode={}, code={}",
+                    stockCode, e.getErrorCode());
+            return null;
+        }
+    }
+
+    private BigDecimal parseBigDecimal(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        try {
+            return new BigDecimal(raw.replace(",", "").trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/StockIndicatorService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/StockIndicatorService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -38,7 +39,7 @@ public class StockIndicatorService {
         HantuStockInfoApiResponse response;
         try {
             response = hantuMarketClient.fetchStockInfo(stockCode);
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("한투 투자지표 조회 실패: type={}", e.getClass().getSimpleName());
             throw new BusinessException(ErrorCode.MARKET_API_FAILED);
         }

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -47,6 +47,11 @@ public class CacheConfig {
                 .maximumSize(5000)
                 .build());
 
+        manager.registerCustomCache("dartDividend", Caffeine.newBuilder()
+                .expireAfterWrite(24, TimeUnit.HOURS)
+                .maximumSize(5000)
+                .build());
+
         return manager;
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -37,6 +37,16 @@ public class CacheConfig {
                 .maximumSize(5000)
                 .build());
 
+        manager.registerCustomCache("stockBasicInfo", Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(5000)
+                .build());
+
+        manager.registerCustomCache("stockIndicator", Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(5000)
+                .build());
+
         return manager;
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -48,7 +48,7 @@ public class CacheConfig {
                 .build());
 
         manager.registerCustomCache("dartDividend", Caffeine.newBuilder()
-                .expireAfterWrite(24, TimeUnit.HOURS)
+                .expireAfterWrite(12, TimeUnit.HOURS)
                 .maximumSize(5000)
                 .build());
 

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -195,7 +195,9 @@ public enum ErrorCode {
     DART_COMPANY_NOT_FOUND(404, "DART 기업 정보가 존재하지 않습니다."),
     DART_COMPANY_FETCH_FAILED(503, "DART 기업 정보 조회에 실패했습니다."),
     DART_FINANCIAL_NOT_FOUND(404, "DART 재무제표가 존재하지 않습니다."),
-    DART_FINANCIAL_FETCH_FAILED(503, "DART 재무제표 조회에 실패했습니다.");
+    DART_FINANCIAL_FETCH_FAILED(503, "DART 재무제표 조회에 실패했습니다."),
+    DART_DIVIDEND_NOT_FOUND(404, "DART 배당 정보가 존재하지 않습니다."),
+    DART_DIVIDEND_FETCH_FAILED(503, "DART 배당 정보 조회에 실패했습니다.");
 
     private final int status;
     private final String message;

--- a/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/DailyQuestServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -19,6 +20,8 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.*;
 
 class DailyQuestServiceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private DailyQuestRepository dailyQuestRepository;
     private QuestTemplateRepository questTemplateRepository;
@@ -35,7 +38,7 @@ class DailyQuestServiceTest {
     @DisplayName("오늘의 퀘스트가 이미 있으면 기존 퀘스트를 반환한다")
     void getOrCreateTodayDailyQuests_returns_existing() {
         // given
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(KST);
 
         QuestTemplate template = mock(QuestTemplate.class);
         DailyQuest dailyQuest = DailyQuest.create(template, today, 3, 100);
@@ -57,7 +60,7 @@ class DailyQuestServiceTest {
     @DisplayName("오늘의 퀘스트가 없으면 활성 템플릿 3개로 새로 생성한다")
     void getOrCreateTodayDailyQuests_creates_new() {
         // given
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(KST);
 
         QuestTemplate t1 = mockTemplate(1L, 3, 100);
         QuestTemplate t2 = mockTemplate(2L, 2, 80);
@@ -80,7 +83,7 @@ class DailyQuestServiceTest {
     @DisplayName("활성 템플릿이 3개보다 적으면 예외가 발생한다")
     void getOrCreateTodayDailyQuests_fail_when_templates_not_enough() {
         // given
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(KST);
 
         QuestTemplate t1 = mockTemplate(1L, 3, 100);
         QuestTemplate t2 = mockTemplate(2L, 2, 80);

--- a/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 
@@ -26,6 +27,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class QuestProgressServiceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private UserQuestRepository userQuestRepository;
     private QuestProgressService questProgressService;
@@ -138,7 +141,7 @@ class QuestProgressServiceTest {
         when(template.getTargetValue()).thenReturn(targetValue);
         when(template.getReward()).thenReturn(100_000);
 
-        DailyQuest dailyQuest = DailyQuest.create(template, LocalDate.now(), targetValue, 100_000);
+        DailyQuest dailyQuest = DailyQuest.create(template, LocalDate.now(KST), targetValue, 100_000);
         UserQuest userQuest = UserQuest.assign(user, dailyQuest);
         ReflectionTestUtils.setField(userQuest, "progress", progress);
 

--- a/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,6 +29,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class UserQuestServiceTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private UserRepository userRepository;
     private UserQuestRepository userQuestRepository;
@@ -70,7 +73,7 @@ class UserQuestServiceTest {
     void getOrIssueTodayUserQuests_issues_new() {
         // given
         UUID userId = UUID.randomUUID();
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(KST);
 
         User user = User.builder()
                 .email("test@test.com")
@@ -154,7 +157,7 @@ class UserQuestServiceTest {
         QuestTemplate template = mock(QuestTemplate.class);
         when(template.getReward()).thenReturn(100_000);
 
-        DailyQuest dailyQuest = DailyQuest.create(template, LocalDate.now(), 3, 100_000);
+        DailyQuest dailyQuest = DailyQuest.create(template, LocalDate.now(KST), 3, 100_000);
         UserQuest userQuest = UserQuest.assign(user, dailyQuest);
         ReflectionTestUtils.setField(userQuest, "id", 1L);
         ReflectionTestUtils.setField(userQuest, "status", QuestStatus.COMPLETED);

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartDividendServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartDividendServiceTest.java
@@ -1,0 +1,181 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartDividendClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartDividendApiResponse;
+import com.solv.wefin.domain.trading.dart.client.dto.DartDividendItem;
+import com.solv.wefin.domain.trading.dart.dto.DartDividendInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DartDividendServiceTest {
+
+    @Mock
+    private DartCorpCodeService dartCorpCodeService;
+
+    @Mock
+    private DartDividendClient dartDividendClient;
+
+    @InjectMocks
+    private DartDividendService dartDividendService;
+
+    private DartDividendItem item(String category, String stockKind, String current) {
+        return new DartDividendItem(category, stockKind, current, null, null);
+    }
+
+    private DartDividendApiResponse successResponse() {
+        return new DartDividendApiResponse("000", "정상", List.of(
+                item("주당 현금배당금(원)", "보통주", "1,444"),
+                item("주당 현금배당금(원)", "우선주", "1,445"),
+                item("현금배당수익률(%)", "보통주", "1.8"),
+                item("현금배당성향(%)", "보통주", "17.5")
+        ));
+    }
+
+    @Test
+    void 배당_정상조회_보통주_당기값_추출() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(successResponse());
+
+        // when
+        DartDividendInfo result = dartDividendService.getDividend("005930");
+
+        // then
+        assertThat(result.dividendPerShare()).isEqualByComparingTo(new BigDecimal("1444"));
+        assertThat(result.dividendYieldRate()).isEqualByComparingTo(new BigDecimal("1.8"));
+        assertThat(result.payoutRatio()).isEqualByComparingTo(new BigDecimal("17.5"));
+    }
+
+    @Test
+    void status_013이면_이전연도로_fallback() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        int currentYear = LocalDate.now().getYear();
+        String firstYear = String.valueOf(currentYear - 1);
+        String secondYear = String.valueOf(currentYear - 2);
+
+        DartDividendApiResponse noData = new DartDividendApiResponse("013", "조회된 데이타가 없습니다.", null);
+        given(dartDividendClient.fetch("00126380", firstYear, "11011")).willReturn(noData);
+        given(dartDividendClient.fetch("00126380", secondYear, "11011")).willReturn(successResponse());
+
+        // when
+        DartDividendInfo result = dartDividendService.getDividend("005930");
+
+        // then
+        assertThat(result.businessYear()).isEqualTo(secondYear);
+    }
+
+    @Test
+    void 연도_2회_fallback_모두_실패시_NOT_FOUND() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse noData = new DartDividendApiResponse("013", "조회된 데이타가 없습니다.", null);
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(noData);
+
+        // when & then
+        assertThatThrownBy(() -> dartDividendService.getDividend("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_DIVIDEND_NOT_FOUND);
+    }
+
+    @Test
+    void status가_000도_013도_아니면_FETCH_FAILED() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse error = new DartDividendApiResponse("020", "요청 제한 초과", null);
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(error);
+
+        // when & then
+        assertThatThrownBy(() -> dartDividendService.getDividend("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_DIVIDEND_FETCH_FAILED);
+    }
+
+    @Test
+    void list_비어있으면_NOT_FOUND() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse empty = new DartDividendApiResponse("000", "정상", List.of());
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(empty);
+
+        // when & then
+        assertThatThrownBy(() -> dartDividendService.getDividend("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_DIVIDEND_NOT_FOUND);
+    }
+
+    @Test
+    void 보통주_항목이_없으면_NOT_FOUND() {
+        // given — 우선주만 있음
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse onlyPreferred = new DartDividendApiResponse("000", "정상", List.of(
+                item("주당 현금배당금(원)", "우선주", "1,445"),
+                item("현금배당수익률(%)", "우선주", "2.0")
+        ));
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(onlyPreferred);
+
+        // when & then
+        assertThatThrownBy(() -> dartDividendService.getDividend("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_DIVIDEND_NOT_FOUND);
+    }
+
+    @Test
+    void 금액_대시나_null은_null로_파싱_하지만_다른_항목이_있으면_반환() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse response = new DartDividendApiResponse("000", "정상", List.of(
+                item("주당 현금배당금(원)", "보통주", "1,444"),
+                item("현금배당수익률(%)", "보통주", "-"),
+                item("현금배당성향(%)", "보통주", null)
+        ));
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(response);
+
+        // when
+        DartDividendInfo result = dartDividendService.getDividend("005930");
+
+        // then
+        assertThat(result.dividendPerShare()).isEqualByComparingTo(new BigDecimal("1444"));
+        assertThat(result.dividendYieldRate()).isNull();
+        assertThat(result.payoutRatio()).isNull();
+    }
+
+    @Test
+    void corpCode_미존재시_예외_전파() {
+        // given
+        given(dartCorpCodeService.getCorpCode("999999"))
+                .willThrow(new BusinessException(ErrorCode.DART_CORP_CODE_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> dartDividendService.getDividend("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_CORP_CODE_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoServiceTest.java
@@ -31,7 +31,7 @@ class StockBasicInfoServiceTest {
     private StockBasicInfoService stockBasicInfoService;
 
     @Test
-    void 기본정보_정상조회_시가총액은_억단위를_원단위로_변환() {
+    void 기본정보_정상조회_시가총액은_한투_원본_억단위로_유지() {
         // given
         given(stockService.existsByCode("005930")).willReturn(true);
         given(hantuMarketClient.fetchStockInfo("005930")).willReturn(
@@ -65,11 +65,11 @@ class StockBasicInfoServiceTest {
     }
 
     @Test
-    void 한투_API_예외시_MARKET_API_FAILED() {
+    void 한투_RestClient_예외시_MARKET_API_FAILED() {
         // given
         given(stockService.existsByCode("005930")).willReturn(true);
         given(hantuMarketClient.fetchStockInfo("005930"))
-                .willThrow(new RuntimeException("network"));
+                .willThrow(new org.springframework.web.client.RestClientException("network"));
 
         // when & then
         assertThatThrownBy(() -> stockBasicInfoService.getBasicInfo("005930"))

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/StockBasicInfoServiceTest.java
@@ -1,0 +1,127 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuStockInfoApiResponse;
+import com.solv.wefin.domain.trading.market.dto.StockBasicInfo;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StockBasicInfoServiceTest {
+
+    @Mock
+    private StockService stockService;
+
+    @Mock
+    private HantuMarketClient hantuMarketClient;
+
+    @InjectMocks
+    private StockBasicInfoService stockBasicInfoService;
+
+    @Test
+    void 기본정보_정상조회_시가총액은_억단위를_원단위로_변환() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930")).willReturn(
+                new HantuStockInfoApiResponse(new HantuStockInfoApiResponse.Output(
+                        "4482340",    // 시가총액 448조 2340억 = 448,234,000,000,000원
+                        "5969782550", // 상장주식수
+                        "53.12",      // 외국인 소진율
+                        null, null, null  // per/pbr/eps — 기본정보 테스트 범위 외
+                ))
+        );
+
+        // when
+        StockBasicInfo result = stockBasicInfoService.getBasicInfo("005930");
+
+        // then
+        assertThat(result.marketCapInHundredMillionKrw()).isEqualTo(4482340L);
+        assertThat(result.listedShares()).isEqualTo(5969782550L);
+        assertThat(result.foreignRatio()).isEqualByComparingTo(new BigDecimal("53.12"));
+    }
+
+    @Test
+    void 존재하지_않는_종목조회시_MARKET_STOCK_NOT_FOUND() {
+        // given
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> stockBasicInfoService.getBasicInfo("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+    @Test
+    void 한투_API_예외시_MARKET_API_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willThrow(new RuntimeException("network"));
+
+        // when & then
+        assertThatThrownBy(() -> stockBasicInfoService.getBasicInfo("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void 응답이_null이면_MARKET_API_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> stockBasicInfoService.getBasicInfo("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void output이_null이면_MARKET_API_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willReturn(new HantuStockInfoApiResponse(null));
+
+        // when & then
+        assertThatThrownBy(() -> stockBasicInfoService.getBasicInfo("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void 파싱_실패_필드는_null로_수렴() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930")).willReturn(
+                new HantuStockInfoApiResponse(new HantuStockInfoApiResponse.Output(
+                        "NOT_A_NUMBER", "", null,
+                        null, null, null
+                ))
+        );
+
+        // when
+        StockBasicInfo result = stockBasicInfoService.getBasicInfo("005930");
+
+        // then
+        assertThat(result.marketCapInHundredMillionKrw()).isNull();
+        assertThat(result.listedShares()).isNull();
+        assertThat(result.foreignRatio()).isNull();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/StockIndicatorServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/StockIndicatorServiceTest.java
@@ -1,0 +1,177 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialPeriod;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.domain.trading.dart.service.DartFinancialService;
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuStockInfoApiResponse;
+import com.solv.wefin.domain.trading.market.dto.StockIndicatorInfo;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StockIndicatorServiceTest {
+
+    @Mock
+    private StockService stockService;
+
+    @Mock
+    private HantuMarketClient hantuMarketClient;
+
+    @Mock
+    private DartFinancialService dartFinancialService;
+
+    @InjectMocks
+    private StockIndicatorService stockIndicatorService;
+
+    private HantuStockInfoApiResponse hantuResponse(String per, String pbr, String eps) {
+        return new HantuStockInfoApiResponse(new HantuStockInfoApiResponse.Output(
+                null, null, null, per, pbr, eps
+        ));
+    }
+
+    private DartFinancialSummary financialWithCurrent(BigDecimal netIncome, BigDecimal totalEquity) {
+        DartFinancialPeriod current = new DartFinancialPeriod(
+                "제 55 기",
+                null, null, totalEquity,
+                null, null, netIncome
+        );
+        return new DartFinancialSummary("2024", "11011", "KRW",
+                current, null, null);
+    }
+
+    @Test
+    void 투자지표_정상조회_per_pbr_eps_파싱_roe_계산() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willReturn(hantuResponse("15.2", "1.8", "5800"));
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willReturn(financialWithCurrent(
+                        new BigDecimal("15500000000000"),  // 당기순이익 15.5조
+                        new BigDecimal("356000000000000")  // 자본총계 356조
+                ));
+
+        // when
+        StockIndicatorInfo result = stockIndicatorService.getIndicator("005930");
+
+        // then
+        assertThat(result.per()).isEqualByComparingTo(new BigDecimal("15.2"));
+        assertThat(result.pbr()).isEqualByComparingTo(new BigDecimal("1.8"));
+        assertThat(result.eps()).isEqualByComparingTo(new BigDecimal("5800"));
+        // ROE = 15.5조 / 356조 × 100 ≈ 4.35%
+        assertThat(result.roe()).isEqualByComparingTo(new BigDecimal("4.35"));
+    }
+
+    @Test
+    void 존재하지_않는_종목조회시_MARKET_STOCK_NOT_FOUND() {
+        // given
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> stockIndicatorService.getIndicator("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+    @Test
+    void 한투_API_예외시_MARKET_API_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willThrow(new RuntimeException("network"));
+
+        // when & then
+        assertThatThrownBy(() -> stockIndicatorService.getIndicator("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void DART_재무제표_실패시_ROE는_null_다른_지표는_정상() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willReturn(hantuResponse("15.2", "1.8", "5800"));
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_FINANCIAL_NOT_FOUND));
+
+        // when
+        StockIndicatorInfo result = stockIndicatorService.getIndicator("005930");
+
+        // then
+        assertThat(result.per()).isEqualByComparingTo(new BigDecimal("15.2"));
+        assertThat(result.roe()).isNull();
+    }
+
+    @Test
+    void 자본총계가_0이면_ROE_null() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willReturn(hantuResponse("15.2", "1.8", "5800"));
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willReturn(financialWithCurrent(
+                        new BigDecimal("1000000"),
+                        BigDecimal.ZERO  // 0 division 방지
+                ));
+
+        // when
+        StockIndicatorInfo result = stockIndicatorService.getIndicator("005930");
+
+        // then
+        assertThat(result.roe()).isNull();
+    }
+
+    @Test
+    void 순이익이나_자본총계가_null이면_ROE_null() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willReturn(hantuResponse("15.2", "1.8", "5800"));
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willReturn(financialWithCurrent(null, new BigDecimal("356000000000000")));
+
+        // when
+        StockIndicatorInfo result = stockIndicatorService.getIndicator("005930");
+
+        // then
+        assertThat(result.roe()).isNull();
+    }
+
+    @Test
+    void per_pbr_eps_파싱실패시_해당필드_null() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchStockInfo("005930"))
+                .willReturn(hantuResponse("NOT_A_NUMBER", "", null));
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willReturn(financialWithCurrent(
+                        new BigDecimal("15500000000000"),
+                        new BigDecimal("356000000000000")
+                ));
+
+        // when
+        StockIndicatorInfo result = stockIndicatorService.getIndicator("005930");
+
+        // then
+        assertThat(result.per()).isNull();
+        assertThat(result.pbr()).isNull();
+        assertThat(result.eps()).isNull();
+        assertThat(result.roe()).isNotNull();
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/StockIndicatorServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/StockIndicatorServiceTest.java
@@ -88,11 +88,11 @@ class StockIndicatorServiceTest {
     }
 
     @Test
-    void 한투_API_예외시_MARKET_API_FAILED() {
+    void 한투_RestClient_예외시_MARKET_API_FAILED() {
         // given
         given(stockService.existsByCode("005930")).willReturn(true);
         given(hantuMarketClient.fetchStockInfo("005930"))
-                .willThrow(new RuntimeException("network"));
+                .willThrow(new org.springframework.web.client.RestClientException("network"));
 
         // when & then
         assertThatThrownBy(() -> stockIndicatorService.getIndicator("005930"))


### PR DESCRIPTION
## 📌 PR 설명

  WEF-415 종목정보 탭의 3차 PR입니다. 
이전 PR#1(WEF-647 corpCode)·PR#2(WEF-416/419 DART 기업개요·재무제표) 위에 **KIS 기반 기본정보·투자지표**와 **DART 배당**을 추가했습니다. 

  - WEF-417: 한투 `/inquire-price`에서 **시가총액·상장주식수·외국인비율** 추출
  - WEF-418: 한투 `/inquire-price`에서 PER·PBR·EPS + DART 재무제표 기반 **ROE
  계산**
  - WEF-649: DART `/api/alotMatter.json`에서 **주당 배당금·배당수익률·배당성향**
  추출

  Controller는 이번에도 없음 → WEF-645 통합 엔드포인트(4/N)에서 연결 예정입니다!
<br>

## ✅ 완료한 기능 명세

 ### **WEF-417 기본정보**
  - [x] `HantuStockInfoApiResponse` — `/inquire-price` 응답 중 기본정보/지표 필드
  subset 매핑 (시총/상장주수/외국인율 + PER/PBR/EPS)
  - [x] `StockBasicInfo` — 도메인 DTO. 시가총액은 한투 원본 단위(억원) 유지
  - [x] `HantuMarketClient.fetchStockInfo` — 기존 `fetchCurrentPrice`와 동일
  endpoint, 다른 DTO 매핑
  - [x] `StockBasicInfoService` — 종목 존재 검증 + `@Cacheable("stockBasicInfo",
  TTL 10분)`

###  **WEF-418 투자지표**
  - [x] `StockIndicatorInfo` — 도메인 DTO (PER/PBR/EPS/ROE)
  - [x] `StockIndicatorService` — 한투 `fetchStockInfo`에서 PER/PBR/EPS 추출 +
  DART 재무제표로 **ROE 계산** (당기순이익 / 자본총계 × 100)
  - [x] DART 재무제표 실패 시 ROE만 null, 다른 지표는 정상 반환
  - [x] `@Cacheable("stockIndicator", TTL 10분)`

###  **WEF-649 배당**
  - [x] `DartDividendApiResponse` + `DartDividendItem` — DART 원본 + list row
  - [x] `DartDividendInfo` — 도메인 DTO (businessYear / 주당배당금 / 배당수익률 /
  배당성향)
  - [x] `DartDividendClient` — `/api/alotMatter.json` 호출 + null body 가드
  - [x] `DartDividendService`:
    - 연도 fallback (N-1 → N-2, WEF-419 패턴 재사용)
    - `stock_knd = "보통주"` 필터
    - 핵심 3항목 추출 (`category` contains 매칭)
    - 3개 모두 null이면 `DART_DIVIDEND_NOT_FOUND`
    - `@Cacheable("dartDividend", TTL 24h)`

###  **공통**
  - [x] `CacheConfig` — `stockBasicInfo` / `stockIndicator` / `dartDividend` 캐시
  등록
  - [x] 에러 코드 추가: `DART_DIVIDEND_*` 2종 (기존 `MARKET_*` 재사용)
  - [x] 단위 테스트 19건 (StockBasicInfo 6 + StockIndicator 7 + DartDividend 8
  *수치는 실제 실행값 기준으로 조정 가능*)


<br>

## 📸 스크린샷
  Controller 없어 end-to-end 응답 없음. WEF-645 통합 PR에서 실제 JSON 응답 스크린샷 첨부 예정.

  로컬 단위 테스트 결과:
  StockBasicInfoServiceTest   : pass
  StockIndicatorServiceTest   : pass
  DartDividendServiceTest     : pass
<br>

## 💭 고민과 해결과정
 - **ROE 출처 결정**: 한투 `/inquire-price`에 **ROE 필드 없음**. 
 KIS 다른 API 조사했으나 국내 종목 ROE 직접 제공 API가 없어 **DART 재무제표 기반 계산**으로 결정. `DartFinancialService`에 의존하는 구조 — cross-subdomain Service 호출 (trading-convention.md 허용). DART 실패 시 다른 지표(PER/PBR/EPS)는 영향 없이 반환하도록 부분 실패 허용.
  - **시가총액 단위 유지**: DTO에서 원 단위 변환(× 100,000,000) 도입했으나 FE 표시(`448조 2340억`) 관점에서 불필요한 왕복이라 판단 → 한투 원본 단위(억원)의 `Long`으로 유지. 필드명 `marketCapInHundredMillionKrw`로 단위 명시.
  - **`fetchStockInfo` 재사용 설계**: WEF-417/418 모두 같은 `/inquire-price` endpoint 사용. 기존 `HantuPriceApiResponse` 확장은 호출처 영향 범위 커서 회피, 별도 `HantuStockInfoApiResponse`로 관심사 분리. 같은 API 2번 호출 가능성은 Service 캐시로 완화 (→ WEF-399/548 리팩토링 백로그에 통합안 기록).
  - **배당 `contains` 매칭**: DART `se` 필드 값이 `"주당 현금배당금(원)"` 등 표기 변동 가능성 있어 `exact match` 대신 `contains("주당 현금배당금")` 사용. 보통주 필터(`stock_knd = "보통주"`)와 조합.
  - **DTO 네이밍 컨벤션 적용**: PR#2에서 정리한 `{Vendor}XxxInfo`/`{Vendor}XxxApiResponse` 패턴 일관 유지. `StockBasicInfo`·`StockIndicatorInfo`는 vendor-less (market 도메인 기존 관례 `PriceResponse`와 일관).

<br>

### 🔗 관련 이슈
  Part of #258

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 주식 배당금 정보 조회(배당금액, 배당수익률, 배당성향) 및 연도별 조회(예비 연도 자동 시도) 추가
  * 주식 기본정보(시가총액, 상장주식수, 외국인 지분율) 조회 추가
  * 주식 투자지표(PER, PBR, EPS, ROE) 조회 추가

* **Performance**
  * 반복 호출을 줄이기 위한 캐싱 적용(기본정보·투자지표·배당정보)

* **Bug Fixes**
  * 외부 API 응답 파싱/비정상값 처리 및 오류 대응 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->