### PR TITLE
[WEF-412] 종목 뉴스·공시 조회 엔드포인트

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartDisclosureClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartDisclosureClient.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
 @Slf4j
 @Component
@@ -45,7 +46,7 @@ public class DartDisclosureClient {
                             .build())
                     .retrieve()
                     .body(DartDisclosureApiResponse.class);
-        } catch (Exception e) {
+        } catch (RestClientException e) {
             log.error("DART list.json 호출 실패: type={}", e.getClass().getSimpleName());
             throw new BusinessException(ErrorCode.DART_DISCLOSURE_FETCH_FAILED);
         }

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/DartDisclosureClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/DartDisclosureClient.java
@@ -1,0 +1,58 @@
+package com.solv.wefin.domain.trading.dart.client;
+
+import com.solv.wefin.domain.trading.dart.client.dto.DartDisclosureApiResponse;
+import com.solv.wefin.domain.trading.dart.config.DartProperties;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class DartDisclosureClient {
+
+    private static final String LIST_PATH = "/api/list.json";
+
+    private final RestClient dartRestClient;
+    private final DartProperties dartProperties;
+
+    public DartDisclosureClient(@Qualifier("dartRestClient") RestClient dartRestClient,
+                                DartProperties dartProperties) {
+        this.dartRestClient = dartRestClient;
+        this.dartProperties = dartProperties;
+    }
+
+    /**
+     * 공시 목록 조회.
+     * @param corpCode DART 고유번호
+     * @param bgnDe    조회 시작일 (YYYYMMDD)
+     * @param endDe    조회 종료일 (YYYYMMDD)
+     * @param pageCount 페이지당 건수 (1~100)
+     */
+    public DartDisclosureApiResponse fetch(String corpCode, String bgnDe, String endDe, int pageCount) {
+        DartDisclosureApiResponse body;
+        try {
+            body = dartRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(LIST_PATH)
+                            .queryParam("crtfc_key", dartProperties.getKey())
+                            .queryParam("corp_code", corpCode)
+                            .queryParam("bgn_de", bgnDe)
+                            .queryParam("end_de", endDe)
+                            .queryParam("page_count", pageCount)
+                            .build())
+                    .retrieve()
+                    .body(DartDisclosureApiResponse.class);
+        } catch (Exception e) {
+            log.error("DART list.json 호출 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.DART_DISCLOSURE_FETCH_FAILED);
+        }
+        if (body == null) {
+            log.error("DART list.json 응답 body가 null");
+            throw new BusinessException(ErrorCode.DART_DISCLOSURE_FETCH_FAILED);
+        }
+        return body;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartDisclosureApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/client/dto/DartDisclosureApiResponse.java
@@ -1,0 +1,36 @@
+package com.solv.wefin.domain.trading.dart.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DartDisclosureApiResponse(
+        String status,
+        String message,
+        @JsonProperty("page_no") Integer pageNo,
+        @JsonProperty("page_count") Integer pageCount,
+        @JsonProperty("total_count") Integer totalCount,
+        @JsonProperty("total_page") Integer totalPage,
+        List<Item> list
+) {
+    public boolean isSuccess() {
+        return "000".equals(status);
+    }
+
+    public boolean isNoData() {
+        return "013".equals(status);
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Item(
+            @JsonProperty("rcept_no") String receiptNo,
+            @JsonProperty("report_nm") String reportName,
+            @JsonProperty("rcept_dt") String receiptDate,
+            @JsonProperty("flr_nm") String filerName,
+            @JsonProperty("corp_cls") String corpCls,
+            @JsonProperty("rm") String remark
+    ) {
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartDisclosureInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/dto/DartDisclosureInfo.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.trading.dart.dto;
+
+import com.solv.wefin.domain.trading.dart.client.dto.DartDisclosureApiResponse;
+
+import java.util.List;
+
+public record DartDisclosureInfo(
+        List<Item> items,
+        Integer totalCount
+) {
+    public record Item(
+            String receiptNo,     // 20260413800802
+            String reportName,    // "최대주주등소유주식변동신고서"
+            String receiptDate,   // "20260413" (YYYYMMDD)
+            String filerName,     // "삼성전자"
+            String viewerUrl      // DART 뷰어 URL
+    ) {
+    }
+
+    private static final String DART_VIEWER_URL = "https://dart.fss.or.kr/dsaf001/main.do?rcpNo=";
+
+    public static DartDisclosureInfo from(DartDisclosureApiResponse response) {
+        if (response == null || response.list() == null) {
+            return new DartDisclosureInfo(List.of(), 0);
+        }
+        List<Item> items = response.list().stream()
+                .map(raw -> new Item(
+                        raw.receiptNo(),
+                        raw.reportName() == null ? null : raw.reportName().trim(),
+                        raw.receiptDate(),
+                        raw.filerName(),
+                        raw.receiptNo() != null ? DART_VIEWER_URL + raw.receiptNo() : null
+                ))
+                .toList();
+        return new DartDisclosureInfo(items, response.totalCount());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDisclosureService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDisclosureService.java
@@ -1,0 +1,52 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartDisclosureClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartDisclosureApiResponse;
+import com.solv.wefin.domain.trading.dart.dto.DartDisclosureInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DartDisclosureService {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final DateTimeFormatter DATE_FMT = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final int LOOKBACK_MONTHS = 3;
+    private static final int PAGE_COUNT = 20; // 최근 20건
+
+    private final DartCorpCodeService dartCorpCodeService;
+    private final DartDisclosureClient dartDisclosureClient;
+
+    @Cacheable(cacheNames = "dartDisclosure", key = "#stockCode")
+    public DartDisclosureInfo getDisclosures(String stockCode) {
+        String corpCode = dartCorpCodeService.getCorpCode(stockCode);
+
+        LocalDate today = LocalDate.now(KST);
+        String endDe = today.format(DATE_FMT);
+        String bgnDe = today.minusMonths(LOOKBACK_MONTHS).format(DATE_FMT);
+
+        DartDisclosureApiResponse response =
+                dartDisclosureClient.fetch(corpCode, bgnDe, endDe, PAGE_COUNT);
+
+        if (response.isNoData()) {
+            return new DartDisclosureInfo(java.util.List.of(), 0);
+        }
+        if (!response.isSuccess()) {
+            log.error("DART 공시 에러 응답: status={}, message={}",
+                    response.status(), response.message());
+            throw new BusinessException(ErrorCode.DART_DISCLOSURE_FETCH_FAILED);
+        }
+
+        return DartDisclosureInfo.from(response);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDisclosureService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/dart/service/DartDisclosureService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Slf4j
 @Service
@@ -39,7 +40,7 @@ public class DartDisclosureService {
                 dartDisclosureClient.fetch(corpCode, bgnDe, endDe, PAGE_COUNT);
 
         if (response.isNoData()) {
-            return new DartDisclosureInfo(java.util.List.of(), 0);
+            return new DartDisclosureInfo(List.of(), 0);
         }
         if (!response.isSuccess()) {
             log.error("DART 공시 에러 응답: status={}, message={}",

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/client/WefinNewsClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/client/WefinNewsClient.java
@@ -1,0 +1,46 @@
+package com.solv.wefin.domain.trading.stock.news.client;
+
+import com.solv.wefin.domain.trading.stock.news.client.dto.WefinNewsApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Component
+public class WefinNewsClient {
+
+    private static final String CLUSTERS_PATH = "/api/news/clusters";
+    private static final String TAG_TYPE = "STOCK";
+
+    private final RestClient wefinNewsRestClient;
+
+    public WefinNewsClient(@Qualifier("wefinNewsRestClient") RestClient wefinNewsRestClient) {
+        this.wefinNewsRestClient = wefinNewsRestClient;
+    }
+
+    public WefinNewsApiResponse fetchClusters(String stockCode) {
+        WefinNewsApiResponse body;
+        try {
+            body = wefinNewsRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(CLUSTERS_PATH)
+                            .queryParam("tagType", TAG_TYPE)
+                            .queryParam("tagCodes", stockCode)
+                            .build())
+                    .retrieve()
+                    .body(WefinNewsApiResponse.class);
+        } catch (RestClientException e) {
+            log.error("뉴스팀 API 호출 실패: type={}", e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.STOCK_NEWS_FETCH_FAILED);
+        }
+        if (body == null) {
+            log.error("뉴스팀 API 응답 body가 null");
+            throw new BusinessException(ErrorCode.STOCK_NEWS_FETCH_FAILED);
+        }
+        return body;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/client/dto/WefinNewsApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/client/dto/WefinNewsApiResponse.java
@@ -1,0 +1,44 @@
+package com.solv.wefin.domain.trading.stock.news.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * 뉴스팀 API (dev-api.wefin.ai.kr/api/news/clusters) 응답 원본.
+ * 뉴스팀은 자체 ApiResponse 래핑을 함: { status, code, message, data: { items, hasNext, nextCursor } }
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WefinNewsApiResponse(
+        Integer status,
+        String code,
+        String message,
+        Data data
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Data(
+            List<ClusterItem> items,
+            boolean hasNext,
+            String nextCursor
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ClusterItem(
+            Long clusterId,
+            String title,
+            String summary,
+            String thumbnailUrl,
+            String publishedAt,
+            Integer sourceCount,
+            List<Source> sources
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Source(
+            String publisherName,
+            String url
+    ) {
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/config/WefinNewsProperties.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/config/WefinNewsProperties.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.trading.stock.news.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "wefin-news.api")
+public class WefinNewsProperties {
+
+    private String baseUrl;
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/config/WefinNewsRestClientConfig.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/config/WefinNewsRestClientConfig.java
@@ -1,0 +1,34 @@
+package com.solv.wefin.domain.trading.stock.news.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+
+@Configuration
+@EnableConfigurationProperties(WefinNewsProperties.class)
+@RequiredArgsConstructor
+public class WefinNewsRestClientConfig {
+
+    private final WefinNewsProperties wefinNewsProperties;
+
+    @Bean("wefinNewsRestClient")
+    public RestClient wefinNewsRestClient() {
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+
+        JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+        factory.setReadTimeout(Duration.ofSeconds(10));
+
+        return RestClient.builder()
+                .requestFactory(factory)
+                .baseUrl(wefinNewsProperties.getBaseUrl())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/dto/StockNewsInfo.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/dto/StockNewsInfo.java
@@ -1,0 +1,59 @@
+package com.solv.wefin.domain.trading.stock.news.dto;
+
+import com.solv.wefin.domain.trading.stock.news.client.dto.WefinNewsApiResponse;
+
+import java.util.List;
+
+public record StockNewsInfo(
+        List<Item> items,
+        boolean hasNext,
+        String nextCursor
+) {
+    public record Item(
+            Long clusterId,
+            String title,
+            String summary,
+            String thumbnailUrl,
+            String publishedAt,
+            Integer sourceCount,
+            List<Source> sources
+    ) {
+    }
+
+    public record Source(
+            String publisherName,
+            String url
+    ) {
+    }
+
+    public static StockNewsInfo empty() {
+        return new StockNewsInfo(List.of(), false, null);
+    }
+
+    public static StockNewsInfo from(WefinNewsApiResponse.Data data) {
+        if (data == null) return empty();
+        List<Item> items = data.items() == null
+                ? List.of()
+                : data.items().stream()
+                        .map(StockNewsInfo::mapItem)
+                        .toList();
+        return new StockNewsInfo(items, data.hasNext(), data.nextCursor());
+    }
+
+    private static Item mapItem(WefinNewsApiResponse.ClusterItem c) {
+        List<Source> sources = c.sources() == null
+                ? List.of()
+                : c.sources().stream()
+                        .map(s -> new Source(s.publisherName(), s.url()))
+                        .toList();
+        return new Item(
+                c.clusterId(),
+                c.title(),
+                c.summary(),
+                c.thumbnailUrl(),
+                c.publishedAt(),
+                c.sourceCount(),
+                sources
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsService.java
@@ -24,8 +24,9 @@ public class StockNewsService {
         }
 
         WefinNewsApiResponse response = wefinNewsClient.fetchClusters(stockCode);
-        // 뉴스팀 응답의 status는 Integer HTTP 코드. 200 이외엔 실패.
-        if (response.status() != null && response.status() != 200) {
+        // 뉴스팀 응답의 status는 Integer HTTP 코드. 200만 성공, null·그 외는 실패로 처리.
+        // (null을 성공으로 두면 stockNews 캐시에 빈 값이 저장되어 재조회 시 stale 반환)
+        if (response.status() == null || response.status() != 200) {
             throw new BusinessException(ErrorCode.STOCK_NEWS_FETCH_FAILED);
         }
         return StockNewsInfo.from(response.data());

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsService.java
@@ -1,0 +1,33 @@
+package com.solv.wefin.domain.trading.stock.news.service;
+
+import com.solv.wefin.domain.trading.stock.news.client.WefinNewsClient;
+import com.solv.wefin.domain.trading.stock.news.client.dto.WefinNewsApiResponse;
+import com.solv.wefin.domain.trading.stock.news.dto.StockNewsInfo;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockNewsService {
+
+    private final StockService stockService;
+    private final WefinNewsClient wefinNewsClient;
+
+    @Cacheable(cacheNames = "stockNews", key = "#stockCode")
+    public StockNewsInfo getNews(String stockCode) {
+        if (!stockService.existsByCode(stockCode)) {
+            throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
+        }
+
+        WefinNewsApiResponse response = wefinNewsClient.fetchClusters(stockCode);
+        // 뉴스팀 응답의 status는 Integer HTTP 코드. 200 이외엔 실패.
+        if (response.status() != null && response.status() != 200) {
+            throw new BusinessException(ErrorCode.STOCK_NEWS_FETCH_FAILED);
+        }
+        return StockNewsInfo.from(response.data());
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsService.java
@@ -17,7 +17,7 @@ public class StockNewsService {
     private final StockService stockService;
     private final WefinNewsClient wefinNewsClient;
 
-    @Cacheable(cacheNames = "stockNews", key = "#stockCode")
+    @Cacheable(cacheNames = "stockNews", key = "#stockCode", unless = "#result.items().isEmpty()")
     public StockNewsInfo getNews(String stockCode) {
         if (!stockService.existsByCode(stockCode)) {
             throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -52,6 +52,16 @@ public class CacheConfig {
                 .maximumSize(5000)
                 .build());
 
+        manager.registerCustomCache("dartDisclosure", Caffeine.newBuilder()
+                .expireAfterWrite(30, TimeUnit.MINUTES)
+                .maximumSize(5000)
+                .build());
+
+        manager.registerCustomCache("stockNews", Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(5000)
+                .build());
+
         return manager;
     }
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -197,7 +197,11 @@ public enum ErrorCode {
     DART_FINANCIAL_NOT_FOUND(404, "DART 재무제표가 존재하지 않습니다."),
     DART_FINANCIAL_FETCH_FAILED(503, "DART 재무제표 조회에 실패했습니다."),
     DART_DIVIDEND_NOT_FOUND(404, "DART 배당 정보가 존재하지 않습니다."),
-    DART_DIVIDEND_FETCH_FAILED(503, "DART 배당 정보 조회에 실패했습니다.");
+    DART_DIVIDEND_FETCH_FAILED(503, "DART 배당 정보 조회에 실패했습니다."),
+    DART_DISCLOSURE_FETCH_FAILED(503, "DART 공시 조회에 실패했습니다."),
+
+    // Stock News
+    STOCK_NEWS_FETCH_FAILED(503, "종목 뉴스 조회에 실패했습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/com/solv/wefin/web/trading/stock/StockNewsDisclosureController.java
+++ b/src/main/java/com/solv/wefin/web/trading/stock/StockNewsDisclosureController.java
@@ -1,0 +1,31 @@
+package com.solv.wefin.web.trading.stock;
+
+import com.solv.wefin.domain.trading.dart.dto.DartDisclosureInfo;
+import com.solv.wefin.domain.trading.dart.service.DartDisclosureService;
+import com.solv.wefin.domain.trading.stock.news.dto.StockNewsInfo;
+import com.solv.wefin.domain.trading.stock.news.service.StockNewsService;
+import com.solv.wefin.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stocks")
+@RequiredArgsConstructor
+public class StockNewsDisclosureController {
+
+    private final StockNewsService stockNewsService;
+    private final DartDisclosureService dartDisclosureService;
+
+    @GetMapping("/{code}/news")
+    public ApiResponse<StockNewsInfo> getNews(@PathVariable String code) {
+        return ApiResponse.success(stockNewsService.getNews(code));
+    }
+
+    @GetMapping("/{code}/disclosures")
+    public ApiResponse<DartDisclosureInfo> getDisclosures(@PathVariable String code) {
+        return ApiResponse.success(dartDisclosureService.getDisclosures(code));
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -74,6 +74,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+wefin-news:
+  api:
+    base-url: ${WEFIN_NEWS_BASE_URL:https://dev-api.wefin.ai.kr}
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -86,6 +86,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:-}
 
+wefin-news:
+  api:
+    base-url: https://dev-api.wefin.ai.kr
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -71,6 +71,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+wefin-news:
+  api:
+    base-url: ${WEFIN_NEWS_BASE_URL:https://wefin.ai.kr}
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/test/java/com/solv/wefin/domain/trading/dart/service/DartDisclosureServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/dart/service/DartDisclosureServiceTest.java
@@ -1,0 +1,119 @@
+package com.solv.wefin.domain.trading.dart.service;
+
+import com.solv.wefin.domain.trading.dart.client.DartDisclosureClient;
+import com.solv.wefin.domain.trading.dart.client.dto.DartDisclosureApiResponse;
+import com.solv.wefin.domain.trading.dart.dto.DartDisclosureInfo;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class DartDisclosureServiceTest {
+
+    @Mock
+    private DartCorpCodeService dartCorpCodeService;
+
+    @Mock
+    private DartDisclosureClient dartDisclosureClient;
+
+    @InjectMocks
+    private DartDisclosureService dartDisclosureService;
+
+    private DartDisclosureApiResponse successResponse() {
+        return new DartDisclosureApiResponse("000", "정상", 1, 20, 2, 1, List.of(
+                new DartDisclosureApiResponse.Item(
+                        "20260413800802",
+                        "최대주주등소유주식변동신고서              ",
+                        "20260413",
+                        "삼성전자",
+                        "Y",
+                        "유"
+                ),
+                new DartDisclosureApiResponse.Item(
+                        "20260413002934",
+                        "주식등의대량보유상황보고서(일반)",
+                        "20260413",
+                        "삼성물산",
+                        "Y",
+                        null
+                )
+        ));
+    }
+
+    @Test
+    void 공시_정상조회_items_매핑_및_viewer_url_생성() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartDisclosureClient.fetch(eq("00126380"), anyString(), anyString(), anyInt()))
+                .willReturn(successResponse());
+
+        // when
+        DartDisclosureInfo result = dartDisclosureService.getDisclosures("005930");
+
+        // then
+        assertThat(result.items()).hasSize(2);
+        assertThat(result.items().get(0).receiptNo()).isEqualTo("20260413800802");
+        // trim 확인
+        assertThat(result.items().get(0).reportName()).isEqualTo("최대주주등소유주식변동신고서");
+        assertThat(result.items().get(0).viewerUrl())
+                .isEqualTo("https://dart.fss.or.kr/dsaf001/main.do?rcpNo=20260413800802");
+        assertThat(result.totalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void status_013이면_빈_리스트_반환() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartDisclosureClient.fetch(eq("00126380"), anyString(), anyString(), anyInt()))
+                .willReturn(new DartDisclosureApiResponse("013", "조회된 데이타가 없습니다.",
+                        null, null, 0, 0, null));
+
+        // when
+        DartDisclosureInfo result = dartDisclosureService.getDisclosures("005930");
+
+        // then
+        assertThat(result.items()).isEmpty();
+        assertThat(result.totalCount()).isEqualTo(0);
+    }
+
+    @Test
+    void status가_000도_013도_아니면_FETCH_FAILED() {
+        // given
+        given(dartCorpCodeService.getCorpCode("005930")).willReturn("00126380");
+        given(dartDisclosureClient.fetch(eq("00126380"), anyString(), anyString(), anyInt()))
+                .willReturn(new DartDisclosureApiResponse("020", "요청 제한 초과",
+                        null, null, 0, 0, null));
+
+        // when & then
+        assertThatThrownBy(() -> dartDisclosureService.getDisclosures("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_DISCLOSURE_FETCH_FAILED);
+    }
+
+    @Test
+    void corpCode_미존재시_예외_전파() {
+        // given
+        given(dartCorpCodeService.getCorpCode("999999"))
+                .willThrow(new BusinessException(ErrorCode.DART_CORP_CODE_NOT_FOUND));
+
+        // when & then
+        assertThatThrownBy(() -> dartDisclosureService.getDisclosures("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.DART_CORP_CODE_NOT_FOUND);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsServiceTest.java
@@ -90,8 +90,22 @@ class StockNewsServiceTest {
     }
 
     @Test
-    void 뉴스팀_data가_null이면_empty_반환() {
-        // given
+    void 뉴스팀_응답_status가_null이면_FETCH_FAILED() {
+        // given — 뉴스팀이 status 필드 누락/결측 시 성공 경로로 흘러가지 않도록
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(wefinNewsClient.fetchClusters("005930"))
+                .willReturn(new WefinNewsApiResponse(null, null, null, null));
+
+        // when & then
+        assertThatThrownBy(() -> stockNewsService.getNews("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.STOCK_NEWS_FETCH_FAILED);
+    }
+
+    @Test
+    void 정상응답이고_data가_null이면_empty_반환() {
+        // given — status=200 성공이지만 검색 결과 없음(data=null) 시나리오는 empty로 허용
         given(stockService.existsByCode("005930")).willReturn(true);
         given(wefinNewsClient.fetchClusters("005930"))
                 .willReturn(new WefinNewsApiResponse(200, null, null, null));

--- a/src/test/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/stock/news/service/StockNewsServiceTest.java
@@ -1,0 +1,106 @@
+package com.solv.wefin.domain.trading.stock.news.service;
+
+import com.solv.wefin.domain.trading.stock.news.client.WefinNewsClient;
+import com.solv.wefin.domain.trading.stock.news.client.dto.WefinNewsApiResponse;
+import com.solv.wefin.domain.trading.stock.news.dto.StockNewsInfo;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StockNewsServiceTest {
+
+    @Mock
+    private StockService stockService;
+
+    @Mock
+    private WefinNewsClient wefinNewsClient;
+
+    @InjectMocks
+    private StockNewsService stockNewsService;
+
+    private WefinNewsApiResponse successResponse() {
+        return new WefinNewsApiResponse(200, null, null,
+                new WefinNewsApiResponse.Data(
+                        List.of(
+                                new WefinNewsApiResponse.ClusterItem(
+                                        1186L, "서민금융 재원 확대", "요약",
+                                        "https://example.com/thumb.jpg",
+                                        "2026-04-15T11:04:00Z", 24,
+                                        List.of(
+                                                new WefinNewsApiResponse.Source("dailian.co.kr",
+                                                        "https://example.com/news/1"))
+                                )
+                        ),
+                        false, null));
+    }
+
+    @Test
+    void 뉴스_정상조회_items_매핑() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(wefinNewsClient.fetchClusters("005930")).willReturn(successResponse());
+
+        // when
+        StockNewsInfo result = stockNewsService.getNews("005930");
+
+        // then
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).clusterId()).isEqualTo(1186L);
+        assertThat(result.items().get(0).title()).isEqualTo("서민금융 재원 확대");
+        assertThat(result.items().get(0).sources()).hasSize(1);
+        assertThat(result.hasNext()).isFalse();
+    }
+
+    @Test
+    void 존재하지_않는_종목은_MARKET_STOCK_NOT_FOUND() {
+        // given
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> stockNewsService.getNews("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+    @Test
+    void 뉴스팀_응답_status가_200이_아니면_FETCH_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(wefinNewsClient.fetchClusters("005930"))
+                .willReturn(new WefinNewsApiResponse(500, "SERVER_ERROR", "internal error", null));
+
+        // when & then
+        assertThatThrownBy(() -> stockNewsService.getNews("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.STOCK_NEWS_FETCH_FAILED);
+    }
+
+    @Test
+    void 뉴스팀_data가_null이면_empty_반환() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(wefinNewsClient.fetchClusters("005930"))
+                .willReturn(new WefinNewsApiResponse(200, null, null, null));
+
+        // when
+        StockNewsInfo result = stockNewsService.getNews("005930");
+
+        // then
+        assertThat(result.items()).isEmpty();
+        assertThat(result.hasNext()).isFalse();
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
종목 상세 "뉴스·공시" 탭을 위한 백엔드 엔드포인트 2종을 구현했습니다.
- **WEF-413/414**: 뉴스팀 API 프록시 `GET /api/stocks/{code}/news`
- **WEF-648**: DART `/api/list.json` 공시 조회 `GET /api/stocks/{code}/disclosures`

<br>

## ✅ 완료한 기능 명세

### **WEF-413/414 — 뉴스**
- [x] 환경별 base URL 분리 (local / dev / prod)
  - local: `https://dev-api.wefin.ai.kr` 하드코딩
  - dev: `${WEFIN_NEWS_BASE_URL:https://dev-api.wefin.ai.kr}`
  - prod: `${WEFIN_NEWS_BASE_URL:https://wefin.ai.kr}`
- [x] `WefinNewsApiResponse` + `StockNewsInfo` 도메인 DTO
- [x] `WefinNewsClient` — `tagType=STOCK&tagCodes={code}` 호출
- [x] `StockNewsService` — 종목 존재 검증 + 뉴스팀 status 분기 + `@Cacheable("stockNews", TTL 10분)`
- [x] `ErrorCode.STOCK_NEWS_FETCH_FAILED`

### **WEF-648 — 공시**
- [x] `DartDisclosureApiResponse` + `DartDisclosureInfo` (`reportName.trim()` + viewerUrl 서버 조립)
- [x] `DartDisclosureClient` — `/api/list.json?corp_code=...&bgn_de=...&end_de=...`
- [x] `DartDisclosureService` — corpCode 조회 + 최근 3개월 + 상위 20건 + `@Cacheable("dartDisclosure", TTL 30분)`
- [x] `ErrorCode.DART_DISCLOSURE_FETCH_FAILED`

### **공통**
- [x] `StockNewsDisclosureController` — 엔드포인트 2개
- [x] 단위 테스트 8건 (News 4 + Disclosure 4)
<br>

## 🧪 로컬 스모크 결과:

GET /api/stocks/005930/news
→ 200, items 7건 (clusterId/title/publishedAt/sources 매핑 정상)

GET /api/stocks/005930/disclosures
→ 200, totalCount 1,861 / items 20 (reportName trim, viewerUrl 생성)

GET /api/stocks/999999/news
→ 404 MARKET_STOCK_NOT_FOUND

GET /api/stocks/122630/disclosures (ETF)
→ 404 DART_CORP_CODE_NOT_FOUND (우선주/ETF는 DART corpCode 없음)

캐시 재호출: 7~10ms
<br>

## 💭 고민과 해결과정

 - **환경별 base URL 분리**: dev/prod URL 다름(`dev-api.wefin.ai.kr` vs `wefin.ai.kr`). 초기엔 `application.yml`에 `${WEFIN_NEWS_BASE_URL:https://dev-api.wefin.ai.kr}` 하드 fallback 방식이었으나 **운영에서 env var 누락 시 dev URL 호출 사고 리스크**.
  `application-{profile}.yml` 분리로 각 환경 고유 기본값 명시 + `application.yml` 공통 섹션에서
  제거.

  - **Controller 통합 vs 분리**: 엔드포인트 2개가 같은 "뉴스·공시" 탭에서 병렬 호출되고 경로 prefix(`/api/stocks/{code}/...`)도 같아 `StockNewsDisclosureController` 하나로 통합.

  - **공시 조회 범위 고정**: DART list.json은 `bgn_de`/`end_de` 필수. 탭 UX상 최신 공시만 필요해 **최근 3개월 + 상위 20건** 서버 고정. 기간/페이징 파라미터 노출 않음 — 필요 시 다음 이터레이션에서 확장.

  - **공시 `viewerUrl` 서버 조립**: DART list 응답에 원문 링크 필드 없음. `rcept_no`를 `https://dart.fss.or.kr/dsaf001/main.do?rcpNo={no}` 패턴으로 서버에서 조립해 FE 편의 확보.

  - **뉴스 응답 언래핑**: 뉴스팀 API가 이미 `ApiResponse` 구조(`status/code/message/data`)로 응답. BE가 또 `ApiResponse`로 감싸면 이중 래핑 → `StockNewsInfo.from(data)`로 내부 필드만 추출.

  - **종목 존재 검증 위치**: 뉴스는 `stockCode` 직접 사용이라 `StockService.existsByCode`로 조기 404. 공시는`DartCorpCodeService.getCorpCode()`가 이미 `DART_CORP_CODE_NOT_FOUND` 던져 중복 검증 불필요.

<br>

### 🔗 관련 이슈
Closes #270 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 종목별 DART 공시 조회 API 및 종목 뉴스 클러스터 조회 API 추가
  * 공시·뉴스를 위한 REST 클라이언트 및 변환 DTO/응답 모델 추가
  * 공개된 두 엔드포인트로 공시 및 뉴스 조회 제공

* **성능**
  * 조회 결과 캐싱 추가 (DART 공시 30분, 뉴스 10분)

* **테스트**
  * DART 공시 및 뉴스 서비스에 대한 단위 테스트 추가

* **오류/설정**
  * 관련 오류 코드 및 외부 뉴스 API 설정 추가 (환경변수 기반)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->