### PR TITLE
[WEF-666] SMTP 트랜잭션 분리 

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -13,6 +14,7 @@ public class EmailVerificationEventListener {
 
     private final MailService mailService;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSendEmail(EmailVerificationSendEvent event) {
         try {

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
@@ -1,0 +1,40 @@
+package com.solv.wefin.domain.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EmailVerificationEventListener {
+
+    private final MailService mailService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSendEmail(EmailVerificationSendEvent event) {
+        try {
+            mailService.sendVerificationCode(event.email(), event.code());
+        } catch (Exception e) {
+            log.error("메일 발송 실패 (after commit): email={}", maskEmail(event.email()), e);
+        }
+    }
+
+    private String maskEmail(String email) {
+        if (email == null || !email.contains("@")) {
+            return "***";
+        }
+
+        String[] parts = email.split("@", 2);
+        String local = parts[0];
+        String domain = parts[1];
+
+        if (local.isEmpty()) {
+            return "***@" + domain;
+        }
+
+        return local.charAt(0) + "***@" + domain;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationSendEvent.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationSendEvent.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.auth.service;
+
+import com.solv.wefin.domain.auth.entity.VerificationPurpose;
+
+public record EmailVerificationSendEvent(
+        String email,
+        String code,
+        VerificationPurpose purpose
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationService.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.auth.repository.EmailVerificationRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +30,7 @@ public class EmailVerificationService {
     private static final long RESEND_WINDOW_SECONDS = 600L;
 
     private final EmailVerificationRepository emailVerificationRepository;
-    private final MailService mailService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void sendVerificationCode(String email, VerificationPurpose purpose) {
@@ -44,7 +45,6 @@ public class EmailVerificationService {
                     .orElse(null);
 
             if (verification != null) {
-
                 if (verification.isLocked(now)) {
                     throw new BusinessException(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
                 }
@@ -73,7 +73,10 @@ public class EmailVerificationService {
 
             verification.recordResend(now);
             emailVerificationRepository.saveAndFlush(verification);
-            mailService.sendVerificationCode(normalizedEmail, code);
+
+            eventPublisher.publishEvent(
+                    new EmailVerificationSendEvent(normalizedEmail, code, purpose)
+            );
 
         } catch (ObjectOptimisticLockingFailureException e) {
             throw new BusinessException(ErrorCode.AUTH_VERIFICATION_CONCURRENT_REQUEST);

--- a/src/main/java/com/solv/wefin/global/config/AsyncConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListenerTest.java
@@ -1,0 +1,56 @@
+package com.solv.wefin.domain.auth.service;
+
+import com.solv.wefin.domain.auth.entity.VerificationPurpose;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class EmailVerificationEventListenerTest {
+
+    private final MailService mailService = mock(MailService.class);
+    private final EmailVerificationEventListener listener =
+            new EmailVerificationEventListener(mailService);
+
+    @Test
+    @DisplayName("이벤트 수신 시 인증코드 메일을 발송한다")
+    void handleSendEmail_success() {
+        // given
+        EmailVerificationSendEvent event =
+                new EmailVerificationSendEvent(
+                        "test@example.com",
+                        "123456",
+                        VerificationPurpose.SIGNUP
+                );
+
+        // when
+        listener.handleSendEmail(event);
+
+        // then
+        verify(mailService).sendVerificationCode("test@example.com", "123456");
+    }
+
+    @Test
+    @DisplayName("메일 발송 중 예외가 발생해도 예외를 전파하지 않는다")
+    void handleSendEmail_ignore_exception() {
+        // given
+        EmailVerificationSendEvent event =
+                new EmailVerificationSendEvent(
+                        "test@example.com",
+                        "123456",
+                        VerificationPurpose.SIGNUP
+                );
+
+        doThrow(new RuntimeException("mail send fail"))
+                .when(mailService)
+                .sendVerificationCode("test@example.com", "123456");
+
+        // when
+        listener.handleSendEmail(event);
+
+        // then
+        verify(mailService).sendVerificationCode("test@example.com", "123456");
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationServiceTest.java
@@ -8,9 +8,11 @@ import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -19,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,7 +30,7 @@ class EmailVerificationServiceTest {
     private EmailVerificationRepository repository;
 
     @Mock
-    private MailService mailService;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private EmailVerificationService service;
@@ -48,17 +49,20 @@ class EmailVerificationServiceTest {
     @Test
     @DisplayName("인증코드 5회 틀리면 잠금된다")
     void lock_after_max_attempts() {
+        // given
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
 
         when(repository.findByEmailAndPurpose(email, PURPOSE))
                 .thenReturn(Optional.of(verification));
 
+        // when
         for (int i = 0; i < 5; i++) {
             assertThrows(BusinessException.class,
                     () -> service.confirmVerificationCode(email, "wrong", PURPOSE));
         }
 
+        // then
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.confirmVerificationCode(email, "wrong", PURPOSE));
 
@@ -71,6 +75,7 @@ class EmailVerificationServiceTest {
     @Test
     @DisplayName("잠금 상태에서는 인증이 차단된다")
     void blocked_when_locked() {
+        // given
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
 
@@ -79,9 +84,11 @@ class EmailVerificationServiceTest {
         when(repository.findByEmailAndPurpose(email, PURPOSE))
                 .thenReturn(Optional.of(verification));
 
+        // when
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> service.confirmVerificationCode(email, "123456", PURPOSE));
 
+        // then
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_ATTEMPTS);
     }
@@ -89,6 +96,7 @@ class EmailVerificationServiceTest {
     @Test
     @DisplayName("재발송 쿨타임이 적용된다")
     void resend_cooldown() {
+        // given
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
         OffsetDateTime now = OffsetDateTime.now();
@@ -99,21 +107,24 @@ class EmailVerificationServiceTest {
         when(repository.findByEmailAndPurpose(email, PURPOSE))
                 .thenReturn(Optional.of(verification));
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> service.sendVerificationCode(email, PURPOSE)
         );
 
+        // then
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_FAST_REQUEST);
 
-        verify(mailService, never()).sendVerificationCode(anyString(), anyString());
+        verify(eventPublisher, never()).publishEvent(any());
         verify(repository, never()).saveAndFlush(any(EmailVerification.class));
     }
 
     @Test
     @DisplayName("10분 내 재발송 횟수 초과 시 예외가 발생한다")
     void resend_limit_exceeded_within_window() {
+        // given
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
         OffsetDateTime now = OffsetDateTime.now();
@@ -126,21 +137,24 @@ class EmailVerificationServiceTest {
         when(repository.findByEmailAndPurpose(email, PURPOSE))
                 .thenReturn(Optional.of(verification));
 
+        // when
         BusinessException exception = assertThrows(
                 BusinessException.class,
                 () -> service.sendVerificationCode(email, PURPOSE)
         );
 
+        // then
         assertThat(exception.getErrorCode())
                 .isEqualTo(ErrorCode.AUTH_VERIFICATION_TOO_MANY_REQUESTS);
 
-        verify(mailService, never()).sendVerificationCode(anyString(), anyString());
+        verify(eventPublisher, never()).publishEvent(any());
         verify(repository, never()).saveAndFlush(any(EmailVerification.class));
     }
 
     @Test
     @DisplayName("재발송 윈도우가 만료되면 다시 요청할 수 있다")
     void resend_allowed_when_window_expired() {
+        // given
         String email = "test@example.com";
         EmailVerification verification = createVerification(email, "123456");
         OffsetDateTime now = OffsetDateTime.now();
@@ -155,9 +169,20 @@ class EmailVerificationServiceTest {
         when(repository.saveAndFlush(any(EmailVerification.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
 
+        // when
         assertDoesNotThrow(() -> service.sendVerificationCode(email, PURPOSE));
 
+        // then
         verify(repository).saveAndFlush(verification);
-        verify(mailService).sendVerificationCode(eq(email), anyString());
+
+        ArgumentCaptor<EmailVerificationSendEvent> captor =
+                ArgumentCaptor.forClass(EmailVerificationSendEvent.class);
+
+        verify(eventPublisher).publishEvent(captor.capture());
+
+        EmailVerificationSendEvent event = captor.getValue();
+        assertThat(event.email()).isEqualTo(email);
+        assertThat(event.code()).isNotBlank();
+        assertThat(event.purpose()).isEqualTo(PURPOSE);
     }
 }

--- a/src/test/java/com/solv/wefin/domain/auth/service/TestMailService.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/TestMailService.java
@@ -11,6 +11,6 @@ public class TestMailService implements MailService {
 
     @Override
     public void sendVerificationCode(String to, String code) {
-        // 테스트에서는 실제 메일 발송하지 않음
+        // 테스트 환경에서는 실제 메일 발송하지 않음
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
이메일 인증 코드 발송 로직에서 트랜잭션 내부의 외부 I/O(SMTP 호출)를 제거하고, AFTER_COMMIT 이벤트 기반 구조로 리팩토링.
<br>

## ✅ 완료한 기능 명세

- [x] 트랜잭션 내부 SMTP 호출 제거
- [x] AFTER_COMMIT 이벤트 기반 메일 발송 구조 도입
- [x] EmailVerificationEventListener 추가
- [x] EmailVerificationSendEvent 추가
- [x] EmailVerificationService 테스트 코드 수정 (eventPublisher 검증)
- [x] EmailVerificationEventListener 테스트 코드 추가

- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 기존에는 이메일 인증 코드 발송 시 트랜잭션 내부에서 SMTP 호출을 직접 수행하고 있었는데 외부 I/O로 인해 트랜잭션이 불필요하게 길어지고 DB 커넥션 점유 시간이 증가할 수 있다는 문제가 있었음

-> 인증 정보 저장 이후 ApplicationEventPublisher를 통해 이벤트를 발행하고 @TransactionalEventListener(AFTER_COMMIT)를 활용하여 커밋 이후 메일 발송이 수행되도록 구조를 변경

<br>

### 🔗 관련 이슈
Closes #274 

<br>
