### PR TITLE
[WEF-665] 과거 게임 이력 조회

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/result/dto/GameHistoryInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/dto/GameHistoryInfo.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.domain.game.result.dto;
+
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 과거 게임 이력 조회용 Domain DTO.
+ * GameResult + GameRoom 에서 필요한 필드를 추출.
+ * finalRank: 방 FINISHED 시 실제 순위, 방 IN_PROGRESS 시 null (DB의 0을 null로 매핑).
+ */
+public record GameHistoryInfo(
+        UUID roomId,
+        RoomStatus roomStatus,
+        BigDecimal seedMoney,
+        int periodMonths,
+        int moveDays,
+        LocalDate startDate,
+        LocalDate endDate,
+        int participantCount,
+        BigDecimal finalAsset,
+        BigDecimal profitRate,
+        Integer finalRank,
+        int totalTrades,
+        OffsetDateTime finishedAt
+) {}

--- a/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/repository/GameResultRepository.java
@@ -3,7 +3,11 @@ package com.solv.wefin.domain.game.result.repository;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +22,29 @@ public interface GameResultRepository extends JpaRepository<GameResult, UUID> {
     boolean existsByGameRoomAndParticipant(GameRoom gameRoom, GameParticipant participant);
 
     Optional<GameResult> findByParticipant(GameParticipant participant);
+
+    /**
+     * 내가 FINISHED한 게임 이력 페이징 조회.
+     * GameResult 기준 — GameRoom JOIN FETCH로 방 메타를 N+1 없이 로딩.
+     * countQuery 분리: JOIN FETCH가 포함된 쿼리는 COUNT 자동 변환 시 에러 발생하므로 별도 지정.
+     */
+    @Query(value = "SELECT r FROM GameResult r " +
+            "JOIN FETCH r.gameRoom " +
+            "JOIN FETCH r.participant " +
+            "WHERE r.participant.userId = :userId " +
+            "AND r.gameRoom.groupId = :groupId",
+            countQuery = "SELECT COUNT(r) FROM GameResult r " +
+                    "WHERE r.participant.userId = :userId " +
+                    "AND r.gameRoom.groupId = :groupId")
+    Page<GameResult> findMyHistory(@Param("userId") UUID userId,
+                                   @Param("groupId") Long groupId,
+                                   Pageable pageable);
+
+    /**
+     * 방별 GameResult 개수 (= 완주자 수) 일괄 집계.
+     * 이력 조회 시 participantCount를 N+1 없이 한 번에 가져오기 위한 용도.
+     */
+    @Query("SELECT r.gameRoom.roomId, COUNT(r) FROM GameResult r " +
+            "WHERE r.gameRoom.roomId IN :roomIds GROUP BY r.gameRoom.roomId")
+    List<Object[]> countByRoomIds(@Param("roomIds") List<UUID> roomIds);
 }

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
@@ -6,6 +6,7 @@ import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.GameHistoryInfo;
 import com.solv.wefin.domain.game.result.dto.GameResultInfo;
 import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.result.repository.GameResultRepository;
@@ -17,6 +18,8 @@ import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepos
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -176,6 +179,61 @@ public class GameResultService {
                         o.getFee(),
                         o.getTax()))
                 .toList();
+    }
+
+    /**
+     * 내가 참여해서 FINISHED한 게임 이력 페이징 조회.
+     * 쿼리 기준: game_result (방 나가기(LEFT)는 GameResult 미생성 → 자연스럽게 제외).
+     *
+     * finalRank 매핑 정책:
+     * - 방 FINISHED → 실제 순위 (GameEndService.finalizeRanks()로 확정된 값)
+     * - 방 IN_PROGRESS → null (DB의 0은 "미확정"이므로 클라이언트에 노출하지 않음)
+     *
+     * participantCount: 해당 방의 GameResult 개수 = 완주자 수 (LEFT 제외).
+     */
+    public Page<GameHistoryInfo> getMyGameHistory(Long groupId, UUID userId, Pageable pageable) {
+
+        // 1. 내 이력 페이징 조회 (JOIN FETCH GameRoom, GameParticipant)
+        Page<GameResult> resultPage = gameResultRepository.findMyHistory(userId, groupId, pageable);
+
+        if (resultPage.isEmpty()) {
+            return resultPage.map(r -> null); // 빈 페이지 그대로 반환
+        }
+
+        // 2. 방별 완주자 수 일괄 집계 (N+1 방지)
+        List<UUID> roomIds = resultPage.getContent().stream()
+                .map(r -> r.getGameRoom().getRoomId())
+                .distinct()
+                .toList();
+
+        Map<UUID, Long> participantCountMap = gameResultRepository.countByRoomIds(roomIds).stream()
+                .collect(Collectors.toMap(
+                        row -> (UUID) row[0],
+                        row -> (Long) row[1]));
+
+        // 3. GameResult → GameHistoryInfo 변환
+        return resultPage.map(r -> {
+            GameRoom room = r.getGameRoom();
+            boolean roomFinished = room.getStatus() == RoomStatus.FINISHED;
+            Integer finalRank = roomFinished ? r.getFinalRank() : null;
+            int participantCount = participantCountMap
+                    .getOrDefault(room.getRoomId(), 0L).intValue();
+
+            return new GameHistoryInfo(
+                    room.getRoomId(),
+                    room.getStatus(),
+                    r.getSeedMoney(),
+                    room.getPeriodMonth(),
+                    room.getMoveDays(),
+                    room.getStartDate(),
+                    room.getEndDate(),
+                    participantCount,
+                    r.getFinalAsset(),
+                    r.getProfitRate(),
+                    finalRank,
+                    r.getTotalTrades(),
+                    r.getCreatedAt());
+        });
     }
 
     private Map<UUID, String> buildNicknameMap(List<UUID> userIds) {

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -26,7 +26,6 @@ import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -92,21 +91,13 @@ public class GameRoomService {
         return gameRoom;
     }
 
-    // 게임방 목록 조회
+    // 게임방 목록 조회 — 활성방(WAITING/IN_PROGRESS)만 반환.
+    // FINISHED 이력은 GET /api/rooms/history 로 분리됨.
     public List<RoomListInfo> getRooms(Long groupId, UUID userId) {
-        //그룹 활성화된 방
         List<RoomStatus> activeStatuses = List.of(RoomStatus.WAITING, RoomStatus.IN_PROGRESS);
         List<GameRoom> activeRooms = gameRoomRepository.findByGroupIdAndStatusIn(groupId, activeStatuses);
 
-        // 내 과거 기록
-        List<GameRoom> myFinishedRooms = gameRoomRepository.findFinishedRoomsByGroupIdAndUserId((groupId), userId);
-
-        List<GameRoom> rooms = new ArrayList<>();
-        rooms.addAll(activeRooms);
-        rooms.addAll(myFinishedRooms);
-
-        //참가자 수 count
-        return rooms.stream().map(room -> {
+        return activeRooms.stream().map(room -> {
                     int playerCount = gameParticipantRepository.countByGameRoomAndStatus(room, ParticipantStatus.ACTIVE);
                     return new RoomListInfo(room, playerCount);
                 })

--- a/src/main/java/com/solv/wefin/global/common/PageInfo.java
+++ b/src/main/java/com/solv/wefin/global/common/PageInfo.java
@@ -1,0 +1,25 @@
+package com.solv.wefin.global.common;
+
+import org.springframework.data.domain.Page;
+
+/**
+ * 페이징 메타 정보.
+ * Spring Page의 과다한 필드(20개+)에서 클라이언트에 필요한 5개만 추출.
+ * 다른 페이징 API에서도 재사용 가능.
+ */
+public record PageInfo(
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean hasNext
+) {
+    public static PageInfo from(Page<?> page) {
+        return new PageInfo(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.hasNext());
+    }
+}

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -1,6 +1,8 @@
 package com.solv.wefin.web.game.room;
 
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
+import com.solv.wefin.domain.game.result.dto.GameHistoryInfo;
+import com.solv.wefin.domain.game.result.service.GameResultService;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
 import com.solv.wefin.domain.game.room.dto.RoomDetailInfo;
 import com.solv.wefin.domain.game.room.dto.RoomListInfo;
@@ -12,6 +14,7 @@ import com.solv.wefin.domain.game.room.service.GameRoomService;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.common.PageInfo;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.web.game.room.dto.LeaveRoomResponse;
@@ -19,6 +22,9 @@ import com.solv.wefin.web.game.room.dto.request.CreateRoomRequest;
 import com.solv.wefin.web.game.room.dto.response.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,6 +42,7 @@ public class
 GameRoomController {
 
     private final GameRoomService gameRoomService;
+    private final GameResultService gameResultService;
     private final GroupMemberRepository groupMemberRepository;
     private final UserRepository userRepository;
 
@@ -65,6 +72,34 @@ GameRoomController {
                 r -> RoomListResponse.from(r.room(), r.playerCount())).collect(Collectors.toList());
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    /**
+     * 과거 게임 이력 페이징 조회.
+     * 내가 FINISHED한 게임의 결과(수익률/순위/자산)를 최신순으로 반환.
+     * 정렬은 createdAt DESC 고정 — 클라이언트가 정렬을 조작하지 못하게 서버에서 강제.
+     */
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<GameHistoryPageResponse>> getHistory(
+            @AuthenticationPrincipal UUID userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        Long groupId = getActiveGroupId(userId);
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.max(1, Math.min(size, 50));
+        PageRequest pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+        Page<GameHistoryInfo> historyPage = gameResultService.getMyGameHistory(groupId, userId, pageable);
+
+        List<GameHistoryResponse> content = historyPage.getContent().stream()
+                .map(GameHistoryResponse::from)
+                .toList();
+
+        GameHistoryPageResponse response = new GameHistoryPageResponse(content, PageInfo.from(historyPage));
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    record GameHistoryPageResponse(List<GameHistoryResponse> content, PageInfo pageInfo) {}
 
     @GetMapping("/{roomId}")
     public ResponseEntity<ApiResponse<RoomDetailResponse>> getRoomDetail(@PathVariable UUID roomId){

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/GameHistoryResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/GameHistoryResponse.java
@@ -1,0 +1,42 @@
+package com.solv.wefin.web.game.room.dto.response;
+
+import com.solv.wefin.domain.game.result.dto.GameHistoryInfo;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record GameHistoryResponse(
+        UUID roomId,
+        RoomStatus roomStatus,
+        BigDecimal seedMoney,
+        int periodMonths,
+        int moveDays,
+        LocalDate startDate,
+        LocalDate endDate,
+        int participantCount,
+        BigDecimal finalAsset,
+        BigDecimal profitRate,
+        Integer finalRank,
+        int totalTrades,
+        OffsetDateTime finishedAt
+) {
+    public static GameHistoryResponse from(GameHistoryInfo info) {
+        return new GameHistoryResponse(
+                info.roomId(),
+                info.roomStatus(),
+                info.seedMoney(),
+                info.periodMonths(),
+                info.moveDays(),
+                info.startDate(),
+                info.endDate(),
+                info.participantCount(),
+                info.finalAsset(),
+                info.profitRate(),
+                info.finalRank(),
+                info.totalTrades(),
+                info.finishedAt());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
@@ -9,10 +9,12 @@ import com.solv.wefin.domain.game.order.repository.GameOrderRepository;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
+import com.solv.wefin.domain.game.result.dto.GameHistoryInfo;
 import com.solv.wefin.domain.game.result.dto.GameResultInfo;
 import com.solv.wefin.domain.game.result.entity.GameResult;
 import com.solv.wefin.domain.game.result.repository.GameResultRepository;
 import com.solv.wefin.domain.game.room.entity.GameRoom;
+import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.snapshot.dto.SnapshotInfo;
 import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
@@ -29,8 +31,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -38,8 +46,10 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
 class GameResultServiceTest {
@@ -616,6 +626,132 @@ class GameResultServiceTest {
         }
     }
 
+    // === 게임 이력 조회 ===
+
+    private static final PageRequest HISTORY_PAGEABLE =
+            PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+    @Nested
+    @DisplayName("게임 이력 조회 성공")
+    class GameHistorySuccessTests {
+
+        @Test
+        @DisplayName("방 FINISHED — finalRank 실제 순위 반환")
+        void getHistory_roomFinished_returnsActualRank() {
+            // Given — GameRoom/GameParticipant/GameResult를 mock으로 구성
+            // (실제 Entity.create()은 roomId가 null — JPA @GeneratedValue라 persist 전에는 미할당)
+            GameRoom room = mockRoom(ROOM_ID, RoomStatus.FINISHED);
+            GameParticipant me = mockParticipant(USER_A);
+            GameResult result = mockResult(room, me, 2, SEED,
+                    new BigDecimal("11000000"), new BigDecimal("10.00"), 15);
+
+            Page<GameResult> page = new PageImpl<>(List.of(result), HISTORY_PAGEABLE, 1);
+            given(gameResultRepository.findMyHistory(USER_A, GROUP_ID, HISTORY_PAGEABLE))
+                    .willReturn(page);
+            given(gameResultRepository.countByRoomIds(any()))
+                    .willReturn(List.<Object[]>of(new Object[]{ROOM_ID, 3L}));
+
+            // When
+            Page<GameHistoryInfo> historyPage = gameResultService.getMyGameHistory(GROUP_ID, USER_A, HISTORY_PAGEABLE);
+
+            // Then
+            assertThat(historyPage.getContent()).hasSize(1);
+            GameHistoryInfo info = historyPage.getContent().get(0);
+            assertThat(info.roomId()).isEqualTo(ROOM_ID);
+            assertThat(info.roomStatus()).isEqualTo(RoomStatus.FINISHED);
+            assertThat(info.finalRank()).isEqualTo(2);
+            assertThat(info.participantCount()).isEqualTo(3);
+            assertThat(info.seedMoney()).isEqualByComparingTo("10000000");
+            assertThat(info.finalAsset()).isEqualByComparingTo("11000000");
+            assertThat(info.profitRate()).isEqualByComparingTo("10.00");
+            assertThat(info.totalTrades()).isEqualTo(15);
+            assertThat(info.startDate()).isEqualTo(START_DATE);
+            assertThat(info.endDate()).isEqualTo(END_DATE);
+        }
+
+        @Test
+        @DisplayName("방 IN_PROGRESS — finalRank null 매핑 (DB의 0을 노출하지 않음)")
+        void getHistory_roomInProgress_finalRankNull() {
+            // Given — 나만 FINISHED, 방은 아직 IN_PROGRESS
+            GameRoom room = mockRoom(ROOM_ID, RoomStatus.IN_PROGRESS);
+            GameParticipant me = mockParticipant(USER_A);
+            GameResult result = mockResult(room, me, 0, SEED,
+                    new BigDecimal("9500000"), new BigDecimal("-5.00"), 8);
+
+            Page<GameResult> page = new PageImpl<>(List.of(result), HISTORY_PAGEABLE, 1);
+            given(gameResultRepository.findMyHistory(USER_A, GROUP_ID, HISTORY_PAGEABLE))
+                    .willReturn(page);
+            given(gameResultRepository.countByRoomIds(any()))
+                    .willReturn(List.<Object[]>of(new Object[]{ROOM_ID, 1L}));
+
+            // When
+            Page<GameHistoryInfo> historyPage = gameResultService.getMyGameHistory(GROUP_ID, USER_A, HISTORY_PAGEABLE);
+
+            // Then
+            GameHistoryInfo info = historyPage.getContent().get(0);
+            assertThat(info.roomStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
+            assertThat(info.finalRank()).isNull();
+            assertThat(info.participantCount()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("이력 없는 사용자 — 빈 페이지 반환")
+        void getHistory_empty() {
+            // Given
+            Page<GameResult> emptyPage = new PageImpl<>(List.of(), HISTORY_PAGEABLE, 0);
+            given(gameResultRepository.findMyHistory(USER_A, GROUP_ID, HISTORY_PAGEABLE))
+                    .willReturn(emptyPage);
+
+            // When
+            Page<GameHistoryInfo> historyPage = gameResultService.getMyGameHistory(GROUP_ID, USER_A, HISTORY_PAGEABLE);
+
+            // Then
+            assertThat(historyPage.getContent()).isEmpty();
+            assertThat(historyPage.getTotalElements()).isZero();
+        }
+
+        @Test
+        @DisplayName("페이징 메타 정확성 — totalElements, totalPages, hasNext")
+        void getHistory_pagingMeta() {
+            // Given — 총 25건, page=0, size=10 → totalPages=3, hasNext=true
+            GameRoom room = mockRoom(ROOM_ID, RoomStatus.FINISHED);
+            GameParticipant me = mockParticipant(USER_A);
+            GameResult result = mockResult(room, me, 1, SEED,
+                    new BigDecimal("12000000"), new BigDecimal("20.00"), 30);
+
+            Page<GameResult> page = new PageImpl<>(List.of(result), HISTORY_PAGEABLE, 25);
+            given(gameResultRepository.findMyHistory(USER_A, GROUP_ID, HISTORY_PAGEABLE))
+                    .willReturn(page);
+            given(gameResultRepository.countByRoomIds(any()))
+                    .willReturn(List.<Object[]>of(new Object[]{ROOM_ID, 5L}));
+
+            // When
+            Page<GameHistoryInfo> historyPage = gameResultService.getMyGameHistory(GROUP_ID, USER_A, HISTORY_PAGEABLE);
+
+            // Then
+            assertThat(historyPage.getTotalElements()).isEqualTo(25);
+            assertThat(historyPage.getTotalPages()).isEqualTo(3);
+            assertThat(historyPage.hasNext()).isTrue();
+        }
+
+        @Test
+        @DisplayName("다른 그룹 격리 — groupId가 다르면 빈 결과")
+        void getHistory_otherGroup_empty() {
+            // Given — 다른 그룹 ID로 조회하면 Repository가 빈 결과 반환
+            Long otherGroupId = 999L;
+            Page<GameResult> emptyPage = new PageImpl<>(List.of(), HISTORY_PAGEABLE, 0);
+            given(gameResultRepository.findMyHistory(USER_A, otherGroupId, HISTORY_PAGEABLE))
+                    .willReturn(emptyPage);
+
+            // When
+            Page<GameHistoryInfo> historyPage = gameResultService.getMyGameHistory(otherGroupId, USER_A, HISTORY_PAGEABLE);
+
+            // Then
+            assertThat(historyPage.getContent()).isEmpty();
+            assertThat(historyPage.getTotalElements()).isZero();
+        }
+    }
+
     // === 헬퍼 메서드 ===
 
     private GameRoom createStartedRoom() {
@@ -652,6 +788,41 @@ class GameResultServiceTest {
         given(snapshot.getStockValue()).willReturn(stockValue);
         given(snapshot.getProfitRate()).willReturn(profitRate);
         return snapshot;
+    }
+
+    private GameRoom mockRoom(UUID roomId, RoomStatus status) {
+        GameRoom room = mock(GameRoom.class, withSettings().lenient());
+        given(room.getRoomId()).willReturn(roomId);
+        given(room.getStatus()).willReturn(status);
+        given(room.getSeed()).willReturn(SEED);
+        given(room.getPeriodMonth()).willReturn(6);
+        given(room.getMoveDays()).willReturn(7);
+        given(room.getStartDate()).willReturn(START_DATE);
+        given(room.getEndDate()).willReturn(END_DATE);
+        given(room.getGroupId()).willReturn(GROUP_ID);
+        return room;
+    }
+
+    private GameParticipant mockParticipant(UUID userId) {
+        GameParticipant p = mock(GameParticipant.class, withSettings().lenient());
+        given(p.getUserId()).willReturn(userId);
+        given(p.getStatus()).willReturn(ParticipantStatus.FINISHED);
+        return p;
+    }
+
+    private GameResult mockResult(GameRoom room, GameParticipant participant,
+                                   int finalRank, BigDecimal seedMoney,
+                                   BigDecimal finalAsset, BigDecimal profitRate, int totalTrades) {
+        GameResult r = mock(GameResult.class, withSettings().lenient());
+        given(r.getGameRoom()).willReturn(room);
+        given(r.getParticipant()).willReturn(participant);
+        given(r.getFinalRank()).willReturn(finalRank);
+        given(r.getSeedMoney()).willReturn(seedMoney);
+        given(r.getFinalAsset()).willReturn(finalAsset);
+        given(r.getProfitRate()).willReturn(profitRate);
+        given(r.getTotalTrades()).willReturn(totalTrades);
+        given(r.getCreatedAt()).willReturn(OffsetDateTime.now());
+        return r;
     }
 
     private GameOrder mockOrder(UUID orderId, int turnNumber, LocalDate turnDate,

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -158,37 +158,31 @@ class GameRoomServiceTest {
     // === API 2: 게임방 목록 조회 테스트 ===
 
     @Test
-    @DisplayName("게임방 목록 조회 — 활성방 + 내 완료방 조회")
+    @DisplayName("게임방 목록 조회 — 활성방만 반환 (FINISHED는 history API로 분리)")
     void getRooms() {
-        // Given — 활성방 1개, 내 완료방 1개
+        // Given — 활성방 1개
         GameRoom activeRoom = createGameRoom();
-        GameRoom finishedRoom = createGameRoom();
         given(gameRoomRepository.findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList()))
                 .willReturn(List.of(activeRoom));
-        given(gameRoomRepository.findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID))
-                .willReturn(List.of(finishedRoom));
         given(gameParticipantRepository.countByGameRoomAndStatus(any(GameRoom.class), eq(ParticipantStatus.ACTIVE)))
                 .willReturn(1);
 
         // When
         List<RoomListInfo> result = gameRoomService.getRooms(TEST_GROUP_ID, TEST_USER_ID);
 
-        // Then — 2개 반환 (활성 1 + 완료 1)
-        assertThat(result).hasSize(2);
+        // Then — 활성방 1개만 반환
+        assertThat(result).hasSize(1);
         assertThat(result.get(0).room()).isEqualTo(activeRoom);
         assertThat(result.get(0).playerCount()).isEqualTo(1);
 
         verify(gameRoomRepository).findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList());
-        verify(gameRoomRepository).findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID);
     }
 
     @Test
     @DisplayName("게임방 목록 조회 — 결과 없으면 빈 리스트 반환")
     void getRooms_empty() {
-        // Given — 활성방 없음, 완료방 없음
+        // Given — 활성방 없음
         given(gameRoomRepository.findByGroupIdAndStatusIn(eq(TEST_GROUP_ID), anyList()))
-                .willReturn(Collections.emptyList());
-        given(gameRoomRepository.findFinishedRoomsByGroupIdAndUserId(TEST_GROUP_ID, TEST_USER_ID))
                 .willReturn(Collections.emptyList());
 
         // When


### PR DESCRIPTION
## 📌 PR 설명
<br>내가 참여한 FINISHED 게임의 실제 결과(수익률/순위/자산)를 페이징으로 조회하는 API를 구현했습니다. 기존 GET /api/rooms는 활성방(WAITING/IN_PROGRESS) 전용으로 책임을 분리했습니다

## ✅ 완료한 기능 명세

- [x] 과거 게임 이력 페이징 조회 API 
- [x] GameRoomController#getHistory — size 상한 50 제한, 정렬 createdAt DESC
- [x] 테스트코드 작성

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #283 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게임 이력 조회 기능 추가: 사용자의 완료된 게임과 진행 중인 게임에 대한 상세 정보를 조회할 수 있습니다.
  * 페이지네이션 지원: 게임 이력 조회 시 페이지 단위로 데이터를 조회할 수 있습니다.
  * 게임 이력 항목에 참가자 수, 수익률, 최종 순위, 거래 횟수 등의 상세 정보 표시

* **리팩토링**
  * 활성 게임룸 필터링 로직 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->