### PR TITLE
[WEF-630] 뉴스 배치 크기/주기 외부화 및 클러스터 상세 relatedSectors 추가

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/dto/SectorInfo.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/dto/SectorInfo.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.news.cluster.dto;
+
+/**
+ * 클러스터 관련 섹터 정보 (code + canonical name)
+ */
+public record SectorInfo(String code, String name) {
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
@@ -159,6 +159,8 @@ public class ClusterTagAggregator {
 
     /**
      * 클러스터별 관련 STOCK 태그(code + name)를 집계한다
+     *
+     * 결정적 선택 정책: {@link #selectCanonicalName} 참고
      */
     public Map<Long, List<StockInfo>> aggregateStocks(Map<Long, List<Long>> clusterArticleMap,
                                                       List<Long> allArticleIds) {
@@ -169,12 +171,11 @@ public class ClusterTagAggregator {
 
         Map<Long, List<StockInfo>> result = new HashMap<>();
         for (var entry : clusterArticleMap.entrySet()) {
-            Map<String, StockInfo> seen = new LinkedHashMap<>();
+            List<NewsArticleTag> clusterTags = new ArrayList<>();
             for (Long articleId : entry.getValue()) {
-                tagsByArticle.getOrDefault(articleId, List.of()).forEach(t ->
-                        seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName())));
+                clusterTags.addAll(tagsByArticle.getOrDefault(articleId, List.of()));
             }
-            result.put(entry.getKey(), List.copyOf(seen.values()));
+            result.put(entry.getKey(), selectCanonicalName(clusterTags, StockInfo::new));
         }
         return result;
     }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregator.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
 import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.SectorInfo;
 import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
 import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 /**
@@ -79,18 +81,64 @@ public class ClusterTagAggregator {
 
     /**
      * 단일 클러스터용 — 기사 목록의 관련 STOCK 태그를 집계한다
+     *
+     * 결정적 선택 정책: {@link #selectCanonicalName} 참고
      */
     public List<StockInfo> aggregateStocksForCluster(List<Long> articleIds) {
-        if (articleIds.isEmpty()) {
+        if (articleIds == null || articleIds.isEmpty()) {
             return List.of();
         }
-        Map<String, StockInfo> seen = new LinkedHashMap<>();
         List<NewsArticleTag> stockTags = articleTagRepository.findByNewsArticleIdInAndTagType(
                 articleIds, TagType.STOCK);
-        for (NewsArticleTag t : stockTags) {
-            seen.putIfAbsent(t.getTagCode(), new StockInfo(t.getTagCode(), t.getTagName()));
+        return selectCanonicalName(stockTags, StockInfo::new);
+    }
+
+    /**
+     * 단일 클러스터용 — 기사 목록의 관련 SECTOR 태그를 집계한다
+     */
+    public List<SectorInfo> aggregateSectorsForCluster(List<Long> articleIds) {
+        if (articleIds == null || articleIds.isEmpty()) {
+            return List.of();
         }
-        return List.copyOf(seen.values());
+        List<NewsArticleTag> sectorTags = articleTagRepository.findByNewsArticleIdInAndTagType(
+                articleIds, TagType.SECTOR);
+        return selectCanonicalName(sectorTags, SectorInfo::new);
+    }
+
+    /**
+     * tagCode별 대표 tagName을 결정적으로 선택한다
+     *
+     * 동일 tagCode에 여러 tagName이 섞일 수 있다 (AI 태깅 변동, 동의어 등).
+     * DB 조회 순서에 의존하면 호출 시점마다 라벨이 흔들리므로, 아래 정책으로 고정한다.
+     * - tagCode별 대표 tagName: 해당 code의 tagName 중 출현 빈도(최빈값) 최대. 동점 시 사전순 최소
+     * - 출력 리스트 순서: tagCode 사전순
+     *
+     * @param tags    해당 태그 타입의 전체 태그 목록
+     * @param factory (code, name) → 결과 DTO 생성자
+     */
+    private static <T> List<T> selectCanonicalName(List<NewsArticleTag> tags,
+                                                    BiFunction<String, String, T> factory) {
+        if (tags.isEmpty()) {
+            return List.of();
+        }
+        Map<String, Map<String, Long>> countByCodeName = tags.stream()
+                .collect(Collectors.groupingBy(
+                        NewsArticleTag::getTagCode,
+                        Collectors.groupingBy(NewsArticleTag::getTagName, Collectors.counting())));
+
+        return countByCodeName.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(entry -> {
+                    String code = entry.getKey();
+                    String name = entry.getValue().entrySet().stream()
+                            .min(Comparator
+                                    .<Map.Entry<String, Long>, Long>comparing(Map.Entry::getValue).reversed()
+                                    .thenComparing(Map.Entry::getKey))
+                            .orElseThrow()
+                            .getKey();
+                    return factory.apply(code, name);
+                })
+                .toList();
     }
 
     /**

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusteringService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusteringService.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService.MatchResult;
 import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.ScoreResult;
 import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.Verdict;
@@ -28,7 +29,6 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ClusteringService {
 
-    private static final int BATCH_SIZE = 500;
     private static final int HOURS_RANGE = 24;
 
     private final NewsArticleRepository newsArticleRepository;
@@ -37,6 +37,7 @@ public class ClusteringService {
     private final ClusterMatchingService clusterMatchingService;
     private final SuspiciousScoringService suspiciousScoringService;
     private final ClusteringPersistenceService persistenceService;
+    private final NewsBatchProperties batchProperties;
 
     /**
      * 임베딩이 완료된 기사 중 아직 클러스터에 속하지 않은 기사를 가져온다.
@@ -127,7 +128,7 @@ public class ClusteringService {
                 NewsArticle.EmbeddingStatus.SUCCESS,
                 since,
                 NewsArticle.RelevanceStatus.IRRELEVANT,
-                PageRequest.of(0, BATCH_SIZE));
+                PageRequest.of(0, batchProperties.clusteringSize()));
     }
 
     private ClusterStats getClusterStats(List<NewsCluster> clusters) {

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -18,6 +18,7 @@ import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
 import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.SectorInfo;
 import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
 import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 import com.solv.wefin.global.error.BusinessException;
@@ -281,8 +282,9 @@ public class NewsClusterQueryService {
                 ? List.of()
                 : tagAggregator.aggregateDetailSources(articleIds, sectionSourceArticleIds);
 
-        // 관련 종목 / 마켓 태그 — 단건 전용 오버로드 사용 (Map 래핑 불필요)
+        // 관련 종목 / 관련 분야 / 마켓 태그 — 단건 전용 오버로드 사용 (Map 래핑 불필요)
         List<StockInfo> stocks = tagAggregator.aggregateStocksForCluster(articleIds);
+        List<SectorInfo> sectors = tagAggregator.aggregateSectorsForCluster(articleIds);
         List<String> marketTags = tagAggregator.aggregateMarketTagsForCluster(articleIds);
 
         // 읽음 여부
@@ -313,7 +315,7 @@ public class NewsClusterQueryService {
         return new ClusterDetailResult(
                 cluster.getId(), cluster.getTitle(), cluster.getSummary(),
                 cluster.getThumbnailUrl(), cluster.getPublishedAt(),
-                cluster.getArticleCount(), sources, stocks, marketTags, isRead,
+                cluster.getArticleCount(), sources, stocks, sectors, marketTags, isRead,
                 feedbackType, sectionDetails, suggestedQuestions, articleContent
         );
     }
@@ -412,6 +414,7 @@ public class NewsClusterQueryService {
             int sourceCount,
             List<ArticleSourceInfo> sources,
             List<StockInfo> relatedStocks,
+            List<SectorInfo> relatedSectors,
             List<String> marketTags,
             boolean isRead,
             String feedbackType,

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsBatchProperties.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsBatchProperties.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.news.config;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 뉴스 파이프라인 배치 1회당 처리 건수 설정
+ *
+ * 각 배치의 페이지 크기를 한 곳에서 관리하기 위해 도입되었다.
+ * 운영 중 트래픽/OpenAI 비용에 따라 환경변수에서 조정할 수 있도록 외부화한다.
+ *
+ * 상한은 운영 중 오설정(공란/음수/과대값)으로 인한 런타임 장애와 비용 폭주를 막기 위한
+ * 방어 한계선이다. 상한 자체가 정상 운영 기준치를 뜻하지는 않는다.
+ *
+ * @param crawlSize       크롤링 배치 1회당 처리 기사 수
+ * @param embeddingSize   임베딩 배치 1회당 처리 기사 수.
+ *                        OpenAI embedding batch 단일 호출 2048 한도 대비 보수적 상한
+ * @param taggingSize     태깅 배치 1회당 처리 기사 수.
+ *                        OpenAI chat API TPM(600K) 대비 1000건 × 평균 300토큰 ≈ 300K 기준 상한
+ * @param clusteringSize  클러스터링 배치 1회당 처리 기사 수
+ * @param summarySize     요약 배치 1회당 처리 클러스터 수.
+ *                        OpenAI chat API 호출 비용 방어 (클러스터당 기사 N건 합산)
+ * @param rejudgeMaxLimit 관련성 재판단 수동 실행 시 허용 상한
+ */
+@Validated
+@ConfigurationProperties(prefix = "batch.news")
+public record NewsBatchProperties(
+        @Min(1) @Max(5000) int crawlSize,
+        @Min(1) @Max(1000) int embeddingSize,
+        @Min(1) @Max(1000) int taggingSize,
+        @Min(1) @Max(5000) int clusteringSize,
+        @Min(1) @Max(200) int summarySize,
+        @Min(1) @Max(2000) int rejudgeMaxLimit
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
@@ -1,11 +1,13 @@
 package com.solv.wefin.domain.news.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@EnableConfigurationProperties(NewsBatchProperties.class)
 public class NewsConfig {
 
     @Bean

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.news.article.entity.NewsArticle.CrawlStatus;
 import com.solv.wefin.domain.news.article.entity.NewsArticle.EmbeddingStatus;
 import com.solv.wefin.domain.news.article.entity.NewsArticle.RelevanceStatus;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +31,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class EmbeddingService {
 
-    private static final int BATCH_SIZE = 500;
     private static final int PROCESS_CHUNK_SIZE = 20;
     private static final int MAX_RETRY = 3;
     private static final int STALE_PROCESSING_MINUTES = 30;
@@ -39,6 +39,7 @@ public class EmbeddingService {
     private final OpenAiEmbeddingClient openAiEmbeddingClient;
     private final ArticleChunker articleChunker;
     private final EmbeddingPersistenceService persistenceService;
+    private final NewsBatchProperties batchProperties;
 
     @Value("${openai.embedding.model}")
     private String embeddingModel;
@@ -85,7 +86,7 @@ public class EmbeddingService {
                 MAX_RETRY,
                 staleBefore,
                 RelevanceStatus.IRRELEVANT,
-                PageRequest.of(0, BATCH_SIZE));
+                PageRequest.of(0, batchProperties.embeddingSize()));
     }
 
     private int[] processChunk(List<NewsArticle> articles) {

--- a/src/main/java/com/solv/wefin/domain/news/ingestion/service/ArticleCrawlService.java
+++ b/src/main/java/com/solv/wefin/domain/news/ingestion/service/ArticleCrawlService.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.news.ingestion.crawler.ArticleContentExtractor;
 import com.solv.wefin.domain.news.article.entity.NewsArticle;
 import com.solv.wefin.domain.news.article.entity.NewsArticle.CrawlStatus;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -33,13 +34,13 @@ public class ArticleCrawlService {
     private static final String USER_AGENT = "Mozilla/5.0 (compatible; WefinBot/1.0)";
     private static final int ERROR_MESSAGE_MAX_LENGTH = 500;
     private static final int MAX_RETRY = 3;
-    private static final int CRAWL_BATCH_SIZE = 500;
     private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
 
     private final NewsArticleRepository newsArticleRepository;
     private final ArticleCrawlPersistenceService persistenceService;
     private final List<ArticleContentExtractor> extractors;
     private final RestTemplate newsRestTemplate;
+    private final NewsBatchProperties batchProperties;
 
     /**
      * PENDING/FAILED 상태의 기사를 조회하여 원문 HTML을 크롤링하고 본문/썸네일을 저장한다.
@@ -67,7 +68,7 @@ public class ArticleCrawlService {
                 .findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(
                         List.of(CrawlStatus.PENDING, CrawlStatus.FAILED),
                         MAX_RETRY,
-                        PageRequest.of(0, CRAWL_BATCH_SIZE));
+                        PageRequest.of(0, batchProperties.crawlSize()));
     }
 
     private boolean crawlSingleArticle(NewsArticle article) {

--- a/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/summary/service/SummaryService.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
 import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.summary.client.OpenAiSummaryClient;
 import com.solv.wefin.domain.news.summary.dto.SummaryResult;
 import com.solv.wefin.global.error.BusinessException;
@@ -38,14 +39,13 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class SummaryService {
 
-    private static final int BATCH_SIZE = 50;
-
     private final NewsClusterRepository newsClusterRepository;
     private final NewsClusterArticleRepository clusterArticleRepository;
     private final NewsArticleRepository newsArticleRepository;
     private final OpenAiSummaryClient openAiSummaryClient;
     private final OutlierDetectionService outlierDetectionService;
     private final SummaryPersistenceService persistenceService;
+    private final NewsBatchProperties batchProperties;
 
     /**
      * 요약 생성이 필요한 클러스터를 조회하여 AI 요약을 생성한다.
@@ -59,7 +59,7 @@ public class SummaryService {
         List<NewsCluster> targets = newsClusterRepository.findByStatusAndSummaryStatusIn(
                 ClusterStatus.ACTIVE,
                 List.of(SummaryStatus.PENDING, SummaryStatus.STALE, SummaryStatus.FAILED),
-                PageRequest.of(0, BATCH_SIZE, Sort.by(Sort.Direction.ASC, "id")));
+                PageRequest.of(0, batchProperties.summarySize(), Sort.by(Sort.Direction.ASC, "id")));
 
         log.info("요약 생성 대상 클러스터 수: {}", targets.size());
 

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeService.java
@@ -3,6 +3,7 @@ package com.solv.wefin.domain.news.tagging.service;
 import com.solv.wefin.domain.news.article.entity.NewsArticle;
 import com.solv.wefin.domain.news.article.entity.NewsArticle.RelevanceStatus;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.tagging.client.OpenAiTaggingClient;
 import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
 import com.solv.wefin.global.error.BusinessException;
@@ -22,11 +23,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class RelevanceRejudgeService {
 
-    private static final int MAX_REJUDGE_LIMIT = 500;
-
     private final NewsArticleRepository newsArticleRepository;
     private final OpenAiTaggingClient openAiTaggingClient;
     private final RelevancePersistenceService persistenceService;
+    private final NewsBatchProperties batchProperties;
 
     /**
      * 지정된 article ID들의 관련성을 재판정한다.
@@ -55,7 +55,8 @@ public class RelevanceRejudgeService {
     /**
      * PENDING 상태의 기사를 배치 크기만큼 재판정한다.
      *
-     * @param limit 한 번에 처리할 최대 기사 수 (1~500)
+     * @param limit 한 번에 처리할 최대 기사 수
+     *              (허용 범위: 1 ~ {@code batch.news.rejudge-max-limit})
      * @return 재판정 처리 결과 요약
      */
     public RejudgeSummary rejudgePending(int limit) {
@@ -73,9 +74,10 @@ public class RelevanceRejudgeService {
     }
 
     private void validateLimit(int limit) {
-        if (limit < 1 || limit > MAX_REJUDGE_LIMIT) {
+        int maxLimit = batchProperties.rejudgeMaxLimit();
+        if (limit < 1 || limit > maxLimit) {
             throw new BusinessException(ErrorCode.INVALID_INPUT,
-                    "limit는 1 이상 " + MAX_REJUDGE_LIMIT + " 이하여야 합니다 (요청값: " + limit + ")");
+                    "limit는 1 이상 " + maxLimit + " 이하여야 합니다 (요청값: " + limit + ")");
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/TaggingService.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.news.article.entity.NewsArticle.TaggingStatus;
 import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
 import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.tagging.client.OpenAiTaggingClient;
 import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,6 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class TaggingService {
 
-    private static final int BATCH_SIZE = 500;
     private static final int PROCESS_CHUNK_SIZE = 20;
     private static final int MAX_RETRY = 3;
     private static final int STALE_PROCESSING_MINUTES = 30;
@@ -41,6 +41,7 @@ public class TaggingService {
     private final OpenAiTaggingClient openAiTaggingClient;
     private final TaggingPersistenceService persistenceService;
     private final StockCodeValidator stockCodeValidator;
+    private final NewsBatchProperties batchProperties;
 
     /**
      * 크롤링 완료 + 태깅 미완료 기사를 조회하여 태그를 생성한다.
@@ -80,7 +81,7 @@ public class TaggingService {
                 TaggingStatus.PROCESSING,
                 MAX_RETRY,
                 staleBefore,
-                PageRequest.of(0, BATCH_SIZE));
+                PageRequest.of(0, batchProperties.taggingSize()));
     }
 
     private int[] processChunk(List<NewsArticle> articles, Map<String, String> stockMap) {

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterDetailResponse.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.news.dto.response;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterDetailResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.SectionDetail;
 import com.solv.wefin.domain.news.cluster.dto.ArticleSourceInfo;
+import com.solv.wefin.domain.news.cluster.dto.SectorInfo;
 import com.solv.wefin.domain.news.cluster.dto.StockInfo;
 
 import java.time.OffsetDateTime;
@@ -22,6 +23,7 @@ public record ClusterDetailResponse(
         int sourceCount,
         List<ArticleSourceResponse> sources,
         List<StockResponse> relatedStocks,
+        List<SectorResponse> relatedSectors,
         List<String> marketTags,
         boolean isRead,
         String feedbackType,
@@ -42,6 +44,10 @@ public record ClusterDetailResponse(
                 .map(StockResponse::from)
                 .toList();
 
+        List<SectorResponse> sectors = result.relatedSectors().stream()
+                .map(SectorResponse::from)
+                .toList();
+
         List<SectionResponse> sections = result.sections().stream()
                 .map(SectionResponse::from)
                 .toList();
@@ -49,7 +55,7 @@ public record ClusterDetailResponse(
         return new ClusterDetailResponse(
                 result.clusterId(), result.title(), result.summary(),
                 result.thumbnailUrl(), result.publishedAt(),
-                result.sourceCount(), sources, stocks, result.marketTags(),
+                result.sourceCount(), sources, stocks, sectors, result.marketTags(),
                 result.isRead(), result.feedbackType(), sections,
                 result.suggestedQuestions(), result.articleContent()
         );
@@ -58,6 +64,12 @@ public record ClusterDetailResponse(
     public record StockResponse(String code, String name) {
         public static StockResponse from(StockInfo stock) {
             return new StockResponse(stock.code(), stock.name());
+        }
+    }
+
+    public record SectorResponse(String code, String name) {
+        public static SectorResponse from(SectorInfo sector) {
+            return new SectorResponse(sector.code(), sector.name());
         }
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -60,6 +60,15 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+batch:
+  news:
+    crawl-size: ${NEWS_CRAWL_BATCH_SIZE:500}
+    embedding-size: ${NEWS_EMBEDDING_BATCH_SIZE:500}
+    tagging-size: ${NEWS_TAGGING_BATCH_SIZE:500}
+    clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
+    summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
+    rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
+
 websocket:
   allowed-origins:
     - https://dev.wefin.ai.kr

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -71,6 +71,15 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:-}
 
+batch:
+  news:
+    crawl-size: ${NEWS_CRAWL_BATCH_SIZE:100}
+    embedding-size: ${NEWS_EMBEDDING_BATCH_SIZE:100}
+    tagging-size: ${NEWS_TAGGING_BATCH_SIZE:100}
+    clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:100}
+    summary-size: ${NEWS_SUMMARY_BATCH_SIZE:20}
+    rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:100}
+
 websocket:
   allowed-origins:
     - http://localhost:5173

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -57,6 +57,15 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+batch:
+  news:
+    crawl-size: ${NEWS_CRAWL_BATCH_SIZE:500}
+    embedding-size: ${NEWS_EMBEDDING_BATCH_SIZE:500}
+    tagging-size: ${NEWS_TAGGING_BATCH_SIZE:500}
+    clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
+    summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
+    rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
+
 websocket:
   allowed-origins:
     - https://wefin.ai.kr

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,11 +30,11 @@ openai:
 
 embedding:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${EMBEDDING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 tagging:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${TAGGING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 kis:
   app-key: ${KIS_APP_KEY:}
   app-secret: ${KIS_APP_SECRET:}
@@ -62,15 +62,24 @@ clustering:
   merge:
     threshold: 0.85
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${CLUSTERING_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 summary:
   collect:
-    cron: "0 */30 * * * *"
+    cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
 market:
   trend:
-    cron: "0 */30 * * * *"
+    cron: ${MARKET_TREND_CRON:${MARKET_BATCH_CRON:0 */30 * * * *}}
+
+batch:
+  news:
+    crawl-size: ${NEWS_CRAWL_BATCH_SIZE:500}
+    embedding-size: ${NEWS_EMBEDDING_BATCH_SIZE:500}
+    tagging-size: ${NEWS_TAGGING_BATCH_SIZE:500}
+    clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
+    summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
+    rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
 
 websocket:
   allowed-origins:

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregatorTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregatorTest.java
@@ -88,7 +88,7 @@ class ClusterTagAggregatorTest {
 
         assertThat(result.get(1L))
                 .extracting(StockInfo::code)
-                .containsExactly("005930", "000660");
+                .containsExactly("000660", "005930");
     }
 
     // ---------- aggregateMarketTags (TagType.TOPIC 쿼리) ----------
@@ -196,13 +196,13 @@ class ClusterTagAggregatorTest {
                 .containsExactly("연합", "매일경제");
     }
 
-    // ---------- putIfAbsent 고정 동작 ----------
+    // ---------- canonical name 결정적 선택 ----------
 
     @Test
-    @DisplayName("aggregateStocks — 같은 code에 다른 name이 오면 먼저 본 name을 고정한다 (putIfAbsent)")
-    void aggregateStocks_sameCodeDifferentName_keepsFirstSeenName() {
+    @DisplayName("aggregateStocks — 같은 code에 다른 name이 오면 최빈값(동점 시 사전순 최소)을 선택한다")
+    void aggregateStocks_sameCodeDifferentName_selectsCanonicalName() {
         Map<Long, List<Long>> clusterMap = Map.of(1L, List.of(10L, 20L));
-        // articleId 10이 먼저 순회되므로 "삼성전자"가 고정
+        // "삼성전자"×1, "삼전"×1 → 동점, 사전순 최소 "삼성전자" 선택 ('성' < '전')
         given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK)))
                 .willReturn(List.of(
                         stockTag(10L, "005930", "삼성전자"),

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregatorTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterTagAggregatorTest.java
@@ -229,7 +229,7 @@ class ClusterTagAggregatorTest {
 
         List<StockInfo> result = aggregator.aggregateStocksForCluster(List.of(10L, 20L));
 
-        assertThat(result).extracting(StockInfo::code).containsExactly("005930", "000660");
+        assertThat(result).extracting(StockInfo::code).containsExactly("000660", "005930");
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusteringServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusteringServiceTest.java
@@ -8,10 +8,10 @@ import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService.MatchResult;
 import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.ScoreResult;
 import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.Verdict;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class ClusteringServiceTest {
 
-    @InjectMocks
     private ClusteringService clusteringService;
 
     @Mock
@@ -49,6 +48,14 @@ class ClusteringServiceTest {
 
     @Mock
     private ClusteringPersistenceService persistenceService;
+
+    @BeforeEach
+    void setUp() {
+        clusteringService = new ClusteringService(
+                newsArticleRepository, newsClusterRepository, articleVectorService,
+                clusterMatchingService, suspiciousScoringService, persistenceService,
+                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500));
+    }
 
     private NewsArticle createArticle(Long id) {
         NewsArticle article = NewsArticle.builder()

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -24,6 +24,7 @@ import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadReposito
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterDetailResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
 import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.web.news.dto.response.ClusterDetailResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -330,6 +331,94 @@ class NewsClusterQueryServiceTest {
         ClusterDetailResult result = queryService.getDetail(1L, null);
 
         assertThat(result.suggestedQuestions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("상세 조회 — relatedSectors: tagCode별 최빈 tagName 선택, 동점 시 사전순, Response 매핑 포함")
+    void getDetail_relatedSectorsAreDeterministic() {
+        NewsCluster cluster = createCluster(1L, "제목", "요약", OffsetDateTime.now(), 3);
+
+        given(newsClusterRepository.findById(1L)).willReturn(Optional.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterId(1L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(1L, 100L, 0, false),
+                        NewsClusterArticle.create(1L, 200L, 1, false),
+                        NewsClusterArticle.create(1L, 300L, 2, false)));
+        given(sectionRepository.findByNewsClusterIdOrderBySectionOrderAsc(1L)).willReturn(List.of());
+
+        // SEMI: "반도체/장비"×1, "반도체"×2 → 최빈 "반도체"
+        // AI: "인공지능"×1 → 유일 후보
+        // 출력 순서: tagCode 사전순 → AI, SEMI
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK)))
+                .willReturn(List.of());
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC)))
+                .willReturn(List.of());
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.SECTOR)))
+                .willReturn(List.of(
+                        createTag(100L, TagType.SECTOR, "SEMI", "반도체/장비"),
+                        createTag(200L, TagType.SECTOR, "SEMI", "반도체"),
+                        createTag(300L, TagType.SECTOR, "SEMI", "반도체"),
+                        createTag(200L, TagType.SECTOR, "AI", "인공지능")));
+
+        ClusterDetailResult result = queryService.getDetail(1L, null);
+
+        assertThat(result.relatedSectors())
+                .extracting(s -> s.code())
+                .containsExactly("AI", "SEMI");
+        assertThat(result.relatedSectors())
+                .extracting(s -> s.name())
+                .containsExactly("인공지능", "반도체");
+
+        ClusterDetailResponse response = ClusterDetailResponse.from(result);
+        assertThat(response.relatedSectors())
+                .extracting(r -> r.code())
+                .containsExactly("AI", "SEMI");
+        assertThat(response.relatedSectors())
+                .extracting(r -> r.name())
+                .containsExactly("인공지능", "반도체");
+    }
+
+    @Test
+    @DisplayName("상세 조회 — relatedSectors: SECTOR 태그 0건이면 빈 리스트")
+    void getDetail_relatedSectors_empty() {
+        NewsCluster cluster = createCluster(1L, "제목", "요약", OffsetDateTime.now(), 1);
+
+        given(newsClusterRepository.findById(1L)).willReturn(Optional.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterId(1L)).willReturn(List.of());
+        given(sectionRepository.findByNewsClusterIdOrderBySectionOrderAsc(1L)).willReturn(List.of());
+
+        ClusterDetailResult result = queryService.getDetail(1L, null);
+
+        assertThat(result.relatedSectors()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("상세 조회 — relatedSectors: 최빈값 동점이면 사전순 최소 tagName 선택")
+    void getDetail_relatedSectors_tieBreakByLexicographic() {
+        NewsCluster cluster = createCluster(1L, "제목", "요약", OffsetDateTime.now(), 2);
+
+        given(newsClusterRepository.findById(1L)).willReturn(Optional.of(cluster));
+        given(clusterArticleRepository.findByNewsClusterId(1L))
+                .willReturn(List.of(
+                        NewsClusterArticle.create(1L, 100L, 0, false),
+                        NewsClusterArticle.create(1L, 200L, 1, false)));
+        given(sectionRepository.findByNewsClusterIdOrderBySectionOrderAsc(1L)).willReturn(List.of());
+
+        // BIO: "바이오"×1 vs "바이오/헬스케어"×1 → 동점, 사전순 최소 "바이오" 선택
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.STOCK)))
+                .willReturn(List.of());
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.TOPIC)))
+                .willReturn(List.of());
+        given(articleTagRepository.findByNewsArticleIdInAndTagType(any(), eq(TagType.SECTOR)))
+                .willReturn(List.of(
+                        createTag(100L, TagType.SECTOR, "BIO", "바이오/헬스케어"),
+                        createTag(200L, TagType.SECTOR, "BIO", "바이오")));
+
+        ClusterDetailResult result = queryService.getDetail(1L, null);
+
+        assertThat(result.relatedSectors()).hasSize(1);
+        assertThat(result.relatedSectors().get(0).code()).isEqualTo("BIO");
+        assertThat(result.relatedSectors().get(0).name()).isEqualTo("바이오");
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/news/config/NewsBatchPropertiesBindingTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/config/NewsBatchPropertiesBindingTest.java
@@ -1,0 +1,56 @@
+package com.solv.wefin.domain.news.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link NewsBatchProperties}의 {@code @Validated} 제약 조건이
+ * 실제 Spring Boot binding 시점에 정상 동작하는지 검증한다
+ */
+class NewsBatchPropertiesBindingTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withUserConfiguration(Config.class, ValidationAutoConfiguration.class);
+
+    @Test
+    @DisplayName("정상 값이면 컨텍스트가 기동된다")
+    void validValues_contextStarts() {
+        runner.withPropertyValues(
+                        "batch.news.crawl-size=100",
+                        "batch.news.embedding-size=100",
+                        "batch.news.tagging-size=100",
+                        "batch.news.clustering-size=100",
+                        "batch.news.summary-size=20",
+                        "batch.news.rejudge-max-limit=100")
+                .run(ctx -> {
+                    assertThat(ctx).hasNotFailed();
+                    NewsBatchProperties props = ctx.getBean(NewsBatchProperties.class);
+                    assertThat(props.crawlSize()).isEqualTo(100);
+                });
+    }
+
+    @Test
+    @DisplayName("crawl-size=0이면 컨텍스트 기동이 실패한다 (@Min(1) 위반)")
+    void zeroSize_contextFails() {
+        runner.withPropertyValues("batch.news.crawl-size=0")
+                .run(ctx -> assertThat(ctx).hasFailed());
+    }
+
+    @Test
+    @DisplayName("tagging-size가 @Max(1000)를 초과하면 컨텍스트 기동이 실패한다")
+    void exceedMax_contextFails() {
+        runner.withPropertyValues("batch.news.tagging-size=1001")
+                .run(ctx -> assertThat(ctx).hasFailed());
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(NewsBatchProperties.class)
+    static class Config {
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlServiceTest.java
@@ -73,7 +73,8 @@ class ArticleCrawlServiceTest {
                 newsArticleRepository,
                 persistenceService,
                 List.of(extractor),
-                newsRestTemplate
+                newsRestTemplate,
+                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500)
         );
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
@@ -46,7 +46,8 @@ class EmbeddingServiceTest {
     @BeforeEach
     void setUp() {
         embeddingService = new EmbeddingService(
-                newsArticleRepository, openAiEmbeddingClient, articleChunker, persistenceService);
+                newsArticleRepository, openAiEmbeddingClient, articleChunker, persistenceService,
+                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500));
         ReflectionTestUtils.setField(embeddingService, "embeddingModel", "text-embedding-3-small");
         ReflectionTestUtils.setField(embeddingService, "embeddingVersion", "v1");
     }

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
@@ -11,10 +11,10 @@ import com.solv.wefin.domain.news.summary.client.OpenAiClientException;
 import com.solv.wefin.domain.news.summary.client.OpenAiSummaryClient;
 import com.solv.wefin.domain.news.summary.dto.SummaryResult;
 import com.solv.wefin.domain.news.summary.dto.SummaryResult.SectionItem;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class SummaryServiceTest {
 
-    @InjectMocks
     private SummaryService summaryService;
 
     @Mock
@@ -50,6 +49,14 @@ class SummaryServiceTest {
 
     @Mock
     private SummaryPersistenceService persistenceService;
+
+    @BeforeEach
+    void setUp() {
+        summaryService = new SummaryService(
+                newsClusterRepository, clusterArticleRepository, newsArticleRepository,
+                openAiSummaryClient, outlierDetectionService, persistenceService,
+                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500));
+    }
 
     private NewsCluster createCluster(Long id, int articleCount, SummaryStatus status) {
         float[] vector = {1.0f, 0.0f, 0.0f};

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.news.article.entity.NewsArticle;
 import com.solv.wefin.domain.news.article.entity.NewsArticle.RelevanceStatus;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.tagging.client.OpenAiTaggingClient;
 import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
 import com.solv.wefin.domain.news.tagging.service.RelevanceRejudgeService.RejudgeSummary;
@@ -39,11 +40,16 @@ class RelevanceRejudgeServiceTest {
     private RelevancePersistenceService persistenceService;
 
     private RelevanceRejudgeService rejudgeService;
+    private NewsBatchProperties batchProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final int TEST_REJUDGE_MAX_LIMIT = 100;
 
     @BeforeEach
     void setUp() {
-        rejudgeService = new RelevanceRejudgeService(newsArticleRepository, openAiTaggingClient, persistenceService);
+        batchProperties = new NewsBatchProperties(500, 500, 500, 500, 50, TEST_REJUDGE_MAX_LIMIT);
+        rejudgeService = new RelevanceRejudgeService(newsArticleRepository, openAiTaggingClient, persistenceService,
+                batchProperties);
     }
 
     @Test
@@ -181,13 +187,13 @@ class RelevanceRejudgeServiceTest {
     }
 
     @Test
-    @DisplayName("rejudgePending — limit 0 이하 또는 500 초과면 BusinessException (400)")
+    @DisplayName("rejudgePending — limit가 0 이하이거나 rejudgeMaxLimit을 초과하면 BusinessException (400)")
     void rejudgePending_invalidLimit_throws() {
         assertThatThrownBy(() -> rejudgeService.rejudgePending(0))
                 .isInstanceOf(BusinessException.class);
         assertThatThrownBy(() -> rejudgeService.rejudgePending(-1))
                 .isInstanceOf(BusinessException.class);
-        assertThatThrownBy(() -> rejudgeService.rejudgePending(501))
+        assertThatThrownBy(() -> rejudgeService.rejudgePending(batchProperties.rejudgeMaxLimit() + 1))
                 .isInstanceOf(BusinessException.class);
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.news.article.entity.NewsArticle.CrawlStatus;
 import com.solv.wefin.domain.news.article.entity.NewsArticle.TaggingStatus;
 import com.solv.wefin.domain.news.article.entity.NewsArticleTag;
 import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.tagging.client.OpenAiTaggingClient;
 import com.solv.wefin.domain.news.tagging.dto.TaggingResult;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -51,7 +52,8 @@ class TaggingServiceTest {
     @BeforeEach
     void setUp() {
         taggingService = new TaggingService(newsArticleRepository, openAiTaggingClient,
-                persistenceService, stockCodeValidator);
+                persistenceService, stockCodeValidator,
+                new NewsBatchProperties(500, 500, 500, 500, 50, 500));
         lenient().when(stockCodeValidator.loadStockMap())
                 .thenReturn(java.util.Map.of(
                         "005930", "삼성전자",


### PR DESCRIPTION
## 📌 PR 설명
뉴스 파이프라인의 배치 크기/주기가 각 서비스 내부 상수로 흩어져 있어, 운영 중 조정하려면 소스 재배포가 필요했습니다. 이를 `@ConfigurationProperties` record로 중앙화하고 환경변수 오버라이드를 적용하여 `.env`만으로 튜닝 가능하도록 외부화했습니다.

추가로, 클러스터 상세 응답에 `relatedSectors` 필드를 추가하여 프론트엔드에서 분야(SECTOR) 구독 기능을 연결할 수 있도록 했습니다.
<br>

## ✅ 완료한 기능 명세
### 신규
1. `domain/news/config/NewsBatchProperties.java` — `@ConfigurationProperties` immutable record. `@Min`/`@Max` validation 포함
2. `domain/news/cluster/dto/SectorInfo.java` — 클러스터 관련 섹터 정보 DTO (code + name)
3. `test/.../config/NewsBatchPropertiesBindingTest.java` — validation binding 검증 (정상/`@Min` 위반/`@Max` 초과)

### 수정
4. `domain/news/config/NewsConfig.java` — `@EnableConfigurationProperties(NewsBatchProperties.class)` 등록
5. `domain/news/ingestion/service/ArticleCrawlService.java` — `CRAWL_BATCH_SIZE` 상수 제거, `batchProperties.crawlSize()` 주입
6. `domain/news/embedding/service/EmbeddingService.java` — `BATCH_SIZE` 제거, `batchProperties.embeddingSize()` 주입
7. `domain/news/tagging/service/TaggingService.java` — `BATCH_SIZE` 제거, `batchProperties.taggingSize()` 주입
8. `domain/news/tagging/service/RelevanceRejudgeService.java` — `MAX_REJUDGE_LIMIT` 제거, `batchProperties.rejudgeMaxLimit()` 주입. JavaDoc `(1~500)` → 설정 기반 문구
9. `domain/news/cluster/service/ClusteringService.java` — `BATCH_SIZE` 제거, `batchProperties.clusteringSize()` 주입
10. `domain/news/summary/service/SummaryService.java` — `BATCH_SIZE` 제거, `batchProperties.summarySize()` 주입
11. `domain/news/cluster/service/ClusterTagAggregator.java` — `selectCanonicalName` 헬퍼 추출. STOCK/SECTOR 모두 최빈값 기반 결정적 라벨 선택. null 방어 추가
12. `domain/news/cluster/service/NewsClusterQueryService.java` — `ClusterDetailResult`에 `relatedSectors` 필드 추가
13. `web/news/dto/response/ClusterDetailResponse.java` — `SectorResponse` 추가 + 매핑

### 설정
14. `resources/application.yml` — `batch.news.*` 환경변수 오버라이드 + cron 5곳 env 오버라이드
15. `resources/application-local.yml` — `batch.news.*` 환경변수 오버라이드 (기존)
16. `resources/application-dev.yml` — `batch.news.*` 환경변수 오버라이드 추가
17. `resources/application-prod.yml` — `batch.news.*` 환경변수 오버라이드 추가

### 테스트
18. `test/.../ArticleCrawlServiceTest.java` — all-args constructor 명시 주입
19. `test/.../EmbeddingServiceTest.java` — 동일
20. `test/.../TaggingServiceTest.java` — 동일
21. `test/.../RelevanceRejudgeServiceTest.java` — `TEST_REJUDGE_MAX_LIMIT=100` 명시 + 초과값 검증 동적화
22. `test/.../NewsClusterQueryServiceTest.java` — SECTOR 테스트 3건 추가 (최빈값 선택 / 빈 리스트 / 동점 tie-break)


<br>

## 💭 고민과 해결과정

### 1.  `NewsBatchProperties`를 record로 전환한 이유

초기 구현은 Lombok `@Getter`/`@Setter` 클래스였습니다. 코드 리뷰에서 `@Setter`가 런타임에 validation 우회 경로가 된다는 피드백이 있었습니다. 테스트에서 실제로 `batchProperties.setRejudgeMaxLimit(100)` 형태로 setter를 호출하고 있었고, 운영 코드에서도 누군가 같은 경로를 탈 수 있는 구조였습니다.

Spring Boot 3의 record constructor binding을 활용하면 setter 없이 immutable 바인딩이 가능합니다. `@Validated` + `@Min`/`@Max`도 canonical constructor 파라미터에 그대로 동작합니다. 기본값 생성자는 제거하고, 테스트에서는 all-args constructor를 직접 호출하도록 통일했습니다.

### 2. `application.yml` 처리량 500/50 유지 + env 오버라이드

초기 구현에서 yml 값을 100/20으로 낮췄으나, "배치 크기 외부화"와 "처리량 변경"은 별개 변경입니다. 기존 상수값(500/50)을 기본으로 유지하되, `${NEWS_CRAWL_BATCH_SIZE:500}` 패턴으로 `.env`에서 즉시 조절 가능하도록 했습니다. dev 환경에서 비용 절감이 필요하면 `.env.dev`에 `NEWS_CRAWL_BATCH_SIZE=100` 등을 추가하면 됩니다.

### 3. 배치 주기(cron)도 env 오버라이드

`application.yml`의 cron 5곳이 하드코딩(`"0 */30 * * * *"`)이었습니다. dev/prod yml은 이미 `${EMBEDDING_COLLECT_CRON:${NEWS_BATCH_CRON:...}}` 패턴이 있었으므로 base yml도 동일하게 맞췄습니다. 우선순위: 개별 변수(`EMBEDDING_COLLECT_CRON`) > 일괄 변수(`NEWS_BATCH_CRON`) > yml default.

### 4. SECTOR 라벨 결정적 선택 — 최빈값 정책

동일 `tagCode`에 여러 `tagName`이 섞일 때(AI 태깅 변동) DB 조회 순서에 의존하면 라벨이 흔들립니다. 초기 구현은 "사전순 최소" 정책이었으나, 사전순은 결정적이지만 의미적이지 않다는 리뷰가 있었습니다 (예: 한글/영문 섞임 시 UTF-16 순서로 영문 약어가 선택됨).

**최빈값 기반 선택**(해당 클러스터 내 tagName 출현 빈도 최대, 동점 시 사전순 최소)으로 교체했습니다. 가장 많이 태깅된 이름 = 대표성이 높은 이름이라는 가정입니다. `selectCanonicalName` 제네릭 헬퍼로 추출하여 STOCK/SECTOR 양쪽에 동일 정책을 적용했습니다.
<br>


### `.env.dev` 설정 예시

```bash
# 배치 크기
NEWS_CRAWL_BATCH_SIZE=100
NEWS_EMBEDDING_BATCH_SIZE=100
NEWS_TAGGING_BATCH_SIZE=100
NEWS_CLUSTERING_BATCH_SIZE=100
NEWS_SUMMARY_BATCH_SIZE=20
NEWS_REJUDGE_MAX_LIMIT=100

# 배치 주기 (일괄)
NEWS_BATCH_CRON=0 0 */6 * * *
MARKET_BATCH_CRON=0 0 */6 * * *
```

<br>
### 🔗 관련 이슈
Closes #241

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 뉴스 클러스터에 관련 섹터 정보 추가
  * 배치 크기를 환경 변수로 설정 가능하도록 변경

* **테스트**
  * 섹터 집계 동작에 대한 테스트 추가
  * 구성 속성 검증 테스트 추가

* **Chores**
  * 하드코딩된 배치 크기를 구성 가능한 속성으로 리팩토링
  * 애플리케이션 구성 파일 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->