### PR TITLE
[WEF-641] 투자자 매매동향 조회

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/HantuMarketClient.java
@@ -153,6 +153,26 @@ public class HantuMarketClient {
     }
 
     /**
+     * 종목별 투자자(외국인/기관/개인) 일별 순매수 동향을 조회합니다.
+     * 최근 약 30영업일 데이터가 리스트로 반환됩니다 (최신일 앞).
+     * @param stockCode 종목코드
+     */
+    public HantuInvestorTrendApiResponse fetchInvestorTrend(String stockCode) {
+        return hantuRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/uapi/domestic-stock/v1/quotations/inquire-investor")
+                        .queryParam("FID_COND_MRKT_DIV_CODE", "J")
+                        .queryParam("FID_INPUT_ISCD", stockCode)
+                        .build())
+                .header("authorization", "Bearer " + hantuTokenManager.getAccessToken())
+                .header("appkey", appKey)
+                .header("appsecret", appSecret)
+                .header("tr_id", "FHKST01010900")
+                .header("custtype", "P")
+                .retrieve().body(HantuInvestorTrendApiResponse.class);
+    }
+
+    /**
      * 국내 주식 거래량 순위를 조회
      */
     public HantuRankingApiResponse fetchVolumeRanking() {

--- a/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuInvestorTrendApiResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/client/dto/HantuInvestorTrendApiResponse.java
@@ -1,0 +1,24 @@
+package com.solv.wefin.domain.trading.market.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+/**
+ * 한투 Open API /uapi/domestic-stock/v1/quotations/inquire-investor (TR_ID: FHKST01010900) 응답.
+ * 종목별 투자자(외국인/기관/개인) 일별 순매수 수량을 반환한다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record HantuInvestorTrendApiResponse(List<Output> output) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Output(
+            String stck_bsop_date,   // 주식영업일자 (YYYYMMDD)
+            String stck_clpr,        // 주식종가
+            String prdy_vrss,        // 전일대비
+            String prdy_vrss_sign,   // 전일대비 부호 (1:상한,2:상승,3:보합,4:하한,5:하락)
+            String prsn_ntby_qty,    // 개인순매수수량
+            String frgn_ntby_qty,    // 외국인순매수수량
+            String orgn_ntby_qty     // 기관계순매수수량
+    ) {}
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/dto/InvestorTrendResponse.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/dto/InvestorTrendResponse.java
@@ -1,0 +1,62 @@
+package com.solv.wefin.domain.trading.market.dto;
+
+import com.solv.wefin.domain.trading.market.client.dto.HantuInvestorTrendApiResponse;
+import com.solv.wefin.global.util.ParseUtils;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+/**
+ * 종목 투자자별(외국인/기관/개인) 일별 순매수 동향.
+ * 음수면 순매도. 최신일자가 리스트 앞쪽.
+ */
+public record InvestorTrendResponse(
+        String stockCode,
+        List<Item> items
+) {
+    public record Item(
+            LocalDate date,
+            long closePrice,
+            long priceChange,
+            long foreignNetBuy,
+            long institutionNetBuy,
+            long individualNetBuy
+    ) {}
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    public static InvestorTrendResponse from(String stockCode, HantuInvestorTrendApiResponse response) {
+        List<HantuInvestorTrendApiResponse.Output> raw =
+                response == null || response.output() == null ? List.of() : response.output();
+        List<Item> items = raw.stream()
+                .map(InvestorTrendResponse::toItem)
+                .toList();
+        return new InvestorTrendResponse(stockCode, items);
+    }
+
+    private static Item toItem(HantuInvestorTrendApiResponse.Output o) {
+        return new Item(
+                parseDate(o.stck_bsop_date()),
+                ParseUtils.parseLong(o.stck_clpr()),
+                applySign(o.prdy_vrss(), o.prdy_vrss_sign()),
+                ParseUtils.parseLong(o.frgn_ntby_qty()),
+                ParseUtils.parseLong(o.orgn_ntby_qty()),
+                ParseUtils.parseLong(o.prsn_ntby_qty())
+        );
+    }
+
+    private static LocalDate parseDate(String raw) {
+        if (raw == null || raw.isBlank()) return null;
+        return LocalDate.parse(raw, DATE_FORMAT);
+    }
+
+    /**
+     * 한투 전일대비는 절댓값, 부호는 prdy_vrss_sign(1:상한/2:상승=+, 4:하한/5:하락=-, 3:보합=0)으로 내려온다.
+     */
+    private static long applySign(String rawAbs, String sign) {
+        long abs = ParseUtils.parseLong(rawAbs);
+        if (abs == 0 || sign == null) return abs;
+        return ("4".equals(sign) || "5".equals(sign)) ? -abs : abs;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/InvestorTrendService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/InvestorTrendService.java
@@ -1,0 +1,43 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuInvestorTrendApiResponse;
+import com.solv.wefin.domain.trading.market.dto.InvestorTrendResponse;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InvestorTrendService {
+
+    private final StockService stockService;
+    private final HantuMarketClient hantuMarketClient;
+
+    @Cacheable(cacheNames = "investorTrend", key = "#stockCode")
+    public InvestorTrendResponse getInvestorTrend(String stockCode) {
+        if (!stockService.existsByCode(stockCode)) {
+            throw new BusinessException(ErrorCode.MARKET_STOCK_NOT_FOUND);
+        }
+
+        HantuInvestorTrendApiResponse response;
+        try {
+            response = hantuMarketClient.fetchInvestorTrend(stockCode);
+        } catch (RestClientException e) {
+            log.error("한투 투자자 매매동향 조회 실패: stockCode={}, type={}",
+                    stockCode, e.getClass().getSimpleName());
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+
+        if (response == null) {
+            throw new BusinessException(ErrorCode.MARKET_API_FAILED);
+        }
+        return InvestorTrendResponse.from(stockCode, response);
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -53,7 +53,7 @@ public class CacheConfig {
                 .build());
 
         manager.registerCustomCache("investorTrend", Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .expireAfterWrite(1, TimeUnit.HOURS)
                 .maximumSize(5000)
                 .build());
 

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -52,6 +52,11 @@ public class CacheConfig {
                 .maximumSize(5000)
                 .build());
 
+        manager.registerCustomCache("investorTrend", Caffeine.newBuilder()
+                .expireAfterWrite(10, TimeUnit.MINUTES)
+                .maximumSize(5000)
+                .build());
+
         return manager;
     }
 }

--- a/src/main/java/com/solv/wefin/global/config/CacheConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/CacheConfig.java
@@ -54,6 +54,9 @@ public class CacheConfig {
 
         manager.registerCustomCache("investorTrend", Caffeine.newBuilder()
                 .expireAfterWrite(1, TimeUnit.HOURS)
+                .maximumSize(5000)
+                .build());
+
         manager.registerCustomCache("dartDisclosure", Caffeine.newBuilder()
                 .expireAfterWrite(30, TimeUnit.MINUTES)
                 .maximumSize(5000)

--- a/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
+++ b/src/main/java/com/solv/wefin/web/trading/market/MarketController.java
@@ -4,9 +4,11 @@ import com.solv.wefin.domain.trading.market.client.dto.RankingType;
 import com.solv.wefin.domain.trading.market.client.dto.StockRankingItem;
 import com.solv.wefin.domain.trading.market.client.dto.StockRankingResponse;
 import com.solv.wefin.domain.trading.market.dto.CandleResponse;
+import com.solv.wefin.domain.trading.market.dto.InvestorTrendResponse;
 import com.solv.wefin.domain.trading.market.dto.OrderbookResponse;
 import com.solv.wefin.domain.trading.market.dto.PriceResponse;
 import com.solv.wefin.domain.trading.market.dto.RecentTradeResponse;
+import com.solv.wefin.domain.trading.market.service.InvestorTrendService;
 import com.solv.wefin.domain.trading.market.service.MarketService;
 import com.solv.wefin.domain.trading.stock.dto.StockSearchResponse;
 import com.solv.wefin.domain.trading.stock.service.StockService;
@@ -30,6 +32,7 @@ public class MarketController {
 
     private final MarketService marketService;
     private final StockService stockService;
+    private final InvestorTrendService investorTrendService;
 
     @GetMapping("/{code}/price")
     public ApiResponse<PriceResponse> getPrice(@PathVariable String code) {
@@ -60,6 +63,11 @@ public class MarketController {
     @GetMapping("/{code}/trades/recent")
     public ApiResponse<List<RecentTradeResponse>> getRecentTrades(@PathVariable String code) {
         return ApiResponse.success(marketService.getRecentTrades(code));
+    }
+
+    @GetMapping("/{code}/investor-trend")
+    public ApiResponse<InvestorTrendResponse> getInvestorTrend(@PathVariable String code) {
+        return ApiResponse.success(investorTrendService.getInvestorTrend(code));
     }
 
     @GetMapping("/ranking")

--- a/src/test/java/com/solv/wefin/domain/trading/market/service/InvestorTrendServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/trading/market/service/InvestorTrendServiceTest.java
@@ -1,0 +1,139 @@
+package com.solv.wefin.domain.trading.market.service;
+
+import com.solv.wefin.domain.trading.market.client.HantuMarketClient;
+import com.solv.wefin.domain.trading.market.client.dto.HantuInvestorTrendApiResponse;
+import com.solv.wefin.domain.trading.market.dto.InvestorTrendResponse;
+import com.solv.wefin.domain.trading.stock.service.StockService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClientException;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class InvestorTrendServiceTest {
+
+    @Mock
+    private StockService stockService;
+
+    @Mock
+    private HantuMarketClient hantuMarketClient;
+
+    @InjectMocks
+    private InvestorTrendService investorTrendService;
+
+    private HantuInvestorTrendApiResponse response(HantuInvestorTrendApiResponse.Output... outputs) {
+        return new HantuInvestorTrendApiResponse(List.of(outputs));
+    }
+
+    @Test
+    void 정상조회_일자별_순매수_매핑() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchInvestorTrend("005930"))
+                .willReturn(response(
+                        new HantuInvestorTrendApiResponse.Output(
+                                "20260417", "74500", "500", "2",
+                                "-120000", "85000", "35000"),
+                        new HantuInvestorTrendApiResponse.Output(
+                                "20260416", "74000", "1200", "5",
+                                "50000", "-30000", "-20000")
+                ));
+
+        // when
+        InvestorTrendResponse result = investorTrendService.getInvestorTrend("005930");
+
+        // then
+        assertThat(result.stockCode()).isEqualTo("005930");
+        assertThat(result.items()).hasSize(2);
+
+        InvestorTrendResponse.Item first = result.items().get(0);
+        assertThat(first.date()).isEqualTo(LocalDate.of(2026, 4, 17));
+        assertThat(first.closePrice()).isEqualTo(74500L);
+        assertThat(first.priceChange()).isEqualTo(500L); // sign=2(상승) → +
+        assertThat(first.foreignNetBuy()).isEqualTo(85000L);
+        assertThat(first.institutionNetBuy()).isEqualTo(35000L);
+        assertThat(first.individualNetBuy()).isEqualTo(-120000L);
+
+        InvestorTrendResponse.Item second = result.items().get(1);
+        assertThat(second.priceChange()).isEqualTo(-1200L); // sign=5(하락) → -
+    }
+
+    @Test
+    void 존재하지_않는_종목은_MARKET_STOCK_NOT_FOUND() {
+        // given
+        given(stockService.existsByCode("999999")).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> investorTrendService.getInvestorTrend("999999"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_STOCK_NOT_FOUND);
+    }
+
+    @Test
+    void 한투_RestClient_예외시_MARKET_API_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchInvestorTrend("005930"))
+                .willThrow(new RestClientException("network"));
+
+        // when & then
+        assertThatThrownBy(() -> investorTrendService.getInvestorTrend("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void 응답이_null이면_MARKET_API_FAILED() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchInvestorTrend("005930")).willReturn(null);
+
+        // when & then
+        assertThatThrownBy(() -> investorTrendService.getInvestorTrend("005930"))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.MARKET_API_FAILED);
+    }
+
+    @Test
+    void output이_null이면_빈_리스트_반환() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchInvestorTrend("005930"))
+                .willReturn(new HantuInvestorTrendApiResponse(null));
+
+        // when
+        InvestorTrendResponse result = investorTrendService.getInvestorTrend("005930");
+
+        // then
+        assertThat(result.items()).isEmpty();
+    }
+
+    @Test
+    void 전일대비_0이면_부호_무시하고_0() {
+        // given
+        given(stockService.existsByCode("005930")).willReturn(true);
+        given(hantuMarketClient.fetchInvestorTrend("005930"))
+                .willReturn(response(new HantuInvestorTrendApiResponse.Output(
+                        "20260417", "74500", "0", "3", "0", "0", "0")));
+
+        // when
+        InvestorTrendResponse result = investorTrendService.getInvestorTrend("005930");
+
+        // then
+        assertThat(result.items().get(0).priceChange()).isZero();
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
  종목 상세 페이지의 "개인·외국인·기관" 영역에 표시할 일별 투자자 매매동향 조회 API를 구현했습니다.
  한투 Open API `FHKST01010900` (종목별 투자자)를 호출해 최근 영업일의 외국인/기관/개인 순매수 수량을 내려줍니다.
<br>

## ✅ 완료한 기능 명세
- [x] `GET /api/stocks/{code}/investor-trend` 엔드포인트
- [x] `HantuMarketClient.fetchInvestorTrend` — KIS TR_ID `FHKST01010900`
- [x] `InvestorTrendService` — `StockService.existsByCode` 선검증, `RestClientException` → `MARKET_API_FAILED`
- [x] 응답 매핑: 전일대비는 절댓값 + `prdy_vrss_sign`(4/5=하락)으로 부호 복원
- [x] Caffeine 캐시 `investorTrend` 10분 TTL 등록
- [x] `InvestorTrendService` 단위 테스트 6건 (정상/미존재종목/RestClient예외/null응답/output null/전일대비 0)


<br>

## 📸 스크린샷
  해당 없음 (API 추가)

<br>

## 💭 고민과 해결과정
  - KIS 응답의 `prdy_vrss`는 절댓값으로만 내려오고 부호는 별도 필드(`prdy_vrss_sign`). 1/2=상승,
  3=보합, 4/5=하락 규칙으로 long 값을 복원했다.

  - 캐시 TTL은 `stockBasicInfo`·`stockIndicator`와 동일한 10분. 투자자 매매동향은 장 마감 후에만 의미 있는 변화가 생기므로 과하게 짧을 필요 없음.

  - 다른 market 서비스와 동일하게 `MARKET_STOCK_NOT_FOUND` / `MARKET_API_FAILED` 에러코드 사용 — 신규 코드 추가는 불필요.

<br>

### 🔗 관련 이슈
Closes #257

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 투자자 동향 조회 기능 추가: 특정 종목의 투자자별(개인, 외국인, 기관) 순매수량, 종가, 가격 변동 정보 조회 가능
* 조회 성능 향상을 위한 캐싱 메커니즘 적용

## 테스트
* 투자자 동향 서비스 및 데이터 변환 로직 단위 테스트 추가 (정상 조회, 에러 처리, 엣지 케이스 포함)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->