### PR TITLE
[WEF-669] 캔들 차트 데이터 확장 (일봉/분봉 페이징)

### DIFF
--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -53,6 +53,9 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private static final long CACHE_TTL_MS = 5000; // 5초
     private static final Set<String> VALID_PERIOD_CODES = Set.of("D", "W", "M", "Y");
     private static final Set<String> MINUTE_PERIOD_CODES = Set.of("1", "5", "15", "30", "60");
+    private static final int PERIOD_CANDLE_MAX_PAGES = 4;
+    private static final int PERIOD_CANDLE_PAGE_DAYS = 100;
+    private static final int MINUTE_CANDLE_MAX_PAGES = 5;
 
     public PriceResponse getPrice(String stockCode) {
         validateStockCode(stockCode);
@@ -242,56 +245,98 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             throw new BusinessException(ErrorCode.MARKET_INVALID_PERIOD_CODE);
         }
 
-        HantuCandleApiResponse response = hantuMarketClient.fetchPeriodPrice(stockCode, start, end, periodCode);
-        log.info("캔들 API 응답: {}", response);
+        return getPeriodCandlesWithPaging(stockCode, start, end, periodCode);
+    }
 
-        if (response == null) {
-            return List.of();
-        }
+    private List<CandleResponse> getPeriodCandlesWithPaging(String stockCode, LocalDate start, LocalDate end, String periodCode) {
+        List<CandleResponse> allCandles = new ArrayList<>();
+        LocalDate pageEnd = end;
 
-        if (response.output1() != null) {
-            validateRtCode(response.output1().rt_cd());
-        }
+        for (int page = 0; page < PERIOD_CANDLE_MAX_PAGES && !pageEnd.isBefore(start); page++) {
+            LocalDate pageStart = pageEnd.minusDays(PERIOD_CANDLE_PAGE_DAYS);
+            if (pageStart.isBefore(start)) {
+                pageStart = start;
+            }
 
-        if (response.output2() == null) {
-            return List.of();
-        }
+            HantuCandleApiResponse response = hantuMarketClient.fetchPeriodPrice(stockCode, pageStart, pageEnd, periodCode);
 
-        return response.output2().stream()
+            if (response == null || response.output2() == null || response.output2().isEmpty()) {
+                break;
+            }
+
+            List<CandleResponse> pageCandles = response.output2().stream()
                     .map(CandleResponse::from)
                     .toList();
+            allCandles.addAll(pageCandles);
+
+            // 다음 페이지: 이번 응답의 가장 오래된 날짜 - 1일
+            LocalDate oldestDate = pageCandles.stream()
+                    .map(c -> c.date().toLocalDate())
+                    .min(LocalDate::compareTo)
+                    .orElse(pageStart);
+            pageEnd = oldestDate.minusDays(1);
+        }
+
+        // date 기준 중복 제거 + 오름차순 정렬
+        LinkedHashMap<LocalDateTime, CandleResponse> deduped = new LinkedHashMap<>();
+        allCandles.stream()
+                .sorted(Comparator.comparing(CandleResponse::date))
+                .forEach(c -> deduped.putIfAbsent(c.date(), c));
+        return new ArrayList<>(deduped.values());
     }
 
     private List<CandleResponse> getMinuteCandles(String stockCode, int periodMinutes) {
-        // 현재 KST 시간 기준으로 분봉 조회 (역순으로 반환됨)
+        List<CandleResponse> allOneMinuteCandles = new ArrayList<>();
         String inputHour = LocalDateTime.now(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ofPattern("HHmmss"));
-        HantuMinuteCandleApiResponse response = hantuMarketClient.fetchMinutePrice(stockCode, inputHour);
-        log.info("분봉 API 응답: {}", response);
 
-        if (response == null) {
-            return List.of();
+        for (int page = 0; page < MINUTE_CANDLE_MAX_PAGES; page++) {
+            HantuMinuteCandleApiResponse response = hantuMarketClient.fetchMinutePrice(stockCode, inputHour);
+
+            if (response == null || response.output2() == null || response.output2().isEmpty()) {
+                break;
+            }
+
+            List<CandleResponse> pageCandles = response.output2().stream()
+                    .map(CandleResponse::fromMinute)
+                    .toList();
+            allOneMinuteCandles.addAll(pageCandles);
+
+            // 다음 페이지: 이번 응답의 가장 오래된 시간 - 1분
+            String oldestHour = response.output2().stream()
+                    .map(HantuMinuteCandleApiResponse.Output2::stck_cntg_hour)
+                    .min(String::compareTo)
+                    .orElse(null);
+
+            if (oldestHour == null) {
+                break;
+            }
+
+            // 가장 오래된 시간에서 1분 빼서 다음 페이지 요청 (중복 방지)
+            int hour = Integer.parseInt(oldestHour.substring(0, 2));
+            int min = Integer.parseInt(oldestHour.substring(2, 4));
+            if (min == 0) {
+                hour--;
+                min = 59;
+            } else {
+                min--;
+            }
+            if (hour < 9) {
+                break; // 장 시작(09:00) 이전이면 더 이상 데이터 없음
+            }
+            inputHour = String.format("%02d%02d00", hour, min);
         }
 
-        if (response.output1() != null) {
-            validateRtCode(response.output1().rt_cd());
-        }
-
-        if (response.output2() == null) {
-            return List.of();
-        }
-
-        // 한투 API가 내림차순(최신→과거)으로 반환하므로 오름차순 정렬
-        List<CandleResponse> oneMinuteCandles = response.output2().stream()
-                .map(CandleResponse::fromMinute)
+        // date 기준 중복 제거 + 오름차순 정렬
+        LinkedHashMap<LocalDateTime, CandleResponse> deduped = new LinkedHashMap<>();
+        allOneMinuteCandles.stream()
                 .sorted(Comparator.comparing(CandleResponse::date))
-                .toList();
+                .forEach(c -> deduped.putIfAbsent(c.date(), c));
+        List<CandleResponse> oneMinuteCandles = new ArrayList<>(deduped.values());
 
-        // 1분봉이면 그대로 반환
         if (periodMinutes == 1) {
             return oneMinuteCandles;
         }
 
-        // N분봉 집계
         return aggregateCandles(oneMinuteCandles, periodMinutes);
     }
 

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -54,7 +54,6 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private static final Set<String> VALID_PERIOD_CODES = Set.of("D", "W", "M", "Y");
     private static final Set<String> MINUTE_PERIOD_CODES = Set.of("1", "5", "15", "30", "60");
     private static final int PERIOD_CANDLE_MAX_PAGES = 4;
-    private static final int PERIOD_CANDLE_PAGE_DAYS = 100;
     private static final int MINUTE_CANDLE_MAX_PAGES = 5;
 
     public PriceResponse getPrice(String stockCode) {
@@ -248,12 +247,22 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
         return getPeriodCandlesWithPaging(stockCode, start, end, periodCode);
     }
 
+    private int getPageDays(String periodCode) {
+        return switch (periodCode) {
+            case "W" -> 365;   // 주봉: 1년씩 페이징
+            case "M" -> 1095;  // 월봉: 3년씩 페이징
+            case "Y" -> 3650;  // 년봉: 10년씩 페이징
+            default -> 100;    // 일봉: 100일씩 페이징
+        };
+    }
+
     private List<CandleResponse> getPeriodCandlesWithPaging(String stockCode, LocalDate start, LocalDate end, String periodCode) {
         List<CandleResponse> allCandles = new ArrayList<>();
         LocalDate pageEnd = end;
+        int pageDays = getPageDays(periodCode);
 
         for (int page = 0; page < PERIOD_CANDLE_MAX_PAGES && !pageEnd.isBefore(start); page++) {
-            LocalDate pageStart = pageEnd.minusDays(PERIOD_CANDLE_PAGE_DAYS);
+            LocalDate pageStart = pageEnd.minusDays(pageDays);
             if (pageStart.isBefore(start)) {
                 pageStart = start;
             }

--- a/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
+++ b/src/main/java/com/solv/wefin/domain/trading/market/service/MarketService.java
@@ -55,6 +55,7 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
     private static final Set<String> MINUTE_PERIOD_CODES = Set.of("1", "5", "15", "30", "60");
     private static final int PERIOD_CANDLE_MAX_PAGES = 4;
     private static final int MINUTE_CANDLE_MAX_PAGES = 5;
+    private static final int MARKET_OPEN_HOUR = 9;
 
     public PriceResponse getPrice(String stockCode) {
         validateStockCode(stockCode);
@@ -273,6 +274,10 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
                 break;
             }
 
+            if (response.output1() != null) {
+                validateRtCode(response.output1().rt_cd());
+            }
+
             List<CandleResponse> pageCandles = response.output2().stream()
                     .map(CandleResponse::from)
                     .toList();
@@ -305,6 +310,10 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
                 break;
             }
 
+            if (response.output1() != null) {
+                validateRtCode(response.output1().rt_cd());
+            }
+
             List<CandleResponse> pageCandles = response.output2().stream()
                     .map(CandleResponse::fromMinute)
                     .toList();
@@ -329,8 +338,8 @@ public class MarketService implements MarketPriceProvider, ExchangeRateProvider 
             } else {
                 min--;
             }
-            if (hour < 9) {
-                break; // 장 시작(09:00) 이전이면 더 이상 데이터 없음
+            if (hour < MARKET_OPEN_HOUR) {
+                break;
             }
             inputHour = String.format("%02d%02d00", hour, min);
         }


### PR DESCRIPTION
 ## 📌 PR 설명
  일봉/분봉 API 페이징으로 차트 데이터 확대

  ## ✅ 완료한 기능 명세

  - [x] **[WEF-669]** 캔들 차트 데이터 확장


  ## 💭 고민과 해결과정
  - 일봉: 한투 API가 1회 호출에 ~60개만 반환 → 100일씩 최대 4회 페이징하여 1년치(250개+) 확보
  - 분봉: 1회 호출에 30개만 반환 → inputHour 역순 페이징 최대 5회로 150개 확보
  - 분봉 페이징 시 같은 inputHour 재요청 방지를 위해 1분 차감 처리
  - date 기준 중복 제거 (record equals는 모든 필드 비교라 부정확)

  ### 🔗 관련 이슈
  Closes #288

[WEF-669]: https://sol-v.atlassian.net/browse/WEF-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 분봉 및 기간별 캔들 조회가 페이징 기반으로 전환되어 대용량 데이터 로딩 안정성 향상
  * 조회 반복을 통한 누락 방지 및 최대 페이지 제한으로 안정적 종료 보장
  * 타임스탬프 기준 중복 제거 적용으로 결과 일관성 강화
  * 반환 전 오름차순 정렬 보장으로 시간 순서 일치
  * 다분 단위 집계는 유지되며 집계 전 중복 제거로 정확도 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->