### PR TITLE
[WEF-645] 종목정보 통합 엔드포인트 + 실제 데이터 검증 (4/4)

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
@@ -28,7 +28,9 @@ public class DartDividendService {
 
     private static final String CATEGORY_DIVIDEND_PER_SHARE = "주당 현금배당금(원)";
     private static final String CATEGORY_YIELD_RATE = "현금배당수익률(%)";
-    private static final String CATEGORY_PAYOUT_RATIO = "현금배당성향(%)";
+    // 배당성향은 DART가 "(연결)현금배당성향(%)"/"(별도)현금배당성향(%)"/"현금배당성향(%)" 등 접두어를
+    // 회사별로 다르게 붙임. 또한 회사 전체 기준이라 stock_knd가 null이므로 contains + stock_knd 무필터.
+    private static final String CATEGORY_PAYOUT_RATIO_KEYWORD = "현금배당성향";
 
     private final DartCorpCodeService dartCorpCodeService;
     private final DartDividendClient dartDividendClient;
@@ -72,9 +74,9 @@ public class DartDividendService {
             throw new BusinessException(ErrorCode.DART_DIVIDEND_NOT_FOUND);
         }
 
-        BigDecimal dividendPerShare = pickCurrent(items, CATEGORY_DIVIDEND_PER_SHARE);
-        BigDecimal yieldRate = pickCurrent(items, CATEGORY_YIELD_RATE);
-        BigDecimal payoutRatio = pickCurrent(items, CATEGORY_PAYOUT_RATIO);
+        BigDecimal dividendPerShare = pickCommonStock(items, CATEGORY_DIVIDEND_PER_SHARE);
+        BigDecimal yieldRate = pickCommonStock(items, CATEGORY_YIELD_RATE);
+        BigDecimal payoutRatio = pickPayoutRatio(items);
 
         if (dividendPerShare == null && yieldRate == null && payoutRatio == null) {
             log.error("DART 배당 응답에 핵심 항목 3개 모두 없음 (보통주 기준)");
@@ -84,10 +86,34 @@ public class DartDividendService {
         return new DartDividendInfo(businessYear, dividendPerShare, yieldRate, payoutRatio);
     }
 
-    private BigDecimal pickCurrent(List<DartDividendItem> items, String category) {
-        Optional<DartDividendItem> item = items.stream()
+    /**
+     * 주식종류별 값(주당배당금, 배당수익률) 추출.
+     * DART가 회사별로 stock_knd를 다르게 줌:
+     *   - 삼성전자: "보통주"/"우선주" 명시 → 명시 매칭
+     *   - 셀트리온: stock_knd 필드 자체 없음(null) → 같은 category row 중 첫 번째 사용 (보통 보통주가 먼저)
+     */
+    private BigDecimal pickCommonStock(List<DartDividendItem> items, String category) {
+        Optional<DartDividendItem> explicit = items.stream()
                 .filter(i -> category.equals(i.category()))
                 .filter(i -> COMMON_STOCK.equals(i.stockKind()))
+                .findFirst();
+        if (explicit.isPresent()) {
+            return parseAmount(explicit.get().currentAmount());
+        }
+        Optional<DartDividendItem> implicit = items.stream()
+                .filter(i -> category.equals(i.category()))
+                .filter(i -> i.stockKind() == null)
+                .findFirst();
+        return implicit.map(i -> parseAmount(i.currentAmount())).orElse(null);
+    }
+
+    /**
+     * 배당성향은 회사 전체 기준이라 stock_knd가 null인 경우가 많고,
+     * "(연결)"/"(별도)" 접두어 변동이 있어 contains 매칭으로 유연하게 처리.
+     */
+    private BigDecimal pickPayoutRatio(List<DartDividendItem> items) {
+        Optional<DartDividendItem> item = items.stream()
+                .filter(i -> i.category() != null && i.category().contains(CATEGORY_PAYOUT_RATIO_KEYWORD))
                 .findFirst();
         return item.map(i -> parseAmount(i.currentAmount())).orElse(null);
     }

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDividendService.java
@@ -50,8 +50,12 @@ public class DartDividendService {
                     dartDividendClient.fetch(corpCode, year, DEFAULT_REPORT_CODE);
 
             if (response.isSuccess()) {
-                log.debug("DART 배당 조회 성공: corp_code={}, year={}", corpCode, year);
-                return new YearlyResponse(response, year);
+                if (response.list() != null && !response.list().isEmpty()) {
+                    log.debug("DART 배당 조회 성공: corp_code={}, year={}", corpCode, year);
+                    return new YearlyResponse(response, year);
+                }
+                log.debug("DART 배당 성공 응답이지만 데이터 없음, 연도 fallback: corp_code={}, year={}", corpCode, year);
+                continue;
             }
             if (!response.isNoData()) {
                 log.error("DART 배당 에러 응답: status={}, message={}",

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
@@ -57,8 +57,12 @@ public class DartFinancialService {
                 throw new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED);
             }
             if (response.isSuccess()) {
-                log.debug("DART 재무제표 조회 성공: corp_code={}, year={}", corpCode, year);
-                return new YearlyResponse(response, year);
+                if (response.list() != null && !response.list().isEmpty()) {
+                    log.debug("DART 재무제표 조회 성공: corp_code={}, year={}", corpCode, year);
+                    return new YearlyResponse(response, year);
+                }
+                log.debug("DART 재무제표 성공 응답이지만 데이터 없음, 연도 fallback: corp_code={}, year={}", corpCode, year);
+                continue;
             }
             if (!response.isNoData()) {
                 log.error("DART 재무제표 에러 응답: status={}, message={}",

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartFinancialService.java
@@ -31,7 +31,9 @@ public class DartFinancialService {
     private static final String ACCOUNT_LIABILITIES = "ifrs-full_Liabilities";
     private static final String ACCOUNT_EQUITY = "ifrs-full_Equity";
     private static final String ACCOUNT_REVENUE = "ifrs-full_Revenue";
+    // 영업이익: 제조업은 dart_OperatingIncomeLoss, 금융지주/보험업은 ifrs-full_ProfitLossFromOperatingActivities
     private static final String ACCOUNT_OPERATING_INCOME = "dart_OperatingIncomeLoss";
+    private static final String ACCOUNT_OPERATING_INCOME_IFRS = "ifrs-full_ProfitLossFromOperatingActivities";
     private static final String ACCOUNT_NET_INCOME = "ifrs-full_ProfitLoss";
 
     private final DartCorpCodeService dartCorpCodeService;
@@ -96,6 +98,10 @@ public class DartFinancialService {
         DartFinancialItem equity = byAccountId.get(ACCOUNT_EQUITY);
         DartFinancialItem revenue = byAccountId.get(ACCOUNT_REVENUE);
         DartFinancialItem operatingIncome = byAccountId.get(ACCOUNT_OPERATING_INCOME);
+        if (operatingIncome == null) {
+            // 금융지주/보험업 fallback
+            operatingIncome = byAccountId.get(ACCOUNT_OPERATING_INCOME_IFRS);
+        }
         DartFinancialItem netIncome = byAccountId.get(ACCOUNT_NET_INCOME);
 
         if (java.util.stream.Stream.of(assets, liabilities, equity, revenue, operatingIncome, netIncome)

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/StockIndicatorService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/StockIndicatorService.java
@@ -64,6 +64,7 @@ public class StockIndicatorService {
     private BigDecimal calculateRoe(String stockCode) {
         try {
             DartFinancialSummary summary = dartFinancialService.getFinancialSummary(stockCode);
+            if (summary == null) return null;
             DartFinancialPeriod current = summary.currentPeriod();
             if (current == null) return null;
 

--- a/src/main/java/com/solv/wefin/domain/trading/stock/service/StockInfoService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/service/StockInfoService.java
@@ -1,0 +1,66 @@
+package com.solv.wefin.domain.trading.stock.service;
+
+import com.solv.wefin.domain.trading.dart.dto.DartCompanyInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartDividendInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.domain.trading.dart.service.DartCompanyService;
+import com.solv.wefin.domain.trading.dart.service.DartDividendService;
+import com.solv.wefin.domain.trading.dart.service.DartFinancialService;
+import com.solv.wefin.domain.trading.market.dto.StockBasicInfo;
+import com.solv.wefin.domain.trading.market.dto.StockIndicatorInfo;
+import com.solv.wefin.domain.trading.market.service.StockBasicInfoService;
+import com.solv.wefin.domain.trading.market.service.StockIndicatorService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.trading.stock.dto.response.StockInfoResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.function.Supplier;
+
+/**
+ * WEF-645 — GET /api/stocks/{code}/info 통합 조회 서비스.
+ * 5개 sub-service 결과를 합쳐 반환. 개별 sub-service 실패는 해당 섹션 null로 graceful degrade.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StockInfoService {
+
+    private final StockService stockService;
+    private final DartCompanyService dartCompanyService;
+    private final DartFinancialService dartFinancialService;
+    private final StockBasicInfoService stockBasicInfoService;
+    private final StockIndicatorService stockIndicatorService;
+    private final DartDividendService dartDividendService;
+
+    public StockInfoResponse getStockInfo(String stockCode) {
+        if (!stockService.existsByCode(stockCode)) {
+            throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
+        }
+
+        DartCompanyInfo company = safeCall(() -> dartCompanyService.getCompany(stockCode), "company", stockCode);
+        DartFinancialSummary financial = safeCall(() -> dartFinancialService.getFinancialSummary(stockCode), "financial", stockCode);
+        StockBasicInfo basic = safeCall(() -> stockBasicInfoService.getBasicInfo(stockCode), "basic", stockCode);
+        StockIndicatorInfo indicator = safeCall(() -> stockIndicatorService.getIndicator(stockCode), "indicator", stockCode);
+        DartDividendInfo dividend = safeCall(() -> dartDividendService.getDividend(stockCode), "dividend", stockCode);
+
+        return new StockInfoResponse(company, financial, basic, indicator, dividend);
+    }
+
+    /**
+     * Sub-service 호출을 방어적으로 감쌈.
+     * BusinessException은 로그 후 null로 변환 (부분 실패 허용).
+     * 그 외 예외는 전체 장애 가능성이라 상위로 전파.
+     */
+    private <T> T safeCall(Supplier<T> supplier, String section, String stockCode) {
+        try {
+            return supplier.get();
+        } catch (BusinessException e) {
+            log.warn("StockInfo 섹션 조회 실패 (null로 대체): section={}, stockCode={}, code={}",
+                    section, stockCode, e.getErrorCode());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/stock/StockInfoController.java
+++ b/src/main/java/com/solv/wefin/web/trading/stock/StockInfoController.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.web.trading.stock;
+
+import com.solv.wefin.domain.trading.stock.service.StockInfoService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.trading.stock.dto.response.StockInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stocks")
+@RequiredArgsConstructor
+public class StockInfoController {
+
+    private final StockInfoService stockInfoService;
+
+    @GetMapping("/{code}/info")
+    public ApiResponse<StockInfoResponse> getStockInfo(@PathVariable String code) {
+        return ApiResponse.success(stockInfoService.getStockInfo(code));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/trading/stock/dto/response/StockInfoResponse.java
+++ b/src/main/java/com/solv/wefin/web/trading/stock/dto/response/StockInfoResponse.java
@@ -1,0 +1,20 @@
+package com.solv.wefin.web.trading.stock.dto.response;
+
+import com.solv.wefin.domain.trading.dart.dto.DartCompanyInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartDividendInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.domain.trading.market.dto.StockBasicInfo;
+import com.solv.wefin.domain.trading.market.dto.StockIndicatorInfo;
+
+/**
+ * GET /api/stocks/{code}/info — 종목정보 탭 통합 응답.
+ * 개별 섹션이 실패하면 해당 필드는 null로 반환 (부분 실패 허용).
+ */
+public record StockInfoResponse(
+        DartCompanyInfo company,
+        DartFinancialSummary financial,
+        StockBasicInfo basic,
+        StockIndicatorInfo indicator,
+        DartDividendInfo dividend
+) {
+}

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartDividendServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartDividendServiceTest.java
@@ -167,6 +167,70 @@ class DartDividendServiceTest {
     }
 
     @Test
+    void 배당성향은_연결_접두어와_null_stock_knd도_매칭() {
+        // given — 삼성전자 실제 DART 응답 패턴 재현: "(연결)현금배당성향(%)" + stock_knd null
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse samsungLike = new DartDividendApiResponse("000", "정상", List.of(
+                item("주당 현금배당금(원)", "보통주", "1,444"),
+                item("현금배당수익률(%)", "보통주", "1.50"),
+                item("(연결)현금배당성향(%)", null, "25.10")
+        ));
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(samsungLike);
+
+        // when
+        DartDividendInfo result = dartDividendService.getDividend("005930");
+
+        // then
+        assertThat(result.dividendPerShare()).isEqualByComparingTo(new BigDecimal("1444"));
+        assertThat(result.dividendYieldRate()).isEqualByComparingTo(new BigDecimal("1.50"));
+        assertThat(result.payoutRatio()).isEqualByComparingTo(new BigDecimal("25.10"));
+    }
+
+    @Test
+    void 배당성향은_별도_접두어_버전도_매칭() {
+        // given — "(별도)현금배당성향(%)" 변형
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        DartDividendApiResponse response = new DartDividendApiResponse("000", "정상", List.of(
+                item("주당 현금배당금(원)", "보통주", "1,000"),
+                item("현금배당수익률(%)", "보통주", "2.0"),
+                item("(별도)현금배당성향(%)", null, "30.5")
+        ));
+        given(dartDividendClient.fetch(eq("00126380"), anyString(), anyString()))
+                .willReturn(response);
+
+        // when
+        DartDividendInfo result = dartDividendService.getDividend("005930");
+
+        // then
+        assertThat(result.payoutRatio()).isEqualByComparingTo(new BigDecimal("30.5"));
+    }
+
+    @Test
+    void stock_knd가_모든_row에서_null이면_첫번째_매칭을_보통주로_취급() {
+        // given — 셀트리온 실제 DART 응답 패턴: stock_knd 필드 자체 없음(null)
+        // 같은 category가 두 번 나타나면 첫 번째는 보통 보통주, 두 번째는 우선주(배당 없으면 "-")
+        given(dartCorpCodeService.getCorpCode("068270")).willReturn("00413046");
+        DartDividendApiResponse celltrionLike = new DartDividendApiResponse("000", "정상", List.of(
+                new DartDividendItem("주당 현금배당금(원)", null, "750", null, null),
+                new DartDividendItem("주당 현금배당금(원)", null, "-", null, null),
+                new DartDividendItem("현금배당수익률(%)", null, "0.40", null, null),
+                new DartDividendItem("현금배당수익률(%)", null, "-", null, null),
+                new DartDividendItem("(연결)현금배당성향(%)", null, "15.92", null, null)
+        ));
+        given(dartDividendClient.fetch(eq("00413046"), anyString(), anyString()))
+                .willReturn(celltrionLike);
+
+        // when
+        DartDividendInfo result = dartDividendService.getDividend("068270");
+
+        // then — 보통주 명시 없어도 첫 번째 매칭으로 보통주 값 추출
+        assertThat(result.dividendPerShare()).isEqualByComparingTo(new BigDecimal("750"));
+        assertThat(result.dividendYieldRate()).isEqualByComparingTo(new BigDecimal("0.40"));
+        assertThat(result.payoutRatio()).isEqualByComparingTo(new BigDecimal("15.92"));
+    }
+
+    @Test
     void corpCode_미존재시_예외_전파() {
         // given
         given(dartCorpCodeService.getCorpCode("999999"))

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartFinancialServiceTest.java
@@ -177,6 +177,35 @@ class DartFinancialServiceTest {
     }
 
     @Test
+    void 영업이익은_금융지주의_ifrs_표준_account_id도_매칭() {
+        // given — 신한지주 패턴: dart_OperatingIncomeLoss 없고 ifrs-full_ProfitLossFromOperatingActivities 사용
+        given(dartCorpCodeService.getCorpCode("055550")).willReturn("00382199");
+        DartFinancialApiResponse response = new DartFinancialApiResponse("000", "정상", List.of(
+                item("ifrs-full_Assets", "500000000000000", "480000000000000", "450000000000000"),
+                item("ifrs-full_Liabilities", "450000000000000", "430000000000000", "400000000000000"),
+                item("ifrs-full_Equity", "50000000000000", "50000000000000", "50000000000000"),
+                // dart_OperatingIncomeLoss 없음 — IFRS 표준 영업이익만
+                new DartFinancialItem("IS", "ifrs-full_ProfitLossFromOperatingActivities",
+                        "영업이익", "제 24 기", "5000000000000",
+                        "제 23 기", "4500000000000",
+                        "제 22 기", "4000000000000",
+                        "KRW"),
+                item("ifrs-full_ProfitLoss", "4000000000000", "3500000000000", "3000000000000")
+        ));
+        given(dartFinancialClient.fetch(eq("00382199"), anyString(), anyString(), anyString()))
+                .willReturn(response);
+
+        // when
+        DartFinancialSummary result = dartFinancialService.getFinancialSummary("055550");
+
+        // then — IFRS 영업이익이 매핑됨
+        assertThat(result.currentPeriod().operatingIncome())
+                .isEqualByComparingTo(new BigDecimal("5000000000000"));
+        assertThat(result.currentPeriod().netIncome())
+                .isEqualByComparingTo(new BigDecimal("4000000000000"));
+    }
+
+    @Test
     void 핵심_6개_계정이_하나도_매칭안되면_NOT_FOUND() {
         // given — list는 비어있지 않지만 6개 account_id 중 하나도 매칭 안 됨
         given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");

--- a/src/test/java/com/solv/wefin/domain/trading/stock/service/StockInfoServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/stock/service/StockInfoServiceTest.java
@@ -1,0 +1,188 @@
+package com.solv.wefin.domain.trading.stock.service;
+
+import com.solv.wefin.domain.trading.dart.dto.DartCompanyInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartDividendInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialPeriod;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.domain.trading.dart.service.DartCompanyService;
+import com.solv.wefin.domain.trading.dart.service.DartDividendService;
+import com.solv.wefin.domain.trading.dart.service.DartFinancialService;
+import com.solv.wefin.domain.trading.market.dto.StockBasicInfo;
+import com.solv.wefin.domain.trading.market.dto.StockIndicatorInfo;
+import com.solv.wefin.domain.trading.market.service.StockBasicInfoService;
+import com.solv.wefin.domain.trading.market.service.StockIndicatorService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.trading.stock.dto.response.StockInfoResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StockInfoServiceTest {
+
+    @Mock private StockService stockService;
+    @Mock private DartCompanyService dartCompanyService;
+    @Mock private DartFinancialService dartFinancialService;
+    @Mock private StockBasicInfoService stockBasicInfoService;
+    @Mock private StockIndicatorService stockIndicatorService;
+    @Mock private DartDividendService dartDividendService;
+
+    @InjectMocks
+    private StockInfoService stockInfoService;
+
+    private DartCompanyInfo sampleCompany() {
+        return new DartCompanyInfo("삼성전자", "SAMSUNG ELECTRONICS", "삼성전자", "005930",
+                "한종희", "경기도 수원시", "www.samsung.com", "",
+                "02-2255-0114", "031-200-7538", "264", "19690113", "12");
+    }
+
+    private DartFinancialSummary sampleFinancial() {
+        DartFinancialPeriod p = new DartFinancialPeriod("제 55 기",
+                new BigDecimal("448234000000000"), null, new BigDecimal("356000000000000"),
+                null, null, new BigDecimal("15500000000000"));
+        return new DartFinancialSummary("2024", "11011", "KRW", p, null, null);
+    }
+
+    private StockBasicInfo sampleBasic() {
+        return new StockBasicInfo(4482340L, 5969782550L, new BigDecimal("53.12"));
+    }
+
+    private StockIndicatorInfo sampleIndicator() {
+        return new StockIndicatorInfo(new BigDecimal("15.2"), new BigDecimal("1.8"),
+                new BigDecimal("5800"), new BigDecimal("4.35"));
+    }
+
+    private DartDividendInfo sampleDividend() {
+        return new DartDividendInfo("2024",
+                new BigDecimal("1444"), new BigDecimal("1.8"), new BigDecimal("17.5"));
+    }
+
+    @Test
+    void 통합조회_전부_성공_5개_섹션_모두_채워짐() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(dartCompanyService.getCompany("005930")).willReturn(sampleCompany());
+        given(dartFinancialService.getFinancialSummary("005930")).willReturn(sampleFinancial());
+        given(stockBasicInfoService.getBasicInfo("005930")).willReturn(sampleBasic());
+        given(stockIndicatorService.getIndicator("005930")).willReturn(sampleIndicator());
+        given(dartDividendService.getDividend("005930")).willReturn(sampleDividend());
+
+        // when
+        StockInfoResponse result = stockInfoService.getStockInfo("005930");
+
+        // then
+        assertThat(result.company()).isNotNull();
+        assertThat(result.company().corpName()).isEqualTo("삼성전자");
+        assertThat(result.financial()).isNotNull();
+        assertThat(result.basic()).isNotNull();
+        assertThat(result.indicator()).isNotNull();
+        assertThat(result.dividend()).isNotNull();
+    }
+
+    @Test
+    void 종목_미존재시_MARKET_STOCK_NOT_FOUND() {
+        // given
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> stockInfoService.getStockInfo("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+    @Test
+    void DART_기업개요_실패시_company_null_나머지_정상() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(dartCompanyService.getCompany("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_COMPANY_NOT_FOUND));
+        given(dartFinancialService.getFinancialSummary("005930")).willReturn(sampleFinancial());
+        given(stockBasicInfoService.getBasicInfo("005930")).willReturn(sampleBasic());
+        given(stockIndicatorService.getIndicator("005930")).willReturn(sampleIndicator());
+        given(dartDividendService.getDividend("005930")).willReturn(sampleDividend());
+
+        // when
+        StockInfoResponse result = stockInfoService.getStockInfo("005930");
+
+        // then
+        assertThat(result.company()).isNull();
+        assertThat(result.financial()).isNotNull();
+        assertThat(result.basic()).isNotNull();
+        assertThat(result.indicator()).isNotNull();
+        assertThat(result.dividend()).isNotNull();
+    }
+
+    @Test
+    void 여러_섹션_실패해도_성공한_섹션만_반환() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(dartCompanyService.getCompany("005930")).willReturn(sampleCompany());
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_FINANCIAL_NOT_FOUND));
+        given(stockBasicInfoService.getBasicInfo("005930"))
+                .willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED));
+        given(stockIndicatorService.getIndicator("005930")).willReturn(sampleIndicator());
+        given(dartDividendService.getDividend("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_DIVIDEND_NOT_FOUND));
+
+        // when
+        StockInfoResponse result = stockInfoService.getStockInfo("005930");
+
+        // then
+        assertThat(result.company()).isNotNull();
+        assertThat(result.financial()).isNull();
+        assertThat(result.basic()).isNull();
+        assertThat(result.indicator()).isNotNull();
+        assertThat(result.dividend()).isNull();
+    }
+
+    @Test
+    void 모든_sub_service_실패시_응답은_모두_null_이지만_200_유지() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(dartCompanyService.getCompany("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_COMPANY_FETCH_FAILED));
+        given(dartFinancialService.getFinancialSummary("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_FINANCIAL_FETCH_FAILED));
+        given(stockBasicInfoService.getBasicInfo("005930"))
+                .willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED));
+        given(stockIndicatorService.getIndicator("005930"))
+                .willThrow(new BusinessException(ErrorCode.MARKET_API_FAILED));
+        given(dartDividendService.getDividend("005930"))
+                .willThrow(new BusinessException(ErrorCode.DART_DIVIDEND_FETCH_FAILED));
+
+        // when
+        StockInfoResponse result = stockInfoService.getStockInfo("005930");
+
+        // then — 전부 null이지만 응답 객체 자체는 반환
+        assertThat(result).isNotNull();
+        assertThat(result.company()).isNull();
+        assertThat(result.financial()).isNull();
+        assertThat(result.basic()).isNull();
+        assertThat(result.indicator()).isNull();
+        assertThat(result.dividend()).isNull();
+    }
+
+    @Test
+    void BusinessException_외_예외는_상위_전파() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(dartCompanyService.getCompany("005930"))
+                .willThrow(new RuntimeException("unexpected"));
+
+        // when & then — safeCall이 BusinessException만 잡으므로 RuntimeException은 전파
+        assertThatThrownBy(() -> stockInfoService.getStockInfo("005930"))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("unexpected");
+    }
+}

--- a/src/test/java/com/solv/wefin/web/trading/stock/StockInfoControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/trading/stock/StockInfoControllerTest.java
@@ -1,0 +1,117 @@
+package com.solv.wefin.web.trading.stock;
+
+import com.solv.wefin.domain.trading.dart.dto.DartCompanyInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartDividendInfo;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialPeriod;
+import com.solv.wefin.domain.trading.dart.dto.DartFinancialSummary;
+import com.solv.wefin.domain.trading.market.dto.StockBasicInfo;
+import com.solv.wefin.domain.trading.market.dto.StockIndicatorInfo;
+import com.solv.wefin.domain.trading.stock.service.StockInfoService;
+import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.web.trading.stock.dto.response.StockInfoResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(StockInfoController.class)
+class StockInfoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private StockInfoService stockInfoService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    private StockInfoResponse sampleResponse() {
+        DartCompanyInfo company = new DartCompanyInfo("삼성전자", "SAMSUNG", "삼성전자", "005930",
+                "한종희", "경기도 수원시", "www.samsung.com", "",
+                "02-2255-0114", "031-200-7538", "264", "19690113", "12");
+        DartFinancialPeriod period = new DartFinancialPeriod("제 55 기",
+                new BigDecimal("448234000000000"), null, new BigDecimal("356000000000000"),
+                null, null, new BigDecimal("15500000000000"));
+        DartFinancialSummary financial = new DartFinancialSummary("2024", "11011", "KRW",
+                period, null, null);
+        StockBasicInfo basic = new StockBasicInfo(4482340L, 5969782550L, new BigDecimal("53.12"));
+        StockIndicatorInfo indicator = new StockIndicatorInfo(
+                new BigDecimal("15.2"), new BigDecimal("1.8"),
+                new BigDecimal("5800"), new BigDecimal("4.35"));
+        DartDividendInfo dividend = new DartDividendInfo("2024",
+                new BigDecimal("1444"), new BigDecimal("1.8"), new BigDecimal("17.5"));
+        return new StockInfoResponse(company, financial, basic, indicator, dividend);
+    }
+
+    @Test
+    void 종목정보_조회_정상응답() throws Exception {
+        // given
+        given(stockInfoService.getStockInfo("005930")).willReturn(sampleResponse());
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/005930/info")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(null, null, List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.company.corpName").value("삼성전자"))
+                .andExpect(jsonPath("$.data.company.stockCode").value("005930"))
+                .andExpect(jsonPath("$.data.financial.businessYear").value("2024"))
+                .andExpect(jsonPath("$.data.basic.marketCapInHundredMillionKrw").value(4482340))
+                .andExpect(jsonPath("$.data.indicator.per").value(15.2))
+                .andExpect(jsonPath("$.data.indicator.roe").value(4.35))
+                .andExpect(jsonPath("$.data.dividend.dividendPerShare").value(1444));
+    }
+
+    @Test
+    void 일부_섹션_null_응답() throws Exception {
+        // given — company/dividend 만 성공, 나머지 null
+        DartCompanyInfo company = new DartCompanyInfo("카카오", null, null, "035720",
+                null, null, null, null, null, null, null, null, null);
+        DartDividendInfo dividend = new DartDividendInfo("2024",
+                new BigDecimal("50"), new BigDecimal("0.1"), new BigDecimal("3.2"));
+        StockInfoResponse partial = new StockInfoResponse(company, null, null, null, dividend);
+        given(stockInfoService.getStockInfo("035720")).willReturn(partial);
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/035720/info")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(null, null, List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.company.corpName").value("카카오"))
+                .andExpect(jsonPath("$.data.financial").doesNotExist())
+                .andExpect(jsonPath("$.data.basic").doesNotExist())
+                .andExpect(jsonPath("$.data.indicator").doesNotExist())
+                .andExpect(jsonPath("$.data.dividend.dividendPerShare").value(50));
+    }
+
+    @Test
+    void 존재하지_않는_종목은_404_MARKET_STOCK_NOT_FOUND() throws Exception {
+        // given
+        given(stockInfoService.getStockInfo("999999"))
+                .willThrow(new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/stocks/999999/info")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(null, null, List.of())
+                        )))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("MARKET_STOCK_NOT_FOUND"));
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명

  WEF-415 종목정보 탭의 **마지막 BE PR**. PR#1~#3에서 쌓은 6개 sub-service(corpCode/company/financial/basic/indicator/dividend)를 묶는 **통합 엔드포인트 `GET /api/stocks/{code}/info`**를 추가하고, **시총 상위 20개 종목 스모크 검증**으로 발견한 실제 DART 응답 변형 3건을 해결했습니다.

  - WEF-645: 5개 섹션(company/financial/basic/indicator/dividend)을 composition한 단일 응답
  - 부분 실패 허용(graceful degradation) — 개별 sub-service 실패는 해당 섹션 null로 대체, 종목 미존재만 404 hard fail
  - PR#3 리뷰 코멘트 2건 반영 (빈 list fallback, summary null guard)
  - 실제 DART 응답 변형 3건 해결 (top 20 스모크 기반)
<br>

## ✅ 완료한 기능 명세

###  **WEF-645 통합 엔드포인트**
  - [x] `GET /api/stocks/{code}/info` 엔드포인트 (`StockInfoController`)
  - [x] `StockInfoResponse` — 5 섹션 composition DTO
  - [x] `StockInfoService` — 종목 존재 검증 + 5개 sub-service `safeCall`
    - `BusinessException`만 잡아 섹션 null로 변환 (런타임 버그는 전파해 은폐 방지)
  - [x] 단위 테스트 6건 (정상/404/부분 실패/전체 null/예외 전파)
  - [x] 슬라이스 테스트 3건 (`@WebMvcTest` — 정상/null 필드/404)

###  **PR#3 리뷰 반영**
  - [x] DART 배당·재무제표: 성공 응답이어도 `list` 비어있으면 다음 연도로 fallback
  continue
  - [x] `StockIndicatorService.calculateRoe`: `summary == null` 방어 추가

###  **실제 DART 응답 변형 대응** (top 20 스모크 기반)
  - [x] 배당성향 `(연결)`/`(별도)` 접두어 매칭 → `contains("현금배당성향")` + `stock_knd` 필터 제거
  - [x] `stock_knd` 필드 부재 응답(셀트리온) → 2단계 fallback (명시 보통주 → null stock_knd 첫 매칭)
  - [x] 금융지주 영업이익 → `ifrs-full_ProfitLossFromOperatingActivities` fallback 추가 (제조업 `dart_OperatingIncomeLoss`와 병존)

###  **테스트 회귀 방지**
  - [x] `DartDividendServiceTest` 8 → 11 케이스
  - [x] `DartFinancialServiceTest` 9 → 10 케이스

<br>

## 📸 스크린샷
### **로컬 스모크 (샘플)**

  삼성전자 (005930) — 5 섹션 전부 채워짐:
  company.corpName: 삼성전자(주)
  financial.businessYear: 2025 (N-1 바로 성공)
  financial.currentPeriod.totalAssets: 566,942,110,000,000
  basic.marketCapInHundredMillionKrw: 12,715,656 (= 1,271조 5,656억)
  indicator: per 33.14 / pbr 3.40 / eps 6,564 / roe 10.36
  dividend: 주당 1,668원 / 수익률 1.5% / 성향 25.1%

  셀트리온 (068270) — `stock_knd` null 응답 변형 대응 후 정상:
  dividend: 주당 750원 / 수익률 0.4% / 성향 15.92%

  신한지주 (055550) — 영업이익 IFRS fallback 작동:
  financial.currentPeriod.operatingIncome: 5,000,000,000,000

  존재하지 않는 종목 (999999):
  {"status":404,"code":"MARKET_STOCK_NOT_FOUND","message":"종목을 찾을 수 없습니다."}

  캐시 히트 — 첫 호출 이후 재호출 8ms (5개 sub-service 전부 Caffeine hit).

<br>

## 💭 고민과 해결과정

  - 통합 Service 위치: domain/trading/stock/에 StockInfoService 배치. stock이 종목 도메인의 hub 역할이고, 기존 StockService(Stock entity ops)와 관심사 분리. 
  - 부분 실패 전략: FE에서 "정보 없음"으로 graceful rendering 가능하도록 개별 sub-service 실패는 섹션 null로 수렴. BusinessException만 잡고 RuntimeException은 전파 — 내부 버그는 숨기지 않음. 종목 자체 미존재 (MARKET_STOCK_NOT_FOUND)만 404 hard fail로 경계 유지.
  - Sub-service 순차 호출: 첫 호출 latency = 5×(외부 API 왕복)로 무겁지만, 각 sub-service가 이미 @Cacheable이라 캐시 히트 후엔 ms 단위. 실측 캐시 히트 8ms. 
병렬화(CompletableFuture)는 리팩토링 백로그로 분리.
  - 실제 데이터 검증의 가치: 단위 테스트만으로는 DART가 회사별로 응답 필드 구조를 달리 주는 걸 catch 못함. Top 20 시총 종목 스모크로 3개 실질 버그 발견:
    a. 배당성향 접두어 — 삼성전자 "(연결)현금배당성향(%)" vs 카카오 "현금배당성향(%)"  → exact match 실패 → contains 매칭 + stock_knd 필터 제거
    b. stock_knd 부재 — 셀트리온은 응답 전 row에서 stock_knd 필드 자체 없음 → 보통주 필터 시 전부 null → 2단계 fallback
    c. 금융업 영업이익 — 신한·KB는 dart_OperatingIncomeLoss 없고 ifrs-full_ProfitLossFromOperatingActivities 사용 → fallback 추가
  - 알려진 한계 (이번 PR 스코프 외):
    - 우선주(예: 005935 삼성전자우) — DART가 우선주용 corpCode 미제공. "우선주 → 원주 corpCode 자동 매핑"은 추후 리팩토링 후보
    - 금융업 매출액 — 단일 "매출액" 개념 없음(이자수익·수수료수익 분리). null 허용 유지가 현실적
  - 리팩토링 백로그 누적 (Sprint 6+ 대상):
    - HantuMarketClient.fetchCurrentPrice/fetchStockInfo 중복 endpoint 통합
    - dartRestClient connect vs read timeout 분리 (corpCode.xml 30s / 작은 JSON 5s)
    - 통합 엔드포인트 sub-service 병렬 호출 (첫 호출 latency 개선)
    - DART corpCode 주기 갱신 자동화 (@Scheduled)

<br>

### 🔗 관련 이슈
Closes #258 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 종목의 통합 정보 조회 API 추가: 기업정보, 재무현황, 기본정보, 기술지표, 배당정보를 단일 API로 조회 가능

* **개선사항**
  * 국제회계기준(IFRS) 재무제표 지원으로 재무데이터 추출 범위 확대
  * 배당률 추출 로직 개선으로 다양한 데이터 형식에 안정적으로 대응
  * 주가지표 계산 시 데이터 유효성 검증 강화로 신뢰성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->