### PR TITLE
[WEF-667] 메일 실패 보상 처리

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendLog.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendLog.java
@@ -1,0 +1,71 @@
+package com.solv.wefin.domain.auth.entity;
+
+import com.solv.wefin.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "email_send_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EmailSendLog extends BaseEntity {
+
+    private static final int VISIBLE_CODE_LENGTH = 2;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VerificationPurpose purpose;
+
+    @Column(nullable = false, length = 20)
+    private String code;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EmailSendStatus status;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    private OffsetDateTime lastTriedAt;
+
+    @Builder
+    public EmailSendLog(String email, VerificationPurpose purpose, String code) {
+        this.email = email;
+        this.purpose = purpose;
+        this.code = maskCode(code);
+        this.status = EmailSendStatus.PENDING;
+        this.retryCount = 0;
+    }
+
+    public void markSuccess(OffsetDateTime now) {
+        this.status = EmailSendStatus.SUCCESS;
+        this.lastTriedAt = now;
+    }
+
+    public void markFail(OffsetDateTime now) {
+        this.status = EmailSendStatus.FAIL;
+        this.retryCount++;
+        this.lastTriedAt = now;
+    }
+
+    private static String maskCode(String code) {
+        if (code == null || code.length() < VISIBLE_CODE_LENGTH) {
+            return "****";
+        }
+
+        String visiblePart = code.substring(code.length() - VISIBLE_CODE_LENGTH);
+        return "****" + visiblePart;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendLog.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendLog.java
@@ -36,7 +36,7 @@ public class EmailSendLog extends BaseEntity {
     private EmailSendStatus status;
 
     @Column(nullable = false)
-    private int retryCount;
+    private int attemptCount;
 
     private OffsetDateTime lastTriedAt;
 
@@ -46,7 +46,7 @@ public class EmailSendLog extends BaseEntity {
         this.purpose = purpose;
         this.code = maskCode(code);
         this.status = EmailSendStatus.PENDING;
-        this.retryCount = 0;
+        this.attemptCount = 1; // 최초 시도
     }
 
     public void markSuccess(OffsetDateTime now) {
@@ -56,7 +56,6 @@ public class EmailSendLog extends BaseEntity {
 
     public void markFail(OffsetDateTime now) {
         this.status = EmailSendStatus.FAIL;
-        this.retryCount++;
         this.lastTriedAt = now;
     }
 

--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendLog.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendLog.java
@@ -61,7 +61,7 @@ public class EmailSendLog extends BaseEntity {
     }
 
     private static String maskCode(String code) {
-        if (code == null || code.length() < VISIBLE_CODE_LENGTH) {
+        if (code == null || code.length() <= VISIBLE_CODE_LENGTH) {
             return "****";
         }
 

--- a/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendStatus.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/EmailSendStatus.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.auth.entity;
+
+public enum EmailSendStatus {
+    PENDING,
+    SUCCESS,
+    FAIL
+}

--- a/src/main/java/com/solv/wefin/domain/auth/repository/EmailSendLogRepository.java
+++ b/src/main/java/com/solv/wefin/domain/auth/repository/EmailSendLogRepository.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.auth.repository;
+
+import com.solv.wefin.domain.auth.entity.EmailSendLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailSendLogRepository extends JpaRepository<EmailSendLog, Long> {
+}

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
@@ -1,11 +1,17 @@
 package com.solv.wefin.domain.auth.service;
 
+import com.solv.wefin.domain.auth.entity.EmailSendLog;
+import com.solv.wefin.domain.auth.repository.EmailSendLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.OffsetDateTime;
 
 @Slf4j
 @Component
@@ -13,15 +19,33 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class EmailVerificationEventListener {
 
     private final MailService mailService;
+    private final EmailSendLogRepository emailSendLogRepository;
 
     @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSendEmail(EmailVerificationSendEvent event) {
+        EmailSendLog emailSendLog = EmailSendLog.builder()
+                .email(event.email())
+                .purpose(event.purpose())
+                .code(event.code())
+                .build();
+
         try {
             mailService.sendVerificationCode(event.email(), event.code());
+            emailSendLog.markSuccess(OffsetDateTime.now());
         } catch (Exception e) {
-            log.error("메일 발송 실패 (after commit): email={}", maskEmail(event.email()), e);
+            emailSendLog.markFail(OffsetDateTime.now());
+            log.error(
+                    "메일 발송 실패 (after commit): email={}, purpose={}, retryCount={}",
+                    maskEmail(event.email()),
+                    event.purpose(),
+                    emailSendLog.getRetryCount(),
+                    e
+            );
         }
+
+        emailSendLogRepository.save(emailSendLog);
     }
 
     private String maskEmail(String email) {

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
@@ -45,7 +45,18 @@ public class EmailVerificationEventListener {
             );
         }
 
-        emailSendLogRepository.save(emailSendLog);
+        try {
+            emailSendLogRepository.save(emailSendLog);
+        } catch (Exception e) {
+            log.error(
+                    "메일 발송 로그 저장 실패: email={}, purpose={}, status={}, retryCount={}",
+                    maskEmail(event.email()),
+                    event.purpose(),
+                    emailSendLog.getStatus(),
+                    emailSendLog.getRetryCount(),
+                    e
+            );
+        }
     }
 
     private String maskEmail(String email) {

--- a/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListener.java
@@ -25,6 +25,8 @@ public class EmailVerificationEventListener {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleSendEmail(EmailVerificationSendEvent event) {
+        OffsetDateTime now = OffsetDateTime.now();
+
         EmailSendLog emailSendLog = EmailSendLog.builder()
                 .email(event.email())
                 .purpose(event.purpose())
@@ -33,14 +35,14 @@ public class EmailVerificationEventListener {
 
         try {
             mailService.sendVerificationCode(event.email(), event.code());
-            emailSendLog.markSuccess(OffsetDateTime.now());
+            emailSendLog.markSuccess(now);
         } catch (Exception e) {
-            emailSendLog.markFail(OffsetDateTime.now());
+            emailSendLog.markFail(now);
             log.error(
-                    "메일 발송 실패 (after commit): email={}, purpose={}, retryCount={}",
+                    "메일 발송 실패 (after commit): email={}, purpose={}, attemptCount={}",
                     maskEmail(event.email()),
                     event.purpose(),
-                    emailSendLog.getRetryCount(),
+                    emailSendLog.getAttemptCount(),
                     e
             );
         }
@@ -49,11 +51,11 @@ public class EmailVerificationEventListener {
             emailSendLogRepository.save(emailSendLog);
         } catch (Exception e) {
             log.error(
-                    "메일 발송 로그 저장 실패: email={}, purpose={}, status={}, retryCount={}",
+                    "메일 발송 로그 저장 실패: email={}, purpose={}, status={}, attemptCount={}",
                     maskEmail(event.email()),
                     event.purpose(),
                     emailSendLog.getStatus(),
-                    emailSendLog.getRetryCount(),
+                    emailSendLog.getAttemptCount(),
                     e
             );
         }

--- a/src/main/resources/db/migration/V44__create_email_send_log.sql
+++ b/src/main/resources/db/migration/V44__create_email_send_log.sql
@@ -1,0 +1,15 @@
+CREATE TABLE email_send_log (
+                                id BIGSERIAL PRIMARY KEY,
+                                email VARCHAR(100) NOT NULL,
+                                purpose VARCHAR(30) NOT NULL,
+                                code VARCHAR(20) NOT NULL,
+                                status VARCHAR(20) NOT NULL,
+                                retry_count INT NOT NULL,
+                                last_tried_at TIMESTAMPTZ,
+                                created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                                updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+ALTER TABLE email_send_log
+    ADD CONSTRAINT chk_email_send_log_status
+        CHECK (status IN ('PENDING', 'SUCCESS', 'FAIL'));

--- a/src/main/resources/db/migration/V45__rename_retry_count_to_attempt_count.sql
+++ b/src/main/resources/db/migration/V45__rename_retry_count_to_attempt_count.sql
@@ -1,0 +1,2 @@
+ALTER TABLE email_send_log
+    RENAME COLUMN retry_count TO attempt_count;

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListenerTest.java
@@ -1,21 +1,26 @@
 package com.solv.wefin.domain.auth.service;
 
+import com.solv.wefin.domain.auth.entity.EmailSendLog;
+import com.solv.wefin.domain.auth.entity.EmailSendStatus;
 import com.solv.wefin.domain.auth.entity.VerificationPurpose;
+import com.solv.wefin.domain.auth.repository.EmailSendLogRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 class EmailVerificationEventListenerTest {
 
     private final MailService mailService = mock(MailService.class);
+    private final EmailSendLogRepository emailSendLogRepository = mock(EmailSendLogRepository.class);
+
     private final EmailVerificationEventListener listener =
-            new EmailVerificationEventListener(mailService);
+            new EmailVerificationEventListener(mailService, emailSendLogRepository);
 
     @Test
-    @DisplayName("이벤트 수신 시 인증코드 메일을 발송한다")
+    @DisplayName("이벤트 수신 시 인증코드 메일을 발송하고 성공 로그를 저장한다")
     void handleSendEmail_success() {
         // given
         EmailVerificationSendEvent event =
@@ -25,15 +30,27 @@ class EmailVerificationEventListenerTest {
                         VerificationPurpose.SIGNUP
                 );
 
+        ArgumentCaptor<EmailSendLog> captor =
+                ArgumentCaptor.forClass(EmailSendLog.class);
+
         // when
         listener.handleSendEmail(event);
 
         // then
         verify(mailService).sendVerificationCode("test@example.com", "123456");
+        verify(emailSendLogRepository).save(captor.capture());
+
+        EmailSendLog savedLog = captor.getValue();
+        assertThat(savedLog.getEmail()).isEqualTo("test@example.com");
+        assertThat(savedLog.getPurpose()).isEqualTo(VerificationPurpose.SIGNUP);
+        assertThat(savedLog.getCode()).isEqualTo("****56");
+        assertThat(savedLog.getStatus()).isEqualTo(EmailSendStatus.SUCCESS);
+        assertThat(savedLog.getRetryCount()).isEqualTo(0);
+        assertThat(savedLog.getLastTriedAt()).isNotNull();
     }
 
     @Test
-    @DisplayName("메일 발송 중 예외가 발생해도 예외를 전파하지 않는다")
+    @DisplayName("메일 발송 중 예외가 발생해도 예외를 전파하지 않고 실패 로그를 저장한다")
     void handleSendEmail_ignore_exception() {
         // given
         EmailVerificationSendEvent event =
@@ -42,6 +59,9 @@ class EmailVerificationEventListenerTest {
                         "123456",
                         VerificationPurpose.SIGNUP
                 );
+
+        ArgumentCaptor<EmailSendLog> captor =
+                ArgumentCaptor.forClass(EmailSendLog.class);
 
         doThrow(new RuntimeException("mail send fail"))
                 .when(mailService)
@@ -52,5 +72,14 @@ class EmailVerificationEventListenerTest {
 
         // then
         verify(mailService).sendVerificationCode("test@example.com", "123456");
+        verify(emailSendLogRepository).save(captor.capture());
+
+        EmailSendLog savedLog = captor.getValue();
+        assertThat(savedLog.getEmail()).isEqualTo("test@example.com");
+        assertThat(savedLog.getPurpose()).isEqualTo(VerificationPurpose.SIGNUP);
+        assertThat(savedLog.getCode()).isEqualTo("****56");
+        assertThat(savedLog.getStatus()).isEqualTo(EmailSendStatus.FAIL);
+        assertThat(savedLog.getRetryCount()).isEqualTo(1);
+        assertThat(savedLog.getLastTriedAt()).isNotNull();
     }
 }

--- a/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/EmailVerificationEventListenerTest.java
@@ -9,7 +9,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class EmailVerificationEventListenerTest {
 
@@ -45,13 +48,13 @@ class EmailVerificationEventListenerTest {
         assertThat(savedLog.getPurpose()).isEqualTo(VerificationPurpose.SIGNUP);
         assertThat(savedLog.getCode()).isEqualTo("****56");
         assertThat(savedLog.getStatus()).isEqualTo(EmailSendStatus.SUCCESS);
-        assertThat(savedLog.getRetryCount()).isEqualTo(0);
+        assertThat(savedLog.getAttemptCount()).isEqualTo(1);
         assertThat(savedLog.getLastTriedAt()).isNotNull();
     }
 
     @Test
     @DisplayName("메일 발송 중 예외가 발생해도 예외를 전파하지 않고 실패 로그를 저장한다")
-    void handleSendEmail_ignore_exception() {
+    void handleSendEmail_fail_but_save_log() {
         // given
         EmailVerificationSendEvent event =
                 new EmailVerificationSendEvent(
@@ -68,7 +71,7 @@ class EmailVerificationEventListenerTest {
                 .sendVerificationCode("test@example.com", "123456");
 
         // when
-        listener.handleSendEmail(event);
+        assertDoesNotThrow(() -> listener.handleSendEmail(event));
 
         // then
         verify(mailService).sendVerificationCode("test@example.com", "123456");
@@ -79,7 +82,31 @@ class EmailVerificationEventListenerTest {
         assertThat(savedLog.getPurpose()).isEqualTo(VerificationPurpose.SIGNUP);
         assertThat(savedLog.getCode()).isEqualTo("****56");
         assertThat(savedLog.getStatus()).isEqualTo(EmailSendStatus.FAIL);
-        assertThat(savedLog.getRetryCount()).isEqualTo(1);
+        assertThat(savedLog.getAttemptCount()).isEqualTo(1);
         assertThat(savedLog.getLastTriedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("로그 저장 중 예외가 발생해도 예외를 전파하지 않는다")
+    void handleSendEmail_ignore_log_save_exception() {
+        // given
+        EmailVerificationSendEvent event =
+                new EmailVerificationSendEvent(
+                        "test@example.com",
+                        "123456",
+                        VerificationPurpose.SIGNUP
+                );
+
+        doThrow(new RuntimeException("log save fail"))
+                .when(emailSendLogRepository)
+                .save(org.mockito.ArgumentMatchers.any(EmailSendLog.class));
+
+        // when
+        assertDoesNotThrow(() -> listener.handleSendEmail(event));
+
+        // then
+        verify(mailService).sendVerificationCode("test@example.com", "123456");
+        verify(emailSendLogRepository)
+                .save(org.mockito.ArgumentMatchers.any(EmailSendLog.class));
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
이메일 인증 코드 발송 실패에 대한 추적 및 후속 처리를 위해 이메일 발송 로그를 저장하는 구조를 추가.
메일 발송 성공/실패 여부를 기록하고 실패 시 재시도 기반을 마련.

## ✅ 완료한 기능 명세

- [x] EmailSendLog 엔티티 추가
- [x] EmailSendStatus enum 추가
- [x] EmailSendLogRepository 추가
- [x] 이메일 발송 성공/실패 로그 저장 로직 구현
- [x] 실패 시 retryCount 증가 및 lastTriedAt 기록
- [x] 인증 코드 DB 저장 시 마스킹 처리 적용
- [x] EventListener 테스트 코드 보강 (로그 저장 및 상태 검증)
- [x] email_send_log 테이블 Flyway 마이그레이션 추가

- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 기존 구조에서는 메일 발송 실패 시 로그만 남기고 별도의 추적이나 보상 처리가 불가능했음
-> 이메일 발송 결과를 DB에 기록하는 구조를 추가했습니다.

- 인증 코드 원문이 그대로 저장되는 문제를 고려하여 로그에는 마스킹된 값만 저장하도록 처리

- 트랜잭션 외부에서 실행되는 이벤트 리스너에서 별도 트랜잭션(REQUIRES_NEW)으로 로그를 저장하도록 구성해 메일 발송 실패와 관계없이 기록이 남도록 함
<br>

### 🔗 관련 이슈
Closes #282 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 이메일 인증 전송 이력 추적 기능이 추가되었습니다. 시스템은 이제 모든 인증 이메일 전송 시도를 기록하며, 각 시도의 성공/실패 상태, 재시도 횟수, 그리고 전송 시간을 추적합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->