### PR TITLE
[WEF-187] 그룹 채팅 투표 기능 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/ChatMessageInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/ChatMessageInfo.java
@@ -12,6 +12,7 @@ public record ChatMessageInfo(
         String content,
         OffsetDateTime createdAt,
         ReplyMessageInfo replyTo,
-        NewsShareInfo newsShare
+        NewsShareInfo newsShare,
+        VoteShareInfo voteShare
 ) {
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/VoteShareInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/VoteShareInfo.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.chat.groupChat.dto.info;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record VoteShareInfo(
+        Long voteId,
+        String title,
+        String status,
+        int maxSelectCount,
+        OffsetDateTime endsAt,
+        boolean closed,
+        List<VoteShareOptionInfo> options
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/VoteShareOptionInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/dto/info/VoteShareOptionInfo.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.chat.groupChat.dto.info;
+
+public record VoteShareOptionInfo(
+        Long optionId,
+        String optionText
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
@@ -36,6 +36,13 @@ public class ChatMessage {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ref_type", length = 20)
+    private RefType refType;
+
+    @Column(name = "ref_id")
+    private Long refId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reply_to_message_id")
     private ChatMessage replyToMessage;
@@ -47,11 +54,13 @@ public class ChatMessage {
     private OffsetDateTime createdAt;
 
     @Builder
-    public ChatMessage(User user, Group group, MessageType messageType, String content, ChatMessage replyToMessage, OffsetDateTime createdAt) {
+    public ChatMessage(User user, Group group, MessageType messageType, String content, RefType refType, Long refId, ChatMessage replyToMessage, OffsetDateTime createdAt) {
         this.user = user;
         this.group = group;
         this.messageType = messageType;
         this.content = content;
+        this.refType = refType;
+        this.refId = refId;
         this.replyToMessage = replyToMessage;
         this.createdAt = createdAt;
     }
@@ -62,6 +71,8 @@ public class ChatMessage {
                 .group(group)
                 .messageType(MessageType.CHAT)
                 .content(content)
+                .refType(null)
+                .refId(null)
                 .replyToMessage(replyToMessage)
                 .createdAt(OffsetDateTime.now())
                 .build();
@@ -73,6 +84,21 @@ public class ChatMessage {
                 .group(group)
                 .messageType(MessageType.NEWS)
                 .content(title)
+                .refType(null)
+                .refId(null)
+                .replyToMessage(null)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+
+    public static ChatMessage createVoteMessage(User user, Group group, String content, Long voteId) {
+        return ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.CHAT)
+                .content(content)
+                .refType(RefType.VOTE)
+                .refId(voteId)
                 .replyToMessage(null)
                 .createdAt(OffsetDateTime.now())
                 .build();

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/RefType.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/RefType.java
@@ -1,5 +1,5 @@
 package com.solv.wefin.domain.chat.groupChat.entity;
 
 public enum RefType {
-    VOTE
+    VOTE, BET, TRANSFER
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/RefType.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/RefType.java
@@ -1,0 +1,5 @@
+package com.solv.wefin.domain.chat.groupChat.entity;
+
+public enum RefType {
+    VOTE
+}

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -5,13 +5,11 @@ import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
-import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
-import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
-import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
-import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.*;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessageNewsShare;
 import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
+import com.solv.wefin.domain.chat.groupChat.entity.RefType;
 import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
 import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageRepository;
 import com.solv.wefin.domain.group.entity.Group;
@@ -21,6 +19,11 @@ import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.quest.entity.QuestEventType;
 import com.solv.wefin.domain.quest.service.QuestProgressService;
+import com.solv.wefin.domain.vote.entity.Vote;
+import com.solv.wefin.domain.vote.entity.VoteOption;
+import com.solv.wefin.domain.vote.entity.VoteStatus;
+import com.solv.wefin.domain.vote.repository.VoteOptionRepository;
+import com.solv.wefin.domain.vote.repository.VoteRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +40,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -50,6 +55,8 @@ public class ChatMessageService {
     private final GroupMemberRepository groupMemberRepository;
     private final ChatSpamGuard chatSpamGuard;
     private final QuestProgressService questProgressService;
+    private final VoteRepository voteRepository;
+    private final VoteOptionRepository voteOptionRepository;
 
     private static final long SPAM_WINDOW_SECONDS = 3L;
     private static final String SYSTEM = "시스템";
@@ -131,6 +138,47 @@ public class ChatMessageService {
         return info;
     }
 
+    @Transactional
+    public ChatMessageInfo shareVote(UUID userId, Vote vote) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        if (vote == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        boolean isActiveMember = groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                vote.getGroup(),
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        if (!isActiveMember) {
+            throw new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN);
+        }
+
+        ChatMessage chatMessage = chatMessageRepository.save(
+                ChatMessage.createVoteMessage(
+                        user,
+                        vote.getGroup(),
+                        vote.getTitle(),
+                        vote.getVoteId()
+                )
+        );
+
+        ChatMessageInfo info = toInfo(chatMessage);
+
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(vote.getGroup().getId(), info));
+
+        handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);
+
+        return info;
+    }
+
     public ChatMessagesInfo getMessages(UUID userId, Long beforeMessageId, int size) {
 
         Group group = findActiveUserGroup(userId);
@@ -152,16 +200,69 @@ public class ChatMessageService {
                 ? fetched.get(fetched.size() - 1).getId()
                 :null;
 
+        List<Long> voteIds = fetched.stream()
+                .filter(message -> message.getRefType() == RefType.VOTE && message.getRefId() != null)
+                .map(ChatMessage::getRefId)
+                .distinct()
+                .toList();
+
+        Map<Long, Vote> voteMap = voteIds.isEmpty()
+                ? Map.of()
+                : voteRepository.findAllByVoteIdIn(voteIds).stream()
+                        .collect(Collectors.toMap(Vote::getVoteId, Function.identity()));
+
+        Map<Long, List<VoteOption>> voteOptionMap = voteIds.isEmpty()
+                ? Map.of()
+                : voteOptionRepository.findAllByVote_VoteIdInOrderByVote_VoteIdAscIdAsc(voteIds).stream()
+                        .collect(Collectors.groupingBy(option -> option.getVote().getVoteId()));
+
         List<ChatMessageInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(ChatMessage::getId))
-                .map(this::toInfo)
+                .map(message -> toInfo(message, voteMap, voteOptionMap))
                 .toList();
 
         return new ChatMessagesInfo(messages, nextCursor, hasNext);
     }
 
     private ChatMessageInfo toInfo(ChatMessage message) {
+        return toInfo(message, Map.of(), Map.of());
+    }
+
+    private ChatMessageInfo toInfo(
+            ChatMessage message,
+            Map<Long, Vote> voteMap,
+            Map<Long, List<VoteOption>> voteOptionMap
+    ) {
         NewsShareInfo newsShareInfo = null;
+        VoteShareInfo voteShareInfo = null;
+
+        if (message.getRefType() == RefType.VOTE && message.getRefId() != null) {
+            Vote vote = voteMap.isEmpty()
+                    ? voteRepository.findById(message.getRefId()).orElse(null)
+                    : voteMap.get(message.getRefId());
+
+            if (vote != null) {
+                List<VoteShareOptionInfo> options = (voteOptionMap.isEmpty()
+                        ? voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(vote.getVoteId())
+                        : voteOptionMap.getOrDefault(vote.getVoteId(), List.of()))
+                        .stream()
+                        .map(option -> new VoteShareOptionInfo(option.getId(), option.getOptionText()))
+                        .toList();
+
+                boolean closed = vote.getStatus() == VoteStatus.CLOSED
+                        || (vote.getEndsAt() != null && OffsetDateTime.now().isAfter(vote.getEndsAt()));
+
+                voteShareInfo = new VoteShareInfo(
+                        vote.getVoteId(),
+                        vote.getTitle(),
+                        vote.getStatus().name(),
+                        vote.getMaxSelectCount(),
+                        vote.getEndsAt(),
+                        closed,
+                        options
+                );
+            }
+        }
 
         if (message.getNewsShare() != null) {
             ChatMessageNewsShare newsShare = message.getNewsShare();
@@ -182,7 +283,8 @@ public class ChatMessageService {
                 message.getContent(),
                 message.getCreatedAt(),
                 toReplyInfo(message.getReplyToMessage()),
-                newsShareInfo
+                newsShareInfo,
+                voteShareInfo
         );
     }
 

--- a/src/main/java/com/solv/wefin/domain/vote/dto/command/CreateVoteCommand.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/command/CreateVoteCommand.java
@@ -1,0 +1,16 @@
+package com.solv.wefin.domain.vote.dto.command;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record CreateVoteCommand(
+        Long groupId,
+        String title,
+        List<String> options,
+        int maxSelectCount,
+        Long durationHours
+) {
+    public CreateVoteCommand {
+        options = options == null ? List.of() : List.copyOf(options);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/dto/command/SubmitVoteCommand.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/command/SubmitVoteCommand.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.domain.vote.dto.command;
+
+import java.util.List;
+
+public record SubmitVoteCommand(
+        List<Long> optionIds
+) {
+    public SubmitVoteCommand {
+        optionIds = optionIds == null ? List.of() : List.copyOf(optionIds);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteDetailInfo.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteDetailInfo.java
@@ -1,0 +1,22 @@
+package com.solv.wefin.domain.vote.dto.info;
+
+import com.solv.wefin.domain.vote.entity.VoteStatus;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record VoteDetailInfo(
+        Long voteId,
+        String title,
+        VoteStatus status,
+        int maxSelectCount,
+        OffsetDateTime endsAt,
+        boolean closed,
+        List<VoteOptionInfo> options,
+        List<Long> myOptionIds
+) {
+    public VoteDetailInfo {
+        options = options == null ? List.of() : List.copyOf(options);
+        myOptionIds = myOptionIds == null ? List.of() : List.copyOf(myOptionIds);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteInfo.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteInfo.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.vote.dto.info;
+
+import com.solv.wefin.domain.vote.entity.VoteStatus;
+
+import java.time.OffsetDateTime;
+
+public record VoteInfo(
+        Long voteId,
+        String title,
+        VoteStatus status,
+        int maxSelectCount,
+        OffsetDateTime endsAt
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteOptionInfo.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteOptionInfo.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.vote.dto.info;
+
+public record VoteOptionInfo(
+        Long optionId,
+        String optionText
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteOptionResultInfo.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteOptionResultInfo.java
@@ -1,0 +1,10 @@
+package com.solv.wefin.domain.vote.dto.info;
+
+public record VoteOptionResultInfo(
+        Long optionId,
+        String optionText,
+        long voteCount,
+        double rate,
+        boolean selectedByMe
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteResultInfo.java
+++ b/src/main/java/com/solv/wefin/domain/vote/dto/info/VoteResultInfo.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.domain.vote.dto.info;
+
+import com.solv.wefin.domain.vote.entity.VoteStatus;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record VoteResultInfo(
+        Long voteId,
+        String title,
+        VoteStatus status,
+        int maxSelectCount,
+        OffsetDateTime endsAt,
+        boolean closed,
+        long participantCount,
+        List<VoteOptionResultInfo> options
+) {
+    public VoteResultInfo {
+        options = options == null ? List.of() : List.copyOf(options);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/entity/Vote.java
+++ b/src/main/java/com/solv/wefin/domain/vote/entity/Vote.java
@@ -1,0 +1,70 @@
+package com.solv.wefin.domain.vote.entity;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "vote")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Vote extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "vote_id")
+    private Long voteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false)
+    private User createdBy;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private VoteStatus status;
+
+    @Column(name = "ends_at")
+    private OffsetDateTime endsAt;
+
+    @Column(name = "max_select_count", nullable = false)
+    private int maxSelectCount;
+
+    @Builder
+    private Vote(Group group, User createdBy, String title, VoteStatus status, OffsetDateTime endsAt, int maxSelectCount) {
+        this.group = group;
+        this.createdBy = createdBy;
+        this.title = title;
+        this.status = status;
+        this.endsAt = endsAt;
+        this.maxSelectCount = maxSelectCount;
+    }
+
+    public static Vote create(Group group, User createdBy, String title, OffsetDateTime endsAt, int maxSelectCount) {
+        return Vote.builder()
+                .group(group)
+                .createdBy(createdBy)
+                .title(title)
+                .status(VoteStatus.OPEN)
+                .endsAt(endsAt)
+                .maxSelectCount(maxSelectCount)
+                .build();
+    }
+
+    public void close() {
+        this.status = VoteStatus.CLOSED;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/entity/VoteAnswer.java
+++ b/src/main/java/com/solv/wefin/domain/vote/entity/VoteAnswer.java
@@ -1,0 +1,62 @@
+package com.solv.wefin.domain.vote.entity;
+
+
+import com.solv.wefin.domain.auth.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(
+        name = "vote_answer",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_vote_answer_user_option",
+                columnNames = {"user_id", "option_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VoteAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "answer_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_id", nullable = false)
+    private VoteOption voteOption;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private VoteAnswer(VoteOption voteOption, Vote vote, User user, OffsetDateTime createdAt) {
+        this.voteOption = voteOption;
+        this.vote = vote;
+        this.user = user;
+        this.createdAt = createdAt;
+    }
+
+    public static VoteAnswer voted(VoteOption voteOption, Vote vote, User user) {
+
+        return VoteAnswer.builder()
+                .voteOption(voteOption)
+                .vote(vote)
+                .user(user)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/entity/VoteOption.java
+++ b/src/main/java/com/solv/wefin/domain/vote/entity/VoteOption.java
@@ -1,0 +1,47 @@
+package com.solv.wefin.domain.vote.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Entity
+@Table(name = "vote_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class VoteOption {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "option_id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "vote_id", nullable = false)
+    private Vote vote;
+
+    @Column(name = "option_text", nullable = false)
+    private String optionText;
+
+    @Column(name = "created_at", nullable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private VoteOption(Vote vote, String optionText, OffsetDateTime createdAt) {
+        this.vote = vote;
+        this.optionText = optionText;
+        this.createdAt = createdAt;
+    }
+
+    public static VoteOption create(Vote vote, String optionText) {
+
+        return VoteOption.builder()
+                .vote(vote)
+                .optionText(optionText)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/entity/VoteStatus.java
+++ b/src/main/java/com/solv/wefin/domain/vote/entity/VoteStatus.java
@@ -1,0 +1,5 @@
+package com.solv.wefin.domain.vote.entity;
+
+public enum VoteStatus {
+    OPEN, CLOSED
+}

--- a/src/main/java/com/solv/wefin/domain/vote/repository/VoteAnswerRepository.java
+++ b/src/main/java/com/solv/wefin/domain/vote/repository/VoteAnswerRepository.java
@@ -1,0 +1,34 @@
+package com.solv.wefin.domain.vote.repository;
+
+import com.solv.wefin.domain.vote.entity.VoteAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface VoteAnswerRepository extends JpaRepository<VoteAnswer, Long> {
+    List<VoteAnswer> findAllByVote_VoteIdAndUser_UserId(Long voteId, UUID userId);
+
+    long countByVote_VoteIdAndUser_UserId(Long voteId, UUID userId);
+
+    void deleteAllByVote_VoteIdAndUser_UserId(Long voteId, UUID userId);
+
+    boolean existsByVote_VoteIdAndVoteOption_IdAndUser_UserId(Long voteId, Long optionId, UUID userId);
+
+    @Query("""
+    select va.voteOption.id, count(va)
+    from VoteAnswer va
+    where va.vote.voteId = :voteId
+    group by va.voteOption.id
+    """)
+    List<Object[]> countByVoteIdGroupByOptionId(Long voteId);
+
+    @Query("""
+    select count(distinct va.user.userId)
+    from VoteAnswer va
+    where va.vote.voteId = :voteId
+    """)
+    long countDistinctUsersByVoteId(Long voteId);
+
+}

--- a/src/main/java/com/solv/wefin/domain/vote/repository/VoteOptionRepository.java
+++ b/src/main/java/com/solv/wefin/domain/vote/repository/VoteOptionRepository.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.vote.repository;
+
+import com.solv.wefin.domain.vote.entity.VoteOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface VoteOptionRepository extends JpaRepository<VoteOption, Long> {
+    List<VoteOption> findAllByVote_VoteIdOrderByIdAsc(Long voteId);
+    List<VoteOption> findAllByVote_VoteIdInOrderByVote_VoteIdAscIdAsc(List<Long> voteIds);
+    List<VoteOption> findAllByIdIn(List<Long> optionIds);
+}

--- a/src/main/java/com/solv/wefin/domain/vote/repository/VoteRepository.java
+++ b/src/main/java/com/solv/wefin/domain/vote/repository/VoteRepository.java
@@ -1,0 +1,14 @@
+package com.solv.wefin.domain.vote.repository;
+
+import com.solv.wefin.domain.vote.entity.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+    Optional<Vote> findById(Long voteId);
+    List<Vote> findAllByGroup_IdOrderByVoteIdDesc(Long groupId);
+    List<Vote> findAllByVoteIdIn(List<Long> voteIds);
+}

--- a/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
+++ b/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
@@ -48,6 +48,7 @@ public class VoteService {
     @Transactional
     public VoteInfo createVote(UUID userId, CreateVoteCommand command) {
         validateCreateCommand(command);
+        OffsetDateTime now = OffsetDateTime.now();
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
@@ -65,7 +66,7 @@ public class VoteService {
             throw new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN);
         }
 
-        OffsetDateTime endsAt = OffsetDateTime.now().plusHours(command.durationHours());
+        OffsetDateTime endsAt = now.plusHours(command.durationHours());
 
         Vote vote = Vote.create(
                 group,
@@ -96,6 +97,7 @@ public class VoteService {
 
     public VoteDetailInfo getVoteDetail(UUID userId, Long voteId) {
         Vote vote = getVote(voteId);
+        OffsetDateTime now = OffsetDateTime.now();
 
         validateActiveGroupMember(userId, vote.getGroup());
 
@@ -116,7 +118,7 @@ public class VoteService {
                 vote.getStatus(),
                 vote.getMaxSelectCount(),
                 vote.getEndsAt(),
-                isClosed(vote),
+                isClosed(vote, now),
                 optionInfos,
                 myOptionIds
         );
@@ -125,13 +127,14 @@ public class VoteService {
     @Transactional
     public VoteResultInfo submitVote(UUID userId, Long voteId, SubmitVoteCommand command) {
         Vote vote = getVote(voteId);
+        OffsetDateTime now = OffsetDateTime.now();
 
         validateActiveGroupMember(userId, vote.getGroup());
 
-        closeIfExpired(vote);
+        closeIfExpired(vote, now);
 
-        if (isClosed(vote)) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        if (isClosed(vote, now)) {
+            throw new BusinessException(ErrorCode.VOTE_CLOSED);
         }
 
         validateSubmitCommand(command, vote.getMaxSelectCount());
@@ -139,14 +142,14 @@ public class VoteService {
         List<VoteOption> options = voteOptionRepository.findAllByIdIn(command.optionIds());
 
         if (options.size() != command.optionIds().size()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VOTE_OPTION_INVALID);
         }
 
         boolean allBelongToVote = options.stream()
                 .allMatch(option -> option.getVote().getVoteId().equals(voteId));
 
         if (!allBelongToVote) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VOTE_OPTION_INVALID);
         }
 
         User user = userRepository.findById(userId)
@@ -166,6 +169,7 @@ public class VoteService {
 
     public VoteResultInfo getVoteResult(UUID userId, Long voteId) {
         Vote vote = getVote(voteId);
+        OffsetDateTime now = OffsetDateTime.now();
 
         validateActiveGroupMember(userId, vote.getGroup());
 
@@ -204,7 +208,7 @@ public class VoteService {
                 vote.getStatus(),
                 vote.getMaxSelectCount(),
                 vote.getEndsAt(),
-                isClosed(vote),
+                isClosed(vote, now),
                 participantCount,
                 optionResults
         );
@@ -212,7 +216,7 @@ public class VoteService {
 
     private Vote getVote(Long voteId) {
         return voteRepository.findById(voteId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+                .orElseThrow(() -> new BusinessException(ErrorCode.VOTE_NOT_FOUND));
     }
 
     private void validateCreateCommand(CreateVoteCommand command) {
@@ -245,16 +249,16 @@ public class VoteService {
 
     private void validateSubmitCommand(SubmitVoteCommand command, int maxSelectCount) {
         if (command.optionIds() == null || command.optionIds().isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VOTE_OPTION_INVALID);
         }
 
         if (command.optionIds().size() > maxSelectCount) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VOTE_MAX_SELECT_EXCEEDED);
         }
 
         long distinctCount = command.optionIds().stream().distinct().count();
         if (distinctCount != command.optionIds().size()) {
-            throw new BusinessException(ErrorCode.INVALID_INPUT);
+            throw new BusinessException(ErrorCode.VOTE_OPTION_INVALID);
         }
     }
 
@@ -270,15 +274,15 @@ public class VoteService {
         }
     }
 
-    private boolean isClosed(Vote vote) {
+    private boolean isClosed(Vote vote, OffsetDateTime now) {
         return vote.getStatus() == VoteStatus.CLOSED
-                || (vote.getEndsAt() != null && OffsetDateTime.now().isAfter(vote.getEndsAt()));
+                || (vote.getEndsAt() != null && now.isAfter(vote.getEndsAt()));
     }
 
-    private void closeIfExpired(Vote vote) {
+    private void closeIfExpired(Vote vote, OffsetDateTime now) {
         if (vote.getStatus() == VoteStatus.OPEN
                 && vote.getEndsAt() != null
-                && OffsetDateTime.now().isAfter(vote.getEndsAt())) {
+                && now.isAfter(vote.getEndsAt())) {
             vote.close();
         }
     }

--- a/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
+++ b/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
@@ -4,6 +4,8 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
 import com.solv.wefin.domain.vote.dto.command.CreateVoteCommand;
 import com.solv.wefin.domain.vote.dto.command.SubmitVoteCommand;
@@ -40,6 +42,7 @@ public class VoteService {
     private final VoteAnswerRepository voteAnswerRepository;
     private final UserRepository userRepository;
     private final GroupRepository groupRepository;
+    private final GroupMemberRepository groupMemberRepository;
     private final ChatMessageService chatMessageService;
 
     @Transactional
@@ -51,6 +54,16 @@ public class VoteService {
 
         Group group = groupRepository.findById(command.groupId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        boolean isActiveMember = groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                group,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        if (!isActiveMember) {
+            throw new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN);
+        }
 
         OffsetDateTime endsAt = OffsetDateTime.now().plusHours(command.durationHours());
 
@@ -65,7 +78,7 @@ public class VoteService {
         voteRepository.save(vote);
 
         List<VoteOption> options = command.options().stream()
-                .map(optionText -> VoteOption.create(vote, optionText))
+                .map(optionText -> VoteOption.create(vote, optionText.trim()))
                 .toList();
 
         voteOptionRepository.saveAll(options);
@@ -190,11 +203,8 @@ public class VoteService {
     }
 
     private Vote getVote(Long voteId) {
-        Vote vote = voteRepository.findById(voteId)
+        return voteRepository.findById(voteId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
-
-        closeIfExpired(vote);
-        return vote;
     }
 
     private void validateCreateCommand(CreateVoteCommand command) {
@@ -203,6 +213,16 @@ public class VoteService {
         }
 
         if (command.options() == null || command.options().size() < 2) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        long normalizedOptionCount = command.options().stream()
+                .map(option -> option == null ? "" : option.trim())
+                .filter(option -> !option.isBlank())
+                .distinct()
+                .count();
+
+        if (normalizedOptionCount != command.options().size()) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
 
@@ -231,14 +251,7 @@ public class VoteService {
     }
 
     private boolean isClosed(Vote vote) {
-        return vote.getStatus() == VoteStatus.CLOSED;
-    }
-
-    private void closeIfExpired(Vote vote) {
-        if (vote.getStatus() == VoteStatus.OPEN
-                && vote.getEndsAt() != null
-                && OffsetDateTime.now().isAfter(vote.getEndsAt())) {
-            vote.close();
-        }
+        return vote.getStatus() == VoteStatus.CLOSED
+                || (vote.getEndsAt() != null && OffsetDateTime.now().isAfter(vote.getEndsAt()));
     }
 }

--- a/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
+++ b/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
@@ -1,0 +1,244 @@
+package com.solv.wefin.domain.vote.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
+import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.repository.GroupRepository;
+import com.solv.wefin.domain.vote.dto.command.CreateVoteCommand;
+import com.solv.wefin.domain.vote.dto.command.SubmitVoteCommand;
+import com.solv.wefin.domain.vote.dto.info.*;
+import com.solv.wefin.domain.vote.entity.Vote;
+import com.solv.wefin.domain.vote.entity.VoteAnswer;
+import com.solv.wefin.domain.vote.entity.VoteOption;
+import com.solv.wefin.domain.vote.entity.VoteStatus;
+import com.solv.wefin.domain.vote.repository.VoteAnswerRepository;
+import com.solv.wefin.domain.vote.repository.VoteOptionRepository;
+import com.solv.wefin.domain.vote.repository.VoteRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VoteService {
+
+    private static final Set<Long> ALLOWED_DURATION_HOURS = Set.of(1L, 4L, 8L, 24L, 72L);
+
+    private final VoteRepository voteRepository;
+    private final VoteOptionRepository voteOptionRepository;
+    private final VoteAnswerRepository voteAnswerRepository;
+    private final UserRepository userRepository;
+    private final GroupRepository groupRepository;
+    private final ChatMessageService chatMessageService;
+
+    @Transactional
+    public VoteInfo createVote(UUID userId, CreateVoteCommand command) {
+        validateCreateCommand(command);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Group group = groupRepository.findById(command.groupId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        OffsetDateTime endsAt = OffsetDateTime.now().plusHours(command.durationHours());
+
+        Vote vote = Vote.create(
+                group,
+                user,
+                command.title(),
+                endsAt,
+                command.maxSelectCount()
+        );
+
+        voteRepository.save(vote);
+
+        List<VoteOption> options = command.options().stream()
+                .map(optionText -> VoteOption.create(vote, optionText))
+                .toList();
+
+        voteOptionRepository.saveAll(options);
+
+        chatMessageService.shareVote(userId, vote);
+
+        return new VoteInfo(
+                vote.getVoteId(),
+                vote.getTitle(),
+                vote.getStatus(),
+                vote.getMaxSelectCount(),
+                vote.getEndsAt()
+        );
+    }
+
+    public VoteDetailInfo getVoteDetail(UUID userId, Long voteId) {
+        Vote vote = getVote(voteId);
+
+        List<VoteOption> options = voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(voteId);
+        List<VoteAnswer> myAnswers = voteAnswerRepository.findAllByVote_VoteIdAndUser_UserId(voteId, userId);
+
+        List<VoteOptionInfo> optionInfos = options.stream()
+                .map(option -> new VoteOptionInfo(option.getId(), option.getOptionText()))
+                .toList();
+
+        List<Long> myOptionIds = myAnswers.stream()
+                .map(answer -> answer.getVoteOption().getId())
+                .toList();
+
+        return new VoteDetailInfo(
+                vote.getVoteId(),
+                vote.getTitle(),
+                vote.getStatus(),
+                vote.getMaxSelectCount(),
+                vote.getEndsAt(),
+                isClosed(vote),
+                optionInfos,
+                myOptionIds
+        );
+    }
+
+    @Transactional
+    public VoteResultInfo submitVote(UUID userId, Long voteId, SubmitVoteCommand command) {
+        Vote vote = getVote(voteId);
+
+        if (isClosed(vote)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        validateSubmitCommand(command, vote.getMaxSelectCount());
+
+        List<VoteOption> options = voteOptionRepository.findAllByIdIn(command.optionIds());
+
+        if (options.size() != command.optionIds().size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        boolean allBelongToVote = options.stream()
+                .allMatch(option -> option.getVote().getVoteId().equals(voteId));
+
+        if (!allBelongToVote) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        voteAnswerRepository.deleteAllByVote_VoteIdAndUser_UserId(voteId, userId);
+        voteAnswerRepository.flush();
+
+        List<VoteAnswer> answers = options.stream()
+                .map(option -> VoteAnswer.voted(option, vote, user))
+                .toList();
+
+        voteAnswerRepository.saveAll(answers);
+
+        return getVoteResult(userId, voteId);
+    }
+
+    public VoteResultInfo getVoteResult(UUID userId, Long voteId) {
+        Vote vote = getVote(voteId);
+
+        List<VoteOption> options = voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(voteId);
+        List<VoteAnswer> myAnswers = voteAnswerRepository.findAllByVote_VoteIdAndUser_UserId(voteId, userId);
+        long participantCount = voteAnswerRepository.countDistinctUsersByVoteId(voteId);
+
+        Set<Long> myOptionIds = myAnswers.stream()
+                .map(answer -> answer.getVoteOption().getId())
+                .collect(Collectors.toSet());
+
+        Map<Long, Long> countMap = voteAnswerRepository.countByVoteIdGroupByOptionId(voteId).stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        List<VoteOptionResultInfo> optionResults = options.stream()
+                .map(option -> {
+                    long voteCount = countMap.getOrDefault(option.getId(), 0L);
+                    double rate = participantCount == 0 ? 0.0 : (double) voteCount / participantCount * 100;
+
+                    return new VoteOptionResultInfo(
+                            option.getId(),
+                            option.getOptionText(),
+                            voteCount,
+                            rate,
+                            myOptionIds.contains(option.getId())
+                    );
+                })
+                .toList();
+
+        return new VoteResultInfo(
+                vote.getVoteId(),
+                vote.getTitle(),
+                vote.getStatus(),
+                vote.getMaxSelectCount(),
+                vote.getEndsAt(),
+                isClosed(vote),
+                participantCount,
+                optionResults
+        );
+    }
+
+    private Vote getVote(Long voteId) {
+        Vote vote = voteRepository.findById(voteId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+
+        closeIfExpired(vote);
+        return vote;
+    }
+
+    private void validateCreateCommand(CreateVoteCommand command) {
+        if (command.title() == null || command.title().isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (command.options() == null || command.options().size() < 2) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (command.maxSelectCount() <= 0 || command.maxSelectCount() > command.options().size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (!ALLOWED_DURATION_HOURS.contains(command.durationHours())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateSubmitCommand(SubmitVoteCommand command, int maxSelectCount) {
+        if (command.optionIds() == null || command.optionIds().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        if (command.optionIds().size() > maxSelectCount) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        long distinctCount = command.optionIds().stream().distinct().count();
+        if (distinctCount != command.optionIds().size()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private boolean isClosed(Vote vote) {
+        return vote.getStatus() == VoteStatus.CLOSED;
+    }
+
+    private void closeIfExpired(Vote vote) {
+        if (vote.getStatus() == VoteStatus.OPEN
+                && vote.getEndsAt() != null
+                && OffsetDateTime.now().isAfter(vote.getEndsAt())) {
+            vote.close();
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
+++ b/src/main/java/com/solv/wefin/domain/vote/service/VoteService.java
@@ -97,6 +97,8 @@ public class VoteService {
     public VoteDetailInfo getVoteDetail(UUID userId, Long voteId) {
         Vote vote = getVote(voteId);
 
+        validateActiveGroupMember(userId, vote.getGroup());
+
         List<VoteOption> options = voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(voteId);
         List<VoteAnswer> myAnswers = voteAnswerRepository.findAllByVote_VoteIdAndUser_UserId(voteId, userId);
 
@@ -123,6 +125,10 @@ public class VoteService {
     @Transactional
     public VoteResultInfo submitVote(UUID userId, Long voteId, SubmitVoteCommand command) {
         Vote vote = getVote(voteId);
+
+        validateActiveGroupMember(userId, vote.getGroup());
+
+        closeIfExpired(vote);
 
         if (isClosed(vote)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
@@ -160,6 +166,8 @@ public class VoteService {
 
     public VoteResultInfo getVoteResult(UUID userId, Long voteId) {
         Vote vote = getVote(voteId);
+
+        validateActiveGroupMember(userId, vote.getGroup());
 
         List<VoteOption> options = voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(voteId);
         List<VoteAnswer> myAnswers = voteAnswerRepository.findAllByVote_VoteIdAndUser_UserId(voteId, userId);
@@ -250,8 +258,29 @@ public class VoteService {
         }
     }
 
+    private void validateActiveGroupMember(UUID userId, Group group) {
+        boolean isActiveMember = groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                group,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        if (!isActiveMember) {
+            throw new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN);
+        }
+    }
+
     private boolean isClosed(Vote vote) {
         return vote.getStatus() == VoteStatus.CLOSED
                 || (vote.getEndsAt() != null && OffsetDateTime.now().isAfter(vote.getEndsAt()));
     }
+
+    private void closeIfExpired(Vote vote) {
+        if (vote.getStatus() == VoteStatus.OPEN
+                && vote.getEndsAt() != null
+                && OffsetDateTime.now().isAfter(vote.getEndsAt())) {
+            vote.close();
+        }
+    }
+
 }

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -175,6 +175,11 @@ public enum ErrorCode {
     VOTE_ALREADY_CAST(409, "이미 투표하였습니다."),
     VOTE_NOT_IN_PROGRESS(400, "진행 중인 투표가 없습니다."),
     VOTE_ALREADY_IN_PROGRESS(409, "이미 투표가 진행 중입니다."),
+    VOTE_NOT_FOUND(404, "Vote not found."),
+    VOTE_CLOSED(409, "Vote is already closed."),
+    VOTE_OPTION_INVALID(400, "Invalid vote option."),
+    VOTE_MAX_SELECT_EXCEEDED(400, "Maximum selectable option count exceeded."),
+
     // MarketTrend
     MARKET_TREND_ALREADY_RUNNING(409, "금융 동향 생성이 이미 실행 중입니다.");
 

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -175,10 +175,10 @@ public enum ErrorCode {
     VOTE_ALREADY_CAST(409, "이미 투표하였습니다."),
     VOTE_NOT_IN_PROGRESS(400, "진행 중인 투표가 없습니다."),
     VOTE_ALREADY_IN_PROGRESS(409, "이미 투표가 진행 중입니다."),
-    VOTE_NOT_FOUND(404, "Vote not found."),
-    VOTE_CLOSED(409, "Vote is already closed."),
-    VOTE_OPTION_INVALID(400, "Invalid vote option."),
-    VOTE_MAX_SELECT_EXCEEDED(400, "Maximum selectable option count exceeded."),
+    VOTE_NOT_FOUND(404, "투표를 찾을 수 없습니다."),
+    VOTE_CLOSED(409, "이미 마감된 투표입니다."),
+    VOTE_OPTION_INVALID(400, "유효하지 않은 투표 선택지입니다."),
+    VOTE_MAX_SELECT_EXCEEDED(400, "선택 가능한 개수를 초과했습니다."),
 
     // MarketTrend
     MARKET_TREND_ALREADY_RUNNING(409, "금융 동향 생성이 이미 실행 중입니다.");

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/ChatMessageResponse.java
@@ -3,6 +3,7 @@ package com.solv.wefin.web.chat.groupChat.dto.response;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.VoteShareInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +26,7 @@ public class ChatMessageResponse {
     private OffsetDateTime createdAt;
     private ReplyMessageInfo replyTo;
     private NewsShareInfo newsShare;
+    private VoteShareInfo voteShare;
 
     public static ChatMessageResponse from(ChatMessageInfo info) {
         return ChatMessageResponse.builder()
@@ -37,6 +39,7 @@ public class ChatMessageResponse {
                 .createdAt(info.createdAt())
                 .replyTo(info.replyTo())
                 .newsShare(info.newsShare())
+                .voteShare(info.voteShare())
                 .build();
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/VoteShareOptionResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/VoteShareOptionResponse.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.chat.groupChat.dto.response;
+
+import com.solv.wefin.domain.chat.groupChat.dto.info.VoteShareOptionInfo;
+
+public record VoteShareOptionResponse(
+        Long optionId,
+        String optionText
+) {
+    public static VoteShareOptionResponse from(VoteShareOptionInfo info) {
+        return new VoteShareOptionResponse(
+                info.optionId(),
+                info.optionText()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/VoteShareResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/dto/response/VoteShareResponse.java
@@ -1,0 +1,30 @@
+package com.solv.wefin.web.chat.groupChat.dto.response;
+
+import com.solv.wefin.domain.chat.groupChat.dto.info.VoteShareInfo;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record VoteShareResponse(
+        Long voteId,
+        String title,
+        String status,
+        int maxSelectCount,
+        OffsetDateTime endsAt,
+        boolean closed,
+        List<VoteShareOptionResponse> options
+) {
+    public static VoteShareResponse from(VoteShareInfo info) {
+        return new VoteShareResponse(
+                info.voteId(),
+                info.title(),
+                info.status(),
+                info.maxSelectCount(),
+                info.endsAt(),
+                info.closed(),
+                info.options().stream()
+                        .map(VoteShareOptionResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/vote/VoteController.java
+++ b/src/main/java/com/solv/wefin/web/vote/VoteController.java
@@ -1,0 +1,63 @@
+package com.solv.wefin.web.vote;
+
+import com.solv.wefin.domain.vote.dto.info.VoteDetailInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteResultInfo;
+import com.solv.wefin.domain.vote.service.VoteService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.vote.dto.request.CreateVoteRequest;
+import com.solv.wefin.web.vote.dto.request.SubmitVoteRequest;
+import com.solv.wefin.web.vote.dto.response.VoteDetailResponse;
+import com.solv.wefin.web.vote.dto.response.VoteResponse;
+import com.solv.wefin.web.vote.dto.response.VoteResultResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/votes")
+@RequiredArgsConstructor
+public class VoteController {
+
+    private final VoteService voteService;
+
+    @PostMapping
+    public ApiResponse<VoteResponse> createVote(
+            @AuthenticationPrincipal UUID userId,
+            @Valid @RequestBody CreateVoteRequest request
+    ) {
+        VoteInfo info = voteService.createVote(userId, request.toCommand());
+        return ApiResponse.success(VoteResponse.from(info));
+    }
+
+    @GetMapping("/{voteId}")
+    public ApiResponse<VoteDetailResponse> getVoteDetail(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable Long voteId
+    ) {
+        VoteDetailInfo info =  voteService.getVoteDetail(userId, voteId);
+        return ApiResponse.success(VoteDetailResponse.from(info));
+    }
+
+    @PostMapping("/{voteId}/answers")
+    public ApiResponse<VoteResultResponse> submitVote(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable Long voteId,
+            @Valid @RequestBody SubmitVoteRequest request
+    ) {
+        VoteResultInfo info = voteService.submitVote(userId, voteId, request.toCommand());
+        return ApiResponse.success(VoteResultResponse.from(info));
+    }
+
+    @GetMapping("/{voteId}/result")
+    public ApiResponse<VoteResultResponse> getVoteResult(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable Long voteId
+    ) {
+        VoteResultInfo info = voteService.getVoteResult(userId, voteId);
+        return ApiResponse.success(VoteResultResponse.from(info));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/vote/dto/request/CreateVoteRequest.java
+++ b/src/main/java/com/solv/wefin/web/vote/dto/request/CreateVoteRequest.java
@@ -1,0 +1,24 @@
+package com.solv.wefin.web.vote.dto.request;
+
+import com.solv.wefin.domain.vote.dto.command.CreateVoteCommand;
+import jakarta.validation.constraints.*;
+
+import java.util.List;
+
+public record CreateVoteRequest(
+        @NotNull Long groupId,
+        @NotBlank String title,
+        @NotEmpty List<@NotBlank String> options,
+        @Min(1) int maxSelectCount,
+        @NotNull @Min(1) Long durationHours
+        ) {
+    public CreateVoteCommand toCommand() {
+        return new CreateVoteCommand(
+                groupId,
+                title,
+                options,
+                maxSelectCount,
+                durationHours
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/vote/dto/request/SubmitVoteRequest.java
+++ b/src/main/java/com/solv/wefin/web/vote/dto/request/SubmitVoteRequest.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.web.vote.dto.request;
+
+import com.solv.wefin.domain.vote.dto.command.SubmitVoteCommand;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record SubmitVoteRequest(
+        @NotEmpty List<@NotNull Long> optionIds
+) {
+    public SubmitVoteCommand toCommand() {
+        return new SubmitVoteCommand(optionIds);
+    }
+}

--- a/src/main/java/com/solv/wefin/web/vote/dto/response/VoteDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/vote/dto/response/VoteDetailResponse.java
@@ -1,0 +1,42 @@
+package com.solv.wefin.web.vote.dto.response;
+
+import com.solv.wefin.domain.vote.dto.info.VoteDetailInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteOptionInfo;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record VoteDetailResponse(
+        Long voteId,
+        String title,
+        String status,
+        int maxSelectCount,
+        OffsetDateTime endsAt,
+        boolean closed,
+        List<VoteOptionItem> options,
+        List<Long> myOptionIds
+) {
+    public record VoteOptionItem(
+            Long optionId,
+            String optionText
+    ) {
+        public static VoteOptionItem from(VoteOptionInfo info) {
+            return new VoteOptionItem(info.optionId(), info.optionText());
+        }
+    }
+
+    public static VoteDetailResponse from(VoteDetailInfo info) {
+        return new VoteDetailResponse(
+                info.voteId(),
+                info.title(),
+                info.status().name(),
+                info.maxSelectCount(),
+                info.endsAt(),
+                info.closed(),
+                info.options().stream()
+                        .map(VoteOptionItem::from)
+                        .toList(),
+                info.myOptionIds()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/vote/dto/response/VoteResponse.java
+++ b/src/main/java/com/solv/wefin/web/vote/dto/response/VoteResponse.java
@@ -1,0 +1,23 @@
+package com.solv.wefin.web.vote.dto.response;
+
+import com.solv.wefin.domain.vote.dto.info.VoteInfo;
+
+import java.time.OffsetDateTime;
+
+public record VoteResponse(
+        Long voteId,
+        String title,
+        String status,
+        int maxSelectCount,
+        OffsetDateTime endsAt
+) {
+    public static VoteResponse from(VoteInfo info) {
+        return new VoteResponse(
+                info.voteId(),
+                info.title(),
+                info.status().name(),
+                info.maxSelectCount(),
+                info.endsAt()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/vote/dto/response/VoteResultResponse.java
+++ b/src/main/java/com/solv/wefin/web/vote/dto/response/VoteResultResponse.java
@@ -1,0 +1,51 @@
+package com.solv.wefin.web.vote.dto.response;
+
+import com.solv.wefin.domain.vote.dto.info.VoteOptionResultInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteResultInfo;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record VoteResultResponse(
+        Long voteId,
+        String title,
+        String status,
+        int maxSelectCount,
+        OffsetDateTime endsAt,
+        boolean closed,
+        long participantCount,
+        List<VoteOptionResultItem> options
+) {
+    public record VoteOptionResultItem(
+            Long optionId,
+            String optionText,
+            long voteCount,
+            double rate,
+            boolean selectedByMe
+    ) {
+        public static VoteOptionResultItem from(VoteOptionResultInfo info) {
+            return new VoteOptionResultItem(
+                    info.optionId(),
+                    info.optionText(),
+                    info.voteCount(),
+                    info.rate(),
+                    info.selectedByMe()
+            );
+        }
+    }
+
+    public static VoteResultResponse from(VoteResultInfo info) {
+        return new VoteResultResponse(
+                info.voteId(),
+                info.title(),
+                info.status().name(),
+                info.maxSelectCount(),
+                info.endsAt(),
+                info.closed(),
+                info.participantCount(),
+                info.options().stream()
+                        .map(VoteOptionResultItem::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V39__add_vote_multi_select_constraints.sql
+++ b/src/main/resources/db/migration/V39__add_vote_multi_select_constraints.sql
@@ -1,0 +1,16 @@
+-- 최대 선택 개수 칼럼 추가
+ALTER TABLE vote
+    ADD COLUMN max_select_count INT NOT NULL DEFAULT 1;
+
+-- vote_answer에 vote_id 추가
+ALTER TABLE vote_answer
+    ADD COLUMN vote_id BIGINT NOT NULL;
+
+ALTER TABLE vote_answer
+    ADD CONSTRAINT fk_vote_answer_vote
+        FOREIGN KEY (vote_id) REFERENCES vote(vote_id);
+
+-- 같은 옵션 중복 선택 방지
+ALTER TABLE vote_answer
+    ADD CONSTRAINT uq_vote_answer_user_option
+        UNIQUE (user_id, option_id);

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -18,6 +18,8 @@ import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.quest.entity.QuestEventType;
 import com.solv.wefin.domain.quest.service.QuestProgressService;
+import com.solv.wefin.domain.vote.repository.VoteOptionRepository;
+import com.solv.wefin.domain.vote.repository.VoteRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,9 +35,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -54,6 +60,8 @@ class ChatMessageServiceTest {
     private NewsClusterRepository newsClusterRepository;
     private ChatMessageNewsShareService chatMessageNewsShareService;
     private QuestProgressService questProgressService;
+    private VoteRepository voteRepository;
+    private VoteOptionRepository voteOptionRepository;
 
     @BeforeEach
     void setUp() {
@@ -65,6 +73,8 @@ class ChatMessageServiceTest {
         newsClusterRepository = mock(NewsClusterRepository.class);
         chatMessageNewsShareService = mock(ChatMessageNewsShareService.class);
         questProgressService = mock(QuestProgressService.class);
+        voteRepository = mock(VoteRepository.class);
+        voteOptionRepository = mock(VoteOptionRepository.class);
 
         chatMessageService = new ChatMessageService(
                 chatMessageRepository,
@@ -73,17 +83,18 @@ class ChatMessageServiceTest {
                 groupMemberRepository,
                 chatSpamGuard,
                 questProgressService,
+                voteRepository,
+                voteOptionRepository,
                 newsClusterRepository,
                 chatMessageNewsShareService
         );
     }
 
     @Test
-    @DisplayName("그룹 채팅 메시지 전송 시 저장 후 이벤트를 발행한다")
+    @DisplayName("sendMessage publishes event and quest progress")
     void sendMessage_success() {
-        // given
         UUID userId = UUID.randomUUID();
-        String content = "안녕하세요";
+        String content = "hello";
 
         User user = User.builder()
                 .email("test@test.com")
@@ -92,9 +103,7 @@ class ChatMessageServiceTest {
                 .build();
         ReflectionTestUtils.setField(user, "userId", userId);
 
-        Group group = Group.builder()
-                .name("1조")
-                .build();
+        Group group = Group.builder().name("group-1").build();
         ReflectionTestUtils.setField(group, "id", 1L);
 
         GroupMember groupMember = GroupMember.builder()
@@ -123,10 +132,8 @@ class ChatMessageServiceTest {
 
         ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
 
-        // when
         chatMessageService.sendMessage(content, userId, null);
 
-        // then
         verify(chatMessageRepository, times(1))
                 .countByGroup_IdAndUser_UserIdAndCreatedAtAfter(eq(1L), eq(userId), any(OffsetDateTime.class));
         verify(chatSpamGuard, times(1))
@@ -144,12 +151,10 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("메시지가 비어 있으면 예외가 발생한다")
+    @DisplayName("sendMessage rejects blank content")
     void sendMessage_fail_blank() {
-        // given
         UUID userId = UUID.randomUUID();
 
-        // when // then
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> chatMessageService.sendMessage(" ", userId, null));
 
@@ -159,223 +164,8 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("활성 그룹 멤버가 아니면 예외가 발생한다")
-    void sendMessage_fail_when_group_member_not_found() {
-        // given
-        UUID userId = UUID.randomUUID();
-
-        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
-                .thenReturn(Optional.empty());
-
-        // when // then
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> chatMessageService.sendMessage("안녕하세요", userId, null));
-
-        assertEquals(ErrorCode.GROUP_MEMBER_FORBIDDEN, exception.getErrorCode());
-        verify(chatMessageRepository, never()).save(any());
-        verify(eventPublisher, never()).publishEvent(any());
-    }
-
-    @Test
-    @DisplayName("최근 메시지 조회 시 현재 사용자의 그룹 메시지만 반환한다")
-    void getRecentMessages_success() {
-        // given
-        UUID userId = UUID.randomUUID();
-
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        Group group = Group.builder()
-                .name("1조")
-                .build();
-        ReflectionTestUtils.setField(group, "id", 3L);
-
-        GroupMember groupMember = GroupMember.builder()
-                .user(user)
-                .group(group)
-                .role(GroupMember.GroupMemberRole.MEMBER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
-
-        ChatMessage message = ChatMessage.builder()
-                .user(user)
-                .group(group)
-                .messageType(MessageType.CHAT)
-                .content("최근 메시지")
-                .createdAt(OffsetDateTime.now())
-                .build();
-        ReflectionTestUtils.setField(message, "id", 7L);
-
-        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
-                .thenReturn(Optional.of(groupMember));
-        when(chatMessageRepository.findMessagesByGroupId(eq(3L), any(Pageable.class)))
-                .thenReturn(List.of(message));
-
-        // when
-        ChatMessagesInfo result = chatMessageService.getMessages(userId, null, 30);
-
-        // then
-        assertEquals(1, result.messages().size());
-        assertEquals(7L, result.messages().get(0).messageId());
-        assertEquals(3L, result.messages().get(0).groupId());
-        assertEquals("groupUser", result.messages().get(0).sender());
-        assertEquals("CHAT", result.messages().get(0).messageType());
-        assertNull(result.messages().get(0).replyTo());
-        assertEquals(false, result.hasNext());
-        assertEquals(null, result.nextCursor());
-    }
-
-    @Test
-    @DisplayName("내 그룹 메타 정보 조회 시 활성 그룹을 반환한다")
-    void getMyGroup_success() {
-        // given
-        UUID userId = UUID.randomUUID();
-
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        Group group = Group.builder()
-                .name("우리 그룹")
-                .build();
-        ReflectionTestUtils.setField(group, "id", 5L);
-
-        GroupMember groupMember = GroupMember.builder()
-                .user(user)
-                .group(group)
-                .role(GroupMember.GroupMemberRole.LEADER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
-
-        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
-                .thenReturn(Optional.of(groupMember));
-
-        // when
-        Group result = chatMessageService.getMyGroup(userId);
-
-        // then
-        assertNotNull(result);
-        assertEquals(5L, result.getId());
-        assertEquals("우리 그룹", result.getName());
-    }
-
-    @Test
-    @DisplayName("답장 대상 메시지가 있으면 replyToMessage를 저장한다")
-    void sendMessage_success_with_reply() {
-        // given
-        UUID userId = UUID.randomUUID();
-        String content = "답장합니다";
-
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        Group group = Group.builder()
-                .name("1조")
-                .build();
-        ReflectionTestUtils.setField(group, "id", 1L);
-
-        GroupMember groupMember = GroupMember.builder()
-                .user(user)
-                .group(group)
-                .role(GroupMember.GroupMemberRole.MEMBER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
-
-        ChatMessage replyTarget = ChatMessage.builder()
-                .user(user)
-                .group(group)
-                .messageType(MessageType.CHAT)
-                .content("원본 메시지")
-                .createdAt(OffsetDateTime.now())
-                .build();
-        ReflectionTestUtils.setField(replyTarget, "id", 99L);
-
-        ChatMessage savedMessage = ChatMessage.builder()
-                .user(user)
-                .group(group)
-                .messageType(MessageType.CHAT)
-                .content(content)
-                .replyToMessage(replyTarget)
-                .createdAt(OffsetDateTime.now())
-                .build();
-        ReflectionTestUtils.setField(savedMessage, "id", 10L);
-
-        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
-                .thenReturn(Optional.of(groupMember));
-        when(chatMessageRepository.findByIdAndGroup_Id(99L, 1L))
-                .thenReturn(Optional.of(replyTarget));
-        when(chatMessageRepository.countByGroup_IdAndUser_UserIdAndCreatedAtAfter(
-                eq(1L), eq(userId), any(OffsetDateTime.class))
-        ).thenReturn(0L);
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(chatMessageRepository.save(any(ChatMessage.class))).thenReturn(savedMessage);
-
-        ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
-
-        // when
-        chatMessageService.sendMessage(content, userId, 99L);
-
-        // then
-        verify(chatMessageRepository).save(captor.capture());
-
-        ChatMessage capturedMessage = captor.getValue();
-        assertEquals(replyTarget, capturedMessage.getReplyToMessage());
-    }
-
-    @Test
-    @DisplayName("답장 대상 메시지가 없으면 예외가 발생한다")
-    void sendMessage_fail_when_reply_target_not_found() {
-        // given
-        UUID userId = UUID.randomUUID();
-
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        Group group = Group.builder()
-                .name("1조")
-                .build();
-        ReflectionTestUtils.setField(group, "id", 1L);
-
-        GroupMember groupMember = GroupMember.builder()
-                .user(user)
-                .group(group)
-                .role(GroupMember.GroupMemberRole.MEMBER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
-
-        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
-                .thenReturn(Optional.of(groupMember));
-        when(chatMessageRepository.findByIdAndGroup_Id(99L, 1L))
-                .thenReturn(Optional.empty());
-
-        // when
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> chatMessageService.sendMessage("답장", userId, 99L));
-
-        // then
-        assertEquals(ErrorCode.CHAT_MESSAGE_NOT_FOUND, exception.getErrorCode());
-        verify(chatMessageRepository, never()).save(any());
-    }
-
-    @Test
-    @DisplayName("그룹 채팅 메시지 조회 시 hasNext와 nextCursor를 계산한다")
+    @DisplayName("getMessages computes hasNext and nextCursor")
     void getMessages_success_with_hasNext_and_nextCursor() {
-        // given
         UUID userId = UUID.randomUUID();
 
         User user = User.builder()
@@ -385,9 +175,7 @@ class ChatMessageServiceTest {
                 .build();
         ReflectionTestUtils.setField(user, "userId", userId);
 
-        Group group = Group.builder()
-                .name("1조")
-                .build();
+        Group group = Group.builder().name("group-1").build();
         ReflectionTestUtils.setField(group, "id", 3L);
 
         GroupMember groupMember = GroupMember.builder()
@@ -401,7 +189,7 @@ class ChatMessageServiceTest {
                 .user(user)
                 .group(group)
                 .messageType(MessageType.CHAT)
-                .content("세 번째 메시지")
+                .content("third")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(latestMessage, "id", 3L);
@@ -410,7 +198,7 @@ class ChatMessageServiceTest {
                 .user(user)
                 .group(group)
                 .messageType(MessageType.CHAT)
-                .content("두 번째 메시지")
+                .content("second")
                 .createdAt(OffsetDateTime.now().minusMinutes(1))
                 .build();
         ReflectionTestUtils.setField(middleMessage, "id", 2L);
@@ -419,7 +207,7 @@ class ChatMessageServiceTest {
                 .user(user)
                 .group(group)
                 .messageType(MessageType.CHAT)
-                .content("첫 번째 메시지")
+                .content("first")
                 .createdAt(OffsetDateTime.now().minusMinutes(2))
                 .build();
         ReflectionTestUtils.setField(oldestMessage, "id", 1L);
@@ -429,24 +217,20 @@ class ChatMessageServiceTest {
         when(chatMessageRepository.findMessagesByGroupId(eq(3L), any(Pageable.class)))
                 .thenReturn(List.of(latestMessage, middleMessage, oldestMessage));
 
-        // when
         ChatMessagesInfo result = chatMessageService.getMessages(userId, null, 2);
 
-        // then
         assertEquals(2, result.messages().size());
         assertTrue(result.hasNext());
         assertEquals(2L, result.nextCursor());
-
         assertEquals(2L, result.messages().get(0).messageId());
-        assertEquals("두 번째 메시지", result.messages().get(0).content());
+        assertEquals("second", result.messages().get(0).content());
         assertEquals(3L, result.messages().get(1).messageId());
-        assertEquals("세 번째 메시지", result.messages().get(1).content());
+        assertEquals("third", result.messages().get(1).content());
     }
 
     @Test
-    @DisplayName("뉴스 공유 메시지를 저장하고 뉴스 공유 정보를 포함한 응답을 반환한다")
+    @DisplayName("shareNews returns response with news share payload")
     void shareNews_success() {
-        // given
         UUID userId = UUID.randomUUID();
 
         User user = User.builder()
@@ -456,9 +240,7 @@ class ChatMessageServiceTest {
                 .build();
         ReflectionTestUtils.setField(user, "userId", userId);
 
-        Group group = Group.builder()
-                .name("group")
-                .build();
+        Group group = Group.builder().name("group").build();
         ReflectionTestUtils.setField(group, "id", 1L);
 
         GroupMember groupMember = GroupMember.builder()
@@ -500,10 +282,8 @@ class ChatMessageServiceTest {
                     return newsShare;
                 });
 
-        // when
         var result = chatMessageService.shareNews(userId, new ShareNewsCommand(55L));
 
-        // then
         verify(chatMessageRepository).save(argThat(message ->
                 message.getMessageType() == MessageType.NEWS
                         && "cluster title".equals(message.getContent())
@@ -521,48 +301,5 @@ class ChatMessageServiceTest {
         assertEquals("cluster title", result.newsShare().title());
         assertEquals("cluster summary", result.newsShare().summary());
         assertEquals("https://image.test/thumb.png", result.newsShare().thumbnailUrl());
-    }
-
-    @Test
-    @DisplayName("공유할 뉴스 클러스터가 없으면 예외가 발생한다")
-    void shareNews_fail_when_news_cluster_not_found() {
-        // given
-        UUID userId = UUID.randomUUID();
-
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
-        ReflectionTestUtils.setField(user, "userId", userId);
-
-        Group group = Group.builder()
-                .name("group")
-                .build();
-        ReflectionTestUtils.setField(group, "id", 1L);
-
-        GroupMember groupMember = GroupMember.builder()
-                .user(user)
-                .group(group)
-                .role(GroupMember.GroupMemberRole.MEMBER)
-                .status(GroupMember.GroupMemberStatus.ACTIVE)
-                .build();
-
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
-                .thenReturn(Optional.of(groupMember));
-        when(newsClusterRepository.findById(999L)).thenReturn(Optional.empty());
-
-        // when
-        BusinessException exception = assertThrows(
-                BusinessException.class,
-                () -> chatMessageService.shareNews(userId, new ShareNewsCommand(999L))
-        );
-
-        // then
-        assertEquals(ErrorCode.NEWS_CLUSTER_NOT_FOUND, exception.getErrorCode());
-        verify(chatMessageRepository, never()).save(any());
-        verify(chatMessageNewsShareService, never()).save(any(), any());
-        verify(eventPublisher, never()).publishEvent(any());
     }
 }

--- a/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
@@ -1,0 +1,204 @@
+package com.solv.wefin.domain.vote.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
+import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.repository.GroupRepository;
+import com.solv.wefin.domain.vote.dto.command.CreateVoteCommand;
+import com.solv.wefin.domain.vote.dto.command.SubmitVoteCommand;
+import com.solv.wefin.domain.vote.dto.info.VoteInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteResultInfo;
+import com.solv.wefin.domain.vote.entity.Vote;
+import com.solv.wefin.domain.vote.entity.VoteAnswer;
+import com.solv.wefin.domain.vote.entity.VoteOption;
+import com.solv.wefin.domain.vote.repository.VoteAnswerRepository;
+import com.solv.wefin.domain.vote.repository.VoteOptionRepository;
+import com.solv.wefin.domain.vote.repository.VoteRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class VoteServiceTest {
+
+    @Mock
+    private VoteRepository voteRepository;
+    @Mock
+    private VoteOptionRepository voteOptionRepository;
+    @Mock
+    private VoteAnswerRepository voteAnswerRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private GroupRepository groupRepository;
+    @Mock
+    private ChatMessageService chatMessageService;
+
+    private VoteService voteService;
+
+    @BeforeEach
+    void setUp() {
+        voteService = new VoteService(
+                voteRepository,
+                voteOptionRepository,
+                voteAnswerRepository,
+                userRepository,
+                groupRepository,
+                chatMessageService
+        );
+    }
+
+    @Test
+    @DisplayName("createVote saves vote options and shares chat message")
+    void createVote_success() {
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        Group group = createGroup(1L);
+        CreateVoteCommand command = new CreateVoteCommand(
+                1L,
+                "Lunch menu vote",
+                List.of("Chicken", "Pizza"),
+                1,
+                1L
+        );
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(voteRepository.save(any(Vote.class))).willAnswer(invocation -> {
+            Vote vote = invocation.getArgument(0);
+            ReflectionTestUtils.setField(vote, "voteId", 10L);
+            return vote;
+        });
+
+        VoteInfo result = voteService.createVote(userId, command);
+
+        assertThat(result.voteId()).isEqualTo(10L);
+        assertThat(result.title()).isEqualTo("Lunch menu vote");
+        assertThat(result.maxSelectCount()).isEqualTo(1);
+
+        verify(voteRepository).save(any(Vote.class));
+        verify(voteOptionRepository).saveAll(any());
+        verify(chatMessageService).shareVote(eq(userId), any(Vote.class));
+    }
+
+    @Test
+    @DisplayName("submitVote replaces existing selections when user changes vote")
+    void submitVote_success_when_replacing_existing_selection() {
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        Vote vote = createVoteEntity(5L, 2);
+        VoteOption firstOption = createVoteOption(101L, vote, "A");
+        VoteOption secondOption = createVoteOption(102L, vote, "B");
+        VoteAnswer savedAnswer = VoteAnswer.voted(secondOption, vote, user);
+        ReflectionTestUtils.setField(savedAnswer, "id", 401L);
+
+        given(voteRepository.findById(5L)).willReturn(Optional.of(vote));
+        given(voteOptionRepository.findAllByIdIn(List.of(102L))).willReturn(List.of(secondOption));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(voteAnswerRepository.saveAll(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(5L)).willReturn(List.of(firstOption, secondOption));
+        given(voteAnswerRepository.findAllByVote_VoteIdAndUser_UserId(5L, userId)).willReturn(List.of(savedAnswer));
+        given(voteAnswerRepository.countDistinctUsersByVoteId(5L)).willReturn(1L);
+        given(voteAnswerRepository.countByVoteIdGroupByOptionId(5L))
+                .willReturn(List.<Object[]>of(new Object[]{102L, 1L}));
+
+        VoteResultInfo result = voteService.submitVote(userId, 5L, new SubmitVoteCommand(List.of(102L)));
+
+        assertThat(result.voteId()).isEqualTo(5L);
+        assertThat(result.options()).hasSize(2);
+        assertThat(result.options().stream().filter(option -> option.selectedByMe())).hasSize(1);
+        assertThat(result.options().stream()
+                .filter(option -> option.optionId().equals(102L))
+                .findFirst())
+                .isPresent()
+                .get()
+                .extracting(option -> option.selectedByMe())
+                .isEqualTo(true);
+
+        verify(voteAnswerRepository).deleteAllByVote_VoteIdAndUser_UserId(5L, userId);
+        verify(voteAnswerRepository).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("submitVote returns result for valid option")
+    void submitVote_success() {
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        Vote vote = createVoteEntity(7L, 2);
+        VoteOption firstOption = createVoteOption(201L, vote, "YES");
+        VoteAnswer savedAnswer = VoteAnswer.voted(firstOption, vote, user);
+        ReflectionTestUtils.setField(savedAnswer, "id", 301L);
+
+        given(voteRepository.findById(7L)).willReturn(Optional.of(vote));
+        given(voteOptionRepository.findAllByIdIn(List.of(201L))).willReturn(List.of(firstOption));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(voteAnswerRepository.saveAll(any())).willAnswer(invocation -> invocation.getArgument(0));
+        given(voteOptionRepository.findAllByVote_VoteIdOrderByIdAsc(7L)).willReturn(List.of(firstOption));
+        given(voteAnswerRepository.findAllByVote_VoteIdAndUser_UserId(7L, userId)).willReturn(List.of(savedAnswer));
+        given(voteAnswerRepository.countDistinctUsersByVoteId(7L)).willReturn(1L);
+        given(voteAnswerRepository.countByVoteIdGroupByOptionId(7L))
+                .willReturn(List.<Object[]>of(new Object[]{201L, 1L}));
+
+        VoteResultInfo result = voteService.submitVote(userId, 7L, new SubmitVoteCommand(List.of(201L)));
+
+        assertThat(result.voteId()).isEqualTo(7L);
+        assertThat(result.participantCount()).isEqualTo(1L);
+        assertThat(result.options()).hasSize(1);
+        assertThat(result.options().get(0).selectedByMe()).isTrue();
+
+        verify(voteAnswerRepository).deleteAllByVote_VoteIdAndUser_UserId(7L, userId);
+        verify(voteAnswerRepository).saveAll(any());
+    }
+
+    private User createUser(UUID userId) {
+        User user = User.builder()
+                .email("vote@test.com")
+                .nickname("vote-user")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
+    }
+
+    private Group createGroup(Long groupId) {
+        Group group = Group.createSharedGroup("test-group");
+        ReflectionTestUtils.setField(group, "id", groupId);
+        return group;
+    }
+
+    private Vote createVoteEntity(Long voteId, int maxSelectCount) {
+        Group group = createGroup(1L);
+        User user = createUser(UUID.randomUUID());
+        Vote vote = Vote.create(
+                group,
+                user,
+                "vote-title",
+                OffsetDateTime.now().plusHours(1),
+                maxSelectCount
+        );
+        ReflectionTestUtils.setField(vote, "voteId", voteId);
+        return vote;
+    }
+
+    private VoteOption createVoteOption(Long optionId, Vote vote, String optionText) {
+        VoteOption option = VoteOption.create(vote, optionText);
+        ReflectionTestUtils.setField(option, "id", optionId);
+        return option;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
@@ -4,6 +4,8 @@ import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.repository.GroupRepository;
 import com.solv.wefin.domain.vote.dto.command.CreateVoteCommand;
 import com.solv.wefin.domain.vote.dto.command.SubmitVoteCommand;
@@ -15,6 +17,8 @@ import com.solv.wefin.domain.vote.entity.VoteOption;
 import com.solv.wefin.domain.vote.repository.VoteAnswerRepository;
 import com.solv.wefin.domain.vote.repository.VoteOptionRepository;
 import com.solv.wefin.domain.vote.repository.VoteRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,9 +33,11 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,6 +54,8 @@ class VoteServiceTest {
     @Mock
     private GroupRepository groupRepository;
     @Mock
+    private GroupMemberRepository groupMemberRepository;
+    @Mock
     private ChatMessageService chatMessageService;
 
     private VoteService voteService;
@@ -60,6 +68,7 @@ class VoteServiceTest {
                 voteAnswerRepository,
                 userRepository,
                 groupRepository,
+                groupMemberRepository,
                 chatMessageService
         );
     }
@@ -80,6 +89,11 @@ class VoteServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                group,
+                GroupMember.GroupMemberStatus.ACTIVE
+        )).willReturn(true);
         given(voteRepository.save(any(Vote.class))).willAnswer(invocation -> {
             Vote vote = invocation.getArgument(0);
             ReflectionTestUtils.setField(vote, "voteId", 10L);
@@ -95,6 +109,57 @@ class VoteServiceTest {
         verify(voteRepository).save(any(Vote.class));
         verify(voteOptionRepository).saveAll(any());
         verify(chatMessageService).shareVote(eq(userId), any(Vote.class));
+    }
+
+    @Test
+    @DisplayName("createVote fails when user is not an active group member")
+    void createVote_fail_when_user_is_not_active_member() {
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        Group group = createGroup(1L);
+        CreateVoteCommand command = new CreateVoteCommand(
+                1L,
+                "Lunch menu vote",
+                List.of("Chicken", "Pizza"),
+                1,
+                1L
+        );
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(groupRepository.findById(1L)).willReturn(Optional.of(group));
+        given(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                group,
+                GroupMember.GroupMemberStatus.ACTIVE
+        )).willReturn(false);
+
+        assertThatThrownBy(() -> voteService.createVote(userId, command))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GROUP_MEMBER_FORBIDDEN);
+
+        verify(voteRepository, never()).save(any(Vote.class));
+        verify(voteOptionRepository, never()).saveAll(any());
+        verify(chatMessageService, never()).shareVote(any(), any());
+    }
+
+    @Test
+    @DisplayName("createVote fails when options contain duplicates after trimming")
+    void createVote_fail_when_options_are_duplicated() {
+        UUID userId = UUID.randomUUID();
+        CreateVoteCommand command = new CreateVoteCommand(
+                1L,
+                "Lunch menu vote",
+                List.of("Chicken", " Chicken "),
+                1,
+                1L
+        );
+
+        assertThatThrownBy(() -> voteService.createVote(userId, command))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
+
+        verify(userRepository, never()).findById(any());
+        verify(voteRepository, never()).save(any(Vote.class));
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
@@ -174,6 +174,11 @@ class VoteServiceTest {
         ReflectionTestUtils.setField(savedAnswer, "id", 401L);
 
         given(voteRepository.findById(5L)).willReturn(Optional.of(vote));
+        given(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                vote.getGroup(),
+                GroupMember.GroupMemberStatus.ACTIVE
+        )).willReturn(true);
         given(voteOptionRepository.findAllByIdIn(List.of(102L))).willReturn(List.of(secondOption));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(voteAnswerRepository.saveAll(any())).willAnswer(invocation -> invocation.getArgument(0));
@@ -211,6 +216,11 @@ class VoteServiceTest {
         ReflectionTestUtils.setField(savedAnswer, "id", 301L);
 
         given(voteRepository.findById(7L)).willReturn(Optional.of(vote));
+        given(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                vote.getGroup(),
+                GroupMember.GroupMemberStatus.ACTIVE
+        )).willReturn(true);
         given(voteOptionRepository.findAllByIdIn(List.of(201L))).willReturn(List.of(firstOption));
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(voteAnswerRepository.saveAll(any())).willAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
@@ -1,7 +1,9 @@
 package com.solv.wefin.web.chat.groupChat;
 
+import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.config.security.JwtProvider;
@@ -13,9 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
@@ -47,9 +49,8 @@ class GroupChatControllerTest {
     private JwtProvider jwtProvider;
 
     @Test
-    @DisplayName("현재 사용자의 그룹 최근 메시지를 응답으로 반환한다")
+    @DisplayName("getRecentMessages returns current group messages")
     void getRecentMessages_success() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
 
         ChatMessageInfo info = new ChatMessageInfo(
@@ -58,20 +59,16 @@ class GroupChatControllerTest {
                 3L,
                 "CHAT",
                 "groupUser",
-                "안녕하세요",
+                "hello",
                 OffsetDateTime.now(),
+                null,
                 null,
                 null
         );
 
         when(chatMessageService.getMessages(userId, null, 30))
-                .thenReturn(new ChatMessagesInfo(
-                        List.of(info),
-                        null,
-                        false
-                ));
+                .thenReturn(new ChatMessagesInfo(List.of(info), null, false));
 
-        // when // then
         mockMvc.perform(get("/api/chat/group/messages")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(
@@ -84,21 +81,19 @@ class GroupChatControllerTest {
                 .andExpect(jsonPath("$.data.messages[0].messageId").value(1))
                 .andExpect(jsonPath("$.data.messages[0].groupId").value(3))
                 .andExpect(jsonPath("$.data.messages[0].sender").value("groupUser"))
-                .andExpect(jsonPath("$.data.messages[0].content").value("안녕하세요"))
+                .andExpect(jsonPath("$.data.messages[0].content").value("hello"))
                 .andExpect(jsonPath("$.data.hasNext").value(false));
     }
 
     @Test
-    @DisplayName("그룹 멤버가 아니면 최근 메시지 조회 시 403을 반환한다")
+    @DisplayName("getRecentMessages returns 403 for forbidden member")
     void getRecentMessages_fail_when_group_member_forbidden() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
 
         doThrow(new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN))
                 .when(chatMessageService)
                 .getMessages(userId, null, 30);
 
-        // when // then
         mockMvc.perform(get("/api/chat/group/messages")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(
@@ -112,19 +107,17 @@ class GroupChatControllerTest {
     }
 
     @Test
-    @DisplayName("내 그룹 메타 정보를 반환한다")
+    @DisplayName("getMyGroup returns active group info")
     void getMyGroup_success() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
 
         Group group = Group.builder()
-                .name("우리 그룹")
+                .name("my-group")
                 .build();
         ReflectionTestUtils.setField(group, "id", 7L);
 
         when(chatMessageService.getMyGroup(userId)).thenReturn(group);
 
-        // when // then
         mockMvc.perform(get("/api/chat/group/me")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(
@@ -135,13 +128,12 @@ class GroupChatControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value(200))
                 .andExpect(jsonPath("$.data.groupId").value(7))
-                .andExpect(jsonPath("$.data.groupName").value("우리 그룹"));
+                .andExpect(jsonPath("$.data.groupName").value("my-group"));
     }
 
     @Test
-    @DisplayName("뉴스 공유 요청을 받으면 성공 응답을 반환한다")
+    @DisplayName("shareNews returns success response")
     void shareNews_success() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
 
         ChatMessageInfo info = new ChatMessageInfo(
@@ -153,20 +145,17 @@ class GroupChatControllerTest {
                 "",
                 OffsetDateTime.now(),
                 null,
-                new com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo(
+                new NewsShareInfo(
                         55L,
                         "cluster title",
                         "cluster summary",
                         "https://image.test/thumb.png"
-                )
+                ),
+                null
         );
 
-        when(chatMessageService.shareNews(
-                userId,
-                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(55L)
-        )).thenReturn(info);
+        when(chatMessageService.shareNews(userId, new ShareNewsCommand(55L))).thenReturn(info);
 
-        // when // then
         mockMvc.perform(post("/api/chat/group/news-share")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(
@@ -177,7 +166,7 @@ class GroupChatControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "newsClusterId": 55
+                                  \"newsClusterId\": 55
                                 }
                                 """))
                 .andExpect(status().isOk())
@@ -185,17 +174,13 @@ class GroupChatControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 뉴스 클러스터를 공유하면 404를 반환한다")
+    @DisplayName("shareNews returns 404 when cluster is missing")
     void shareNews_fail_when_news_cluster_not_found() throws Exception {
-        // given
         UUID userId = UUID.randomUUID();
 
-        when(chatMessageService.shareNews(
-                userId,
-                new com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand(999L)
-        )).thenThrow(new BusinessException(ErrorCode.NEWS_CLUSTER_NOT_FOUND));
+        when(chatMessageService.shareNews(userId, new ShareNewsCommand(999L)))
+                .thenThrow(new BusinessException(ErrorCode.NEWS_CLUSTER_NOT_FOUND));
 
-        // when // then
         mockMvc.perform(post("/api/chat/group/news-share")
                         .with(csrf())
                         .with(authentication(new UsernamePasswordAuthenticationToken(
@@ -206,7 +191,7 @@ class GroupChatControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "newsClusterId": 999
+                                  \"newsClusterId\": 999
                                 }
                                 """))
                 .andExpect(status().isNotFound())

--- a/src/test/java/com/solv/wefin/web/vote/VoteControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/vote/VoteControllerTest.java
@@ -1,0 +1,177 @@
+package com.solv.wefin.web.vote;
+
+import com.solv.wefin.domain.vote.dto.info.VoteDetailInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteOptionInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteOptionResultInfo;
+import com.solv.wefin.domain.vote.dto.info.VoteResultInfo;
+import com.solv.wefin.domain.vote.entity.VoteStatus;
+import com.solv.wefin.domain.vote.service.VoteService;
+import com.solv.wefin.global.config.security.JwtProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VoteController.class)
+class VoteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private VoteService voteService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @Test
+    void createVote_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        VoteInfo info = new VoteInfo(
+                1L,
+                "Snack vote",
+                VoteStatus.OPEN,
+                1,
+                OffsetDateTime.parse("2026-04-17T20:00:00+09:00")
+        );
+
+        given(voteService.createVote(eq(userId), any())).willReturn(info);
+
+        String requestBody = """
+                {
+                  \"groupId\": 1,
+                  \"title\": \"Snack vote\",
+                  \"options\": [\"Chicken\", \"Pizza\"],
+                  \"maxSelectCount\": 1,
+                  \"durationHours\": 1
+                }
+                """;
+
+        mockMvc.perform(post("/api/votes")
+                        .with(csrf())
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+                        ))
+                        .contentType("application/json")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.voteId").value(1))
+                .andExpect(jsonPath("$.data.title").value("Snack vote"))
+                .andExpect(jsonPath("$.data.status").value("OPEN"));
+    }
+
+    @Test
+    void getVoteDetail_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        VoteDetailInfo info = new VoteDetailInfo(
+                2L,
+                "Lunch vote",
+                VoteStatus.OPEN,
+                2,
+                OffsetDateTime.parse("2026-04-17T22:00:00+09:00"),
+                false,
+                List.of(
+                        new VoteOptionInfo(11L, "Chicken"),
+                        new VoteOptionInfo(12L, "Pizza")
+                ),
+                List.of(11L)
+        );
+
+        given(voteService.getVoteDetail(userId, 2L)).willReturn(info);
+
+        mockMvc.perform(get("/api/votes/2")
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.voteId").value(2))
+                .andExpect(jsonPath("$.data.options[0].optionId").value(11))
+                .andExpect(jsonPath("$.data.myOptionIds[0]").value(11));
+    }
+
+    @Test
+    void submitVote_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        VoteResultInfo info = new VoteResultInfo(
+                3L,
+                "Dessert vote",
+                VoteStatus.OPEN,
+                1,
+                OffsetDateTime.parse("2026-04-17T23:00:00+09:00"),
+                false,
+                2L,
+                List.of(
+                        new VoteOptionResultInfo(21L, "Cake", 2L, 100.0, true)
+                )
+        );
+
+        given(voteService.submitVote(eq(userId), eq(3L), any())).willReturn(info);
+
+        String requestBody = """
+                {
+                  \"optionIds\": [21]
+                }
+                """;
+
+        mockMvc.perform(post("/api/votes/3/answers")
+                        .with(csrf())
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+                        ))
+                        .contentType("application/json")
+                        .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.voteId").value(3))
+                .andExpect(jsonPath("$.data.participantCount").value(2))
+                .andExpect(jsonPath("$.data.options[0].optionId").value(21))
+                .andExpect(jsonPath("$.data.options[0].selectedByMe").value(true));
+    }
+
+    @Test
+    void getVoteResult_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        VoteResultInfo info = new VoteResultInfo(
+                4L,
+                "Weekend plan vote",
+                VoteStatus.CLOSED,
+                2,
+                OffsetDateTime.parse("2026-04-17T18:00:00+09:00"),
+                true,
+                3L,
+                List.of(
+                        new VoteOptionResultInfo(31L, "Hiking", 2L, 66.6, true),
+                        new VoteOptionResultInfo(32L, "Movie", 1L, 33.3, false)
+                )
+        );
+
+        given(voteService.getVoteResult(userId, 4L)).willReturn(info);
+
+        mockMvc.perform(get("/api/votes/4/result")
+                        .with(authentication(
+                                new UsernamePasswordAuthenticationToken(userId, null, List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.closed").value(true))
+                .andExpect(jsonPath("$.data.options[0].optionText").value("Hiking"))
+                .andExpect(jsonPath("$.data.options[1].voteCount").value(1));
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
그룹 채팅 내 투표 기능 백엔드를 구현했습니다. 투표 생성, 상세 조회, 참여, 결과 조회 API를 추가했고, 생성된 투표가 그룹 채팅 메시지로 함께 공유되도록 연동했습니다. 또한 duration 기반 마감 시간 계산, 마감 상태 반영, 선택 번복 허용까지 포함해 실제 사용 흐름이 가능하도록 정리했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[#81] 그룹 채팅 투표 기능 백엔드 구현**
- [x] `vote`, `vote_option`, `vote_answer` 기반 투표 도메인 엔티티 및 레포지토리 구현
- [x] 투표 생성 API 구현
- [x] 투표 상세 조회 API 구현
- [x] 투표 참여 API 구현
- [x] 투표 결과 조회 API 구현
- [x] 복수 선택 투표 지원
- [x] 동일 옵션 중복 선택 방지
- [x] 투표별 최대 선택 개수(`maxSelectCount`) 제한 검증 추가
- [x] 마감 시간을 직접 시각 입력이 아닌 `durationHours` 기반으로 받도록 변경
- [x] 서버에서 `durationHours`를 기준으로 `endsAt` 계산 후 저장
- [x] 조회/참여 시점에 만료된 투표를 `CLOSED` 상태로 반영하도록 처리
- [x] 마감된 투표는 추가 참여 불가하도록 검증 추가
- [x] 사용자가 기존 선택을 번복할 수 있도록 `기존 답안 삭제 후 새 답안 저장` 방식으로 제출 로직 변경
- [x] 현재 최종 선택 상태만 `vote_answer`에 유지되도록 정리
- [x] 투표 생성 시 그룹 채팅에 투표 메시지가 함께 생성되도록 연동
- [x] 채팅 메시지의 `ref_type/ref_id`를 활용해 `VOTE` 참조 메시지 구조 적용
- [x] 그룹 채팅 조회 응답에 `voteShare` 정보 포함하도록 DTO 확장
- [x] 채팅 메시지 목록 조회 시 투표/선택지 일괄 조회로 N+1 성격 완화
- [x] 투표 생성/참여/결과/채팅 공유 관련 서비스 테스트 및 컨트롤러 테스트 추가

<br>

## 💭 고민과 해결과정

- 투표 기능은 그룹 채팅 안에서만 쓰이지만, 생성/마감/선택지/응답/결과 집계라는 별도 규칙을 가지기 때문에 `chat` 하위 기능으로 우겨 넣기보다 `vote` 도메인으로 분리했습니다.
- 그룹 채팅과의 연결은 별도 공유 테이블 대신 기존 `chat_message.ref_type/ref_id` 구조를 활용했습니다. 이미 기능 메시지 참조용 필드가 있어서 `ref_type=VOTE`, `ref_id=vote_id`로 연결하는 편이 더 자연스럽고 일관된다고 판단했습니다.
- 처음에는 투표 제출을 누적 선택 기반으로 처리했지만, 선택 번복 요구사항이 생기면서 기존 구조로는 UX가 맞지 않았습니다. 그래서 제출 시 기존 답안을 모두 지우고 새 선택만 저장하도록 바꿔 최종 선택 상태만 유지하게 했습니다.
- 사용자가 마감 시각을 직접 고르기보다 “1시간 / 4시간 / 24시간” 같은 duration 기반 입력이 더 자연스러워 보여, 서버에서 `endsAt`을 계산해 저장하도록 변경했습니다.
- 마감 상태는 스케줄러 없이도 우선 동작해야 해서 조회/참여 시점에 만료 여부를 확인하고 `CLOSED`로 반영하는 방식으로 정리했습니다.
- 그룹 채팅 응답에 투표 정보를 붙일 때, 메시지마다 투표와 선택지를 개별 조회하면 N+1 성격이 생길 수 있어서 vote/refId를 모아 일괄 조회 후 매핑하는 방식으로 보완했습니다.

<br>

### 🔗 관련 이슈
Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 그룹에서 투표 생성, 제출, 결과 조회 API 추가
  * 그룹 채팅에서 투표를 공유하고 채팅 메시지에 투표 정보 포함
  * 다중 선택 투표 지원(선택 개수 제한, 만료/종료 관리)
  * 투표 관련 응답 포맷 및 클라이언트용 DTO 추가
  * 데이터베이스 마이그레이션으로 투표·응답 스키마 확장

* **테스트**
  * 투표 서비스 및 컨트롤러에 대한 단위/웹 계층 테스트 추가

* **오류 처리**
  * 투표 관련 신규 오류 코드(예: 미존재, 종료, 옵션 오류 등) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->