### PR TITLE
[WEF-676] 초대 코드 다회용 변경

### DIFF
--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupInvite.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupInvite.java
@@ -69,8 +69,8 @@ public class GroupInvite {
         }
     }
 
-    public void markAccepted() {
-        this.status = InviteStatus.ACCEPTED;
+    public boolean isExpired(OffsetDateTime now) {
+        return this.expiredAt.isBefore(now) || this.status == InviteStatus.EXPIRED;
     }
 
     public void expire() {

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupInviteRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupInviteRepository.java
@@ -1,12 +1,20 @@
 package com.solv.wefin.domain.group.repository;
 
+import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupInvite;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface GroupInviteRepository extends JpaRepository<GroupInvite, Long> {
 
     Optional<GroupInvite> findByInviteCode(UUID inviteCode);
+
+    Optional<GroupInvite> findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+            Group group,
+            GroupInvite.InviteStatus status,
+            OffsetDateTime now
+    );
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -102,7 +102,7 @@ public class GroupService {
 
     @Transactional
     public GroupInviteInfo createInviteCode(Long groupId, UUID userId) {
-        Group group = groupRepository.findById(groupId)
+        Group group = groupRepository.findByIdForUpdate(groupId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
 
         if (group.isHomeGroup()) {

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -143,7 +143,6 @@ public class GroupService {
         OffsetDateTime now = OffsetDateTime.now();
 
         if (invite.isExpired(now)) {
-            invite.expire();
             throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
         }
 

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -122,10 +122,17 @@ public class GroupService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        GroupInvite invite = GroupInvite.create(group, user);
-        GroupInvite saved = groupInviteRepository.save(invite);
+        OffsetDateTime now = OffsetDateTime.now();
 
-        return GroupInviteInfo.from(saved);
+        GroupInvite invite = groupInviteRepository
+                .findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                        group,
+                        GroupInvite.InviteStatus.PENDING,
+                        now
+                )
+                .orElseGet(() -> groupInviteRepository.save(GroupInvite.create(group, user)));
+
+        return GroupInviteInfo.from(invite);
     }
 
     @Transactional
@@ -135,16 +142,9 @@ public class GroupService {
 
         OffsetDateTime now = OffsetDateTime.now();
 
-        if (invite.getExpiredAt().isBefore(now)) {
+        if (invite.isExpired(now)) {
+            invite.expire();
             throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
-        }
-
-        if (invite.getStatus() == GroupInvite.InviteStatus.EXPIRED) {
-            throw new BusinessException(ErrorCode.GROUP_INVITE_EXPIRED);
-        }
-
-        if (invite.getStatus() == GroupInvite.InviteStatus.ACCEPTED) {
-            throw new BusinessException(ErrorCode.GROUP_INVITE_ALREADY_USED);
         }
 
         User user = getUserForMembershipTransition(userId);
@@ -185,14 +185,12 @@ public class GroupService {
 
         if (targetMembership != null) {
             targetMembership.activate();
-            invite.markAccepted();
             return GroupMemberInfo.from(targetMembership);
         }
 
         GroupMember newMember = GroupMember.createMember(user, targetGroup);
         groupMemberRepository.save(newMember);
 
-        invite.markAccepted();
         return GroupMemberInfo.from(newMember);
     }
 

--- a/src/main/java/com/solv/wefin/domain/payment/dto/PaymentLockedInfo.java
+++ b/src/main/java/com/solv/wefin/domain/payment/dto/PaymentLockedInfo.java
@@ -1,0 +1,4 @@
+package com.solv.wefin.domain.payment.dto;
+
+public record PaymentLockedInfo(Long paymentId) {
+}

--- a/src/main/java/com/solv/wefin/domain/payment/entity/Payment.java
+++ b/src/main/java/com/solv/wefin/domain/payment/entity/Payment.java
@@ -104,9 +104,10 @@ public class Payment extends BaseEntity {
         this.failureReason = failureReason;
     }
 
-    public void markCanceled() {
+    public void markCanceled(String failureReason) {
         this.status = PaymentStatus.CANCELED;
         this.failedAt = OffsetDateTime.now();
+        this.failureReason = failureReason;
     }
 
     public boolean isReady() {

--- a/src/main/java/com/solv/wefin/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/solv/wefin/domain/payment/repository/PaymentRepository.java
@@ -21,6 +21,9 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Payment> findWithLockByOrderIdAndUserUserId(String orderId, UUID userId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Payment> findWithLockByPaymentId(Long paymentId);
+
     // 같은 사용자 / 같은 플랜의 기존 READY결제 재사용 여부 확인
     Optional<Payment> findTopByUserUserIdAndPlanPlanIdAndProviderAndStatusOrderByRequestedAtDesc(
             UUID userId,

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentConfirmWriter.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentConfirmWriter.java
@@ -12,6 +12,7 @@ import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -77,7 +78,8 @@ public class PaymentConfirmWriter {
             String errorCode,
             String errorMessage
     ) {
-        Payment payment = getPayment(paymentId);
+        Payment payment = paymentRepository.findWithLockByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         if (!payment.isPaid()) {
             payment.markFailed("TOSS_API_ERROR");
@@ -103,7 +105,8 @@ public class PaymentConfirmWriter {
             String errorCode,
             String errorMessage
     ) {
-        Payment payment = getPayment(paymentId);
+        Payment payment = paymentRepository.findWithLockByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         if (!payment.isPaid()) {
             payment.markFailed(failureReason);
@@ -129,7 +132,8 @@ public class PaymentConfirmWriter {
             String errorCode,
             String errorMessage
     ) {
-        Payment payment = getPayment(paymentId);
+        Payment payment = paymentRepository.findWithLockByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         if (!payment.isPaid()) {
             payment.markCanceled(failureReason);
@@ -153,7 +157,8 @@ public class PaymentConfirmWriter {
             String paymentKey,
             TossPaymentConfirmResult result
     ) {
-        Payment payment = getPayment(paymentId);
+        Payment payment = paymentRepository.findWithLockByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         if (payment.isPaid()) {
             throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CONFIRMED);
@@ -188,9 +193,13 @@ public class PaymentConfirmWriter {
         );
 
         paymentRepository.save(payment);
-        Subscription savedSubscription = subscriptionRepository.save(subscription);
 
-        return PaymentConfirmInfo.from(payment, savedSubscription);
+        try {
+            Subscription savedSubscription = subscriptionRepository.save(subscription);
+            return PaymentConfirmInfo.from(payment, savedSubscription);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
+        }
     }
 
     @Transactional
@@ -199,7 +208,8 @@ public class PaymentConfirmWriter {
             String paymentKey,
             String errorMessage
     ) {
-        Payment payment = getPayment(paymentId);
+        Payment payment = paymentRepository.findWithLockByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         paymentFailureLogWriter.save(
                 payment,
@@ -218,7 +228,8 @@ public class PaymentConfirmWriter {
             String paymentKey,
             String errorMessage
     ) {
-        Payment payment = getPayment(paymentId);
+        Payment payment = paymentRepository.findWithLockByPaymentId(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         paymentFailureLogWriter.save(
                 payment,
@@ -229,11 +240,6 @@ public class PaymentConfirmWriter {
                 ErrorCode.PAYMENT_CANCEL_FAILED.name(),
                 errorMessage
         );
-    }
-
-    private Payment getPayment(Long paymentId) {
-        return paymentRepository.findById(paymentId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
     }
 
     private OffsetDateTime calculateExpiredAt(

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentConfirmWriter.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentConfirmWriter.java
@@ -1,12 +1,23 @@
 package com.solv.wefin.domain.payment.service;
 
+import com.solv.wefin.domain.payment.dto.PaymentConfirmInfo;
+import com.solv.wefin.domain.payment.dto.PaymentLockedInfo;
+import com.solv.wefin.domain.payment.dto.TossPaymentConfirmResult;
+import com.solv.wefin.domain.payment.entity.BillingCycle;
 import com.solv.wefin.domain.payment.entity.Payment;
 import com.solv.wefin.domain.payment.entity.Subscription;
+import com.solv.wefin.domain.payment.entity.SubscriptionStatus;
 import com.solv.wefin.domain.payment.repository.PaymentRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -14,18 +25,224 @@ public class PaymentConfirmWriter {
 
     private final PaymentRepository paymentRepository;
     private final SubscriptionRepository subscriptionRepository;
+    private final PaymentFailureLogWriter paymentFailureLogWriter;
 
     @Transactional
-    public Subscription savePaidPaymentAndSubscription(
-            Payment payment,
-            Subscription subscription
+    public PaymentLockedInfo loadAndValidateReadyPayment(
+            UUID userId,
+            String orderId,
+            BigDecimal amount,
+            String paymentKey
     ) {
-        paymentRepository.save(payment);
+        Payment payment = paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
-        if (subscription == null) {
-            return null;
+        if (payment.isPaid()) {
+            throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CONFIRMED);
         }
 
-        return subscriptionRepository.save(subscription);
+        if (!payment.isReady()) {
+            paymentFailureLogWriter.save(
+                    payment,
+                    payment.getUser(),
+                    orderId,
+                    paymentKey,
+                    "PRE_CONFIRM_VALIDATION",
+                    ErrorCode.PAYMENT_NOT_READY.name(),
+                    ErrorCode.PAYMENT_NOT_READY.getMessage()
+            );
+            throw new BusinessException(ErrorCode.PAYMENT_NOT_READY);
+        }
+
+        if (payment.getAmount().compareTo(amount) != 0) {
+            throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+        }
+
+        boolean hasActiveSubscription = subscriptionRepository.existsByUserUserIdAndStatus(
+                userId,
+                SubscriptionStatus.ACTIVE
+        );
+
+        if (hasActiveSubscription) {
+            throw new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
+        }
+
+        return new PaymentLockedInfo(payment.getPaymentId());
+    }
+
+    @Transactional
+    public void saveFailedAfterConfirmApiError(
+            Long paymentId,
+            String paymentKey,
+            String errorCode,
+            String errorMessage
+    ) {
+        Payment payment = getPayment(paymentId);
+
+        if (!payment.isPaid()) {
+            payment.markFailed("TOSS_API_ERROR");
+            paymentRepository.save(payment);
+        }
+
+        paymentFailureLogWriter.save(
+                payment,
+                payment.getUser(),
+                payment.getOrderId(),
+                paymentKey,
+                "CONFIRM_API",
+                errorCode,
+                errorMessage
+        );
+    }
+
+    @Transactional
+    public void saveFailedAfterConfirmResult(
+            Long paymentId,
+            String paymentKey,
+            String failureReason,
+            String errorCode,
+            String errorMessage
+    ) {
+        Payment payment = getPayment(paymentId);
+
+        if (!payment.isPaid()) {
+            payment.markFailed(failureReason);
+            paymentRepository.save(payment);
+        }
+
+        paymentFailureLogWriter.save(
+                payment,
+                payment.getUser(),
+                payment.getOrderId(),
+                paymentKey,
+                "CONFIRM_RESULT",
+                errorCode,
+                errorMessage
+        );
+    }
+
+    @Transactional
+    public void saveCanceledAfterConfirmResult(
+            Long paymentId,
+            String paymentKey,
+            String failureReason,
+            String errorCode,
+            String errorMessage
+    ) {
+        Payment payment = getPayment(paymentId);
+
+        if (!payment.isPaid()) {
+            payment.markCanceled(failureReason);
+            paymentRepository.save(payment);
+        }
+
+        paymentFailureLogWriter.save(
+                payment,
+                payment.getUser(),
+                payment.getOrderId(),
+                paymentKey,
+                "CONFIRM_RESULT",
+                errorCode,
+                errorMessage
+        );
+    }
+
+    @Transactional
+    public PaymentConfirmInfo saveConfirmedPayment(
+            Long paymentId,
+            String paymentKey,
+            TossPaymentConfirmResult result
+    ) {
+        Payment payment = getPayment(paymentId);
+
+        if (payment.isPaid()) {
+            throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CONFIRMED);
+        }
+
+        if (!payment.isReady()) {
+            throw new BusinessException(ErrorCode.PAYMENT_NOT_READY);
+        }
+
+        boolean hasActiveSubscription = subscriptionRepository.existsByUserUserIdAndStatus(
+                payment.getUser().getUserId(),
+                SubscriptionStatus.ACTIVE
+        );
+
+        if (hasActiveSubscription) {
+            throw new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
+        }
+
+        payment.markPaid(paymentKey, result.approvedAt());
+
+        OffsetDateTime startedAt = OffsetDateTime.now();
+        OffsetDateTime expiredAt = calculateExpiredAt(
+                startedAt,
+                payment.getPlan().getBillingCycle()
+        );
+
+        Subscription subscription = Subscription.createActive(
+                payment.getPlan(),
+                payment.getUser(),
+                startedAt,
+                expiredAt
+        );
+
+        paymentRepository.save(payment);
+        Subscription savedSubscription = subscriptionRepository.save(subscription);
+
+        return PaymentConfirmInfo.from(payment, savedSubscription);
+    }
+
+    @Transactional
+    public void saveFailureAfterConfirmSaveError(
+            Long paymentId,
+            String paymentKey,
+            String errorMessage
+    ) {
+        Payment payment = getPayment(paymentId);
+
+        paymentFailureLogWriter.save(
+                payment,
+                payment.getUser(),
+                payment.getOrderId(),
+                paymentKey,
+                "SAVE_AFTER_CONFIRM",
+                ErrorCode.INTERNAL_SERVER_ERROR.name(),
+                errorMessage
+        );
+    }
+
+    @Transactional
+    public void saveCancelFailureLog(
+            Long paymentId,
+            String paymentKey,
+            String errorMessage
+    ) {
+        Payment payment = getPayment(paymentId);
+
+        paymentFailureLogWriter.save(
+                payment,
+                payment.getUser(),
+                payment.getOrderId(),
+                paymentKey,
+                "CANCEL_AFTER_CONFIRM",
+                ErrorCode.PAYMENT_CANCEL_FAILED.name(),
+                errorMessage
+        );
+    }
+
+    private Payment getPayment(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    private OffsetDateTime calculateExpiredAt(
+            OffsetDateTime startedAt,
+            BillingCycle billingCycle
+    ) {
+        return switch (billingCycle) {
+            case MONTHLY -> startedAt.plusMonths(1);
+            case YEARLY -> startedAt.plusYears(1);
+        };
     }
 }

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -32,7 +31,6 @@ public class PaymentService {
     private final PaymentWriter paymentWriter;
     private final PaymentConfirmWriter paymentConfirmWriter;
     private final TossPaymentClient tossPaymentClient;
-    private final PaymentFailureLogWriter paymentFailureLogWriter;
 
     @Transactional
     public PaymentReadyInfo createPayment(UUID userId, CreatePaymentCommand command) {
@@ -80,56 +78,28 @@ public class PaymentService {
             String orderId,
             BigDecimal amount
     ) {
-        Payment payment = paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
-
-        if (payment.isPaid()) {
-            throw new BusinessException(ErrorCode.PAYMENT_ALREADY_CONFIRMED);
-        }
-
-        if (!payment.isReady()) {
-            paymentFailureLogWriter.save(
-                    payment,
-                    payment.getUser(),
-                    orderId,
-                    paymentKey,
-                    "PRE_CONFIRM_VALIDATION",
-                    ErrorCode.PAYMENT_NOT_READY.name(),
-                    ErrorCode.PAYMENT_NOT_READY.getMessage()
-            );
-            throw new BusinessException(ErrorCode.PAYMENT_NOT_READY);
-        }
-
-        if (payment.getAmount().compareTo(amount) != 0) {
-            throw new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
-        }
-
-        boolean hasActiveSubscription = subscriptionRepository.existsByUserUserIdAndStatus(
-                userId,
-                SubscriptionStatus.ACTIVE
-        );
-
-        if (hasActiveSubscription) {
-            throw new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
-        }
+        PaymentLockedInfo lockedInfo =
+                paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey);
 
         TossPaymentConfirmResult result;
 
+        log.info("confirm API 진입 userId={}, orderId={}", userId, orderId);
+
         try {
+            log.info("confirm start: paymentKey={}, orderId={}, amount={}", paymentKey, orderId, amount);
+
             result = tossPaymentClient.confirm(
                     paymentKey,
                     orderId,
                     amount
             );
+
+            log.info("confirm success: result={}", result);
+
         } catch (BusinessException e) {
-            payment.markFailed("TOSS_API_ERROR");
-            paymentConfirmWriter.savePaidPaymentAndSubscription(payment, null);
-            paymentFailureLogWriter.save(
-                    payment,
-                    payment.getUser(),
-                    orderId,
+            paymentConfirmWriter.saveFailedAfterConfirmApiError(
+                    lockedInfo.paymentId(),
                     paymentKey,
-                    "CONFIRM_API",
                     e.getErrorCode().name(),
                     e.getMessage()
             );
@@ -137,14 +107,10 @@ public class PaymentService {
         }
 
         if (result.status() == TossPaymentStatus.FAILED) {
-            payment.markFailed("TOSS_FAILED");
-            paymentConfirmWriter.savePaidPaymentAndSubscription(payment, null);
-            paymentFailureLogWriter.save(
-                    payment,
-                    payment.getUser(),
-                    orderId,
+            paymentConfirmWriter.saveFailedAfterConfirmResult(
+                    lockedInfo.paymentId(),
                     paymentKey,
-                    "CONFIRM_RESULT",
+                    "TOSS_FAILED",
                     ErrorCode.PAYMENT_CONFIRM_FAILED.name(),
                     "Toss payment status is FAILED"
             );
@@ -152,47 +118,28 @@ public class PaymentService {
         }
 
         if (result.status() == TossPaymentStatus.CANCELED) {
-            payment.markCanceled();
-            paymentConfirmWriter.savePaidPaymentAndSubscription(payment, null);
-            paymentFailureLogWriter.save(
-                    payment,
-                    payment.getUser(),
-                    orderId,
+            paymentConfirmWriter.saveCanceledAfterConfirmResult(
+                    lockedInfo.paymentId(),
                     paymentKey,
-                    "CONFIRM_RESULT",
+                    "TOSS_CANCELED",
                     ErrorCode.PAYMENT_CANCELED.name(),
                     "Toss payment status is CANCELED"
             );
             throw new BusinessException(ErrorCode.PAYMENT_CANCELED);
         }
 
-        payment.markPaid(result.paymentKey(), result.approvedAt());
-
-        OffsetDateTime startedAt = OffsetDateTime.now();
-        OffsetDateTime expiredAt = calculateExpiredAt(
-                startedAt,
-                payment.getPlan().getBillingCycle()
-        );
-
-        Subscription subscription = Subscription.createActive(
-                payment.getPlan(),
-                payment.getUser(),
-                startedAt,
-                expiredAt
-        );
-
-        Subscription savedSubscription;
         try {
-            savedSubscription =
-                    paymentConfirmWriter.savePaidPaymentAndSubscription(payment, subscription);
-        } catch (Exception e) {
-            paymentFailureLogWriter.save(
-                    payment,
-                    payment.getUser(),
-                    orderId,
+            return paymentConfirmWriter.saveConfirmedPayment(
+                    lockedInfo.paymentId(),
                     paymentKey,
-                    "SAVE_AFTER_CONFIRM",
-                    ErrorCode.INTERNAL_SERVER_ERROR.name(),
+                    result
+            );
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            paymentConfirmWriter.saveFailureAfterConfirmSaveError(
+                    lockedInfo.paymentId(),
+                    paymentKey,
                     e.getMessage()
             );
 
@@ -201,20 +148,14 @@ public class PaymentService {
             } catch (Exception cancelException) {
                 log.error("Payment cancel failed after confirm success. paymentKey={}", result.paymentKey(), cancelException);
 
-                paymentFailureLogWriter.save(
-                        payment,
-                        payment.getUser(),
-                        orderId,
+                paymentConfirmWriter.saveCancelFailureLog(
+                        lockedInfo.paymentId(),
                         paymentKey,
-                        "CANCEL_AFTER_CONFIRM",
-                        ErrorCode.PAYMENT_CANCEL_FAILED.name(),
                         cancelException.getMessage()
                 );
             }
             throw e;
         }
-
-        return PaymentConfirmInfo.from(payment, savedSubscription);
     }
 
     @Transactional(readOnly = true)
@@ -256,15 +197,5 @@ public class PaymentService {
         }
 
         throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-    }
-
-    private OffsetDateTime calculateExpiredAt(
-            OffsetDateTime startedAt,
-            BillingCycle billingCycle
-    ) {
-        return switch (billingCycle) {
-            case MONTHLY -> startedAt.plusMonths(1);
-            case YEARLY -> startedAt.plusYears(1);
-        };
     }
 }

--- a/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/solv/wefin/domain/payment/service/PaymentService.java
@@ -83,10 +83,8 @@ public class PaymentService {
 
         TossPaymentConfirmResult result;
 
-        log.info("confirm API 진입 userId={}, orderId={}", userId, orderId);
-
         try {
-            log.info("confirm start: paymentKey={}, orderId={}, amount={}", paymentKey, orderId, amount);
+            log.info("confirm start: orderId={}, amount={}", orderId, amount);
 
             result = tossPaymentClient.confirm(
                     paymentKey,
@@ -94,7 +92,12 @@ public class PaymentService {
                     amount
             );
 
-            log.info("confirm success: result={}", result);
+            log.info(
+                    "confirm success: orderId={}, status={}, approvedAt={}",
+                    result.orderId(),
+                    result.status(),
+                    result.approvedAt()
+            );
 
         } catch (BusinessException e) {
             paymentConfirmWriter.saveFailedAfterConfirmApiError(

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -18,7 +18,6 @@ public enum ErrorCode {
     GROUP_INVITE_FORBIDDEN(403, "해당 그룹의 초대 코드를 생성할 권한이 없습니다."),
     GROUP_INVITE_NOT_FOUND(404, "초대 코드를 찾을 수 없습니다."),
     GROUP_INVITE_EXPIRED(400, "만료된 초대 코드입니다."),
-    GROUP_INVITE_ALREADY_USED(400, "이미 사용된 초대 코드입니다."),
     GROUP_FULL(400, "그룹 인원이 가득 찼습니다."),
     GROUP_ALREADY_JOINED(409, "이미 참여한 그룹입니다."),
     GROUP_HOME_INVITE_NOT_ALLOWED(400, "홈 그룹에는 초대 코드를 생성할 수 없습니다."),

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
@@ -78,7 +78,7 @@ class GroupInviteServiceTest {
                     GroupInvite.InviteStatus.PENDING
             );
 
-            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
             when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -103,7 +103,7 @@ class GroupInviteServiceTest {
                     () -> assertThat(result.expiredAt()).isNotNull()
             );
 
-            verify(groupRepository).findById(1L);
+            verify(groupRepository).findByIdForUpdate(1L);
             verify(groupMemberRepository).existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -139,7 +139,7 @@ class GroupInviteServiceTest {
                     GroupInvite.InviteStatus.PENDING
             );
 
-            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
             when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -163,7 +163,7 @@ class GroupInviteServiceTest {
                     () -> assertThat(result.expiredAt()).isNotNull()
             );
 
-            verify(groupRepository).findById(1L);
+            verify(groupRepository).findByIdForUpdate(1L);
             verify(groupMemberRepository).existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -184,7 +184,7 @@ class GroupInviteServiceTest {
             UUID userId = UUID.randomUUID();
             Group homeGroup = createGroup(1L, "리더의 그룹", GroupType.HOME);
 
-            when(groupRepository.findById(1L)).thenReturn(Optional.of(homeGroup));
+            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(homeGroup));
 
             BusinessException exception = assertThrows(
                     BusinessException.class,
@@ -206,7 +206,7 @@ class GroupInviteServiceTest {
             UUID userId = UUID.randomUUID();
             Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
 
-            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
             when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -28,7 +29,8 @@ import static com.solv.wefin.domain.group.service.support.GroupTestFixtures.crea
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.any;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -56,9 +58,8 @@ class GroupInviteServiceTest {
     class CreateInviteCodeTest {
 
         @Test
-        @DisplayName("공유 그룹의 ACTIVE 멤버면 초대 코드를 생성한다")
-        void createInviteCode_success() throws Exception {
-            // given
+        @DisplayName("유효한 초대 코드가 없으면 새 초대 코드를 생성한다")
+        void createInviteCode_success_create_new_invite() throws Exception {
             UUID userId = UUID.randomUUID();
 
             Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
@@ -69,7 +70,7 @@ class GroupInviteServiceTest {
                     "encoded-password"
             );
 
-            GroupInvite invite = createGroupInvite(
+            GroupInvite savedInvite = createGroupInvite(
                     10L,
                     group,
                     user,
@@ -83,18 +84,21 @@ class GroupInviteServiceTest {
                     group,
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(true);
-            when(userRepository.findById(userId))
-                    .thenReturn(Optional.of(user));
-            when(groupInviteRepository.save(any(GroupInvite.class))).thenReturn(invite);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(groupInviteRepository.findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            )).thenReturn(Optional.empty());
+            when(groupInviteRepository.save(any(GroupInvite.class))).thenReturn(savedInvite);
 
-            // when
             GroupInviteInfo result = groupService.createInviteCode(1L, userId);
 
-            // then
             assertAll(
                     () -> assertThat(result.codeId()).isEqualTo(10L),
                     () -> assertThat(result.groupId()).isEqualTo(1L),
-                    () -> assertThat(result.inviteCode()).isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")),
+                    () -> assertThat(result.inviteCode())
+                            .isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")),
                     () -> assertThat(result.status()).isEqualTo(GroupInvite.InviteStatus.PENDING),
                     () -> assertThat(result.expiredAt()).isNotNull()
             );
@@ -106,35 +110,99 @@ class GroupInviteServiceTest {
                     GroupMember.GroupMemberStatus.ACTIVE
             );
             verify(userRepository).findById(userId);
+            verify(groupInviteRepository).findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            );
             verify(groupInviteRepository).save(any(GroupInvite.class));
+        }
+
+        @Test
+        @DisplayName("유효한 기존 초대 코드가 있으면 재사용한다")
+        void createInviteCode_success_reuse_existing_invite() throws Exception {
+            UUID userId = UUID.randomUUID();
+
+            Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
+            var user = createUser(
+                    userId,
+                    "leader@test.com",
+                    "리더",
+                    "encoded-password"
+            );
+
+            GroupInvite existingInvite = createGroupInvite(
+                    10L,
+                    group,
+                    user,
+                    UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                    GroupInvite.InviteStatus.PENDING
+            );
+
+            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
+            when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                    userId,
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(true);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(groupInviteRepository.findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            )).thenReturn(Optional.of(existingInvite));
+
+            GroupInviteInfo result = groupService.createInviteCode(1L, userId);
+
+            assertAll(
+                    () -> assertThat(result.codeId()).isEqualTo(10L),
+                    () -> assertThat(result.groupId()).isEqualTo(1L),
+                    () -> assertThat(result.inviteCode())
+                            .isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")),
+                    () -> assertThat(result.status()).isEqualTo(GroupInvite.InviteStatus.PENDING),
+                    () -> assertThat(result.expiredAt()).isNotNull()
+            );
+
+            verify(groupRepository).findById(1L);
+            verify(groupMemberRepository).existsByUser_UserIdAndGroupAndStatus(
+                    userId,
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+            verify(userRepository).findById(userId);
+            verify(groupInviteRepository).findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            );
+            verify(groupInviteRepository, never()).save(any(GroupInvite.class));
         }
 
         @Test
         @DisplayName("홈 그룹이면 초대 코드 생성이 불가하다")
         void createInviteCode_fail_when_home_group() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             Group homeGroup = createGroup(1L, "리더의 그룹", GroupType.HOME);
 
             when(groupRepository.findById(1L)).thenReturn(Optional.of(homeGroup));
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.createInviteCode(1L, userId)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
             verify(groupMemberRepository, never()).existsByUser_UserIdAndGroupAndStatus(any(), any(), any());
             verify(userRepository, never()).findById(any());
+            verify(groupInviteRepository, never()).findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    any(), any(), any()
+            );
             verify(groupInviteRepository, never()).save(any());
         }
 
         @Test
         @DisplayName("공유 그룹의 ACTIVE 멤버가 아니면 예외가 발생한다")
         void createInviteCode_fail_when_not_member() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
 
@@ -145,15 +213,16 @@ class GroupInviteServiceTest {
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(false);
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.createInviteCode(1L, userId)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_FORBIDDEN);
             verify(userRepository, never()).findById(any());
+            verify(groupInviteRepository, never()).findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    any(), any(), any()
+            );
             verify(groupInviteRepository, never()).save(any());
         }
     }

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupJoinServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupJoinServiceTest.java
@@ -19,7 +19,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -61,7 +60,6 @@ class GroupJoinServiceTest {
         @Test
         @DisplayName("초대 코드로 SHARED 그룹에 정상 참여한다")
         void joinGroup_success() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
@@ -113,16 +111,14 @@ class GroupJoinServiceTest {
             when(groupMemberRepository.save(any(GroupMember.class)))
                     .thenReturn(newMember);
 
-            // when
             GroupMemberInfo result = groupService.joinGroup(userId, inviteCode);
 
-            // then
             assertAll(
                     () -> assertThat(result.groupId()).isEqualTo(1L),
                     () -> assertThat(result.groupName()).isEqualTo("공유 그룹"),
                     () -> assertThat(result.role()).isEqualTo("MEMBER"),
                     () -> assertThat(currentActiveHomeMember.isActive()).isFalse(),
-                    () -> assertThat(invite.getStatus()).isEqualTo(GroupInvite.InviteStatus.ACCEPTED)
+                    () -> assertThat(invite.getStatus()).isEqualTo(GroupInvite.InviteStatus.PENDING)
             );
 
             verify(groupMemberRepository).flush();
@@ -132,7 +128,6 @@ class GroupJoinServiceTest {
         @Test
         @DisplayName("기존 멤버십이 있으면 재활성화한다")
         void joinGroup_success_when_membership_exists() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
@@ -182,17 +177,15 @@ class GroupJoinServiceTest {
             when(groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, targetGroup.getId()))
                     .thenReturn(Optional.of(existingMembership));
 
-            // when
             GroupMemberInfo result = groupService.joinGroup(userId, inviteCode);
 
-            // then
             assertAll(
                     () -> assertThat(result.groupId()).isEqualTo(1L),
                     () -> assertThat(result.groupName()).isEqualTo("공유 그룹"),
                     () -> assertThat(result.role()).isEqualTo("MEMBER"),
                     () -> assertThat(currentActiveHomeMember.isActive()).isFalse(),
                     () -> assertThat(existingMembership.isActive()).isTrue(),
-                    () -> assertThat(invite.getStatus()).isEqualTo(GroupInvite.InviteStatus.ACCEPTED)
+                    () -> assertThat(invite.getStatus()).isEqualTo(GroupInvite.InviteStatus.PENDING)
             );
 
             verify(groupMemberRepository).flush();
@@ -202,7 +195,6 @@ class GroupJoinServiceTest {
         @Test
         @DisplayName("홈 그룹에는 참여할 수 없다")
         void joinGroup_fail_when_home_group() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
@@ -224,13 +216,11 @@ class GroupJoinServiceTest {
             when(groupRepository.findByIdForUpdate(homeGroup.getId()))
                     .thenReturn(Optional.of(homeGroup));
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.joinGroup(userId, inviteCode)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_HOME_JOIN_NOT_ALLOWED);
 
             verify(groupMemberRepository, never()).findByUser_UserIdAndStatus(any(), any());
@@ -243,7 +233,6 @@ class GroupJoinServiceTest {
         @Test
         @DisplayName("이미 같은 그룹에 ACTIVE 상태로 참여 중이면 예외가 발생한다")
         void joinGroup_fail_when_already_joined() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
@@ -277,13 +266,11 @@ class GroupJoinServiceTest {
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(Optional.of(currentActiveMember));
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.joinGroup(userId, inviteCode)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_ALREADY_JOINED);
 
             verify(groupMemberRepository, never()).countByGroupAndStatus(any(), any());
@@ -295,7 +282,6 @@ class GroupJoinServiceTest {
         @Test
         @DisplayName("정원이 가득 찬 그룹은 참여할 수 없다")
         void joinGroup_fail_when_group_full() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
@@ -335,13 +321,11 @@ class GroupJoinServiceTest {
                     GroupMember.GroupMemberStatus.ACTIVE
             )).thenReturn(6L);
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.joinGroup(userId, inviteCode)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_FULL);
 
             verify(groupMemberRepository, never()).findByUser_UserIdAndGroup_Id(any(), anyLong());
@@ -352,7 +336,6 @@ class GroupJoinServiceTest {
         @Test
         @DisplayName("만료된 초대 코드는 사용할 수 없다")
         void joinGroup_fail_when_invite_expired() throws Exception {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
@@ -372,67 +355,29 @@ class GroupJoinServiceTest {
             when(groupInviteRepository.findByInviteCode(inviteCode))
                     .thenReturn(Optional.of(invite));
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.joinGroup(userId, inviteCode)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_EXPIRED);
-            verify(groupMemberRepository, never()).flush();
-        }
-
-        @Test
-        @DisplayName("이미 사용된 초대 코드는 사용할 수 없다")
-        void joinGroup_fail_when_invite_already_used() throws Exception {
-            // given
-            UUID userId = UUID.randomUUID();
-            UUID inviteCode = UUID.randomUUID();
-
-            Group targetGroup = createGroup(1L, "공유 그룹", GroupType.SHARED);
-            var user = createUser(userId, "test@test.com", "유저", "pw");
-
-            GroupInvite invite = createGroupInvite(
-                    10L,
-                    targetGroup,
-                    user,
-                    inviteCode,
-                    GroupInvite.InviteStatus.PENDING
-            );
-            invite.markAccepted();
-
-            when(groupInviteRepository.findByInviteCode(inviteCode))
-                    .thenReturn(Optional.of(invite));
-
-            // when
-            BusinessException exception = assertThrows(
-                    BusinessException.class,
-                    () -> groupService.joinGroup(userId, inviteCode)
-            );
-
-            // then
-            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_ALREADY_USED);
             verify(groupMemberRepository, never()).flush();
         }
 
         @Test
         @DisplayName("존재하지 않는 초대 코드는 예외가 발생한다")
         void joinGroup_fail_when_invite_not_found() {
-            // given
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
 
             when(groupInviteRepository.findByInviteCode(inviteCode))
                     .thenReturn(Optional.empty());
 
-            // when
             BusinessException exception = assertThrows(
                     BusinessException.class,
                     () -> groupService.joinGroup(userId, inviteCode)
             );
 
-            // then
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_NOT_FOUND);
             verify(groupMemberRepository, never()).flush();
         }

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupJoinServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupJoinServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -334,7 +335,7 @@ class GroupJoinServiceTest {
         }
 
         @Test
-        @DisplayName("만료된 초대 코드는 사용할 수 없다")
+        @DisplayName("expiredAt이 지난 초대 코드는 사용할 수 없다")
         void joinGroup_fail_when_invite_expired() throws Exception {
             UUID userId = UUID.randomUUID();
             UUID inviteCode = UUID.randomUUID();
@@ -347,10 +348,9 @@ class GroupJoinServiceTest {
                     targetGroup,
                     user,
                     inviteCode,
-                    GroupInvite.InviteStatus.PENDING
+                    GroupInvite.InviteStatus.PENDING,
+                    OffsetDateTime.now().minusHours(1)
             );
-
-            invite.expire();
 
             when(groupInviteRepository.findByInviteCode(inviteCode))
                     .thenReturn(Optional.of(invite));

--- a/src/test/java/com/solv/wefin/domain/group/service/support/GroupTestFixtures.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/support/GroupTestFixtures.java
@@ -70,6 +70,24 @@ public final class GroupTestFixtures {
             UUID inviteCode,
             GroupInvite.InviteStatus status
     ) throws Exception {
+        return createGroupInvite(
+                id,
+                group,
+                createdBy,
+                inviteCode,
+                status,
+                OffsetDateTime.now().plusHours(24)
+        );
+    }
+
+    public static GroupInvite createGroupInvite(
+            Long id,
+            Group group,
+            User createdBy,
+            UUID inviteCode,
+            GroupInvite.InviteStatus status,
+            OffsetDateTime expiredAt
+    ) throws Exception {
         Constructor<GroupInvite> constructor = GroupInvite.class.getDeclaredConstructor(
                 Group.class,
                 User.class,
@@ -84,7 +102,7 @@ public final class GroupTestFixtures {
                 createdBy,
                 inviteCode,
                 status,
-                OffsetDateTime.now().plusHours(24)
+                expiredAt
         );
 
         Field idField = GroupInvite.class.getDeclaredField("id");

--- a/src/test/java/com/solv/wefin/domain/payment/PaymentConfirmServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/payment/PaymentConfirmServiceTest.java
@@ -1,12 +1,18 @@
 package com.solv.wefin.domain.payment;
 
-import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.payment.dto.PaymentConfirmInfo;
+import com.solv.wefin.domain.payment.dto.PaymentLockedInfo;
 import com.solv.wefin.domain.payment.dto.TossPaymentConfirmResult;
-import com.solv.wefin.domain.payment.entity.*;
+import com.solv.wefin.domain.payment.entity.PaymentProvider;
+import com.solv.wefin.domain.payment.entity.TossPaymentStatus;
 import com.solv.wefin.domain.payment.repository.PaymentRepository;
+import com.solv.wefin.domain.payment.repository.SubscriptionPlanRepository;
 import com.solv.wefin.domain.payment.repository.SubscriptionRepository;
-import com.solv.wefin.domain.payment.service.*;
+import com.solv.wefin.domain.payment.service.PaymentConfirmWriter;
+import com.solv.wefin.domain.payment.service.PaymentService;
+import com.solv.wefin.domain.payment.service.PaymentWriter;
+import com.solv.wefin.domain.payment.service.TossPaymentClient;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,13 +25,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -36,13 +39,19 @@ class PaymentConfirmServiceTest {
     private PaymentRepository paymentRepository;
 
     @Mock
+    private SubscriptionPlanRepository subscriptionPlanRepository;
+
+    @Mock
     private SubscriptionRepository subscriptionRepository;
 
     @Mock
-    private PaymentConfirmWriter paymentConfirmWriter;
+    private UserRepository userRepository;
 
     @Mock
-    private PaymentFailureLogWriter paymentFailureLogWriter;
+    private PaymentWriter paymentWriter;
+
+    @Mock
+    private PaymentConfirmWriter paymentConfirmWriter;
 
     @Mock
     private TossPaymentClient tossPaymentClient;
@@ -58,28 +67,31 @@ class PaymentConfirmServiceTest {
     }
 
     @Test
-    @DisplayName("결제 승인 성공 시 결제 상태를 PAID로 변경하고 활성 구독을 생성한다")
+    @DisplayName("결제 승인 성공 시 승인 결과를 반환한다")
     void confirmPayment_success() {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-20260414-12345";
         BigDecimal amount = new BigDecimal("9900");
-
-        Payment payment = mock(Payment.class);
-        SubscriptionPlan confirmPlan = mock(SubscriptionPlan.class);
-        User confirmUser = mock(User.class);
-        Subscription savedSubscription = mock(Subscription.class);
-
+        Long paymentId = 100L;
         OffsetDateTime approvedAt = OffsetDateTime.now();
-        OffsetDateTime startedAt = OffsetDateTime.now();
-        OffsetDateTime expiredAt = startedAt.plusMonths(1);
 
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
+        PaymentConfirmInfo expected = new PaymentConfirmInfo(
+                paymentId,
+                orderId,
+                1L,
+                "월간 이용권",
+                "MONTHLY",
+                amount,
+                PaymentProvider.TOSS.name(),
+                "PAID",
+                paymentKey,
+                approvedAt,
+                approvedAt,
+                approvedAt.plusMonths(1)
+        );
 
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(false);
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
 
         given(tossPaymentClient.confirm(paymentKey, orderId, amount))
                 .willReturn(new TossPaymentConfirmResult(
@@ -89,67 +101,51 @@ class PaymentConfirmServiceTest {
                         approvedAt
                 ));
 
-        given(payment.getPlan()).willReturn(confirmPlan);
-        given(payment.getUser()).willReturn(confirmUser);
-        given(confirmPlan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
+        given(paymentConfirmWriter.saveConfirmedPayment(paymentId, paymentKey,
+                new TossPaymentConfirmResult(paymentKey, orderId, TossPaymentStatus.DONE, approvedAt)))
+                .willReturn(expected);
 
-        given(paymentConfirmWriter.savePaidPaymentAndSubscription(eq(payment), any(Subscription.class)))
-                .willReturn(savedSubscription);
+        PaymentConfirmInfo result = paymentService.confirmPayment(userId, paymentKey, orderId, amount);
 
-        given(payment.getPaymentId()).willReturn(100L);
-        given(payment.getOrderId()).willReturn(orderId);
-        given(confirmPlan.getPlanId()).willReturn(1L);
-        given(confirmPlan.getPlanName()).willReturn("월간 이용권");
-        given(payment.getProvider()).willReturn(PaymentProvider.TOSS);
-        given(payment.getStatus()).willReturn(PaymentStatus.PAID);
-        given(payment.getProviderPaymentKey()).willReturn(paymentKey);
-        given(payment.getApprovedAt()).willReturn(approvedAt);
+        assertThat(result).isEqualTo(expected);
 
-        given(savedSubscription.getStartedAt()).willReturn(startedAt);
-        given(savedSubscription.getExpiredAt()).willReturn(expiredAt);
-
-        PaymentConfirmInfo result = paymentService.confirmPayment(
-                userId,
-                paymentKey,
-                orderId,
-                amount
-        );
-
-        assertThat(result.paymentId()).isEqualTo(100L);
-        assertThat(result.orderId()).isEqualTo(orderId);
-        assertThat(result.planId()).isEqualTo(1L);
-        assertThat(result.planName()).isEqualTo("월간 이용권");
-        assertThat(result.billingCycle()).isEqualTo("MONTHLY");
-        assertThat(result.amount()).isEqualByComparingTo("9900");
-        assertThat(result.provider()).isEqualTo("TOSS");
-        assertThat(result.status()).isEqualTo("PAID");
-        assertThat(result.providerPaymentKey()).isEqualTo(paymentKey);
-        assertThat(result.approvedAt()).isEqualTo(approvedAt);
-        assertThat(result.subscriptionStartedAt()).isEqualTo(startedAt);
-        assertThat(result.subscriptionExpiredAt()).isEqualTo(expiredAt);
-
+        verify(paymentConfirmWriter).loadAndValidateReadyPayment(userId, orderId, amount, paymentKey);
         verify(tossPaymentClient).confirm(paymentKey, orderId, amount);
-        verify(payment).markPaid(eq(paymentKey), eq(approvedAt));
-        verify(paymentConfirmWriter).savePaidPaymentAndSubscription(eq(payment), any(Subscription.class));
-        verifyNoInteractions(paymentFailureLogWriter);
+        verify(paymentConfirmWriter).saveConfirmedPayment(
+                eq(paymentId),
+                eq(paymentKey),
+                argThat(r ->
+                        r.paymentKey().equals(paymentKey)
+                                && r.orderId().equals(orderId)
+                                && r.status() == TossPaymentStatus.DONE
+                                && r.approvedAt().equals(approvedAt)
+                )
+        );
+        verify(paymentConfirmWriter, never()).saveFailedAfterConfirmApiError(anyLong(), anyString(), anyString(), anyString());
+        verify(paymentConfirmWriter, never()).saveFailedAfterConfirmResult(anyLong(), anyString(), anyString(), anyString(), anyString());
+        verify(paymentConfirmWriter, never()).saveCanceledAfterConfirmResult(anyLong(), anyString(), anyString(), anyString(), anyString());
+        verify(paymentConfirmWriter, never()).saveFailureAfterConfirmSaveError(anyLong(), anyString(), anyString());
+        verify(paymentConfirmWriter, never()).saveCancelFailureLog(anyLong(), anyString(), anyString());
     }
 
     @Test
-    @DisplayName("orderId에 해당하는 결제가 없으면 PAYMENT_NOT_FOUND 예외가 발생한다")
+    @DisplayName("사전 검증에서 PAYMENT_NOT_FOUND가 발생하면 그대로 예외를 던진다")
     void confirmPayment_fail_whenPaymentNotFound() {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-NOT-FOUND";
         BigDecimal amount = new BigDecimal("9900");
 
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.empty());
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willThrow(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PAYMENT_NOT_FOUND);
 
-        verifyNoInteractions(subscriptionRepository, tossPaymentClient, paymentConfirmWriter);
+        verify(paymentConfirmWriter).loadAndValidateReadyPayment(userId, orderId, amount, paymentKey);
+        verifyNoInteractions(tossPaymentClient);
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
@@ -159,15 +155,17 @@ class PaymentConfirmServiceTest {
         String orderId = "ORDER-20260414-OTHER";
         BigDecimal amount = new BigDecimal("9900");
 
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.empty());
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willThrow(new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PAYMENT_NOT_FOUND);
 
-        verifyNoInteractions(subscriptionRepository, tossPaymentClient, paymentConfirmWriter);
+        verify(paymentConfirmWriter).loadAndValidateReadyPayment(userId, orderId, amount, paymentKey);
+        verifyNoInteractions(tossPaymentClient);
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
@@ -177,28 +175,17 @@ class PaymentConfirmServiceTest {
         String orderId = "ORDER-20260414-12345";
         BigDecimal amount = new BigDecimal("9900");
 
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isReady()).willReturn(false);
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willThrow(new BusinessException(ErrorCode.PAYMENT_NOT_READY));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PAYMENT_NOT_READY);
 
-        verifyNoInteractions(tossPaymentClient, paymentConfirmWriter);
-        verify(subscriptionRepository, never()).existsByUserUserIdAndStatus(any(), any());
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("PRE_CONFIRM_VALIDATION"),
-                eq(ErrorCode.PAYMENT_NOT_READY.name()),
-                eq(ErrorCode.PAYMENT_NOT_READY.getMessage())
-        );
+        verify(paymentConfirmWriter).loadAndValidateReadyPayment(userId, orderId, amount, paymentKey);
+        verifyNoInteractions(tossPaymentClient);
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
@@ -207,12 +194,12 @@ class PaymentConfirmServiceTest {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-20260414-12345";
 
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(new BigDecimal("9900"));
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(
+                userId,
+                orderId,
+                new BigDecimal("10000"),
+                paymentKey
+        )).willThrow(new BusinessException(ErrorCode.PAYMENT_AMOUNT_MISMATCH));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(
                 userId,
@@ -224,8 +211,14 @@ class PaymentConfirmServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
 
-        verifyNoInteractions(tossPaymentClient, paymentConfirmWriter);
-        verify(subscriptionRepository, never()).existsByUserUserIdAndStatus(any(), any());
+        verify(paymentConfirmWriter).loadAndValidateReadyPayment(
+                userId,
+                orderId,
+                new BigDecimal("10000"),
+                paymentKey
+        );
+        verifyNoInteractions(tossPaymentClient);
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
@@ -235,39 +228,29 @@ class PaymentConfirmServiceTest {
         String orderId = "ORDER-20260414-12345";
         BigDecimal amount = new BigDecimal("9900");
 
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(true);
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willThrow(new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
                 .isInstanceOf(BusinessException.class)
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
 
-        verifyNoInteractions(tossPaymentClient, paymentConfirmWriter);
-        verify(payment, never()).markPaid(any(), any());
+        verify(paymentConfirmWriter).loadAndValidateReadyPayment(userId, orderId, amount, paymentKey);
+        verifyNoInteractions(tossPaymentClient);
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
-    @DisplayName("토스 승인에 실패하면 PAYMENT_CONFIRM_FAILED 예외가 발생한다")
-    void confirmPayment_fail_whenTossConfirmFails() {
+    @DisplayName("토스 confirm API에서 예외가 발생하면 실패 저장 후 예외를 다시 던진다")
+    void confirmPayment_fail_whenTossConfirmApiThrows() {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-20260414-12345";
         BigDecimal amount = new BigDecimal("9900");
+        Long paymentId = 100L;
 
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(false);
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
 
         given(tossPaymentClient.confirm(paymentKey, orderId, amount))
                 .willThrow(new BusinessException(ErrorCode.PAYMENT_CONFIRM_FAILED));
@@ -278,58 +261,26 @@ class PaymentConfirmServiceTest {
                 .isEqualTo(ErrorCode.PAYMENT_CONFIRM_FAILED);
 
         verify(tossPaymentClient).confirm(paymentKey, orderId, amount);
-        verify(payment, never()).markPaid(any(), any());
-        verify(paymentConfirmWriter).savePaidPaymentAndSubscription(eq(payment), isNull());
-        verify(payment).markFailed(any());
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("CONFIRM_API"),
-                eq(ErrorCode.PAYMENT_CONFIRM_FAILED.name()),
-                any()
+        verify(paymentConfirmWriter).saveFailedAfterConfirmApiError(
+                paymentId,
+                paymentKey,
+                ErrorCode.PAYMENT_CONFIRM_FAILED.name(),
+                ErrorCode.PAYMENT_CONFIRM_FAILED.getMessage()
         );
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
-    @DisplayName("이미 PAID 상태면 PAYMENT_ALREADY_CONFIRMED 예외가 발생한다")
-    void confirmPayment_fail_whenAlreadyPaid() {
-        String paymentKey = "pay_test_123";
-        String orderId = "ORDER-123";
-        BigDecimal amount = new BigDecimal("9900");
-
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isPaid()).willReturn(true);
-
-        assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
-                .isInstanceOf(BusinessException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.PAYMENT_ALREADY_CONFIRMED);
-
-        verifyNoInteractions(tossPaymentClient, paymentConfirmWriter);
-    }
-
-    @Test
-    @DisplayName("토스 상태가 FAILED면 PAYMENT_CONFIRM_FAILED 예외가 발생하고 결제를 실패 처리한다")
+    @DisplayName("토스 상태가 FAILED면 실패 저장 후 PAYMENT_CONFIRM_FAILED 예외를 던진다")
     void confirmPayment_fail_whenTossStatusFailed() {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-123";
         BigDecimal amount = new BigDecimal("9900");
+        Long paymentId = 100L;
         OffsetDateTime approvedAt = OffsetDateTime.now();
 
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isPaid()).willReturn(false);
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(false);
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
 
         given(tossPaymentClient.confirm(paymentKey, orderId, amount))
                 .willReturn(new TossPaymentConfirmResult(
@@ -344,36 +295,27 @@ class PaymentConfirmServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PAYMENT_CONFIRM_FAILED);
 
-        verify(payment).markFailed("TOSS_FAILED");
-        verify(paymentConfirmWriter).savePaidPaymentAndSubscription(eq(payment), isNull());
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("CONFIRM_RESULT"),
-                eq(ErrorCode.PAYMENT_CONFIRM_FAILED.name()),
-                eq("Toss payment status is FAILED")
+        verify(paymentConfirmWriter).saveFailedAfterConfirmResult(
+                paymentId,
+                paymentKey,
+                "TOSS_FAILED",
+                ErrorCode.PAYMENT_CONFIRM_FAILED.name(),
+                "Toss payment status is FAILED"
         );
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
-    @DisplayName("토스 상태가 CANCELED면 PAYMENT_CANCELED 예외가 발생하고 결제를 취소 처리한다")
+    @DisplayName("토스 상태가 CANCELED면 취소 저장 후 PAYMENT_CANCELED 예외를 던진다")
     void confirmPayment_fail_whenTossCanceled() {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-123";
         BigDecimal amount = new BigDecimal("9900");
+        Long paymentId = 100L;
         OffsetDateTime approvedAt = OffsetDateTime.now();
 
-        Payment payment = mock(Payment.class);
-
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isPaid()).willReturn(false);
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(false);
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
 
         given(tossPaymentClient.confirm(paymentKey, orderId, amount))
                 .willReturn(new TossPaymentConfirmResult(
@@ -388,71 +330,83 @@ class PaymentConfirmServiceTest {
                 .extracting("errorCode")
                 .isEqualTo(ErrorCode.PAYMENT_CANCELED);
 
-        verify(payment).markCanceled();
-        verify(paymentConfirmWriter).savePaidPaymentAndSubscription(eq(payment), isNull());
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("CONFIRM_RESULT"),
-                eq(ErrorCode.PAYMENT_CANCELED.name()),
-                eq("Toss payment status is CANCELED")
+        verify(paymentConfirmWriter).saveCanceledAfterConfirmResult(
+                paymentId,
+                paymentKey,
+                "TOSS_CANCELED",
+                ErrorCode.PAYMENT_CANCELED.name(),
+                "Toss payment status is CANCELED"
         );
+        verify(paymentConfirmWriter, never()).saveConfirmedPayment(anyLong(), anyString(), any());
     }
 
     @Test
-    @DisplayName("토스 승인 성공 후 저장에 실패하면 결제를 취소하고 예외를 다시 던진다")
+    @DisplayName("저장 단계에서 BusinessException이 발생하면 취소하지 않고 그대로 다시 던진다")
+    void confirmPayment_rethrowBusinessException_whenSaveConfirmedPaymentThrowsBusinessException() {
+        String paymentKey = "pay_test_123";
+        String orderId = "ORDER-20260414-12345";
+        BigDecimal amount = new BigDecimal("9900");
+        Long paymentId = 100L;
+        OffsetDateTime approvedAt = OffsetDateTime.now();
+
+        TossPaymentConfirmResult confirmResult = new TossPaymentConfirmResult(
+                paymentKey,
+                orderId,
+                TossPaymentStatus.DONE,
+                approvedAt
+        );
+
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
+        given(tossPaymentClient.confirm(paymentKey, orderId, amount))
+                .willReturn(confirmResult);
+        given(paymentConfirmWriter.saveConfirmedPayment(paymentId, paymentKey, confirmResult))
+                .willThrow(new BusinessException(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS));
+
+        assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ACTIVE_SUBSCRIPTION_ALREADY_EXISTS);
+
+        verify(paymentConfirmWriter, never()).saveFailureAfterConfirmSaveError(anyLong(), anyString(), anyString());
+        verify(tossPaymentClient, never()).cancel(anyString(), anyString());
+        verify(paymentConfirmWriter, never()).saveCancelFailureLog(anyLong(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("토스 승인 성공 후 저장에 실패하면 결제 취소를 시도하고 예외를 다시 던진다")
     void confirmPayment_cancelWhenSaveFailsAfterConfirm() {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-20260414-12345";
         BigDecimal amount = new BigDecimal("9900");
+        Long paymentId = 100L;
         OffsetDateTime approvedAt = OffsetDateTime.now();
 
-        Payment payment = mock(Payment.class);
-        SubscriptionPlan confirmPlan = mock(SubscriptionPlan.class);
-        User confirmUser = mock(User.class);
+        TossPaymentConfirmResult confirmResult = new TossPaymentConfirmResult(
+                paymentKey,
+                orderId,
+                TossPaymentStatus.DONE,
+                approvedAt
+        );
 
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isPaid()).willReturn(false);
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
-
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(false);
-
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
         given(tossPaymentClient.confirm(paymentKey, orderId, amount))
-                .willReturn(new TossPaymentConfirmResult(
-                        paymentKey,
-                        orderId,
-                        TossPaymentStatus.DONE,
-                        approvedAt
-                ));
-
-        given(payment.getPlan()).willReturn(confirmPlan);
-        given(payment.getUser()).willReturn(confirmUser);
-        given(confirmPlan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
-
-        given(paymentConfirmWriter.savePaidPaymentAndSubscription(eq(payment), any(Subscription.class)))
+                .willReturn(confirmResult);
+        given(paymentConfirmWriter.saveConfirmedPayment(paymentId, paymentKey, confirmResult))
                 .willThrow(new RuntimeException("save failed"));
 
         assertThatThrownBy(() -> paymentService.confirmPayment(userId, paymentKey, orderId, amount))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("save failed");
 
-        verify(payment).markPaid(eq(paymentKey), eq(approvedAt));
-        verify(paymentConfirmWriter).savePaidPaymentAndSubscription(eq(payment), any(Subscription.class));
-        verify(tossPaymentClient).cancel(paymentKey, "INTERNAL_ERROR");
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("SAVE_AFTER_CONFIRM"),
-                eq(ErrorCode.INTERNAL_SERVER_ERROR.name()),
-                eq("save failed")
+        verify(paymentConfirmWriter).saveFailureAfterConfirmSaveError(
+                paymentId,
+                paymentKey,
+                "save failed"
         );
+        verify(tossPaymentClient).cancel(paymentKey, "INTERNAL_ERROR");
+        verify(paymentConfirmWriter, never()).saveCancelFailureLog(anyLong(), anyString(), anyString());
     }
 
     @Test
@@ -461,34 +415,21 @@ class PaymentConfirmServiceTest {
         String paymentKey = "pay_test_123";
         String orderId = "ORDER-20260414-12345";
         BigDecimal amount = new BigDecimal("9900");
+        Long paymentId = 100L;
         OffsetDateTime approvedAt = OffsetDateTime.now();
 
-        Payment payment = mock(Payment.class);
-        SubscriptionPlan confirmPlan = mock(SubscriptionPlan.class);
-        User confirmUser = mock(User.class);
+        TossPaymentConfirmResult confirmResult = new TossPaymentConfirmResult(
+                paymentKey,
+                orderId,
+                TossPaymentStatus.DONE,
+                approvedAt
+        );
 
-        given(paymentRepository.findWithLockByOrderIdAndUserUserId(orderId, userId))
-                .willReturn(Optional.of(payment));
-        given(payment.isPaid()).willReturn(false);
-        given(payment.isReady()).willReturn(true);
-        given(payment.getAmount()).willReturn(amount);
-
-        given(subscriptionRepository.existsByUserUserIdAndStatus(userId, SubscriptionStatus.ACTIVE))
-                .willReturn(false);
-
+        given(paymentConfirmWriter.loadAndValidateReadyPayment(userId, orderId, amount, paymentKey))
+                .willReturn(new PaymentLockedInfo(paymentId));
         given(tossPaymentClient.confirm(paymentKey, orderId, amount))
-                .willReturn(new TossPaymentConfirmResult(
-                        paymentKey,
-                        orderId,
-                        TossPaymentStatus.DONE,
-                        approvedAt
-                ));
-
-        given(payment.getPlan()).willReturn(confirmPlan);
-        given(payment.getUser()).willReturn(confirmUser);
-        given(confirmPlan.getBillingCycle()).willReturn(BillingCycle.MONTHLY);
-
-        given(paymentConfirmWriter.savePaidPaymentAndSubscription(eq(payment), any(Subscription.class)))
+                .willReturn(confirmResult);
+        given(paymentConfirmWriter.saveConfirmedPayment(paymentId, paymentKey, confirmResult))
                 .willThrow(new RuntimeException("save failed"));
         doThrow(new BusinessException(ErrorCode.PAYMENT_CANCEL_FAILED))
                 .when(tossPaymentClient).cancel(paymentKey, "INTERNAL_ERROR");
@@ -497,27 +438,16 @@ class PaymentConfirmServiceTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("save failed");
 
-        verify(payment).markPaid(eq(paymentKey), eq(approvedAt));
-        verify(paymentConfirmWriter).savePaidPaymentAndSubscription(eq(payment), any(Subscription.class));
-        verify(tossPaymentClient).cancel(paymentKey, "INTERNAL_ERROR");
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("SAVE_AFTER_CONFIRM"),
-                eq(ErrorCode.INTERNAL_SERVER_ERROR.name()),
-                eq("save failed")
+        verify(paymentConfirmWriter).saveFailureAfterConfirmSaveError(
+                paymentId,
+                paymentKey,
+                "save failed"
         );
-
-        verify(paymentFailureLogWriter).save(
-                eq(payment),
-                any(),
-                eq(orderId),
-                eq(paymentKey),
-                eq("CANCEL_AFTER_CONFIRM"),
-                eq(ErrorCode.PAYMENT_CANCEL_FAILED.name()),
-                any()
+        verify(tossPaymentClient).cancel(paymentKey, "INTERNAL_ERROR");
+        verify(paymentConfirmWriter).saveCancelFailureLog(
+                paymentId,
+                paymentKey,
+                ErrorCode.PAYMENT_CANCEL_FAILED.getMessage()
         );
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
그룹 초대 코드를 일회용에서 24시간 동안 재사용 가능한 구조로 변경. 기존에는 한 번 사용하면 더 이상 사용할 수 없었지만, 이제 만료 전까지 여러 사용자가 동일한 초대 코드를 사용할 수 있도록 개선함.
<br>

## ✅ 완료한 기능 명세

- [x] 초대 코드 재사용 가능하도록 로직 변경 (일회용 → 다회용)
- [x] 초대 코드 생성 시 기존 유효 코드 재사용하도록 수정
- [x] 초대 코드 사용 시 ACCEPTED 상태 제거
- [x] 만료(expiredAt) 기반으로만 유효성 판단하도록 변경

- [x] **Label**을 붙여주세요. ⏰

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
- 요구사항에 맞게 “사용 여부”가 아닌 “만료 여부” 기준으로 로직을 단순화
- DB 스키마 변경 없이 처리하기 위해 status는 유지하되ACCEPTED는 사용하지 않는 방향 선택
- 초대 코드 생성 시 항상 새로 만드는 것이 아니라 유효한 기존 코드가 존재하면 재사용하도록 최적화

<br>

### 🔗 관련 이슈
Closes #299 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 그룹 초대 코드 재사용 기능 추가 (유효한 미완료 초대 코드 자동 재활용)
  * 결제 실패 사유 상세 기록 기능 추가

* **Improvements**
  * 초대 코드 만료 시간 검증 로직 개선
  * 결제 확인 프로세스 안정성 및 오류 처리 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->