### PR TITLE
[WEF-677] 마지막 턴 결과페이지 리다이렉트 버그 수정

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockDailyRepository.java
@@ -29,6 +29,9 @@ public interface StockDailyRepository extends JpaRepository<StockDaily, UUID> {
     @Query("SELECT MAX(sd.tradeDate) FROM StockDaily sd WHERE sd.tradeDate <= :date")
     Optional<LocalDate> findLatestTradeDateOnOrBefore(@Param("date") LocalDate date);
 
+    @Query("SELECT MIN(sd.tradeDate) FROM StockDaily sd WHERE sd.tradeDate > :date")
+    Optional<LocalDate> findEarliestTradeDateAfter(@Param("date") LocalDate date);
+
     /** 수집된 주가 데이터의 최초 거래일 (방 생성 시 시작일 범위 하한용) */
     @Query("SELECT MIN(sd.tradeDate) FROM StockDaily sd")
     Optional<LocalDate> findEarliestTradeDate();

--- a/src/main/java/com/solv/wefin/domain/game/turn/event/GameFinishedEvent.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/event/GameFinishedEvent.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.game.turn.event;
+
+import java.util.UUID;
+
+/**
+ * 게임 종료 시 발행되는 도메인 이벤트.
+ * 리스너에서 WebSocket 브로드캐스트 → 프론트가 결과 페이지로 리다이렉트한다.
+ *
+ * @param roomId 게임방 ID
+ */
+public record GameFinishedEvent(UUID roomId) {
+}

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -271,11 +271,20 @@ public class TurnAdvanceService {
     /**
      * 다음 거래일을 계산한다.
      * 현재 날짜 + moveDays 후, 비거래일이면 가장 가까운 이전 거래일로 보정.
+     * 단, currentDate 이후의 거래일만 반환하여 무한 루프를 방지한다.
      */
     private LocalDate calculateNextTradeDate(LocalDate currentDate, int moveDays) {
         LocalDate targetDate = currentDate.plusDays(moveDays);
 
-        return stockDailyRepository.findLatestTradeDateOnOrBefore(targetDate)
+        LocalDate nextTradeDate = stockDailyRepository.findLatestTradeDateOnOrBefore(targetDate)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+
+        // 보정 결과가 현재 날짜 이하면 currentDate 다음 날부터 재탐색
+        if (!nextTradeDate.isAfter(currentDate)) {
+            nextTradeDate = stockDailyRepository.findEarliestTradeDateAfter(currentDate)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.GAME_STOCK_PRICE_NOT_FOUND));
+        }
+
+        return nextTradeDate;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
+++ b/src/main/java/com/solv/wefin/domain/game/turn/service/TurnAdvanceService.java
@@ -23,6 +23,7 @@ import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.domain.game.turn.event.GameFinishedEvent;
 import com.solv.wefin.domain.game.turn.event.TurnChangeEvent;
 import com.solv.wefin.domain.game.turn.event.TurnChangeEvent.SnapshotData;
 import lombok.RequiredArgsConstructor;
@@ -105,6 +106,7 @@ public class TurnAdvanceService {
             forceEndAllActive(gameRoom, snapshots);
             gameRoom.finish();
             log.info("[턴 전환] 게임 종료: roomId={}, 마지막 턴={}", roomId, currentTurn.getTurnNumber());
+            eventPublisher.publishEvent(new GameFinishedEvent(roomId));
             return null;
         }
 
@@ -245,6 +247,25 @@ public class TurnAdvanceService {
 
         // 전원(기존 FINISHED + 방금 FINISHED) 순위 확정
         gameEndService.finalizeRanks(gameRoom);
+    }
+
+    /**
+     * 게임의 총 턴 수를 계산한다.
+     * startDate부터 endDate까지 moveDays 간격으로 거래일을 이동하며 카운트.
+     */
+    @Transactional(readOnly = true)
+    public int calculateTotalTurns(LocalDate startDate, LocalDate endDate, int moveDays) {
+        int turns = 1; // 첫 턴 포함
+        LocalDate current = startDate;
+
+        while (true) {
+            LocalDate next = calculateNextTradeDate(current, moveDays);
+            if (next.isAfter(endDate)) break;
+            turns++;
+            current = next;
+        }
+
+        return turns;
     }
 
     /**

--- a/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
+++ b/src/main/java/com/solv/wefin/web/game/room/GameRoomController.java
@@ -11,6 +11,7 @@ import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.game.room.service.GameRoomService;
+import com.solv.wefin.domain.game.turn.service.TurnAdvanceService;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.global.common.ApiResponse;
@@ -43,6 +44,7 @@ GameRoomController {
 
     private final GameRoomService gameRoomService;
     private final GameResultService gameResultService;
+    private final TurnAdvanceService turnAdvanceService;
     private final GroupMemberRepository groupMemberRepository;
     private final UserRepository userRepository;
 
@@ -115,7 +117,11 @@ GameRoomController {
                 p -> ParticipantDetailDto.from(p, nicknameMap.getOrDefault(p.getUserId(), "알 수 없음"))
         ).collect(Collectors.toList());
 
-        RoomDetailResponse response = RoomDetailResponse.from(detail.room(), participantDtos);
+        GameRoom room = detail.room();
+        int totalTurns = turnAdvanceService.calculateTotalTurns(
+                room.getStartDate(), room.getEndDate(), room.getMoveDays());
+
+        RoomDetailResponse response = RoomDetailResponse.from(room, participantDtos, totalTurns);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/room/dto/response/RoomDetailResponse.java
@@ -23,9 +23,11 @@ public class RoomDetailResponse {
     private LocalDate startDate;
     private LocalDate endDate;
     private RoomStatus status;
+    private Integer totalTurns;
     private List<ParticipantDetailDto> participants;
 
-    public static RoomDetailResponse from(GameRoom room, List<ParticipantDetailDto> participants) {
+    public static RoomDetailResponse from(GameRoom room, List<ParticipantDetailDto> participants,
+                                           int totalTurns) {
         return new RoomDetailResponse(
                 room.getRoomId(),
                 room.getUserId(),
@@ -35,6 +37,7 @@ public class RoomDetailResponse {
                 room.getStartDate(),
                 room.getEndDate(),
                 room.getStatus(),
+                totalTurns,
                 participants
         );
     }

--- a/src/main/java/com/solv/wefin/web/game/turn/listener/GameFinishedEventListener.java
+++ b/src/main/java/com/solv/wefin/web/game/turn/listener/GameFinishedEventListener.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.web.game.turn.listener;
+
+import com.solv.wefin.domain.game.turn.event.GameFinishedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Map;
+
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameFinishedEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handle(GameFinishedEvent event) {
+        String destination = "/topic/rooms/" + event.roomId() + "/turn";
+
+        messagingTemplate.convertAndSend(destination, Map.of("type", "GAME_FINISHED"));
+
+        log.info("[게임 종료 WS] roomId={}", event.roomId());
+    }
+}


### PR DESCRIPTION
## 📌 PR 설명
<br> 마지막 턴에서 다음 턴 종료시 새로고침을 하지 않으면 결과 페이지로 이동되지 않던 버그 수정했습니다.

## ✅ 완료한 기능 명세

- [x] 리다이렉트 버그 수정

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #300 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 게임 방 상세 정보 페이지에 게임의 예상 총 턴 수가 표시되어 게임 진행 예상 시간을 파악할 수 있습니다.
* 게임이 종료되면 실시간 알림이 활성화되어 플레이어들이 게임 완료 상태를 즉시 확인하고 대응할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->