### PR TITLE
[WEF-679] 키워드 검색 추가 및 시작 최소 인원 변경

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/repository/GameRoomRepository.java
@@ -14,8 +14,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 public interface GameRoomRepository extends JpaRepository<GameRoom, UUID> {
-    // 방장 1일 1회 제한
-    boolean existsByUserIdAndStartedAtBetween(UUID userId, OffsetDateTime from, OffsetDateTime to);
+    // 방장 1일 횟수 제한
+    long countByUserIdAndStartedAtBetween(UUID userId, OffsetDateTime from, OffsetDateTime to);
 
     //만들어진 방 체크
     boolean existsByGroupIdAndStatusIn(Long groupId, List<RoomStatus> statuses);

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -57,11 +57,11 @@ public class GameRoomService {
             throw new BusinessException(ErrorCode.ROOM_HOST_ALREADY_EXISTS);
         }
 
-        // 방장 횟수 제한 1일 1회
+        // 방장 횟수 제한 1일 3회
         OffsetDateTime todayStart = LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toOffsetDateTime();
         OffsetDateTime todayEnd = todayStart.plusDays(1);
 
-        if (gameRoomRepository.existsByUserIdAndStartedAtBetween(userId, todayStart, todayEnd)) {
+        if (gameRoomRepository.countByUserIdAndStartedAtBetween(userId, todayStart, todayEnd) >= 3) {
             throw new BusinessException(ErrorCode.ROOM_HOST_DAILY_LIMIT);
         }
 
@@ -243,11 +243,11 @@ public class GameRoomService {
             throw new BusinessException(ErrorCode.ROOM_NOT_HOST);
         }
 
-        // 4. ACTIVE 참가자 2명 이상인지 확인
+        // 4. ACTIVE 참가자 1명 이상인지 확인
         List<GameParticipant> activeParticipants = gameParticipantRepository
                 .findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE);
 
-        if (activeParticipants.size() < 2) {
+        if (activeParticipants.isEmpty()) {
             throw new BusinessException(ErrorCode.ROOM_MIN_PLAYERS);
         }
 

--- a/src/main/java/com/solv/wefin/domain/game/stock/entity/StockInfo.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/entity/StockInfo.java
@@ -27,12 +27,21 @@ public class StockInfo {
     @Column(name = "sector")
     private String sector;
 
+    @Column(name = "keyword", length = 100)
+    private String keyword;
+
     public static StockInfo create(String symbol, String stockName, String market, String sector) {
         StockInfo stockInfo = new StockInfo();
         stockInfo.symbol = symbol;
         stockInfo.stockName = stockName;
         stockInfo.market = market;
         stockInfo.sector = sector;
+        return stockInfo;
+    }
+
+    public static StockInfo create(String symbol, String stockName, String market, String sector, String keyword) {
+        StockInfo stockInfo = create(symbol, stockName, market, sector);
+        stockInfo.keyword = keyword;
         return stockInfo;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/stock/repository/StockInfoRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/repository/StockInfoRepository.java
@@ -2,10 +2,35 @@ package com.solv.wefin.domain.game.stock.repository;
 
 import com.solv.wefin.domain.game.stock.entity.StockInfo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface StockInfoRepository extends JpaRepository<StockInfo, String> {
 
     List<StockInfo> findByMarket(String market);
+
+    /** 섹터 목록 + 섹터별 키워드 개수 조회 */
+    @Query("SELECT si.sector AS sector, COUNT(DISTINCT si.keyword) AS keywordCount " +
+            "FROM StockInfo si " +
+            "WHERE si.sector IS NOT NULL AND si.keyword IS NOT NULL " +
+            "GROUP BY si.sector " +
+            "ORDER BY si.sector")
+    List<SectorKeywordCount> findSectorsWithKeywordCount();
+
+    /** 특정 섹터의 키워드 목록 조회 */
+    @Query("SELECT DISTINCT si.keyword FROM StockInfo si " +
+            "WHERE si.sector = :sector AND si.keyword IS NOT NULL " +
+            "ORDER BY si.keyword")
+    List<String> findKeywordsBySector(@Param("sector") String sector);
+
+    /** 특정 섹터+키워드에 해당하는 종목 목록 (이름순) */
+    List<StockInfo> findBySectorAndKeywordOrderByStockNameAsc(String sector, String keyword);
+
+    /** 섹터별 키워드 개수 projection */
+    interface SectorKeywordCount {
+        String getSector();
+        Long getKeywordCount();
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -5,7 +5,10 @@ import com.solv.wefin.domain.game.participant.repository.GameParticipantReposito
 import com.solv.wefin.domain.game.room.entity.GameRoom;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.entity.StockInfo;
 import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository.SectorKeywordCount;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
@@ -17,8 +20,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +43,7 @@ public class StockSearchService {
     private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
     private final StockDailyRepository stockDailyRepository;
+    private final StockInfoRepository stockInfoRepository;
 
     public List<StockDaily> searchStocks(UUID roomId, UUID userId, String keyword) {
         // 공백/빈 문자열 조기 반환.
@@ -45,31 +53,76 @@ public class StockSearchService {
             return List.of();
         }
 
-        // 1. 게임방 존재 확인
-        GameRoom gameRoom = gameRoomRepository.findById(roomId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+        // 1. 방 + 참가자 검증
+        GameRoom gameRoom = validateParticipant(roomId, userId);
 
-        // 2. 참가자 검증
-        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
-                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
-
-        // 3. ACTIVE 턴 조회 → 턴 날짜 획득
+        // 2. ACTIVE 턴 조회 → 턴 날짜 획득
         GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
 
-        // 4. keyword로 종목 검색 (턴 날짜에 거래 데이터 있는 것만, 최대 MAX_SEARCH_RESULTS건)
+        // 3. keyword로 종목 검색 (턴 날짜에 거래 데이터 있는 것만, 최대 MAX_SEARCH_RESULTS건)
         String escaped = trimmed.toLowerCase(java.util.Locale.ROOT).replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
         String likeKeyword = "%" + escaped + "%";
         Pageable pageable = PageRequest.of(0, MAX_SEARCH_RESULTS);
         return stockDailyRepository.searchByKeywordAndTradeDate(likeKeyword, activeTurn.getTurnDate(), pageable);
     }
+    /** 섹터 목록 + 키워드 개수 조회 */
+    public List<SectorKeywordCount> getSectors(UUID roomId, UUID userId) {
+        validateParticipant(roomId, userId);
+        return stockInfoRepository.findSectorsWithKeywordCount();
+    }
+
+    /** 특정 섹터의 키워드 목록 조회 */
+    public List<String> getKeywords(UUID roomId, UUID userId, String sector) {
+        if (sector == null || sector.isBlank()) {
+            return List.of();
+        }
+        validateParticipant(roomId, userId);
+        return stockInfoRepository.findKeywordsBySector(sector.trim());
+    }
+
+    /** 특정 섹터+키워드의 종목 목록 조회 (현재 턴 종가 포함) */
+    public List<StockDaily> getStocksByKeyword(UUID roomId, UUID userId, String sector, String keyword) {
+        if (sector == null || sector.isBlank() || keyword == null || keyword.isBlank()) {
+            return List.of();
+        }
+        GameRoom gameRoom = validateParticipant(roomId, userId);
+
+        GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GAME_NOT_STARTED));
+
+        LocalDate turnDate = activeTurn.getTurnDate();
+
+        // 해당 섹터+키워드 종목 목록 조회 (이름순)
+        List<StockInfo> stockInfos = stockInfoRepository
+                .findBySectorAndKeywordOrderByStockNameAsc(sector, keyword);
+
+        if (stockInfos.isEmpty()) {
+            return List.of();
+        }
+
+        // 턴 날짜 종가 일괄 조회 (N+1 방지)
+        Map<StockInfo, StockDaily> priceMap = stockDailyRepository
+                .findAllByStockInfoInAndTradeDate(stockInfos, turnDate)
+                .stream()
+                .collect(Collectors.toMap(StockDaily::getStockInfo, Function.identity()));
+
+        // 종가 데이터가 있는 종목만 반환 (이름순 유지)
+        return stockInfos.stream()
+                .filter(priceMap::containsKey)
+                .map(priceMap::get)
+                .toList();
+    }
+
+    /** 방 존재 + 참가자 검증 공통 메서드 */
+    private GameRoom validateParticipant(UUID roomId, UUID userId) {
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+
+        gameParticipantRepository.findByGameRoomAndUserId(gameRoom, userId)
+                .filter(p -> p.getStatus() == ParticipantStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        return gameRoom;
+    }
 }
-
-/**
- 종목 검색 : 날짜 필요 -> 게임룸 검색 -> 턴 조회 -> 날짜 획득
-
- 1. 게임방 확인
- 2. 턴조회 (ACITVE)
- 3. 종목 검색 = keyword로 ** 턴 날짜에 거래 데이터 없으면 제외
- */

--- a/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
+++ b/src/main/java/com/solv/wefin/domain/game/stock/service/StockSearchService.java
@@ -86,6 +86,9 @@ public class StockSearchService {
         if (sector == null || sector.isBlank() || keyword == null || keyword.isBlank()) {
             return List.of();
         }
+        String trimmedSector = sector.trim();
+        String trimmedKeyword = keyword.trim();
+
         GameRoom gameRoom = validateParticipant(roomId, userId);
 
         GameTurn activeTurn = gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE)
@@ -95,7 +98,7 @@ public class StockSearchService {
 
         // 해당 섹터+키워드 종목 목록 조회 (이름순)
         List<StockInfo> stockInfos = stockInfoRepository
-                .findBySectorAndKeywordOrderByStockNameAsc(sector, keyword);
+                .findBySectorAndKeywordOrderByStockNameAsc(trimmedSector, trimmedKeyword);
 
         if (stockInfos.isEmpty()) {
             return List.of();

--- a/src/main/java/com/solv/wefin/web/game/stock/StockSearchController.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/StockSearchController.java
@@ -1,8 +1,10 @@
 package com.solv.wefin.web.game.stock;
 
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository.SectorKeywordCount;
 import com.solv.wefin.domain.game.stock.service.StockSearchService;
 import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.game.stock.dto.response.SectorResponse;
 import com.solv.wefin.web.game.stock.dto.response.StockSearchResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +28,49 @@ public class StockSearchController {
             @RequestParam String keyword) {
 
         List<StockDaily> stocks = stockSearchService.searchStocks(roomId, userId, keyword);
+
+        List<StockSearchResponse> response = stocks.stream()
+                .map(StockSearchResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /** 섹터 목록 조회 (키워드 개수 포함) */
+    @GetMapping("/sectors")
+    public ResponseEntity<ApiResponse<List<SectorResponse>>> getSectors(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID roomId) {
+
+        List<SectorKeywordCount> sectors = stockSearchService.getSectors(roomId, userId);
+
+        List<SectorResponse> response = sectors.stream()
+                .map(SectorResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    /** 특정 섹터의 키워드 목록 조회 */
+    @GetMapping("/sectors/{sector}/keywords")
+    public ResponseEntity<ApiResponse<List<String>>> getKeywords(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID roomId,
+            @PathVariable String sector) {
+
+        List<String> keywords = stockSearchService.getKeywords(roomId, userId, sector);
+        return ResponseEntity.ok(ApiResponse.success(keywords));
+    }
+
+    /** 특정 섹터+키워드의 종목 목록 조회 (현재 턴 종가 포함) */
+    @GetMapping("/sectors/{sector}/stocks")
+    public ResponseEntity<ApiResponse<List<StockSearchResponse>>> getStocksByKeyword(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID roomId,
+            @PathVariable String sector,
+            @RequestParam String keyword) {
+
+        List<StockDaily> stocks = stockSearchService.getStocksByKeyword(roomId, userId, sector, keyword);
 
         List<StockSearchResponse> response = stocks.stream()
                 .map(StockSearchResponse::from)

--- a/src/main/java/com/solv/wefin/web/game/stock/dto/response/SectorResponse.java
+++ b/src/main/java/com/solv/wefin/web/game/stock/dto/response/SectorResponse.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.web.game.stock.dto.response;
+
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository.SectorKeywordCount;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SectorResponse {
+
+    private String sector;
+    private Long keywordCount;
+
+    public static SectorResponse from(SectorKeywordCount projection) {
+        return new SectorResponse(projection.getSector(), projection.getKeywordCount());
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -75,9 +75,9 @@ class GameRoomServiceTest {
                 .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
                 .willReturn(false);
-        given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
+        given(gameRoomRepository.countByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
-                .willReturn(false);
+                .willReturn(0L);
         // DB 최초 거래일 — 방 생성 시 시작일 범위 하한
         given(stockDailyRepository.findEarliestTradeDate())
                 .willReturn(Optional.of(LocalDate.of(2021, 1, 4)));
@@ -108,9 +108,9 @@ class GameRoomServiceTest {
                 .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
                 .willReturn(false);
-        given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
+        given(gameRoomRepository.countByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
-                .willReturn(false);
+                .willReturn(0L);
         given(stockDailyRepository.findEarliestTradeDate())
                 .willReturn(Optional.of(LocalDate.of(2021, 1, 4)));
         LocalDate adjustedTradeDate = LocalDate.of(2022, 1, 3);
@@ -128,16 +128,16 @@ class GameRoomServiceTest {
     }
 
     @Test
-    @DisplayName("게임방 생성 실패 — 방장 1일 1회 제한 위반 시 예외 발생")
+    @DisplayName("게임방 생성 실패 — 방장 1일 3회 제한 위반 시 예외 발생")
     void createRoom_dailyLimitExceeded() {
         // Given — 그룹/방장 활성 방 없음, 오늘 이미 게임 시작 이력 있음
         given(gameRoomRepository.existsByGroupIdAndStatusIn(any(Long.class), any(List.class)))
                 .willReturn(false);
         given(gameRoomRepository.existsByUserIdAndStatusIn(any(UUID.class), any(List.class)))
                 .willReturn(false);
-        given(gameRoomRepository.existsByUserIdAndStartedAtBetween(
+        given(gameRoomRepository.countByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
-                .willReturn(true);
+                .willReturn(3L);
 
         CreateRoomCommand request = createCommand();
 
@@ -695,9 +695,9 @@ class GameRoomServiceTest {
     }
 
     @Test
-    @DisplayName("게임 시작 실패 — 참가자 2명 미만")
+    @DisplayName("게임 시작 실패 — ACTIVE 참가자 0명이면 ROOM_MIN_PLAYERS")
     void startRoom_minPlayers() {
-        // Given — 방장 1명만 있는 방
+        // Given — ACTIVE 참가자가 아무도 없는 방 (전원 퇴장 등)
         GameRoom gameRoom = createGameRoom();
         UUID roomId = gameRoom.getRoomId();
         GameParticipant leader = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
@@ -707,7 +707,7 @@ class GameRoomServiceTest {
         given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
                 .willReturn(Optional.of(leader));
         given(gameParticipantRepository.findByGameRoomAndStatus(gameRoom, ParticipantStatus.ACTIVE))
-                .willReturn(List.of(leader)); // 1명만
+                .willReturn(List.of()); // 0명
 
         // When & Then
         assertThatThrownBy(() -> gameRoomService.startRoom(roomId, TEST_USER_ID))

--- a/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/stock/service/StockSearchServiceTest.java
@@ -7,6 +7,8 @@ import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.entity.StockDaily;
 import com.solv.wefin.domain.game.stock.entity.StockInfo;
 import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository;
+import com.solv.wefin.domain.game.stock.repository.StockInfoRepository.SectorKeywordCount;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
@@ -32,6 +34,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -52,6 +56,9 @@ class StockSearchServiceTest {
 
     @Mock
     private StockDailyRepository stockDailyRepository;
+
+    @Mock
+    private StockInfoRepository stockInfoRepository;
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
@@ -224,6 +231,212 @@ class StockSearchServiceTest {
         verify(stockDailyRepository, never()).searchByKeywordAndTradeDate(any(), any(), any());
     }
 
+    // === 섹터 목록 조회 테스트 ===
+
+    @Test
+    @DisplayName("섹터 목록 조회 성공 — 섹터별 키워드 개수 반환")
+    void getSectors_success() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+
+        SectorKeywordCount it = createSectorKeywordCount("IT", 5L);
+        SectorKeywordCount finance = createSectorKeywordCount("금융", 6L);
+        given(stockInfoRepository.findSectorsWithKeywordCount()).willReturn(List.of(it, finance));
+
+        // When
+        List<SectorKeywordCount> result = stockSearchService.getSectors(roomId, TEST_USER_ID);
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getSector()).isEqualTo("IT");
+        assertThat(result.get(0).getKeywordCount()).isEqualTo(5L);
+        assertThat(result.get(1).getSector()).isEqualTo("금융");
+    }
+
+    @Test
+    @DisplayName("섹터 목록 조회 실패 — 참가자가 아니면 ROOM_NOT_PARTICIPANT")
+    void getSectors_notParticipant() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        UUID outsider = UUID.fromString("00000000-0000-4000-a000-000000000099");
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, outsider))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockSearchService.getSectors(roomId, outsider))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.ROOM_NOT_PARTICIPANT));
+
+        verify(stockInfoRepository, never()).findSectorsWithKeywordCount();
+    }
+
+    // === 키워드 목록 조회 테스트 ===
+
+    @Test
+    @DisplayName("키워드 목록 조회 성공 — 해당 섹터의 키워드 반환")
+    void getKeywords_success() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(stockInfoRepository.findKeywordsBySector("IT"))
+                .willReturn(List.of("반도체", "소프트웨어", "하드웨어"));
+
+        // When
+        List<String> result = stockSearchService.getKeywords(roomId, TEST_USER_ID, "IT");
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly("반도체", "소프트웨어", "하드웨어");
+    }
+
+    @Test
+    @DisplayName("키워드 목록 조회 — 존재하지 않는 섹터면 빈 리스트 반환")
+    void getKeywords_emptySector() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(stockInfoRepository.findKeywordsBySector("없는섹터"))
+                .willReturn(Collections.emptyList());
+
+        // When
+        List<String> result = stockSearchService.getKeywords(roomId, TEST_USER_ID, "없는섹터");
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    // === 섹터+키워드 종목 목록 조회 테스트 ===
+
+    @Test
+    @DisplayName("종목 목록 조회 성공 — 종가 포함, 이름순 정렬")
+    void getStocksByKeyword_success() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+
+        StockInfo samsung = StockInfo.create("005930", "삼성전자", "KOSPI", "IT");
+        StockInfo samsungSDI = StockInfo.create("006400", "삼성SDI", "KOSPI", "IT");
+        StockDaily daily1 = createStockDaily(samsung, TURN_DATE, new BigDecimal("71000"));
+        StockDaily daily2 = createStockDaily(samsungSDI, TURN_DATE, new BigDecimal("450000"));
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockInfoRepository.findBySectorAndKeywordOrderByStockNameAsc("IT", "반도체"))
+                .willReturn(List.of(samsung, samsungSDI));
+        given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(samsung, samsungSDI), TURN_DATE))
+                .willReturn(List.of(daily1, daily2));
+
+        // When
+        List<StockDaily> result = stockSearchService.getStocksByKeyword(roomId, TEST_USER_ID, "IT", "반도체");
+
+        // Then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getStockInfo().getStockName()).isEqualTo("삼성전자");
+        assertThat(result.get(1).getStockInfo().getStockName()).isEqualTo("삼성SDI");
+    }
+
+    @Test
+    @DisplayName("종목 목록 조회 — 해당 키워드에 종목이 없으면 빈 리스트")
+    void getStocksByKeyword_noStocks() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockInfoRepository.findBySectorAndKeywordOrderByStockNameAsc("없는섹터", "없는키워드"))
+                .willReturn(Collections.emptyList());
+
+        // When
+        List<StockDaily> result = stockSearchService.getStocksByKeyword(roomId, TEST_USER_ID, "없는섹터", "없는키워드");
+
+        // Then
+        assertThat(result).isEmpty();
+        verify(stockDailyRepository, never()).findAllByStockInfoInAndTradeDate(any(), any());
+    }
+
+    @Test
+    @DisplayName("종목 목록 조회 — 턴 날짜에 종가 없는 종목은 제외")
+    void getStocksByKeyword_excludeNoPriceStocks() {
+        // Given — 종목 2개 중 1개만 해당 날짜에 종가 존재
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+
+        StockInfo withPrice = StockInfo.create("005930", "삼성전자", "KOSPI", "IT");
+        StockInfo noPrice = StockInfo.create("999999", "상장폐지종목", "KOSPI", "IT");
+        StockDaily daily = createStockDaily(withPrice, TURN_DATE, new BigDecimal("71000"));
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(stockInfoRepository.findBySectorAndKeywordOrderByStockNameAsc("IT", "반도체"))
+                .willReturn(List.of(withPrice, noPrice));
+        given(stockDailyRepository.findAllByStockInfoInAndTradeDate(List.of(withPrice, noPrice), TURN_DATE))
+                .willReturn(List.of(daily));
+
+        // When
+        List<StockDaily> result = stockSearchService.getStocksByKeyword(roomId, TEST_USER_ID, "IT", "반도체");
+
+        // Then — 종가 있는 1개만 반환
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getStockInfo().getStockName()).isEqualTo("삼성전자");
+    }
+
+    @Test
+    @DisplayName("종목 목록 조회 실패 — ACTIVE 턴 없으면 GAME_NOT_STARTED")
+    void getStocksByKeyword_gameNotStarted() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+
+        given(gameRoomRepository.findById(roomId)).willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> stockSearchService.getStocksByKeyword(roomId, TEST_USER_ID, "IT", "반도체"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> assertThat(((BusinessException) ex).getErrorCode())
+                        .isEqualTo(ErrorCode.GAME_NOT_STARTED));
+    }
+
     // === 헬퍼 메서드 ===
 
     private GameRoom createGameRoom() {
@@ -239,5 +452,12 @@ class StockSearchServiceTest {
                 openPrice.add(new BigDecimal("500")),
                 new BigDecimal("1000000"),
                 new BigDecimal("1.5"));
+    }
+
+    private SectorKeywordCount createSectorKeywordCount(String sector, Long keywordCount) {
+        SectorKeywordCount projection = mock(SectorKeywordCount.class);
+        lenient().when(projection.getSector()).thenReturn(sector);
+        lenient().when(projection.getKeywordCount()).thenReturn(keywordCount);
+        return projection;
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
<br> 게임 시작 최소 인원 변경 및 카테고리 검색 추가

## ✅ 완료한 기능 명세

- [x] 카테고리 검색 추가
- [x] 게임 시작 최소 인원 1명 변경

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #305 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 섹터 기반 주식 검색 기능 추가
  * 키워드별 주식 필터링 기능 추가
  * 섹터 및 키워드 조회 API 추가

* **개선사항**
  * 일일 게임룸 생성 한도를 3개로 상향
  * 최소 참여 인원 요구사항 완화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->