### PR TITLE
[WEF-629] 신한 데스크탑 서버 배포 설정 추가

### DIFF
--- a/.github/workflows/backend-cd-desktop.yml
+++ b/.github/workflows/backend-cd-desktop.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Deploy with docker compose
         run: |
           cd ${{ github.workspace }}
-          docker compose -f docker-compose-desktop.yml down || true
-          docker compose -f docker-compose-desktop.yml up -d backend
+          docker compose -f docker-compose-desktop.yml stop backend || true
+          docker compose -f docker-compose-desktop.yml rm -f backend || true
+          docker compose -f docker-compose-desktop.yml up -d
 
       - name: Verify deployment
         run: |

--- a/.github/workflows/backend-cd-desktop.yml
+++ b/.github/workflows/backend-cd-desktop.yml
@@ -1,0 +1,50 @@
+name: Backend CD (Desktop)
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test
+
+      - name: Prepare app.jar
+        run: |
+          JAR_FILE=$(find build/libs -name "*.jar" ! -name "*-plain.jar" | head -n 1)
+          cp "$JAR_FILE" app.jar
+
+      - name: Build Docker image
+        run: docker build -t wefin-backend:desktop .
+
+      - name: Deploy with docker compose
+        run: |
+          cd ${{ github.workspace }}
+          docker compose -f docker-compose-desktop.yml down || true
+          docker compose -f docker-compose-desktop.yml up -d backend
+
+      - name: Verify deployment
+        run: |
+          sleep 10
+          docker ps | grep wefin-backend-desktop
+          echo "Backend deployed successfully"
+
+      - name: Clean unused images
+        run: docker image prune -f

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,5 @@ out/
 .env
 .env.dev
 .env.prod
+.env.desktop
 .DS_Store

--- a/docker-compose-desktop.yml
+++ b/docker-compose-desktop.yml
@@ -1,0 +1,46 @@
+name: wefin-desktop
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: wefin-postgres-desktop
+    environment:
+      POSTGRES_DB: ${DB_NAME:-wefin}
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    image: wefin-backend:desktop
+    container_name: wefin-backend-desktop
+    expose:
+      - "8080"
+    env_file:
+      - .env.desktop
+    entrypoint: ["java", "-Xmx1g", "-jar", "/app/app.jar"]
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: always
+
+  nginx:
+    image: nginx:alpine
+    container_name: wefin-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./frontend:/usr/share/nginx/html
+    depends_on:
+      - backend
+    restart: always
+
+volumes:
+  postgres-data:

--- a/docker-compose-desktop.yml
+++ b/docker-compose-desktop.yml
@@ -5,14 +5,14 @@ services:
     image: pgvector/pgvector:pg16
     container_name: wefin-postgres-desktop
     environment:
-      POSTGRES_DB: ${DB_NAME:-wefin}
-      POSTGRES_USER: ${DB_USERNAME:-postgres}
-      POSTGRES_PASSWORD: ${DB_PASSWORD:-postgres}
+      POSTGRES_DB: ${DB_NAME:?DB_NAME is required}
+      POSTGRES_USER: ${DB_USERNAME:?DB_USERNAME is required}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER:-postgres}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name wefin.shinhanacademy.co.kr;
+
+    # 프론트엔드 정적 파일
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+        try_files $uri $uri/ /index.html;
+    }
+
+    # 백엔드 API 프록시
+    location /api/ {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # WebSocket 프록시
+    location /ws {
+        proxy_pass http://backend:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,6 +2,20 @@ spring:
   config:
     activate:
       on-profile: prod
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
 
   datasource:
     url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
@@ -60,3 +74,4 @@ summary:
 websocket:
   allowed-origins:
     - https://wefin.ai.kr
+    - https://wefin.shinhanacademy.co.kr


### PR DESCRIPTION
## 📌 PR 설명
  신한 데스크탑 서버 배포 설정 추가 (Docker Compose + Nginx + Self-hosted Runner CD)

  ## ✅ 완료한 기능 명세

  - [x] **[WEF-629]** 신한 데스크탑 서버 배포 설정


  ## 💭 고민과 해결과정
  - RDS 공유 시도 → 부캠 네트워크에서 5432 아웃바운드 차단 확인 → Docker PostgreSQL로 전환
  - 스케줄러 중복 실행 방지를 위해 신한 서버는 전부 비활성화 (AWS가 배치 담당)
  - Self-hosted Runner 서비스 등록으로 서버 재부팅 시 자동 시작

  ### 🔗 관련 이슈
  Closes #238

[WEF-629]: https://sol-v.atlassian.net/browse/WEF-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데스크톱 환경을 위한 배포 워크플로우 및 컨테이너 구성 추가
  * 프로덕션 환경 메일 서비스 설정 구성
  * WebSocket 및 API 라우팅 설정 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->