### PR TITLE
[WEF-90] 구독 상태 조회

### DIFF
--- a/src/main/java/com/solv/wefin/domain/payment/dto/MySubscriptionInfo.java
+++ b/src/main/java/com/solv/wefin/domain/payment/dto/MySubscriptionInfo.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.payment.dto;
+
+import com.solv.wefin.domain.payment.entity.BillingCycle;
+import com.solv.wefin.domain.payment.entity.Subscription;
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record MySubscriptionInfo(
+        Long planId,
+        String planName,
+        BigDecimal price,
+        BillingCycle billingCycle,
+        String description,
+        SubscriptionStatus subscriptionStatus,
+        boolean active,
+        OffsetDateTime startedAt,
+        OffsetDateTime expiredAt
+) {
+    public static MySubscriptionInfo from(Subscription subscription) {
+        SubscriptionPlan plan = subscription.getPlan();
+
+        return new MySubscriptionInfo(
+                plan.getPlanId(),
+                plan.getPlanName(),
+                plan.getPrice(),
+                plan.getBillingCycle(),
+                plan.getDescription(),
+                subscription.getStatus(),
+                subscription.isActive(),
+                subscription.getStartedAt(),
+                subscription.getExpiredAt()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -2,10 +2,7 @@ package com.solv.wefin.domain.payment.service;
 
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
-import com.solv.wefin.domain.payment.dto.CreatePaymentCommand;
-import com.solv.wefin.domain.payment.dto.PaymentConfirmInfo;
-import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
-import com.solv.wefin.domain.payment.dto.TossPaymentConfirmResult;
+import com.solv.wefin.domain.payment.dto.*;
 import com.solv.wefin.domain.payment.entity.*;
 import com.solv.wefin.domain.payment.repository.PaymentRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
@@ -218,6 +215,17 @@ public class PaymentService {
         }
 
         return PaymentConfirmInfo.from(payment, savedSubscription);
+    }
+
+    @Transactional(readOnly = true)
+    public MySubscriptionInfo getMySubscription(UUID userId) {
+        Subscription subscription = subscriptionRepository.findByUserUserIdAndStatus(
+                        userId,
+                        SubscriptionStatus.ACTIVE
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_NOT_FOUND));
+
+        return MySubscriptionInfo.from(subscription);
     }
 
     private Payment savePaymentWithRetry(

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -75,6 +75,7 @@ public enum ErrorCode {
     PLAN_NOT_FOUND(404, "구독 상품을 찾을 수 없습니다."),
     PLAN_INACTIVE(400, "비활성화된 구독 상품입니다."),
     ACTIVE_SUBSCRIPTION_ALREADY_EXISTS(409, "이미 활성 구독이 존재합니다."),
+    ACTIVE_SUBSCRIPTION_NOT_FOUND(404, "활성 구독 정보를 찾을 수 없습니다."),
     INVALID_PROVIDER(400, "지원하지 않는 결제사입니다."),
     PAYMENT_NOT_FOUND(404, "결제 정보를 찾을 수 없습니다."),
     PAYMENT_OWNERSHIP_MISMATCH(403, "본인의 결제만 처리할 수 있습니다."),

--- a/src/main/java/com/solv/wefin/web/payment/PaymentController.java
+++ b/src/main/java/com/solv/wefin/web/payment/PaymentController.java
@@ -1,15 +1,13 @@
 package com.solv.wefin.web.payment;
 
+import com.solv.wefin.domain.payment.dto.MySubscriptionInfo;
 import com.solv.wefin.domain.payment.dto.PaymentConfirmInfo;
 import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
 import com.solv.wefin.domain.payment.service.PaymentService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
-import com.solv.wefin.web.payment.dto.ConfirmPaymentRequest;
-import com.solv.wefin.web.payment.dto.ConfirmPaymentResponse;
-import com.solv.wefin.web.payment.dto.CreatePaymentRequest;
-import com.solv.wefin.web.payment.dto.CreatePaymentResponse;
+import com.solv.wefin.web.payment.dto.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -58,5 +56,18 @@ public class PaymentController {
         );
 
         return ApiResponse.success(ConfirmPaymentResponse.from(info));
+    }
+
+    @GetMapping("/me/subscription")
+    public ApiResponse<MySubscriptionResponse> getMySubscription(
+            @AuthenticationPrincipal UUID userId
+    ) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        MySubscriptionInfo info = paymentService.getMySubscription(userId);
+
+        return ApiResponse.success(MySubscriptionResponse.from(info));
     }
 }

--- a/src/main/java/com/solv/wefin/web/payment/dto/MySubscriptionResponse.java
+++ b/src/main/java/com/solv/wefin/web/payment/dto/MySubscriptionResponse.java
@@ -1,0 +1,32 @@
+package com.solv.wefin.web.payment.dto;
+
+import com.solv.wefin.domain.payment.dto.MySubscriptionInfo;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+public record MySubscriptionResponse(
+        Long planId,
+        String planName,
+        BigDecimal price,
+        String billingCycle,
+        String description,
+        String subscriptionStatus,
+        boolean active,
+        OffsetDateTime startedAt,
+        OffsetDateTime expiredAt
+) {
+    public static MySubscriptionResponse from(MySubscriptionInfo info) {
+        return new MySubscriptionResponse(
+                info.planId(),
+                info.planName(),
+                info.price(),
+                info.billingCycle().name(),
+                info.description(),
+                info.subscriptionStatus().name(),
+                info.active(),
+                info.startedAt(),
+                info.expiredAt()
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentCreateServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentCreateServiceTest.java
@@ -13,10 +13,7 @@ import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
 import com.solv.wefin.domain.payment.repository.PaymentRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
-import com.solv.wefin.domain.payment.service.PaymentConfirmWriter;
-import com.solv.wefin.domain.payment.service.PaymentService;
-import com.solv.wefin.domain.payment.service.PaymentWriter;
-import com.solv.wefin.domain.payment.service.TossPaymentClient;
+import com.solv.wefin.domain.payment.service.*;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +59,9 @@ class PaymentCreateServiceTest {
 
     @Mock
     private TossPaymentClient tossPaymentClient;
+
+    @Mock
+    private PaymentFailureLogWriter paymentFailureLogWriter;
 
     @InjectMocks
     private PaymentService paymentService;

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentQueryServiceTest.java
@@ -1,0 +1,145 @@
+package com.solv.wefin.domain.payment;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.payment.dto.MySubscriptionInfo;
+import com.solv.wefin.domain.payment.entity.BillingCycle;
+import com.solv.wefin.domain.payment.entity.Subscription;
+import com.solv.wefin.domain.payment.entity.SubscriptionPlan;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
+import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
+import com.solv.wefin.domain.payment.service.PaymentConfirmWriter;
+import com.solv.wefin.domain.payment.service.PaymentFailureLogWriter;
+import com.solv.wefin.domain.payment.service.PaymentService;
+import com.solv.wefin.domain.payment.service.PaymentWriter;
+import com.solv.wefin.domain.payment.service.TossPaymentClient;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentQueryServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private SubscriptionPlanRepository subscriptionPlanRepository;
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PaymentWriter paymentWriter;
+
+    @Mock
+    private PaymentConfirmWriter paymentConfirmWriter;
+
+    @Mock
+    private TossPaymentClient tossPaymentClient;
+
+    @Mock
+    private PaymentFailureLogWriter paymentFailureLogWriter;
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    private UUID userId;
+    private Subscription subscription;
+    private SubscriptionPlan plan;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        subscription = mock(Subscription.class);
+        plan = mock(SubscriptionPlan.class);
+    }
+
+    @Test
+    @DisplayName("내 활성 구독 조회에 성공한다")
+    void getMySubscription_success() {
+        OffsetDateTime startedAt = OffsetDateTime.parse("2026-04-17T10:00:00+09:00");
+        OffsetDateTime expiredAt = OffsetDateTime.parse("2026-05-17T10:00:00+09:00");
+
+        given(subscriptionRepository.findByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(Optional.of(subscription));
+
+        given(subscription.getPlan()).willReturn(plan);
+        given(subscription.getStatus()).willReturn(SubscriptionStatus.ACTIVE);
+        given(subscription.isActive()).willReturn(true);
+        given(subscription.getStartedAt()).willReturn(startedAt);
+        given(subscription.getExpiredAt()).willReturn(expiredAt);
+
+        given(plan.getPlanId()).willReturn(1L);
+        given(plan.getPlanName()).willReturn("프로 플랜");
+        given(plan.getPrice()).willReturn(new BigDecimal("9900"));
+        given(plan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
+        given(plan.getDescription()).willReturn("무제한 AI 기능과 고급 분석 도구를 제공합니다.");
+
+        MySubscriptionInfo result = paymentService.getMySubscription(userId);
+
+        assertThat(result.planId()).isEqualTo(1L);
+        assertThat(result.planName()).isEqualTo("프로 플랜");
+        assertThat(result.price()).isEqualByComparingTo("9900");
+        assertThat(result.billingCycle()).isEqualTo(BillingCycle.MONTHLY);
+        assertThat(result.description()).isEqualTo("무제한 AI 기능과 고급 분석 도구를 제공합니다.");
+        assertThat(result.subscriptionStatus()).isEqualTo(SubscriptionStatus.ACTIVE);
+        assertThat(result.active()).isTrue();
+        assertThat(result.startedAt()).isEqualTo(startedAt);
+        assertThat(result.expiredAt()).isEqualTo(expiredAt);
+
+        verify(subscriptionRepository).findByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
+        verifyNoInteractions(
+                paymentRepository,
+                subscriptionPlanRepository,
+                userRepository,
+                paymentWriter,
+                paymentConfirmWriter,
+                tossPaymentClient,
+                paymentFailureLogWriter
+        );
+    }
+
+    @Test
+    @DisplayName("활성 구독이 없으면 ACTIVE_SUBSCRIPTION_NOT_FOUND 예외가 발생한다")
+    void getMySubscription_fail_whenActiveSubscriptionNotFound() {
+        given(subscriptionRepository.findByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> paymentService.getMySubscription(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ACTIVE_SUBSCRIPTION_NOT_FOUND);
+
+        verify(subscriptionRepository).findByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE);
+        verifyNoInteractions(
+                paymentRepository,
+                subscriptionPlanRepository,
+                userRepository,
+                paymentWriter,
+                paymentConfirmWriter,
+                tossPaymentClient,
+                paymentFailureLogWriter
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/web/payment/PaymentControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/payment/PaymentControllerTest.java
@@ -1,7 +1,10 @@
 package com.solv.wefin.web.payment;
 
+import com.solv.wefin.domain.payment.dto.MySubscriptionInfo;
 import com.solv.wefin.domain.payment.dto.PaymentConfirmInfo;
 import com.solv.wefin.domain.payment.dto.PaymentReadyInfo;
+import com.solv.wefin.domain.payment.entity.BillingCycle;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
 import com.solv.wefin.domain.payment.service.PaymentService;
 import com.solv.wefin.global.config.SecurityConfig;
 import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
@@ -27,6 +30,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -258,5 +262,65 @@ class PaymentControllerTest {
                         .contentType(APPLICATION_JSON)
                         .content(requestBody))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("내 활성 구독 조회에 성공한다")
+    void getMySubscription_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        MySubscriptionInfo info = new MySubscriptionInfo(
+                1L,
+                "프로 플랜",
+                new BigDecimal("9900"),
+                BillingCycle.MONTHLY,
+                "무제한 AI 기능과 고급 분석 도구를 제공합니다.",
+                SubscriptionStatus.ACTIVE,
+                true,
+                OffsetDateTime.parse("2026-04-17T10:00:00+09:00"),
+                OffsetDateTime.parse("2026-05-17T10:00:00+09:00")
+        );
+
+        given(paymentService.getMySubscription(eq(userId)))
+                .willReturn(info);
+
+        mockMvc.perform(get("/api/payments/me/subscription")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        userId,
+                                        null,
+                                        java.util.List.of()
+                                )
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.planId").value(1))
+                .andExpect(jsonPath("$.data.planName").value("프로 플랜"))
+                .andExpect(jsonPath("$.data.price").value(9900))
+                .andExpect(jsonPath("$.data.billingCycle").value("MONTHLY"))
+                .andExpect(jsonPath("$.data.description").value("무제한 AI 기능과 고급 분석 도구를 제공합니다."))
+                .andExpect(jsonPath("$.data.subscriptionStatus").value("ACTIVE"))
+                .andExpect(jsonPath("$.data.active").value(true))
+                .andExpect(jsonPath("$.data.startedAt").exists())
+                .andExpect(jsonPath("$.data.expiredAt").exists());
+    }
+
+    @Test
+    @DisplayName("활성 구독이 없으면 404를 반환한다")
+    void getMySubscription_fail_whenActiveSubscriptionNotFound() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        given(paymentService.getMySubscription(eq(userId)))
+                .willThrow(new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_NOT_FOUND));
+
+        mockMvc.perform(get("/api/payments/me/subscription")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(
+                                        userId,
+                                        null,
+                                        java.util.List.of()
+                                )
+                        )))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("ACTIVE_SUBSCRIPTION_NOT_FOUND"));
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
현재 로그인한 사용자의 활성 구독 플랜 조회 API를 추가하고 관련 DTO 및 테스트 코드를 구현.
<br>

## ✅ 완료한 기능 명세

- [x] GET /api/payments/me/subscription 엔드포인트 추가
- [x] 활성 구독 정보 조회 서비스 로직 구현
- [x] MySubscriptionInfo, MySubscriptionResponse DTO 추가
- [x] Controller 테스트 및 Service 테스트 코드 작성

- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 기존 결제 로직과의 책임 분리를 고려하여 조회 로직은 PaymentService에 추가
- 활성 구독 조회는 단건 조회이므로 SubscriptionRepository의 기존 메서드를 재사용
- Lazy Loading으로 인한 추가 쿼리 발생 가능성이 있으나, 단건 조회이므로 현재 단계에서는 성능 영향이 없다고 판단
- 활성 구독이 없는 경우를 명확히 구분하기 위해 ACTIVE_SUBSCRIPTION_NOT_FOUND 에러 코드를 추가
<br>

### 🔗 관련 이슈
Closes #268 

<br>
