### PR TITLE
[WEF-663] 게임차트, ai 분석, 자산 변동 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/news/repository/BriefingCacheRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/repository/BriefingCacheRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -14,6 +15,8 @@ import java.util.UUID;
 public interface BriefingCacheRepository extends JpaRepository<BriefingCache, UUID> {
 
     Optional<BriefingCache> findByTargetDate(LocalDate targetDate);
+
+    List<BriefingCache> findByTargetDateIn(Collection<LocalDate> targetDates);
 
     @Query("SELECT bc.targetDate " +
             "FROM BriefingCache bc " +

--- a/src/main/java/com/solv/wefin/domain/game/news/scheduler/NewsBatchScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/scheduler/NewsBatchScheduler.java
@@ -20,7 +20,7 @@ public class NewsBatchScheduler {
      * 약 3일이면 전체 기간(2020~2024, 1,825일) 완료.
      * 수집 완료 후에는 이미 처리된 날짜를 건너뛰므로 추가 부하 없음.
      */
-    @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 43 4 * * *", zone = "Asia/Seoul")
     public void collectMorning() {
         runBatch("04:00");
     }
@@ -30,7 +30,7 @@ public class NewsBatchScheduler {
         runBatch("12:00");
     }
 
-    @Scheduled(cron = "0 0 19 * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Seoul")
     public void collectEvening() {
         runBatch("19:00");
     }

--- a/src/main/java/com/solv/wefin/domain/game/openai/OpenAiAnalysisReportClient.java
+++ b/src/main/java/com/solv/wefin/domain/game/openai/OpenAiAnalysisReportClient.java
@@ -1,0 +1,202 @@
+package com.solv.wefin.domain.game.openai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+public class OpenAiAnalysisReportClient {
+
+    private final RestClient restClient;
+    private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper;
+
+    public OpenAiAnalysisReportClient(
+            @Qualifier("openAiRestClient") RestClient restClient,
+            OpenAiProperties properties,
+            ObjectMapper objectMapper) {
+        this.restClient = restClient;
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    public AnalysisParts generateReport(AnalysisContext context) {
+        String userPrompt = buildPrompt(context);
+
+        log.info("[분석리포트] OpenAI 호출 시작: 기간={}~{}, 턴 {}건",
+                context.startDate(), context.endDate(), context.dailyContexts().size());
+
+        OpenAiProperties.Report reportProps = properties.getReport();
+        ChatRequest request = new ChatRequest(
+                reportProps.getModel(),
+                List.of(
+                        new ChatRequest.Message("system", SYSTEM_PROMPT),
+                        new ChatRequest.Message("user", userPrompt)
+                ),
+                reportProps.getMaxTokens(),
+                reportProps.getTemperature(),
+                new ChatRequest.ResponseFormat("json_object")
+        );
+
+        ChatResponse response;
+        try {
+            response = restClient.post()
+                    .uri("/v1/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(ChatResponse.class);
+        } catch (RestClientException e) {
+            log.error("[분석리포트] OpenAI 호출 실패: {}", e.getMessage());
+            throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
+        }
+
+        if (response == null || response.choices() == null || response.choices().isEmpty()) {
+            log.error("[분석리포트] OpenAI 응답 비어있음");
+            throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
+        }
+
+        String content = response.choices().get(0).message().content();
+        log.info("[분석리포트] OpenAI 호출 완료");
+        return parseReportJson(content);
+    }
+
+    private AnalysisParts parseReportJson(String json) {
+        try {
+            JsonNode node = objectMapper.readTree(json);
+            String performance = node.path("performance").asText("");
+            String pattern = node.path("pattern").asText("");
+            String suggestion = node.path("suggestion").asText("");
+
+            if (performance.isBlank() || pattern.isBlank() || suggestion.isBlank()) {
+                log.error("[분석리포트] JSON 필수 필드 누락: {}", json);
+                throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
+            }
+            return new AnalysisParts(performance, pattern, suggestion);
+        } catch (JsonProcessingException e) {
+            log.error("[분석리포트] JSON 파싱 실패: {}", json);
+            throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
+        }
+    }
+
+    private String buildPrompt(AnalysisContext context) {
+        StringBuilder daily = new StringBuilder();
+        for (DailyContext day : context.dailyContexts()) {
+            daily.append("\n[").append(day.turnDate()).append(" 시장 개요]\n");
+            daily.append(day.marketOverview()).append("\n");
+
+            if (day.trades().isEmpty()) {
+                daily.append("→ 이 날 매매 없음\n");
+            } else {
+                String tradeSummary = day.trades().stream()
+                        .map(t -> String.format("%s %s %d주 @%,d원",
+                                t.stockName(),
+                                "BUY".equals(t.orderType()) ? "매수" : "매도",
+                                t.quantity(),
+                                t.price().longValue()))
+                        .reduce((a, b) -> a + ", " + b)
+                        .orElse("");
+                daily.append("→ 이 날 매매: ").append(tradeSummary).append("\n");
+            }
+        }
+
+        return String.format("""
+                아래는 주식 투자 시뮬레이션 게임의 시장 동향과 매매 내역입니다.
+
+                게임 기간: %s ~ %s
+                시드머니: %,d원
+                최종 자산: %,d원
+                수익률: %s%%
+                %s
+
+                위의 각 날짜별 시장 동향과 해당 날의 매매를 비교 분석해주세요.
+                특히 시장 상황에 비추어 각 매매가 적절했는지 평가해주세요.
+
+                규칙:
+                - 한국어로 작성하세요.
+                - 이모티콘을 사용하지 마세요.
+                - 종목명을 언급할 때는 실제 매매한 종목만 사용하세요.
+                - 제공된 시장 동향과 매매 내역에 근거하여 작성하세요.
+                - 위에 명시된 게임 기간 이후의 시장 흐름·주가·뉴스는 절대 언급하지 마세요.
+                - 종목/산업에 대한 일반적 분석과 투자 원칙(분산 투자, 손절·익절, 매매 빈도 등)은 자유롭게 활용하세요.
+                - 일반 원칙을 언급할 때는 이번 게임의 구체적 매매 사례와 연결하여 설명하세요.
+
+                반드시 아래 JSON 형식으로 응답하세요:
+                {
+                  "performance": "3문장. 전체 수익률에 대한 평가, 매매 빈도/스타일 요약, 두드러진 강점 또는 아쉬움",
+                  "pattern": "3~4문장. 시장 동향과 매매 결정을 연결한 패턴 분석. 매매한 종목의 특성이나 산업 맥락을 함께 활용해도 좋습니다.",
+                  "suggestion": "2~3문장. 이번 게임의 매매에서 드러난 약점과 연결한 구체적 개선점. 일반 투자 원칙(분산, 손절 등)을 끌어와도 좋되, 어떤 매매에 적용되는지 함께 제시하세요."
+                }
+                """,
+                context.startDate(),
+                context.endDate(),
+                context.seedMoney().longValue(),
+                context.finalAsset().longValue(),
+                context.profitRate().toPlainString(),
+                daily
+        );
+    }
+
+    private static final String SYSTEM_PROMPT =
+            "당신은 주식 투자 시뮬레이션 게임의 투자 코치 '위피니'입니다. "
+                    + "투자자의 매매 내역과 시장 동향을 비교하여, 종목·산업·일반 투자 원칙에 대한 "
+                    + "전문 지식을 활용해 유익한 피드백을 제공합니다. 이모티콘을 사용하지 마세요.";
+
+    public record AnalysisContext(
+            LocalDate startDate,
+            LocalDate endDate,
+            BigDecimal seedMoney,
+            BigDecimal finalAsset,
+            BigDecimal profitRate,
+            List<DailyContext> dailyContexts
+    ) {}
+
+    public record DailyContext(
+            LocalDate turnDate,
+            String marketOverview,
+            List<TradeSummary> trades
+    ) {}
+
+    public record TradeSummary(
+            String stockName,
+            String orderType,
+            int quantity,
+            BigDecimal price
+    ) {}
+
+    public record AnalysisParts(
+            String performance,
+            String pattern,
+            String suggestion
+    ) {}
+
+    record ChatRequest(
+            String model,
+            List<Message> messages,
+            @JsonProperty("max_tokens") int maxTokens,
+            double temperature,
+            @JsonProperty("response_format") ResponseFormat responseFormat
+    ) {
+        record Message(String role, String content) {}
+        record ResponseFormat(String type) {}
+    }
+
+    record ChatResponse(
+            List<Choice> choices
+    ) {
+        record Choice(Message message) {}
+        record Message(String content) {}
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/openai/OpenAiAnalysisReportClient.java
+++ b/src/main/java/com/solv/wefin/domain/game/openai/OpenAiAnalysisReportClient.java
@@ -69,6 +69,10 @@ public class OpenAiAnalysisReportClient {
         }
 
         String content = response.choices().get(0).message().content();
+        if (content == null || content.isBlank()) {
+            log.error("[분석리포트] OpenAI content 비어있음");
+            throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
+        }
         log.info("[분석리포트] OpenAI 호출 완료");
         return parseReportJson(content);
     }

--- a/src/main/java/com/solv/wefin/domain/game/openai/OpenAiAnalysisReportClient.java
+++ b/src/main/java/com/solv/wefin/domain/game/openai/OpenAiAnalysisReportClient.java
@@ -85,12 +85,12 @@ public class OpenAiAnalysisReportClient {
             String suggestion = node.path("suggestion").asText("");
 
             if (performance.isBlank() || pattern.isBlank() || suggestion.isBlank()) {
-                log.error("[분석리포트] JSON 필수 필드 누락: {}", json);
+                log.error("[분석리포트] JSON 필수 필드 누락: {}", truncate(json));
                 throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
             }
             return new AnalysisParts(performance, pattern, suggestion);
         } catch (JsonProcessingException e) {
-            log.error("[분석리포트] JSON 파싱 실패: {}", json);
+            log.error("[분석리포트] JSON 파싱 실패: {}", truncate(json));
             throw new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED);
         }
     }
@@ -195,6 +195,11 @@ public class OpenAiAnalysisReportClient {
     ) {
         record Message(String role, String content) {}
         record ResponseFormat(String type) {}
+    }
+
+    private static String truncate(String text) {
+        if (text == null) return "null";
+        return text.length() <= 200 ? text : text.substring(0, 200) + "...(truncated)";
     }
 
     record ChatResponse(

--- a/src/main/java/com/solv/wefin/domain/game/openai/OpenAiProperties.java
+++ b/src/main/java/com/solv/wefin/domain/game/openai/OpenAiProperties.java
@@ -13,4 +13,14 @@ public class OpenAiProperties {
     private String model = "gpt-4o-mini";
     private int maxTokens = 1500;
     private double temperature = 0.7;
+
+    private Report report = new Report();
+
+    @Getter
+    @Setter
+    public static class Report {
+        private String model = "gpt-4o";
+        private int maxTokens = 1500;
+        private double temperature = 0.7;
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/game/order/dto/OrderHistoryInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/dto/OrderHistoryInfo.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.game.order.dto;
+
+import com.solv.wefin.domain.game.order.entity.OrderType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record OrderHistoryInfo(
+        UUID orderId,
+        Integer turnNumber,
+        LocalDate turnDate,
+        String symbol,
+        String stockName,
+        OrderType orderType,
+        Integer quantity,
+        BigDecimal price,
+        BigDecimal fee,
+        BigDecimal tax
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/order/repository/GameOrderRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/order/repository/GameOrderRepository.java
@@ -3,10 +3,25 @@ package com.solv.wefin.domain.game.order.repository;
 import com.solv.wefin.domain.game.order.entity.GameOrder;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface GameOrderRepository extends JpaRepository<GameOrder, UUID> {
 
     int countByParticipant(GameParticipant participant);
+
+    /**
+     * 참가자의 매매 내역 전체 조회 (결과 페이지용).
+     * - JOIN FETCH t: 응답의 turnNumber/turnDate 접근 시 N+1 방지.
+     * - ORDER BY: 1차 turnNumber ASC(시간순), 2차 orderId ASC(같은 GET 요청 반복 시 순서 결정성 보장).
+     *   같은 턴 내 거래 순서는 비즈니스 의미 없음 — 단순 결정성 확보용.
+     */
+    @Query("SELECT o FROM GameOrder o "
+         + "JOIN FETCH o.turn t "
+         + "WHERE o.participant = :participant "
+         + "ORDER BY t.turnNumber ASC, o.orderId ASC")
+    List<GameOrder> findByParticipantOrderByTurnNumber(@Param("participant") GameParticipant participant);
 }

--- a/src/main/java/com/solv/wefin/domain/game/result/dto/AnalysisReportInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/dto/AnalysisReportInfo.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.game.result.dto;
+
+import java.time.OffsetDateTime;
+
+/**
+ * AI 분석 리포트 조회용 Domain DTO.
+ * 본인이 FINISHED 상태이면 호출 가능. lazy 생성 — 첫 호출 시 OpenAI 호출 후 저장,
+ * 이후 호출은 DB 캐시에서 즉시 반환.
+ */
+public record AnalysisReportInfo(
+        String performance,
+        String pattern,
+        String suggestion,
+        OffsetDateTime generatedAt
+) {}

--- a/src/main/java/com/solv/wefin/domain/game/result/dto/GameResultInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/dto/GameResultInfo.java
@@ -7,22 +7,21 @@ import java.util.UUID;
 
 /**
  * 게임 결과 조회 응답용 Domain DTO.
- * 본인이 FINISHED 상태일 때, 현 시점 game_result 기준 순위와 참가자별 결과를 묶어서 반환한다.
- * 방이 아직 IN_PROGRESS여도 본인이 FINISHED이기만 하면 조회 가능하며,
- * 이 경우 아직 종료하지 않은 참가자는 결과에 포함되지 않는다.
+ * 본인이 FINISHED 상태이면 호출 가능. 방이 아직 IN_PROGRESS여도 호출은 OK이며,
+ * 이 경우 roomFinished=false + rankings는 빈 배열이 반환된다
+ * (rankings는 방 전체 종료 후에만 의미 있음).
  */
 public record GameResultInfo(
         UUID roomId,
         LocalDate startDate,
         LocalDate endDate,
+        boolean roomFinished,
         List<RankingEntry> rankings
 ) {
     public record RankingEntry(
             int rank,
             String userName,
-            BigDecimal seedMoney,
             BigDecimal finalAsset,
-            BigDecimal profitRate,
-            int totalTrades
+            boolean isMine
     ) {}
 }

--- a/src/main/java/com/solv/wefin/domain/game/result/entity/GameAnalysisReport.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/entity/GameAnalysisReport.java
@@ -1,0 +1,68 @@
+package com.solv.wefin.domain.game.result.entity;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "game_analysis_report",
+        uniqueConstraints = @UniqueConstraint(columnNames = "participant_id"))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GameAnalysisReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "report_id")
+    private UUID reportId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    private GameParticipant participant;
+
+    @Column(name = "performance", nullable = false, columnDefinition = "TEXT")
+    private String performance;
+
+    @Column(name = "pattern", nullable = false, columnDefinition = "TEXT")
+    private String pattern;
+
+    @Column(name = "suggestion", nullable = false, columnDefinition = "TEXT")
+    private String suggestion;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private GameAnalysisReport(GameParticipant participant,
+                               String performance,
+                               String pattern,
+                               String suggestion) {
+        this.participant = participant;
+        this.performance = performance;
+        this.pattern = pattern;
+        this.suggestion = suggestion;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        this.createdAt = OffsetDateTime.now();
+    }
+
+    public static GameAnalysisReport create(GameParticipant participant,
+                                            String performance,
+                                            String pattern,
+                                            String suggestion) {
+        return GameAnalysisReport.builder()
+                .participant(participant)
+                .performance(performance)
+                .pattern(pattern)
+                .suggestion(suggestion)
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/repository/GameAnalysisReportRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/repository/GameAnalysisReportRepository.java
@@ -1,0 +1,13 @@
+package com.solv.wefin.domain.game.result.repository;
+
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.result.entity.GameAnalysisReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface GameAnalysisReportRepository extends JpaRepository<GameAnalysisReport, UUID> {
+
+    Optional<GameAnalysisReport> findByParticipant(GameParticipant participant);
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.game.room.entity.GameRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface GameResultRepository extends JpaRepository<GameResult, UUID> {
@@ -15,4 +16,6 @@ public interface GameResultRepository extends JpaRepository<GameResult, UUID> {
     List<GameResult> findByGameRoomOrderByFinalAssetDescCreatedAtAsc(GameRoom gameRoom);
 
     boolean existsByGameRoomAndParticipant(GameRoom gameRoom, GameParticipant participant);
+
+    Optional<GameResult> findByParticipant(GameParticipant participant);
 }

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportService.java
@@ -130,7 +130,8 @@ public class GameAnalysisReportService {
         List<LocalDate> turnDates = turns.stream().map(GameTurn::getTurnDate).distinct().toList();
 
         Map<LocalDate, String> overviewByDate = briefingCacheRepository.findByTargetDateIn(turnDates).stream()
-                .collect(Collectors.toMap(BriefingCache::getTargetDate, BriefingCache::getMarketOverview));
+                .collect(Collectors.toMap(BriefingCache::getTargetDate, BriefingCache::getMarketOverview,
+                        (existing, replacement) -> existing));
 
         List<GameOrder> orders = gameOrderRepository.findByParticipantOrderByTurnNumber(participant);
         Map<LocalDate, List<TradeSummary>> tradesByDate = orders.stream()

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportService.java
@@ -95,7 +95,13 @@ public class GameAnalysisReportService {
 
                 AnalysisParts parts = analysisReportClient.generateReport(rechecked.context());
 
-                return writeTx.execute(status -> saveReport(rechecked.participantId(), parts));
+                try {
+                    return writeTx.execute(status -> saveReport(rechecked.participantId(), parts));
+                } catch (DataIntegrityViolationException ex) {
+                    log.info("[분석리포트] 동시 INSERT 감지, 별도 TX로 기존 캐시 재조회: participantId={}",
+                            rechecked.participantId());
+                    return readOnlyTx.execute(status -> reloadByParticipantId(rechecked.participantId()));
+                }
             } finally {
                 participantLocks.remove(result.participantId(), lock);
             }
@@ -167,20 +173,13 @@ public class GameAnalysisReportService {
                             "Participant disappeared between transactions: " + participantId);
                 });
 
-        try {
-            GameAnalysisReport saved = analysisReportRepository.save(
-                    GameAnalysisReport.create(
-                            participant,
-                            parts.performance(),
-                            parts.pattern(),
-                            parts.suggestion()));
-            return toInfo(saved);
-        } catch (DataIntegrityViolationException e) {
-            log.info("[분석리포트] 동시 INSERT 감지, 기존 캐시 사용: participantId={}", participantId);
-            return analysisReportRepository.findByParticipant(participant)
-                    .map(this::toInfo)
-                    .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED));
-        }
+        GameAnalysisReport saved = analysisReportRepository.save(
+                GameAnalysisReport.create(
+                        participant,
+                        parts.performance(),
+                        parts.pattern(),
+                        parts.suggestion()));
+        return toInfo(saved);
     }
 
     private AnalysisReportInfo toInfo(GameAnalysisReport report) {
@@ -189,6 +188,14 @@ public class GameAnalysisReportService {
                 report.getPattern(),
                 report.getSuggestion(),
                 report.getCreatedAt());
+    }
+
+    private AnalysisReportInfo reloadByParticipantId(UUID participantId) {
+        GameParticipant participant = gameParticipantRepository.findById(participantId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED));
+        return analysisReportRepository.findByParticipant(participant)
+                .map(this::toInfo)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED));
     }
 
     private record ContextResult(AnalysisReportInfo cached,

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportService.java
@@ -1,0 +1,204 @@
+package com.solv.wefin.domain.game.result.service;
+
+import com.solv.wefin.domain.game.news.entity.BriefingCache;
+import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient.AnalysisContext;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient.AnalysisParts;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient.DailyContext;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient.TradeSummary;
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.AnalysisReportInfo;
+import com.solv.wefin.domain.game.result.entity.GameAnalysisReport;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameAnalysisReportRepository;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * AI 최종 분석 리포트 lazy 생성 + 캐시 조회.
+ *
+ * 트랜잭션 분리 정책:
+ *  - readOnly TX: 검증 + 캐시 조회 + 컨텍스트 빌드 (짧음)
+ *  - 트랜잭션 밖: OpenAI 호출 (5~10초, DB 커넥션을 들고 있으면 안 됨)
+ *  - write TX: INSERT만 (짧음)
+ *
+ * 동시성:
+ *  - participantId in-process 락: 같은 참가자의 multi-tab 동시 호출 직렬화
+ *  - DB UNIQUE(participant_id) 제약: 다중 인스턴스/락 만료 사이의 race 최후 방어
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GameAnalysisReportService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+    private final GameTurnRepository gameTurnRepository;
+    private final BriefingCacheRepository briefingCacheRepository;
+    private final GameOrderRepository gameOrderRepository;
+    private final GameResultRepository gameResultRepository;
+    private final GameAnalysisReportRepository analysisReportRepository;
+    private final OpenAiAnalysisReportClient analysisReportClient;
+    private final PlatformTransactionManager transactionManager;
+
+    private TransactionTemplate readOnlyTx;
+    private TransactionTemplate writeTx;
+
+    private final ConcurrentHashMap<UUID, Object> participantLocks = new ConcurrentHashMap<>();
+
+    @PostConstruct
+    void initTransactionTemplates() {
+        this.readOnlyTx = new TransactionTemplate(transactionManager);
+        this.readOnlyTx.setReadOnly(true);
+        this.writeTx = new TransactionTemplate(transactionManager);
+    }
+
+    public AnalysisReportInfo getOrGenerateReport(UUID roomId, UUID userId) {
+
+        ContextResult result = readOnlyTx.execute(status -> lookupOrBuildContext(roomId, userId));
+        if (result.cached() != null) {
+            return result.cached();
+        }
+
+        Object lock = participantLocks.computeIfAbsent(result.participantId(), k -> new Object());
+        synchronized (lock) {
+            try {
+                ContextResult rechecked = readOnlyTx.execute(status -> lookupOrBuildContext(roomId, userId));
+                if (rechecked.cached() != null) {
+                    return rechecked.cached();
+                }
+
+                AnalysisParts parts = analysisReportClient.generateReport(rechecked.context());
+
+                return writeTx.execute(status -> saveReport(rechecked.participantId(), parts));
+            } finally {
+                participantLocks.remove(result.participantId(), lock);
+            }
+        }
+    }
+
+    private ContextResult lookupOrBuildContext(UUID roomId, UUID userId) {
+
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        GameParticipant participant = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.FINISHED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
+
+        Optional<GameAnalysisReport> cached = analysisReportRepository.findByParticipant(participant);
+        if (cached.isPresent()) {
+            return ContextResult.cacheHit(toInfo(cached.get()), participant.getParticipantId());
+        }
+
+        GameResult result = gameResultRepository.findByParticipant(participant)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
+
+        List<GameTurn> turns = gameTurnRepository.findByGameRoomOrderByTurnNumberAsc(gameRoom);
+        List<LocalDate> turnDates = turns.stream().map(GameTurn::getTurnDate).distinct().toList();
+
+        Map<LocalDate, String> overviewByDate = briefingCacheRepository.findByTargetDateIn(turnDates).stream()
+                .collect(Collectors.toMap(BriefingCache::getTargetDate, BriefingCache::getMarketOverview));
+
+        List<GameOrder> orders = gameOrderRepository.findByParticipantOrderByTurnNumber(participant);
+        Map<LocalDate, List<TradeSummary>> tradesByDate = orders.stream()
+                .collect(Collectors.groupingBy(
+                        o -> o.getTurn().getTurnDate(),
+                        Collectors.mapping(o -> new TradeSummary(
+                                o.getStockName(),
+                                o.getOrderType().name(),
+                                o.getQuantity(),
+                                o.getOrderPrice()
+                        ), Collectors.toList())
+                ));
+
+        List<DailyContext> dailies = turns.stream()
+                .map(t -> new DailyContext(
+                        t.getTurnDate(),
+                        overviewByDate.getOrDefault(t.getTurnDate(), "시장 데이터 없음"),
+                        tradesByDate.getOrDefault(t.getTurnDate(), List.of())))
+                .toList();
+
+        AnalysisContext context = new AnalysisContext(
+                gameRoom.getStartDate(),
+                gameRoom.getEndDate(),
+                result.getSeedMoney(),
+                result.getFinalAsset(),
+                result.getProfitRate(),
+                dailies);
+
+        return ContextResult.cacheMiss(context, participant.getParticipantId());
+    }
+
+    private AnalysisReportInfo saveReport(UUID participantId, AnalysisParts parts) {
+        // readOnly TX에서 검증된 participantId가 write TX에서 사라지는 건 정상 흐름이 아님
+        // (외부 DELETE 등 데이터 불일치). 사용자 메시지가 아니라 내부 오류로 처리한다.
+        GameParticipant participant = gameParticipantRepository.findById(participantId)
+                .orElseThrow(() -> {
+                    log.error("[분석리포트] readOnly TX 이후 참가자 사라짐 — 데이터 불일치: participantId={}",
+                            participantId);
+                    return new IllegalStateException(
+                            "Participant disappeared between transactions: " + participantId);
+                });
+
+        try {
+            GameAnalysisReport saved = analysisReportRepository.save(
+                    GameAnalysisReport.create(
+                            participant,
+                            parts.performance(),
+                            parts.pattern(),
+                            parts.suggestion()));
+            return toInfo(saved);
+        } catch (DataIntegrityViolationException e) {
+            log.info("[분석리포트] 동시 INSERT 감지, 기존 캐시 사용: participantId={}", participantId);
+            return analysisReportRepository.findByParticipant(participant)
+                    .map(this::toInfo)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED));
+        }
+    }
+
+    private AnalysisReportInfo toInfo(GameAnalysisReport report) {
+        return new AnalysisReportInfo(
+                report.getPerformance(),
+                report.getPattern(),
+                report.getSuggestion(),
+                report.getCreatedAt());
+    }
+
+    private record ContextResult(AnalysisReportInfo cached,
+                                 AnalysisContext context,
+                                 UUID participantId) {
+        static ContextResult cacheHit(AnalysisReportInfo cached, UUID participantId) {
+            return new ContextResult(cached, null, participantId);
+        }
+        static ContextResult cacheMiss(AnalysisContext context, UUID participantId) {
+            return new ContextResult(null, context, participantId);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
@@ -1,13 +1,19 @@
 package com.solv.wefin.domain.game.result.service;
 
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.order.dto.OrderHistoryInfo;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
 import com.solv.wefin.domain.game.result.dto.GameResultInfo;
 import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.result.repository.GameResultRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.dto.SnapshotInfo;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -28,13 +34,22 @@ public class GameResultService {
     private final GameRoomRepository gameRoomRepository;
     private final GameParticipantRepository gameParticipantRepository;
     private final GameResultRepository gameResultRepository;
+    private final GamePortfolioSnapshotRepository snapshotRepository;
+    private final GameOrderRepository gameOrderRepository;
     private final UserRepository userRepository;
 
     /**
      * 게임 결과 조회.
-     * 본인이 FINISHED 상태여야 조회 가능.
+     * 본인이 FINISHED 상태이면 호출 가능 (방이 아직 IN_PROGRESS여도 OK).
+     *
+     * rankings 노출 정책:
+     * - 방 FINISHED: 전체 참가자의 finalAsset 기준 순위 노출 (본인 행은 isMine=true)
+     * - 방 IN_PROGRESS: rankings 빈 배열. 일찍 endGame()한 사용자도 결과 페이지 진입은 가능하지만,
+     *   다른 참가자들의 게임 진행이 아직 안 끝나서 부분 랭킹은 의미가 없으므로 노출하지 않는다.
+     *
      * 순위는 매 요청마다 finalAsset DESC로 동적 계산(standard competition rank: 1, 1, 3) —
-     * 방이 아직 IN_PROGRESS면 finalRank=0인 레코드가 섞일 수 있으므로 필드 값을 신뢰하지 않는다.
+     * GameResult.finalRank 필드는 방 종료 시 finalizeRanks()로 확정되지만,
+     * 응답 일관성을 위해 동적 계산을 유지한다.
      */
     public GameResultInfo getGameResult(UUID roomId, UUID userId) {
 
@@ -47,21 +62,33 @@ public class GameResultService {
                 .filter(p -> p.getStatus() == ParticipantStatus.FINISHED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
 
-        // 3. 결과 조회 (finalAsset 내림차순)
+        // 3. 방 종료 여부 — rankings 노출 분기 기준
+        boolean roomFinished = gameRoom.getStatus() == RoomStatus.FINISHED;
+
+        // 4. 방이 아직 진행 중이면 rankings는 빈 배열로 응답
+        if (!roomFinished) {
+            return new GameResultInfo(
+                    gameRoom.getRoomId(),
+                    gameRoom.getStartDate(),
+                    gameRoom.getEndDate(),
+                    false,
+                    List.of());
+        }
+
+        // 5. 결과 조회 (finalAsset 내림차순)
         //    2차 정렬(createdAt ASC): 동률 시 DB 반환 순서 비결정성을 제거 —
         //    같은 요청을 반복해도 동률 참가자들의 순서가 바뀌지 않도록 정렬 결정성을 보장한다.
-        //    (강제 종료 경로에서는 같은 트랜잭션 내 일괄 저장이라 createdAt이 거의 동일하므로
-        //     "먼저 종료한 순" 의미보다는 결정성 보장 용도가 우선이다.)
         List<GameResult> results = gameResultRepository
                 .findByGameRoomOrderByFinalAssetDescCreatedAtAsc(gameRoom);
 
-        // 4. 닉네임 일괄 조회 (N+1 방지)
+        // 6. 닉네임 일괄 조회 (N+1 방지)
         List<UUID> userIds = results.stream()
                 .map(r -> r.getParticipant().getUserId())
                 .toList();
         Map<UUID, String> nicknameMap = buildNicknameMap(userIds);
 
-        // 5. standard competition rank 부여 (동률이면 같은 순위, 다음은 건너뜀: 1, 1, 3)
+        // 7. standard competition rank 부여 + 본인 행 isMine=true 마킹
+        //    JWT 기반 userId로 매칭 — 닉네임 매칭 대비 동명이인/닉네임 변경에 안전.
         List<GameResultInfo.RankingEntry> rankings = new ArrayList<>();
         for (int i = 0; i < results.size(); i++) {
             GameResult r = results.get(i);
@@ -70,20 +97,85 @@ public class GameResultService {
                             ? rankings.get(i - 1).rank()
                             : i + 1;
 
+            boolean isMine = r.getParticipant().getUserId().equals(userId);
+
             rankings.add(new GameResultInfo.RankingEntry(
                     rank,
                     nicknameMap.getOrDefault(r.getParticipant().getUserId(), "알 수 없음"),
-                    r.getSeedMoney(),
                     r.getFinalAsset(),
-                    r.getProfitRate(),
-                    r.getTotalTrades()));
+                    isMine));
         }
 
         return new GameResultInfo(
                 gameRoom.getRoomId(),
                 gameRoom.getStartDate(),
                 gameRoom.getEndDate(),
+                true,
                 rankings);
+    }
+
+    /**
+     * 자산 변동 그래프용 턴별 스냅샷 조회 (본인 전용).
+     * 본인이 FINISHED 상태여야 조회 가능. 본인만 FINISHED면 방 IN_PROGRESS여도 조회 OK.
+     * 결과 페이지는 본인 데이터만 노출하는 정책 — 다른 참가자 스냅샷은 조회 불가.
+     */
+    public List<SnapshotInfo> getSnapshots(UUID roomId, UUID userId) {
+
+        // 1. 방 조회
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2. 요청자 검증 (FINISHED 전용)
+        GameParticipant requester = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.FINISHED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
+
+        // 3. 스냅샷 조회 (turnNumber ASC, JOIN FETCH로 N+1 방지)
+        return snapshotRepository.findByParticipantOrderByTurnNumber(requester).stream()
+                .map(s -> new SnapshotInfo(
+                        s.getTurn().getTurnNumber(),
+                        s.getTurn().getTurnDate(),
+                        s.getTotalAsset(),
+                        s.getCash(),
+                        s.getStockValue(),
+                        s.getProfitRate()))
+                .toList();
+    }
+
+    /**
+     * 본인의 매매 내역 전체 조회 (결과 페이지 매매 내역 테이블용).
+     * 본인이 FINISHED 상태여야 조회 가능. 본인만 FINISHED면 방 IN_PROGRESS여도 조회 OK.
+     * 다른 참가자의 매매 내역은 비공개 — participantId 파라미터 없음.
+     * 정렬: turnNumber ASC, orderId ASC (같은 턴 내 거래 순서는 비즈니스 의미 없으나
+     * 같은 GET 요청 반복 시 행 순서 결정성 확보 — UX 깜빡임 방지).
+     */
+    public List<OrderHistoryInfo> getOrderHistory(UUID roomId, UUID userId) {
+
+        // 1. 방 조회
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        // 2. 요청자 검증 (FINISHED 전용)
+        GameParticipant requester = gameParticipantRepository
+                .findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.FINISHED)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PARTICIPANT_NOT_FINISHED));
+
+        // 3. 매매 내역 조회 (JOIN FETCH로 N+1 방지, 정렬 결정성 보장)
+        return gameOrderRepository.findByParticipantOrderByTurnNumber(requester).stream()
+                .map(o -> new OrderHistoryInfo(
+                        o.getOrderId(),
+                        o.getTurn().getTurnNumber(),
+                        o.getTurn().getTurnDate(),
+                        o.getStockInfo().getSymbol(),
+                        o.getStockName(),
+                        o.getOrderType(),
+                        o.getQuantity(),
+                        o.getOrderPrice(),
+                        o.getFee(),
+                        o.getTax()))
+                .toList();
     }
 
     private Map<UUID, String> buildNicknameMap(List<UUID> userIds) {

--- a/src/main/java/com/solv/wefin/domain/game/snapshot/dto/SnapshotInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/snapshot/dto/SnapshotInfo.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record SnapshotInfo(
-        int turnNumber,
+        Integer turnNumber,
         LocalDate turnDate,
         BigDecimal totalAsset,
         BigDecimal cash,

--- a/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/repository/GameTurnRepository.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +16,6 @@ public interface GameTurnRepository extends JpaRepository<GameTurn, UUID> {
     Optional<GameTurn> findFirstByGameRoomAndStatusOrderByTurnNumberDesc(GameRoom gameRoom, TurnStatus status);
 
     int countByGameRoomAndStatus(GameRoom gameRoom, TurnStatus status);
+
+    List<GameTurn> findByGameRoomOrderByTurnNumberAsc(GameRoom gameRoom);
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -178,6 +178,9 @@ public enum ErrorCode {
     PARTICIPANT_ALREADY_FINISHED(400, "이미 게임을 종료한 참가자입니다."),
     PARTICIPANT_NOT_FINISHED(400, "아직 게임을 종료하지 않은 참가자입니다."),
 
+    // GameAnalysisReport
+    ANALYSIS_GENERATION_FAILED(503, "AI 분석 리포트 생성에 실패했습니다."),
+
     // GameStock
     GAME_STOCK_NOT_FOUND(404, "해당 종목을 찾을 수 없습니다."),
     GAME_STOCK_PRICE_NOT_FOUND(404, "해당 날짜의 주가 데이터가 없습니다."),

--- a/src/main/java/com/solv/wefin/web/game/result/GameResultController.java
+++ b/src/main/java/com/solv/wefin/web/game/result/GameResultController.java
@@ -1,12 +1,19 @@
 package com.solv.wefin.web.game.result;
 
+import com.solv.wefin.domain.game.order.dto.OrderHistoryInfo;
+import com.solv.wefin.domain.game.result.dto.AnalysisReportInfo;
 import com.solv.wefin.domain.game.result.dto.GameEndInfo;
 import com.solv.wefin.domain.game.result.dto.GameResultInfo;
+import com.solv.wefin.domain.game.result.service.GameAnalysisReportService;
 import com.solv.wefin.domain.game.result.service.GameEndService;
 import com.solv.wefin.domain.game.result.service.GameResultService;
+import com.solv.wefin.domain.game.snapshot.dto.SnapshotInfo;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.result.dto.response.AnalysisReportResponse;
 import com.solv.wefin.web.game.result.dto.response.GameEndResponse;
 import com.solv.wefin.web.game.result.dto.response.GameResultResponse;
+import com.solv.wefin.web.game.result.dto.response.OrderHistoryResponse;
+import com.solv.wefin.web.game.result.dto.response.SnapshotResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -25,6 +33,7 @@ public class GameResultController {
 
     private final GameEndService gameEndService;
     private final GameResultService gameResultService;
+    private final GameAnalysisReportService analysisReportService;
 
     @PostMapping("/end")
     public ResponseEntity<ApiResponse<GameEndResponse>> endGame(
@@ -44,6 +53,43 @@ public class GameResultController {
 
         GameResultInfo info = gameResultService.getGameResult(roomId, userId);
         GameResultResponse response = GameResultResponse.from(info);
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/snapshots")
+    public ResponseEntity<ApiResponse<List<SnapshotResponse>>> getSnapshots(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        List<SnapshotInfo> infos = gameResultService.getSnapshots(roomId, userId);
+        List<SnapshotResponse> response = infos.stream()
+                .map(SnapshotResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/orders")
+    public ResponseEntity<ApiResponse<List<OrderHistoryResponse>>> getOrderHistory(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        List<OrderHistoryInfo> infos = gameResultService.getOrderHistory(roomId, userId);
+        List<OrderHistoryResponse> response = infos.stream()
+                .map(OrderHistoryResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/report")
+    public ResponseEntity<ApiResponse<AnalysisReportResponse>> getAnalysisReport(
+            @PathVariable UUID roomId,
+            @AuthenticationPrincipal UUID userId) {
+
+        AnalysisReportInfo info = analysisReportService.getOrGenerateReport(roomId, userId);
+        AnalysisReportResponse response = AnalysisReportResponse.from(info);
 
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/AnalysisReportResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/AnalysisReportResponse.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.web.game.result.dto.response;
+
+import com.solv.wefin.domain.game.result.dto.AnalysisReportInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AnalysisReportResponse {
+
+    private String performance;
+    private String pattern;
+    private String suggestion;
+    private OffsetDateTime generatedAt;
+
+    public static AnalysisReportResponse from(AnalysisReportInfo info) {
+        return new AnalysisReportResponse(
+                info.performance(),
+                info.pattern(),
+                info.suggestion(),
+                info.generatedAt());
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/GameResultResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/GameResultResponse.java
@@ -15,6 +15,7 @@ public class GameResultResponse {
     private UUID roomId;
     private LocalDate startDate;
     private LocalDate endDate;
+    private boolean roomFinished;
     private List<RankingEntryDto> rankings;
 
     public static GameResultResponse from(GameResultInfo info) {
@@ -26,6 +27,7 @@ public class GameResultResponse {
                 info.roomId(),
                 info.startDate(),
                 info.endDate(),
+                info.roomFinished(),
                 rankings);
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/OrderHistoryResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/OrderHistoryResponse.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.web.game.result.dto.response;
+
+import com.solv.wefin.domain.game.order.dto.OrderHistoryInfo;
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class OrderHistoryResponse {
+
+    private UUID orderId;
+    private Integer turnNumber;
+    private LocalDate turnDate;
+    private String symbol;
+    private String stockName;
+    private OrderType orderType;
+    private Integer quantity;
+    private BigDecimal price;
+    private BigDecimal fee;
+    private BigDecimal tax;
+
+    public static OrderHistoryResponse from(OrderHistoryInfo info) {
+        return new OrderHistoryResponse(
+                info.orderId(),
+                info.turnNumber(),
+                info.turnDate(),
+                info.symbol(),
+                info.stockName(),
+                info.orderType(),
+                info.quantity(),
+                info.price(),
+                info.fee(),
+                info.tax());
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/RankingEntryDto.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/RankingEntryDto.java
@@ -12,18 +12,21 @@ public class RankingEntryDto {
 
     private int rank;
     private String userName;
-    private BigDecimal seedMoney;
     private BigDecimal finalAsset;
-    private BigDecimal profitRate;
-    private int totalTrades;
+
+    /**
+     * 본인 행 표시 여부.
+     * Boolean wrapper 로 선언하여 Lombok 이 getIsMine() 게터를 만들도록 한다.
+     * primitive boolean + 'is' prefix 필드는 isMine() 게터가 생성되어
+     * Jackson 이 JSON 키를 "mine" 으로 직렬화하는 문제를 회피한다.
+     */
+    private Boolean isMine;
 
     public static RankingEntryDto from(GameResultInfo.RankingEntry entry) {
         return new RankingEntryDto(
                 entry.rank(),
                 entry.userName(),
-                entry.seedMoney(),
                 entry.finalAsset(),
-                entry.profitRate(),
-                entry.totalTrades());
+                entry.isMine());
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/result/dto/response/SnapshotResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/result/dto/response/SnapshotResponse.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.web.game.result.dto.response;
+
+import com.solv.wefin.domain.game.snapshot.dto.SnapshotInfo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class SnapshotResponse {
+
+    private Integer turnNumber;
+    private LocalDate turnDate;
+    private BigDecimal totalAsset;
+    private BigDecimal cash;
+    private BigDecimal stockValue;
+    private BigDecimal profitRate;
+
+    public static SnapshotResponse from(SnapshotInfo info) {
+        return new SnapshotResponse(
+                info.turnNumber(),
+                info.turnDate(),
+                info.totalAsset(),
+                info.cash(),
+                info.stockValue(),
+                info.profitRate());
+    }
+}

--- a/src/main/resources/db/migration/V43__create_table_analysis_report.sql
+++ b/src/main/resources/db/migration/V43__create_table_analysis_report.sql
@@ -1,0 +1,35 @@
+-- 1) 기존 FK 제거
+ALTER TABLE game_analysis_report
+DROP CONSTRAINT "FK_stock_daily_TO_game_analysis_report_1";
+
+ALTER TABLE game_analysis_report
+DROP CONSTRAINT "FK_game_participant_TO_game_analysis_report_1";
+
+  -- 2) 기존 UNIQUE (daily_id, participant_id) 제거
+ALTER TABLE game_analysis_report
+DROP CONSTRAINT uk_report_daily_participant;
+
+  -- 3) 사용하지 않을 컬럼 제거
+ALTER TABLE game_analysis_report
+DROP COLUMN daily_id,
+      DROP COLUMN report_text;
+
+  -- 4) 새 컬럼 추가
+ALTER TABLE game_analysis_report
+    ADD COLUMN performance TEXT NOT NULL,
+      ADD COLUMN pattern     TEXT NOT NULL,
+      ADD COLUMN suggestion  TEXT NOT NULL;
+
+-- 5) DEFAULT 부여 (report_id, created_at은 코드에서 채우지 않고 DB가 자동 생성)
+ALTER TABLE game_analysis_report
+    ALTER COLUMN report_id  SET DEFAULT gen_random_uuid(),
+ALTER COLUMN created_at SET DEFAULT now();
+
+  -- 6) 새 FK (participant_id → game_participant)
+ALTER TABLE game_analysis_report
+    ADD CONSTRAINT fk_analysis_report_participant
+        FOREIGN KEY (participant_id) REFERENCES game_participant(participant_id);
+
+-- 7) 새 UNIQUE (참가자당 리포트 1개)
+ALTER TABLE game_analysis_report
+    ADD CONSTRAINT uk_analysis_report_participant UNIQUE (participant_id);

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameAnalysisReportServiceTest.java
@@ -1,0 +1,348 @@
+package com.solv.wefin.domain.game.result.service;
+
+import com.solv.wefin.domain.game.news.entity.BriefingCache;
+import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient.AnalysisContext;
+import com.solv.wefin.domain.game.openai.OpenAiAnalysisReportClient.AnalysisParts;
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
+import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
+import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.AnalysisReportInfo;
+import com.solv.wefin.domain.game.result.entity.GameAnalysisReport;
+import com.solv.wefin.domain.game.result.entity.GameResult;
+import com.solv.wefin.domain.game.result.repository.GameAnalysisReportRepository;
+import com.solv.wefin.domain.game.result.repository.GameResultRepository;
+import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class GameAnalysisReportServiceTest {
+
+    @InjectMocks
+    private GameAnalysisReportService service;
+
+    @Mock private GameRoomRepository gameRoomRepository;
+    @Mock private GameParticipantRepository gameParticipantRepository;
+    @Mock private GameTurnRepository gameTurnRepository;
+    @Mock private BriefingCacheRepository briefingCacheRepository;
+    @Mock private GameOrderRepository gameOrderRepository;
+    @Mock private GameResultRepository gameResultRepository;
+    @Mock private GameAnalysisReportRepository analysisReportRepository;
+    @Mock private OpenAiAnalysisReportClient analysisReportClient;
+    @Mock private PlatformTransactionManager transactionManager;
+
+    private static final UUID ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
+    private static final UUID USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
+    private static final Long GROUP_ID = 1L;
+    private static final LocalDate START_DATE = LocalDate.of(2022, 3, 2);
+    private static final LocalDate END_DATE = LocalDate.of(2022, 9, 2);
+    private static final BigDecimal SEED = new BigDecimal("10000000");
+
+    @BeforeEach
+    void setUp() {
+        // @PostConstruct가 단위 테스트에서는 자동 호출되지 않으므로 수동 초기화
+        service.initTransactionTemplates();
+    }
+
+    @Nested
+    @DisplayName("AI 분석 리포트 조회/생성 성공")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("캐시 히트 — DB에 이미 리포트 있으면 OpenAI 호출 안 됨")
+        void cacheHit_returnsImmediately_noOpenAiCall() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant participant = createFinishedParticipant(room);
+            GameAnalysisReport cached = createSavedReport(participant,
+                    "캐시된 성과", "캐시된 패턴", "캐시된 제안");
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.findByParticipant(participant))
+                    .willReturn(Optional.of(cached));
+
+            // When
+            AnalysisReportInfo result = service.getOrGenerateReport(ROOM_ID, USER_ID);
+
+            // Then
+            assertThat(result.performance()).isEqualTo("캐시된 성과");
+            assertThat(result.pattern()).isEqualTo("캐시된 패턴");
+            assertThat(result.suggestion()).isEqualTo("캐시된 제안");
+            assertThat(result.generatedAt()).isNotNull();
+
+            verify(analysisReportClient, never()).generateReport(any());
+            verify(analysisReportRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("캐시 미스 — OpenAI 호출 후 DB INSERT, 컨텍스트가 제대로 빌드됨")
+        void cacheMiss_callsOpenAi_savesReport() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant participant = createFinishedParticipant(room);
+            GameResult gameResult = GameResult.create(room, participant, 1, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 5);
+
+            GameTurn turn1 = GameTurn.createFirst(room);
+            GameTurn turn2 = GameTurn.createNext(turn1, START_DATE.plusDays(1));
+            BriefingCache briefing1 = BriefingCache.create(START_DATE, "1일차 시장개요", "1일차 이슈", "1일차 힌트");
+
+            GameOrder order = mock(GameOrder.class);
+            given(order.getTurn()).willReturn(turn1);
+            given(order.getStockName()).willReturn("삼성전자");
+            given(order.getOrderType()).willReturn(OrderType.BUY);
+            given(order.getQuantity()).willReturn(10);
+            given(order.getOrderPrice()).willReturn(new BigDecimal("70000"));
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.findByParticipant(participant))
+                    .willReturn(Optional.empty());
+            given(gameResultRepository.findByParticipant(participant))
+                    .willReturn(Optional.of(gameResult));
+            given(gameTurnRepository.findByGameRoomOrderByTurnNumberAsc(room))
+                    .willReturn(List.of(turn1, turn2));
+            given(briefingCacheRepository.findByTargetDateIn(anyCollection()))
+                    .willReturn(List.of(briefing1));
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(participant))
+                    .willReturn(List.of(order));
+
+            // OpenAI 응답
+            given(analysisReportClient.generateReport(any(AnalysisContext.class)))
+                    .willReturn(new AnalysisParts("OpenAI 성과", "OpenAI 패턴", "OpenAI 제안"));
+
+            // 저장된 리포트 (createdAt 자동 세팅 시뮬레이션)
+            given(gameParticipantRepository.findById(participant.getParticipantId()))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.save(any(GameAnalysisReport.class)))
+                    .willAnswer(invocation -> {
+                        GameAnalysisReport entity = invocation.getArgument(0);
+                        ReflectionTestUtils.setField(entity, "createdAt", OffsetDateTime.now());
+                        return entity;
+                    });
+
+            // When
+            AnalysisReportInfo result = service.getOrGenerateReport(ROOM_ID, USER_ID);
+
+            // Then
+            assertThat(result.performance()).isEqualTo("OpenAI 성과");
+            assertThat(result.pattern()).isEqualTo("OpenAI 패턴");
+            assertThat(result.suggestion()).isEqualTo("OpenAI 제안");
+            assertThat(result.generatedAt()).isNotNull();
+
+            verify(analysisReportClient).generateReport(any(AnalysisContext.class));
+            verify(analysisReportRepository).save(any(GameAnalysisReport.class));
+        }
+
+        @Test
+        @DisplayName("동시 INSERT race — DataIntegrityViolation 잡고 기존 캐시 재조회")
+        void concurrentInsert_recoversFromCachedRow() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant participant = createFinishedParticipant(room);
+            GameResult gameResult = GameResult.create(room, participant, 1, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 5);
+            GameTurn turn = GameTurn.createFirst(room);
+
+            // 다른 스레드/인스턴스가 먼저 INSERT 한 결과
+            GameAnalysisReport raceWinnerReport = createSavedReport(participant,
+                    "레이스 위너 성과", "레이스 위너 패턴", "레이스 위너 제안");
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.findByParticipant(participant))
+                    .willReturn(Optional.empty())  // lookupOrBuildContext 호출 시 캐시 없음
+                    .willReturn(Optional.empty())  // 락 안에서 재조회 시에도 없음
+                    .willReturn(Optional.of(raceWinnerReport));  // 충돌 후 재조회 시 있음
+            given(gameResultRepository.findByParticipant(participant))
+                    .willReturn(Optional.of(gameResult));
+            given(gameTurnRepository.findByGameRoomOrderByTurnNumberAsc(room))
+                    .willReturn(List.of(turn));
+            given(briefingCacheRepository.findByTargetDateIn(anyCollection()))
+                    .willReturn(List.of());
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(participant))
+                    .willReturn(List.of());
+            given(analysisReportClient.generateReport(any(AnalysisContext.class)))
+                    .willReturn(new AnalysisParts("내 성과", "내 패턴", "내 제안"));
+            given(gameParticipantRepository.findById(participant.getParticipantId()))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.save(any(GameAnalysisReport.class)))
+                    .willThrow(new DataIntegrityViolationException("UNIQUE 위반"));
+
+            // When
+            AnalysisReportInfo result = service.getOrGenerateReport(ROOM_ID, USER_ID);
+
+            // Then — 충돌 후 재조회한 캐시(레이스 위너) 반환
+            assertThat(result.performance()).isEqualTo("레이스 위너 성과");
+            assertThat(result.pattern()).isEqualTo("레이스 위너 패턴");
+            assertThat(result.suggestion()).isEqualTo("레이스 위너 제안");
+        }
+    }
+
+    @Nested
+    @DisplayName("AI 분석 리포트 조회/생성 실패")
+    class FailTests {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void roomNotFound() {
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getOrGenerateReport(ROOM_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+
+            verify(analysisReportClient, never()).generateReport(any());
+        }
+
+        @Test
+        @DisplayName("참가자 자체가 없으면 PARTICIPANT_NOT_FINISHED")
+        void participantNotFound() {
+            GameRoom room = createFinishedRoom();
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getOrGenerateReport(ROOM_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("참가자가 FINISHED 아니면 PARTICIPANT_NOT_FINISHED")
+        void participantNotFinished() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant active = GameParticipant.createLeader(room, USER_ID); // ACTIVE 상태
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.of(active));
+
+            assertThatThrownBy(() -> service.getOrGenerateReport(ROOM_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("FINISHED인데 GameResult가 없으면 PARTICIPANT_NOT_FINISHED (데이터 불일치 방어)")
+        void gameResultMissing() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant participant = createFinishedParticipant(room);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.findByParticipant(participant))
+                    .willReturn(Optional.empty());
+            given(gameResultRepository.findByParticipant(participant))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.getOrGenerateReport(ROOM_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+
+            verify(analysisReportClient, never()).generateReport(any());
+        }
+
+        @Test
+        @DisplayName("OpenAI 호출 실패 시 ANALYSIS_GENERATION_FAILED 그대로 전파")
+        void openAiCallFailed() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant participant = createFinishedParticipant(room);
+            GameResult gameResult = GameResult.create(room, participant, 1, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 5);
+            GameTurn turn = GameTurn.createFirst(room);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_ID))
+                    .willReturn(Optional.of(participant));
+            given(analysisReportRepository.findByParticipant(participant))
+                    .willReturn(Optional.empty());
+            given(gameResultRepository.findByParticipant(participant))
+                    .willReturn(Optional.of(gameResult));
+            given(gameTurnRepository.findByGameRoomOrderByTurnNumberAsc(room))
+                    .willReturn(List.of(turn));
+            given(briefingCacheRepository.findByTargetDateIn(anyCollection()))
+                    .willReturn(List.of());
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(participant))
+                    .willReturn(List.of());
+            given(analysisReportClient.generateReport(any(AnalysisContext.class)))
+                    .willThrow(new BusinessException(ErrorCode.ANALYSIS_GENERATION_FAILED));
+
+            assertThatThrownBy(() -> service.getOrGenerateReport(ROOM_ID, USER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ANALYSIS_GENERATION_FAILED);
+
+            verify(analysisReportRepository, never()).save(any());
+        }
+    }
+
+    // === 헬퍼 메서드 ===
+
+    private GameRoom createFinishedRoom() {
+        GameRoom room = GameRoom.create(GROUP_ID, USER_ID, SEED,
+                6, 7, START_DATE, END_DATE);
+        room.start();
+        room.finish();
+        return room;
+    }
+
+    private GameParticipant createFinishedParticipant(GameRoom room) {
+        GameParticipant participant = GameParticipant.createLeader(room, USER_ID);
+        participant.finish();
+        // 실제 환경에서는 JPA가 @GeneratedValue로 PK를 채우지만, 단위 테스트에서는
+        // ConcurrentHashMap 락 키로 쓰이는 participantId가 null이면 NPE가 나므로 강제 세팅
+        ReflectionTestUtils.setField(participant, "participantId",
+                UUID.fromString("00000000-0000-4000-a000-000000000099"));
+        return participant;
+    }
+
+    /** 캐시 히트 시뮬레이션용 — createdAt까지 채워서 반환 */
+    private GameAnalysisReport createSavedReport(GameParticipant participant,
+                                                 String performance,
+                                                 String pattern,
+                                                 String suggestion) {
+        GameAnalysisReport report = GameAnalysisReport.create(participant, performance, pattern, suggestion);
+        ReflectionTestUtils.setField(report, "createdAt", OffsetDateTime.now());
+        return report;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
@@ -2,6 +2,10 @@ package com.solv.wefin.domain.game.result.service;
 
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.game.order.dto.OrderHistoryInfo;
+import com.solv.wefin.domain.game.order.entity.GameOrder;
+import com.solv.wefin.domain.game.order.entity.OrderType;
+import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
@@ -10,6 +14,11 @@ import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.result.repository.GameResultRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
+import com.solv.wefin.domain.game.snapshot.dto.SnapshotInfo;
+import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
+import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
+import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -44,6 +53,10 @@ class GameResultServiceTest {
     private GameParticipantRepository gameParticipantRepository;
     @Mock
     private GameResultRepository gameResultRepository;
+    @Mock
+    private GamePortfolioSnapshotRepository snapshotRepository;
+    @Mock
+    private GameOrderRepository gameOrderRepository;
     @Mock
     private UserRepository userRepository;
 
@@ -100,22 +113,24 @@ class GameResultServiceTest {
             // Then
             assertThat(info.startDate()).isEqualTo(START_DATE);
             assertThat(info.endDate()).isEqualTo(END_DATE);
+            assertThat(info.roomFinished()).isTrue();
             assertThat(info.rankings()).hasSize(3);
 
-            // 1위: B
+            // 1위: B (요청자 A 가 아니므로 isMine=false)
             assertThat(info.rankings().get(0).rank()).isEqualTo(1);
             assertThat(info.rankings().get(0).userName()).isEqualTo("길동");
             assertThat(info.rankings().get(0).finalAsset()).isEqualByComparingTo("12500000");
-            assertThat(info.rankings().get(0).profitRate()).isEqualByComparingTo("25.00");
-            assertThat(info.rankings().get(0).totalTrades()).isEqualTo(42);
+            assertThat(info.rankings().get(0).isMine()).isFalse();
 
             // 2위: C
             assertThat(info.rankings().get(1).rank()).isEqualTo(2);
             assertThat(info.rankings().get(1).userName()).isEqualTo("철수");
+            assertThat(info.rankings().get(1).isMine()).isFalse();
 
-            // 3위: A
+            // 3위: A (요청자 본인)
             assertThat(info.rankings().get(2).rank()).isEqualTo(3);
             assertThat(info.rankings().get(2).userName()).isEqualTo("재훈");
+            assertThat(info.rankings().get(2).isMine()).isTrue();
         }
 
         @Test
@@ -154,39 +169,37 @@ class GameResultServiceTest {
             GameResultInfo info = gameResultService.getGameResult(ROOM_ID, USER_A);
 
             // Then
+            assertThat(info.roomFinished()).isTrue();
             assertThat(info.rankings()).hasSize(3);
             assertThat(info.rankings().get(0).rank()).isEqualTo(1);
-            assertThat(info.rankings().get(1).rank()).isEqualTo(1);  // 동률
-            assertThat(info.rankings().get(2).rank()).isEqualTo(3);  // 1위가 2명 → 다음은 3위
+            assertThat(info.rankings().get(0).isMine()).isTrue();   // A 가 첫 번째 위치 (요청자 본인)
+            assertThat(info.rankings().get(1).rank()).isEqualTo(1); // 동률
+            assertThat(info.rankings().get(1).isMine()).isFalse();
+            assertThat(info.rankings().get(2).rank()).isEqualTo(3); // 1위가 2명 → 다음은 3위
+            assertThat(info.rankings().get(2).isMine()).isFalse();
         }
 
         @Test
-        @DisplayName("방이 아직 IN_PROGRESS여도 본인 FINISHED면 조회 가능")
-        void inProgressRoom_finishedParticipant_canQuery() {
+        @DisplayName("방 IN_PROGRESS — 호출은 가능하지만 rankings 빈 배열 + roomFinished=false")
+        void inProgressRoom_returnsEmptyRankings() {
             // Given — 방은 IN_PROGRESS, A만 FINISHED
+            // (다른 참가자는 아직 게임 진행 중이므로 부분 랭킹은 의미가 없어 노출하지 않음)
             GameRoom room = createStartedRoom();
             GameParticipant participantA = GameParticipant.createLeader(room, USER_A);
             participantA.finish();
 
-            GameResult resultA = GameResult.create(room, participantA, 0, SEED,
-                    new BigDecimal("11000000"), new BigDecimal("10.00"), 12);
-
             given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
             given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
                     .willReturn(Optional.of(participantA));
-            given(gameResultRepository.findByGameRoomOrderByFinalAssetDescCreatedAtAsc(room))
-                    .willReturn(List.of(resultA));
-
-            User userA = mockUser(USER_A, "재훈");
-            given(userRepository.findAllById(any())).willReturn(List.of(userA));
 
             // When
             GameResultInfo info = gameResultService.getGameResult(ROOM_ID, USER_A);
 
-            // Then
-            assertThat(info.rankings()).hasSize(1);
-            assertThat(info.rankings().get(0).rank()).isEqualTo(1);
-            assertThat(info.rankings().get(0).userName()).isEqualTo("재훈");
+            // Then — 방 상태 검증 통과 후 early return: gameResultRepository/userRepository 호출되지 않음
+            assertThat(info.roomFinished()).isFalse();
+            assertThat(info.rankings()).isEmpty();
+            assertThat(info.startDate()).isEqualTo(START_DATE);
+            assertThat(info.endDate()).isEqualTo(END_DATE);
         }
 
         @Test
@@ -287,6 +300,322 @@ class GameResultServiceTest {
         }
     }
 
+    // === 스냅샷 조회 ===
+
+    @Nested
+    @DisplayName("스냅샷 조회 성공")
+    class SnapshotSuccessTests {
+
+        @Test
+        @DisplayName("participantId 미지정 — 본인 스냅샷을 turnNumber ASC로 반환")
+        void getSnapshots_self_orderedByTurnAsc() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.finish();
+
+            GamePortfolioSnapshot s1 = mockSnapshot(1, LocalDate.of(2022, 3, 2),
+                    new BigDecimal("10000000"), new BigDecimal("10000000"),
+                    BigDecimal.ZERO, BigDecimal.ZERO);
+            GamePortfolioSnapshot s2 = mockSnapshot(2, LocalDate.of(2022, 3, 9),
+                    new BigDecimal("10500000"), new BigDecimal("9000000"),
+                    new BigDecimal("1500000"), new BigDecimal("5.00"));
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+            given(snapshotRepository.findByParticipantOrderByTurnNumber(me))
+                    .willReturn(List.of(s1, s2));
+
+            // When
+            List<SnapshotInfo> infos = gameResultService.getSnapshots(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(infos).hasSize(2);
+            assertThat(infos.get(0).turnNumber()).isEqualTo(1);
+            assertThat(infos.get(0).totalAsset()).isEqualByComparingTo("10000000");
+            assertThat(infos.get(1).turnNumber()).isEqualTo(2);
+            assertThat(infos.get(1).profitRate()).isEqualByComparingTo("5.00");
+        }
+
+        @Test
+        @DisplayName("스냅샷이 0건이면 빈 리스트 반환 — 첫 턴에 즉시 종료한 참가자 케이스")
+        void getSnapshots_empty() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.finish();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+            given(snapshotRepository.findByParticipantOrderByTurnNumber(me))
+                    .willReturn(List.of());
+
+            List<SnapshotInfo> infos = gameResultService.getSnapshots(ROOM_ID, USER_A);
+            assertThat(infos).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("스냅샷 조회 실패")
+    class SnapshotFailTests {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void roomNotFound() {
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameResultService.getSnapshots(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("본인이 ACTIVE면 PARTICIPANT_NOT_FINISHED")
+        void requesterActive() {
+            GameRoom room = createStartedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+
+            assertThatThrownBy(() -> gameResultService.getSnapshots(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("본인이 LEFT면 PARTICIPANT_NOT_FINISHED — FINISHED 필터의 LEFT 분기 보장")
+        void requesterLeft() {
+            GameRoom room = createStartedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.leave();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+
+            assertThatThrownBy(() -> gameResultService.getSnapshots(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("요청자가 해당 방 참가자가 아니면 PARTICIPANT_NOT_FINISHED")
+        void requesterNotParticipant() {
+            GameRoom room = createFinishedRoom();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameResultService.getSnapshots(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+    }
+
+    // === 매매 내역 조회 ===
+
+    @Nested
+    @DisplayName("매매 내역 조회 성공")
+    class OrderHistorySuccessTests {
+
+        @Test
+        @DisplayName("매매 내역이 0건이면 빈 리스트 반환")
+        void getOrderHistory_empty() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.finish();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(me))
+                    .willReturn(List.of());
+
+            List<OrderHistoryInfo> infos = gameResultService.getOrderHistory(ROOM_ID, USER_A);
+            assertThat(infos).isEmpty();
+        }
+
+        @Test
+        @DisplayName("BUY/SELL 모두 매핑 — orderId/turn/symbol/orderType/quantity/price/fee/tax 전체 필드")
+        void getOrderHistory_buyAndSell() {
+            // Given
+            GameRoom room = createFinishedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.finish();
+
+            UUID orderId1 = UUID.fromString("aaaaaaaa-0000-4000-a000-000000000001");
+            UUID orderId2 = UUID.fromString("aaaaaaaa-0000-4000-a000-000000000002");
+            GameOrder buyOrder = mockOrder(orderId1, 1, LocalDate.of(2022, 3, 2),
+                    "005930", "삼성전자", OrderType.BUY, 10,
+                    new BigDecimal("60000.00"), new BigDecimal("90.00"), BigDecimal.ZERO);
+            GameOrder sellOrder = mockOrder(orderId2, 2, LocalDate.of(2022, 3, 9),
+                    "005930", "삼성전자", OrderType.SELL, 5,
+                    new BigDecimal("65000.00"), new BigDecimal("48.75"), new BigDecimal("812.50"));
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(me))
+                    .willReturn(List.of(buyOrder, sellOrder));
+
+            // When
+            List<OrderHistoryInfo> infos = gameResultService.getOrderHistory(ROOM_ID, USER_A);
+
+            // Then
+            assertThat(infos).hasSize(2);
+
+            OrderHistoryInfo buy = infos.get(0);
+            assertThat(buy.orderId()).isEqualTo(orderId1);
+            assertThat(buy.turnNumber()).isEqualTo(1);
+            assertThat(buy.turnDate()).isEqualTo(LocalDate.of(2022, 3, 2));
+            assertThat(buy.symbol()).isEqualTo("005930");
+            assertThat(buy.stockName()).isEqualTo("삼성전자");
+            assertThat(buy.orderType()).isEqualTo(OrderType.BUY);
+            assertThat(buy.quantity()).isEqualTo(10);
+            assertThat(buy.price()).isEqualByComparingTo("60000.00");
+            assertThat(buy.fee()).isEqualByComparingTo("90.00");
+            assertThat(buy.tax()).isEqualByComparingTo("0");
+
+            OrderHistoryInfo sell = infos.get(1);
+            assertThat(sell.orderType()).isEqualTo(OrderType.SELL);
+            assertThat(sell.tax()).isEqualByComparingTo("812.50");
+        }
+
+        @Test
+        @DisplayName("Repository 결과 순서를 그대로 보존 — 정렬은 Repository JPQL 책임")
+        void getOrderHistory_preservesRepositoryOrder() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.finish();
+
+            // Repository가 turn 1, 2, 3 순으로 반환한다고 가정 (실제 ORDER BY t.turnNumber ASC, o.orderId ASC)
+            GameOrder o1 = mockOrder(UUID.randomUUID(), 1, LocalDate.of(2022, 3, 2),
+                    "005930", "삼성전자", OrderType.BUY, 10,
+                    new BigDecimal("60000.00"), BigDecimal.ZERO, BigDecimal.ZERO);
+            GameOrder o2 = mockOrder(UUID.randomUUID(), 2, LocalDate.of(2022, 3, 9),
+                    "000660", "SK하이닉스", OrderType.BUY, 5,
+                    new BigDecimal("120000.00"), BigDecimal.ZERO, BigDecimal.ZERO);
+            GameOrder o3 = mockOrder(UUID.randomUUID(), 3, LocalDate.of(2022, 3, 16),
+                    "005930", "삼성전자", OrderType.SELL, 10,
+                    new BigDecimal("65000.00"), BigDecimal.ZERO, BigDecimal.ZERO);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(me))
+                    .willReturn(List.of(o1, o2, o3));
+
+            List<OrderHistoryInfo> infos = gameResultService.getOrderHistory(ROOM_ID, USER_A);
+
+            assertThat(infos).hasSize(3);
+            assertThat(infos).extracting(OrderHistoryInfo::turnNumber)
+                    .containsExactly(1, 2, 3);
+        }
+
+        @Test
+        @DisplayName("같은 턴 내 여러 주문 — Repository가 orderId ASC로 반환한 순서 그대로 보존")
+        void getOrderHistory_sameTurnPreservesOrderIdAscFromRepo() {
+            GameRoom room = createFinishedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.finish();
+
+            // 같은 턴(turn=2) 내 3건. Repository는 ORDER BY ..., o.orderId ASC로 정렬해 반환.
+            // UUID 자체는 정렬 보장 안 되므로, 결정적인 값으로 직접 세팅한 뒤 그 순서대로 mock한다.
+            UUID id1 = UUID.fromString("00000000-0000-4000-a000-000000000010");
+            UUID id2 = UUID.fromString("00000000-0000-4000-a000-000000000011");
+            UUID id3 = UUID.fromString("00000000-0000-4000-a000-000000000012");
+            GameOrder o1 = mockOrder(id1, 2, LocalDate.of(2022, 3, 9),
+                    "005930", "삼성전자", OrderType.BUY, 10,
+                    new BigDecimal("60000.00"), BigDecimal.ZERO, BigDecimal.ZERO);
+            GameOrder o2 = mockOrder(id2, 2, LocalDate.of(2022, 3, 9),
+                    "000660", "SK하이닉스", OrderType.BUY, 5,
+                    new BigDecimal("120000.00"), BigDecimal.ZERO, BigDecimal.ZERO);
+            GameOrder o3 = mockOrder(id3, 2, LocalDate.of(2022, 3, 9),
+                    "035720", "카카오", OrderType.SELL, 3,
+                    new BigDecimal("45000.00"), BigDecimal.ZERO, BigDecimal.ZERO);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+            given(gameOrderRepository.findByParticipantOrderByTurnNumber(me))
+                    .willReturn(List.of(o1, o2, o3));
+
+            List<OrderHistoryInfo> infos = gameResultService.getOrderHistory(ROOM_ID, USER_A);
+
+            // 같은 턴 내 행 순서는 Repository가 결정 — 매 요청마다 동일한 순서가 반환되어야 한다 (UX 깜빡임 방지)
+            assertThat(infos).hasSize(3);
+            assertThat(infos).extracting(OrderHistoryInfo::orderId)
+                    .containsExactly(id1, id2, id3);
+            assertThat(infos).extracting(OrderHistoryInfo::turnNumber)
+                    .containsExactly(2, 2, 2);
+        }
+    }
+
+    @Nested
+    @DisplayName("매매 내역 조회 실패")
+    class OrderHistoryFailTests {
+
+        @Test
+        @DisplayName("방이 없으면 ROOM_NOT_FOUND")
+        void roomNotFound() {
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameResultService.getOrderHistory(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("본인이 ACTIVE면 PARTICIPANT_NOT_FINISHED")
+        void requesterActive() {
+            GameRoom room = createStartedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+
+            assertThatThrownBy(() -> gameResultService.getOrderHistory(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("본인이 LEFT면 PARTICIPANT_NOT_FINISHED")
+        void requesterLeft() {
+            GameRoom room = createStartedRoom();
+            GameParticipant me = GameParticipant.createLeader(room, USER_A);
+            me.leave();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.of(me));
+
+            assertThatThrownBy(() -> gameResultService.getOrderHistory(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+
+        @Test
+        @DisplayName("요청자가 해당 방 참가자가 아니면 PARTICIPANT_NOT_FINISHED")
+        void requesterNotParticipant() {
+            GameRoom room = createFinishedRoom();
+
+            given(gameRoomRepository.findById(ROOM_ID)).willReturn(Optional.of(room));
+            given(gameParticipantRepository.findByGameRoomAndUserId(room, USER_A))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> gameResultService.getOrderHistory(ROOM_ID, USER_A))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_NOT_FINISHED);
+        }
+    }
+
     // === 헬퍼 메서드 ===
 
     private GameRoom createStartedRoom() {
@@ -307,5 +636,44 @@ class GameResultServiceTest {
         given(user.getUserId()).willReturn(userId);
         given(user.getNickname()).willReturn(nickname);
         return user;
+    }
+
+    private GamePortfolioSnapshot mockSnapshot(int turnNumber, LocalDate turnDate,
+                                                BigDecimal totalAsset, BigDecimal cash,
+                                                BigDecimal stockValue, BigDecimal profitRate) {
+        GameTurn turn = mock(GameTurn.class);
+        given(turn.getTurnNumber()).willReturn(turnNumber);
+        given(turn.getTurnDate()).willReturn(turnDate);
+
+        GamePortfolioSnapshot snapshot = mock(GamePortfolioSnapshot.class);
+        given(snapshot.getTurn()).willReturn(turn);
+        given(snapshot.getTotalAsset()).willReturn(totalAsset);
+        given(snapshot.getCash()).willReturn(cash);
+        given(snapshot.getStockValue()).willReturn(stockValue);
+        given(snapshot.getProfitRate()).willReturn(profitRate);
+        return snapshot;
+    }
+
+    private GameOrder mockOrder(UUID orderId, int turnNumber, LocalDate turnDate,
+                                 String symbol, String stockName, OrderType orderType,
+                                 int quantity, BigDecimal orderPrice, BigDecimal fee, BigDecimal tax) {
+        GameTurn turn = mock(GameTurn.class);
+        given(turn.getTurnNumber()).willReturn(turnNumber);
+        given(turn.getTurnDate()).willReturn(turnDate);
+
+        StockInfo stockInfo = mock(StockInfo.class);
+        given(stockInfo.getSymbol()).willReturn(symbol);
+
+        GameOrder order = mock(GameOrder.class);
+        given(order.getOrderId()).willReturn(orderId);
+        given(order.getTurn()).willReturn(turn);
+        given(order.getStockInfo()).willReturn(stockInfo);
+        given(order.getStockName()).willReturn(stockName);
+        given(order.getOrderType()).willReturn(orderType);
+        given(order.getQuantity()).willReturn(quantity);
+        given(order.getOrderPrice()).willReturn(orderPrice);
+        given(order.getFee()).willReturn(fee);
+        given(order.getTax()).willReturn(tax);
+        return order;
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
<br>게임 종료 후 결과 페이지에서 사용할 API 5종을 구현했습니다. 본인 최종 결과, 전체 랭킹, 자산 변화 차트, 주문 내역, AI 분석 리포트(OpenAI 연동)로 구성되며, 랭킹 확정 / 과거 재진입 / AI 호출 캐싱 로직을 포함합니다.

## ✅ 완료한 기능 명세

- [x]  본인 최종 결과 + 방 FINISHED 시 전체 랭킹
- [x] 자산 변화 차트 데이터
- [x]  본인 주문 내역 조회
- [x]  AI 분석 리포트
- [x] V43 마이그레이션
- [x] 테스트 코드
- [x] 에러코드 수정

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
랭킹 확정 타이밍 -> 방 전체 FINISHED 시점에만
본인이 FINISHED 상태면 ResultPage에 언제든 다시 들어올 수 있고  방이 IN_PROGRESS여도 본인 결과 / 스냅샷 / 주문내역은 조회 가능, 랭킹만 roomFinished = false로 숨겼습니다.
<br>

### 🔗 관련 이슈
Closes #265 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * AI 분석 리포트 생성 및 조회 API 추가 (/report)
  * 게임 내 거래 이력 조회 API 추가 (/orders)
  * 포트폴리오 스냅샷 조회 API 추가 (/snapshots)

* **개선사항**
  * 게임 결과에 방 완료 상태(roomFinished) 표시 추가
  * 순위 목록에 본인 표기(isMine) 추가
  * 뉴스 배치 수집 스케줄 일부 조정

* **데이터베이스**
  * AI 분석 리포트 저장용 테이블 구조 변경 및 마이그레이션 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->