### PR TITLE
[WEF-674] 종목 검색 대소문자 매핑

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -43,7 +43,7 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     @Query("SELECT sd FROM StockDaily sd " +
             "JOIN FETCH sd.stockInfo si " +
             "WHERE sd.tradeDate = :tradeDate " +
-            "AND (si.stockName LIKE :keyword ESCAPE '\\' OR si.symbol LIKE :keyword ESCAPE '\\') " +
+            "AND (LOWER(si.stockName) LIKE :keyword ESCAPE '\\' OR LOWER(si.symbol) LIKE :keyword ESCAPE '\\') " +
             "ORDER BY si.stockName ASC")
     List<StockDaily> searchByKeywordAndTradeDate(@Param("keyword") String keyword,
                                                  @Param("tradeDate") LocalDate tradeDate,

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -59,7 +59,7 @@ public class StockSearchService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
         // 4. keyword로 종목 검색 (턴 날짜에 거래 데이터 있는 것만, 최대 MAX_SEARCH_RESULTS건)
-        String escaped = trimmed.toLowerCase().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        String escaped = trimmed.toLowerCase(java.util.Locale.ROOT).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
         String likeKeyword = "%" + escaped + "%";
         Pageable pageable = PageRequest.of(0, MAX_SEARCH_RESULTS);
         return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate(), pageable);

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -59,7 +59,7 @@ public class StockSearchService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
         // 4. keyword로 종목 검색 (턴 날짜에 거래 데이터 있는 것만, 최대 MAX_SEARCH_RESULTS건)
-        String escaped = trimmed.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        String escaped = trimmed.toLowerCase().replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
         String likeKeyword = "%" + escaped + "%";
         Pageable pageable = PageRequest.of(0, MAX_SEARCH_RESULTS);
         return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate(), pageable);


### PR DESCRIPTION
## 📌 PR 설명
<br>
종목 검색 시 대소문자 구분 없이 검색 할 수 있도록 개선 했습니다
ex) lg,LG
## ✅ 완료한 기능 명세

- [x] 대소문자 매핑

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #292 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정

- 종목 검색이 대소문자를 구분하지 않도록 변경되었습니다. 사용자가 입력한 종목명이나 기호는 대소문자와 관계없이 검색됩니다. 검색 기능의 쿼리 처리가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->