### PR TITLE
[WEF-286] 지정가 주문 API stockCode 기반 전환

### DIFF
--- a/src/main/java/com/solv/wefin/web/trading/order/LimitOrderController.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/LimitOrderController.java
@@ -2,8 +2,10 @@ package com.solv.wefin.web.trading.order;
 
 import com.solv.wefin.domain.trading.account.entity.VirtualAccount;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
+import com.solv.wefin.domain.trading.common.StockInfoProvider;
 import com.solv.wefin.domain.trading.order.dto.OrderInfo;
 import com.solv.wefin.domain.trading.order.service.LimitOrderService;
+import com.solv.wefin.domain.trading.stock.entity.Stock;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.trading.order.dto.request.LimitOrderBuyRequest;
 import com.solv.wefin.web.trading.order.dto.request.LimitOrderSellRequest;
@@ -25,6 +27,7 @@ public class LimitOrderController {
 
     private final LimitOrderService limitOrderService;
     private final VirtualAccountService accountService;
+    private final StockInfoProvider stockInfoProvider;
 
     @PostMapping("/buy")
     public ApiResponse<OrderResponse> buy(
@@ -32,9 +35,10 @@ public class LimitOrderController {
             @Valid @RequestBody LimitOrderBuyRequest request
     ) {
         VirtualAccount account = accountService.getAccountByUserId(userId);
+        Stock stock = stockInfoProvider.getStockByCode(request.stockCode());
         OrderInfo orderInfo = limitOrderService.buyLimit(
                 account.getVirtualAccountId(),
-                request.stockId(),
+                stock.getId(),
                 request.quantity(),
                 request.requestPrice()
         );
@@ -47,9 +51,10 @@ public class LimitOrderController {
             @Valid @RequestBody LimitOrderSellRequest request
     ) {
         VirtualAccount account = accountService.getAccountByUserId(userId);
+        Stock stock = stockInfoProvider.getStockByCode(request.stockCode());
         OrderInfo orderInfo = limitOrderService.sellLimit(
                 account.getVirtualAccountId(),
-                request.stockId(),
+                stock.getId(),
                 request.quantity(),
                 request.requestPrice()
         );

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderBuyRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderBuyRequest.java
@@ -1,13 +1,14 @@
 package com.solv.wefin.web.trading.order.dto.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 
 public record LimitOrderBuyRequest(
-        @NotNull Long stockId,
+        @NotBlank String stockCode,
         @NotNull @Min(1) Integer quantity,
         @NotNull @Positive BigDecimal requestPrice
 ) {

--- a/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderSellRequest.java
+++ b/src/main/java/com/solv/wefin/web/trading/order/dto/request/LimitOrderSellRequest.java
@@ -1,13 +1,14 @@
 package com.solv.wefin.web.trading.order.dto.request;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 
 import java.math.BigDecimal;
 
 public record LimitOrderSellRequest(
-        @NotNull Long stockId,
+        @NotBlank String stockCode,
         @NotNull @Min(1) Integer quantity,
         @NotNull @Positive BigDecimal requestPrice
 ) {


### PR DESCRIPTION
## 📌 PR 설명

지정가 주문 API의 요청 식별자를 `stockId`(Long) → `stockCode`(String)로 변경했습니다.
시장가 주문(`OrderBuyRequest`)과 인터페이스를 통일하여 FE에서 별도 ID 매핑 없이 호출 가능하도록 수정했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] `LimitOrderBuyRequest`: `stockId` (Long) → `stockCode` (String, @NotBlank)
- [x] `LimitOrderSellRequest`: 동일 변경
- [x] `LimitOrderController`: `StockInfoProvider.getStockByCode()` → `stock.getId()` 변환 추가

<br>

## 📸 스크린샷
해당 없음 (API 인터페이스 변경)

<br>

## 💭 고민과 해결과정
시장가 주문은 `stockCode`를 받는데 지정가만 `stockId`(DB PK)를 요구해서, FE에서 stockId를 알 방법이 없었음. 
Service 레이어는 내부적으로 stockId가 필요하므로 Controller에서 stockCode → Stock 엔티티 조회 후 getId()로 변환하는 방식 채택.

<br>

### 🔗 관련 이슈
Closes #286 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경사항

* **기능 개선**
  * 지정가 주문(매수/매도) API에서 주식 ID 대신 주식 코드 입력 지원으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->