### PR TITLE
[WEF-188] 그룹채팅 커맨드 기능 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/entity/ChatMessage.java
@@ -104,6 +104,19 @@ public class ChatMessage {
                 .build();
     }
 
+    public static ChatMessage createSystemMessage(Group group, String content) {
+        return ChatMessage.builder()
+                .user(null)
+                .group(group)
+                .messageType(MessageType.SYSTEM)
+                .content(content)
+                .refType(null)
+                .refId(null)
+                .replyToMessage(null)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+
     public void attachNewsShare(ChatMessageNewsShare newsShare) {
         this.newsShare = newsShare;
     }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -61,12 +61,11 @@ public class ChatMessageService {
     private final OpenAiChatClient openAiChatClient;
 
     private static final long SPAM_WINDOW_SECONDS = 3L;
-    private static final String YOUNG_COMMAND = "/영";
-    private static final String YOUNG_RESPONSE = "차";
     private static final String WEFINI_COMMAND_PREFIX = "/wefini";
-    private static final String YOUNG_COMMAND_LITERAL = "/\uC601";
-    private static final String YOUNG_DISPLAY_MESSAGE_LITERAL = "\uC601";
-    private static final String YOUNG_RESPONSE_LITERAL = "\uCC28";
+    private static final String YOUNG_COMMAND_LITERAL = "/영";
+    private static final String YOUNG_DISPLAY_MESSAGE_LITERAL = "영";
+    private static final String YOUNG_RESPONSE_LITERAL = "차";
+    private static final String WEFINI_FAILURE_MESSAGE = "AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.";
     private static final String WEFINI_USAGE_MESSAGE = "/wefini 뒤에 질문을 함께 입력해 주세요.";
     private static final String SYSTEM = "시스템";
     private static final int MAX_MESSAGE_LENGTH = 1000;
@@ -145,9 +144,16 @@ public class ChatMessageService {
             return true;
         }
 
-        publishUserMessage(user, group, content);
+        publishUserMessage(user, group, trimmed);
 
-        String answer = openAiChatClient.ask(List.of(), question, null);
+        String answer;
+        try {
+            answer = openAiChatClient.ask(List.of(), question, null);
+        } catch (BusinessException e) {
+            log.warn("AI 응답 실패 userId={}, code={}", userId, e.getErrorCode(), e);
+            publishSystemMessage(group, WEFINI_FAILURE_MESSAGE);
+            return true;
+        }
         publishSystemMessage(group, answer);
         handleQuestEventSafely(userId, QuestEventType.USE_AI_CHAT);
         handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -6,7 +6,12 @@ import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
-import com.solv.wefin.domain.chat.groupChat.dto.info.*;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.VoteShareInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.VoteShareOptionInfo;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
 import com.solv.wefin.domain.chat.groupChat.entity.ChatMessageNewsShare;
 import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
@@ -33,6 +38,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -50,6 +56,17 @@ import java.util.stream.Collectors;
 @Slf4j
 public class ChatMessageService {
 
+    private static final long SPAM_WINDOW_SECONDS = 3L;
+    private static final String WEFINI_COMMAND_PREFIX = "/wefini";
+    private static final String YOUNG_COMMAND_LITERAL = "/영";
+    private static final String YOUNG_DISPLAY_MESSAGE_LITERAL = "영";
+    private static final String YOUNG_RESPONSE_LITERAL = "차";
+    private static final String WEFINI_FAILURE_MESSAGE = "AI AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+    private static final String WEFINI_USAGE_MESSAGE = "/wefini 뒤에 질문을 함께 입력해 주세요.";
+    private static final String SYSTEM = "시스템";
+    private static final int MAX_MESSAGE_LENGTH = 1000;
+    private static final int MAX_PAGE_SIZE = 100;
+
     private final ChatMessageRepository chatMessageRepository;
     private final UserRepository userRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -59,23 +76,13 @@ public class ChatMessageService {
     private final VoteRepository voteRepository;
     private final VoteOptionRepository voteOptionRepository;
     private final OpenAiChatClient openAiChatClient;
-
-    private static final long SPAM_WINDOW_SECONDS = 3L;
-    private static final String WEFINI_COMMAND_PREFIX = "/wefini";
-    private static final String YOUNG_COMMAND_LITERAL = "/영";
-    private static final String YOUNG_DISPLAY_MESSAGE_LITERAL = "영";
-    private static final String YOUNG_RESPONSE_LITERAL = "차";
-    private static final String WEFINI_FAILURE_MESSAGE = "AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.";
-    private static final String WEFINI_USAGE_MESSAGE = "/wefini 뒤에 질문을 함께 입력해 주세요.";
-    private static final String SYSTEM = "시스템";
-    private static final int MAX_MESSAGE_LENGTH = 1000;
-    private static final int MAX_PAGE_SIZE = 100;
-
-    private final Map<String, Object> chatLocks = new ConcurrentHashMap<>();
+    private final ChatMessageWriteService chatMessageWriteService;
     private final NewsClusterRepository newsClusterRepository;
     private final ChatMessageNewsShareService chatMessageNewsShareService;
 
-    @Transactional
+    private final Map<String, Object> chatLocks = new ConcurrentHashMap<>();
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public void sendMessage(String content, UUID userId, Long replyToMessageId) {
         if (userId == null) {
             throw new BusinessException(ErrorCode.USER_NOT_FOUND);
@@ -108,12 +115,7 @@ public class ChatMessageService {
             }
 
             ChatMessage replyTarget = findReplyTarget(replyToMessageId, groupId);
-
-            ChatMessage savedMessage = chatMessageRepository.save(
-                    ChatMessage.createUserMessage(user, group, content, replyTarget)
-            );
-
-            eventPublisher.publishEvent(toEvent(savedMessage));
+            chatMessageWriteService.publishUserMessage(user, group, content, replyTarget);
         }
 
         questProgressService.handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
@@ -123,14 +125,14 @@ public class ChatMessageService {
         String trimmed = content.trim();
 
         if (trimmed.equals(YOUNG_COMMAND_LITERAL)) {
-            publishUserMessage(user, group, YOUNG_DISPLAY_MESSAGE_LITERAL);
-            publishSystemMessage(group, YOUNG_RESPONSE_LITERAL);
+            chatMessageWriteService.publishUserMessage(user, group, YOUNG_DISPLAY_MESSAGE_LITERAL, null);
+            chatMessageWriteService.publishSystemMessage(group, YOUNG_RESPONSE_LITERAL);
             handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);
             return true;
         }
 
         if (trimmed.equals(WEFINI_COMMAND_PREFIX)) {
-            publishSystemMessage(group, WEFINI_USAGE_MESSAGE);
+            chatMessageWriteService.publishSystemMessage(group, WEFINI_USAGE_MESSAGE);
             return true;
         }
 
@@ -140,40 +142,25 @@ public class ChatMessageService {
 
         String question = trimmed.substring(WEFINI_COMMAND_PREFIX.length()).trim();
         if (question.isBlank()) {
-            publishSystemMessage(group, WEFINI_USAGE_MESSAGE);
+            chatMessageWriteService.publishSystemMessage(group, WEFINI_USAGE_MESSAGE);
             return true;
         }
 
-        publishUserMessage(user, group, trimmed);
+        chatMessageWriteService.publishUserMessage(user, group, trimmed, null);
 
         String answer;
         try {
             answer = openAiChatClient.ask(List.of(), question, null);
         } catch (BusinessException e) {
             log.warn("AI 응답 실패 userId={}, code={}", userId, e.getErrorCode(), e);
-            publishSystemMessage(group, WEFINI_FAILURE_MESSAGE);
+            chatMessageWriteService.publishSystemMessage(group, WEFINI_FAILURE_MESSAGE);
             return true;
         }
-        publishSystemMessage(group, answer);
+
+        chatMessageWriteService.publishSystemMessage(group, answer);
         handleQuestEventSafely(userId, QuestEventType.USE_AI_CHAT);
         handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);
         return true;
-    }
-
-    private void publishUserMessage(User user, Group group, String content) {
-        ChatMessage userMessage = chatMessageRepository.save(
-                ChatMessage.createUserMessage(user, group, content, null)
-        );
-
-        eventPublisher.publishEvent(toEvent(userMessage));
-    }
-
-    private void publishSystemMessage(Group group, String content) {
-        ChatMessage systemMessage = chatMessageRepository.save(
-                ChatMessage.createSystemMessage(group, content)
-        );
-
-        eventPublisher.publishEvent(toEvent(systemMessage));
     }
 
     @Transactional
@@ -198,7 +185,6 @@ public class ChatMessageService {
         chatMessageNewsShareService.save(chatMessage, newsCluster);
 
         ChatMessageInfo info = toInfo(chatMessage);
-
         eventPublisher.publishEvent(new ChatMessageCreatedEvent(group.getId(), info));
 
         handleQuestEventSafely(userId, QuestEventType.SHARE_NEWS);
@@ -240,16 +226,13 @@ public class ChatMessageService {
         );
 
         ChatMessageInfo info = toInfo(chatMessage);
-
         eventPublisher.publishEvent(new ChatMessageCreatedEvent(vote.getGroup().getId(), info));
 
         handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);
-
         return info;
     }
 
     public ChatMessagesInfo getMessages(UUID userId, Long beforeMessageId, int size) {
-
         Group group = findActiveUserGroup(userId);
         Long groupId = group.getId();
 
@@ -267,7 +250,7 @@ public class ChatMessageService {
 
         Long nextCursor = hasNext && !fetched.isEmpty()
                 ? fetched.get(fetched.size() - 1).getId()
-                :null;
+                : null;
 
         List<Long> voteIds = fetched.stream()
                 .filter(message -> message.getRefType() == RefType.VOTE && message.getRefId() != null)
@@ -278,12 +261,12 @@ public class ChatMessageService {
         Map<Long, Vote> voteMap = voteIds.isEmpty()
                 ? Map.of()
                 : voteRepository.findAllByVoteIdIn(voteIds).stream()
-                        .collect(Collectors.toMap(Vote::getVoteId, Function.identity()));
+                .collect(Collectors.toMap(Vote::getVoteId, Function.identity()));
 
         Map<Long, List<VoteOption>> voteOptionMap = voteIds.isEmpty()
                 ? Map.of()
                 : voteOptionRepository.findAllByVote_VoteIdInOrderByVote_VoteIdAscIdAsc(voteIds).stream()
-                        .collect(Collectors.groupingBy(option -> option.getVote().getVoteId()));
+                .collect(Collectors.groupingBy(option -> option.getVote().getVoteId()));
 
         List<ChatMessageInfo> messages = fetched.stream()
                 .sorted(Comparator.comparing(ChatMessage::getId))
@@ -358,7 +341,7 @@ public class ChatMessageService {
     }
 
     private ReplyMessageInfo toReplyInfo(ChatMessage replyMessage) {
-        if(replyMessage == null) {
+        if (replyMessage == null) {
             return null;
         }
 
@@ -369,15 +352,8 @@ public class ChatMessageService {
         );
     }
 
-    private ChatMessageCreatedEvent toEvent(ChatMessage message) {
-        return new ChatMessageCreatedEvent(
-                extractGroupId(message),
-                toInfo(message)
-        );
-    }
-
     private void validateShareNewsCommand(ShareNewsCommand command) {
-        if(command == null || command.newsClusterId() == null) {
+        if (command == null || command.newsClusterId() == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
     }
@@ -438,12 +414,11 @@ public class ChatMessageService {
     }
 
     private ChatMessage findReplyTarget(Long replyToMessageId, Long groupId) {
-        if(replyToMessageId == null) {
+        if (replyToMessageId == null) {
             return null;
         }
 
         return chatMessageRepository.findByIdAndGroup_Id(replyToMessageId, groupId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CHAT_MESSAGE_NOT_FOUND));
     }
-
 }

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -61,7 +61,7 @@ public class ChatMessageService {
     private static final String YOUNG_COMMAND_LITERAL = "/영";
     private static final String YOUNG_DISPLAY_MESSAGE_LITERAL = "영";
     private static final String YOUNG_RESPONSE_LITERAL = "차";
-    private static final String WEFINI_FAILURE_MESSAGE = "AI AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.";
+    private static final String WEFINI_FAILURE_MESSAGE = "AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.";
     private static final String WEFINI_USAGE_MESSAGE = "/wefini 뒤에 질문을 함께 입력해 주세요.";
     private static final String SYSTEM = "시스템";
     private static final int MAX_MESSAGE_LENGTH = 1000;

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageService.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.chat.groupChat.service;
 
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
@@ -57,8 +58,16 @@ public class ChatMessageService {
     private final QuestProgressService questProgressService;
     private final VoteRepository voteRepository;
     private final VoteOptionRepository voteOptionRepository;
+    private final OpenAiChatClient openAiChatClient;
 
     private static final long SPAM_WINDOW_SECONDS = 3L;
+    private static final String YOUNG_COMMAND = "/영";
+    private static final String YOUNG_RESPONSE = "차";
+    private static final String WEFINI_COMMAND_PREFIX = "/wefini";
+    private static final String YOUNG_COMMAND_LITERAL = "/\uC601";
+    private static final String YOUNG_DISPLAY_MESSAGE_LITERAL = "\uC601";
+    private static final String YOUNG_RESPONSE_LITERAL = "\uCC28";
+    private static final String WEFINI_USAGE_MESSAGE = "/wefini 뒤에 질문을 함께 입력해 주세요.";
     private static final String SYSTEM = "시스템";
     private static final int MAX_MESSAGE_LENGTH = 1000;
     private static final int MAX_PAGE_SIZE = 100;
@@ -78,8 +87,6 @@ public class ChatMessageService {
         Group group = findActiveUserGroup(userId);
         Long groupId = group.getId();
 
-        ChatMessage replyTarget = findReplyTarget(replyToMessageId, groupId);
-
         String blockKey = ChatScope.groupKey(groupId, userId);
         Object lock = chatLocks.computeIfAbsent(blockKey, key -> new Object());
 
@@ -97,6 +104,12 @@ public class ChatMessageService {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
+            if (handleCommandMessage(content, userId, user, group)) {
+                return;
+            }
+
+            ChatMessage replyTarget = findReplyTarget(replyToMessageId, groupId);
+
             ChatMessage savedMessage = chatMessageRepository.save(
                     ChatMessage.createUserMessage(user, group, content, replyTarget)
             );
@@ -105,6 +118,56 @@ public class ChatMessageService {
         }
 
         questProgressService.handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
+    }
+
+    private boolean handleCommandMessage(String content, UUID userId, User user, Group group) {
+        String trimmed = content.trim();
+
+        if (trimmed.equals(YOUNG_COMMAND_LITERAL)) {
+            publishUserMessage(user, group, YOUNG_DISPLAY_MESSAGE_LITERAL);
+            publishSystemMessage(group, YOUNG_RESPONSE_LITERAL);
+            handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);
+            return true;
+        }
+
+        if (trimmed.equals(WEFINI_COMMAND_PREFIX)) {
+            publishSystemMessage(group, WEFINI_USAGE_MESSAGE);
+            return true;
+        }
+
+        if (!trimmed.startsWith(WEFINI_COMMAND_PREFIX + " ")) {
+            return false;
+        }
+
+        String question = trimmed.substring(WEFINI_COMMAND_PREFIX.length()).trim();
+        if (question.isBlank()) {
+            publishSystemMessage(group, WEFINI_USAGE_MESSAGE);
+            return true;
+        }
+
+        publishUserMessage(user, group, content);
+
+        String answer = openAiChatClient.ask(List.of(), question, null);
+        publishSystemMessage(group, answer);
+        handleQuestEventSafely(userId, QuestEventType.USE_AI_CHAT);
+        handleQuestEventSafely(userId, QuestEventType.SEND_GROUP_CHAT);
+        return true;
+    }
+
+    private void publishUserMessage(User user, Group group, String content) {
+        ChatMessage userMessage = chatMessageRepository.save(
+                ChatMessage.createUserMessage(user, group, content, null)
+        );
+
+        eventPublisher.publishEvent(toEvent(userMessage));
+    }
+
+    private void publishSystemMessage(Group group, String content) {
+        ChatMessage systemMessage = chatMessageRepository.save(
+                ChatMessage.createSystemMessage(group, content)
+        );
+
+        eventPublisher.publishEvent(toEvent(systemMessage));
     }
 
     @Transactional

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageWriteService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageWriteService.java
@@ -1,0 +1,100 @@
+package com.solv.wefin.domain.chat.groupChat.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ReplyMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.entity.ChatMessage;
+import com.solv.wefin.domain.chat.groupChat.entity.MessageType;
+import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
+import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageRepository;
+import com.solv.wefin.domain.group.entity.Group;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageWriteService {
+
+    private static final String SYSTEM = "시스템";
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public ChatMessageInfo publishUserMessage(User user, Group group, String content, ChatMessage replyTarget) {
+        ChatMessage userMessage = chatMessageRepository.save(
+                ChatMessage.createUserMessage(user, group, content, replyTarget)
+        );
+
+        ChatMessageInfo info = toInfo(userMessage);
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(group.getId(), info));
+        return info;
+    }
+
+    @Transactional
+    public ChatMessageInfo publishSystemMessage(Group group, String content) {
+        ChatMessage systemMessage = chatMessageRepository.save(
+                ChatMessage.createSystemMessage(group, content)
+        );
+
+        ChatMessageInfo info = toInfo(systemMessage);
+        eventPublisher.publishEvent(new ChatMessageCreatedEvent(group.getId(), info));
+        return info;
+    }
+
+    private ChatMessageInfo toInfo(ChatMessage message) {
+        return new ChatMessageInfo(
+                message.getId(),
+                extractUserId(message),
+                extractGroupId(message),
+                message.getMessageType().name(),
+                resolveSender(message),
+                message.getContent(),
+                message.getCreatedAt(),
+                toReplyInfo(message.getReplyToMessage()),
+                null,
+                null
+        );
+    }
+
+    private ReplyMessageInfo toReplyInfo(ChatMessage replyMessage) {
+        if (replyMessage == null) {
+            return null;
+        }
+
+        return new ReplyMessageInfo(
+                replyMessage.getId(),
+                resolveSender(replyMessage),
+                replyMessage.getContent()
+        );
+    }
+
+    private String resolveSender(ChatMessage message) {
+        User user = message.getUser();
+
+        if (message.getMessageType() == MessageType.SYSTEM || user == null) {
+            return SYSTEM;
+        }
+
+        return user.getNickname();
+    }
+
+    private UUID extractUserId(ChatMessage message) {
+        User user = message.getUser();
+
+        if (message.getMessageType() == MessageType.SYSTEM || user == null) {
+            return null;
+        }
+
+        return user.getUserId();
+    }
+
+    private Long extractGroupId(ChatMessage message) {
+        Group group = message.getGroup();
+        return group != null ? group.getId() : null;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -208,7 +208,7 @@ class ChatMessageServiceTest {
                 .user(user)
                 .group(group)
                 .messageType(MessageType.CHAT)
-                .content("\uC601")
+                .content("영")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(savedUserMessage, "id", 22L);
@@ -216,7 +216,7 @@ class ChatMessageServiceTest {
         ChatMessage savedSystemMessage = ChatMessage.builder()
                 .group(group)
                 .messageType(MessageType.SYSTEM)
-                .content("\uCC28")
+                .content("차")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(savedSystemMessage, "id", 23L);

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -79,6 +79,11 @@ class ChatMessageServiceTest {
         voteOptionRepository = mock(VoteOptionRepository.class);
         openAiChatClient = mock(OpenAiChatClient.class);
 
+        ChatMessageWriteService chatMessageWriteService = new ChatMessageWriteService(
+                chatMessageRepository,
+                eventPublisher
+        );
+
         chatMessageService = new ChatMessageService(
                 chatMessageRepository,
                 userRepository,
@@ -89,6 +94,7 @@ class ChatMessageServiceTest {
                 voteRepository,
                 voteOptionRepository,
                 openAiChatClient,
+                chatMessageWriteService,
                 newsClusterRepository,
                 chatMessageNewsShareService
         );
@@ -141,10 +147,10 @@ class ChatMessageServiceTest {
         chatMessageService.sendMessage(content, userId, null);
 
         // then
-        verify(chatMessageRepository, times(1))
-                .countByGroup_IdAndUser_UserIdAndCreatedAtAfter(eq(1L), eq(userId), any(OffsetDateTime.class));
-        verify(chatSpamGuard, times(1))
-                .validate(eq(ChatScope.groupKey(1L, userId)), eq(0L), any(OffsetDateTime.class));
+        verify(chatMessageRepository).countByGroup_IdAndUser_UserIdAndCreatedAtAfter(
+                eq(1L), eq(userId), any(OffsetDateTime.class)
+        );
+        verify(chatSpamGuard).validate(eq(ChatScope.groupKey(1L, userId)), eq(0L), any(OffsetDateTime.class));
         verify(chatMessageRepository).save(captor.capture());
         verify(eventPublisher).publishEvent(any(ChatMessageCreatedEvent.class));
         verify(questProgressService).handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
@@ -164,8 +170,10 @@ class ChatMessageServiceTest {
         UUID userId = UUID.randomUUID();
 
         // when
-        BusinessException exception = assertThrows(BusinessException.class,
-                () -> chatMessageService.sendMessage(" ", userId, null));
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> chatMessageService.sendMessage(" ", userId, null)
+        );
 
         // then
         assertEquals(ErrorCode.CHAT_MESSAGE_EMPTY, exception.getErrorCode());
@@ -200,7 +208,7 @@ class ChatMessageServiceTest {
                 .user(user)
                 .group(group)
                 .messageType(MessageType.CHAT)
-                .content("영")
+                .content("\uC601")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(savedUserMessage, "id", 22L);
@@ -208,7 +216,7 @@ class ChatMessageServiceTest {
         ChatMessage savedSystemMessage = ChatMessage.builder()
                 .group(group)
                 .messageType(MessageType.SYSTEM)
-                .content("차")
+                .content("\uCC28")
                 .createdAt(OffsetDateTime.now())
                 .build();
         ReflectionTestUtils.setField(savedSystemMessage, "id", 23L);
@@ -307,7 +315,10 @@ class ChatMessageServiceTest {
         assertEquals(MessageType.CHAT, capturedMessages.get(0).getMessageType());
         assertEquals("/wefini 질문", capturedMessages.get(0).getContent());
         assertEquals(MessageType.SYSTEM, capturedMessages.get(1).getMessageType());
-        assertEquals("AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.", capturedMessages.get(1).getContent());
+        assertEquals(
+                "AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.",
+                capturedMessages.get(1).getContent()
+        );
         assertNull(capturedMessages.get(1).getUser());
     }
 

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -2,6 +2,7 @@ package com.solv.wefin.domain.chat.groupChat.service;
 
 import com.solv.wefin.domain.auth.entity.User;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.aiChat.client.OpenAiChatClient;
 import com.solv.wefin.domain.chat.common.constant.ChatScope;
 import com.solv.wefin.domain.chat.common.service.ChatSpamGuard;
 import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
@@ -62,6 +63,7 @@ class ChatMessageServiceTest {
     private QuestProgressService questProgressService;
     private VoteRepository voteRepository;
     private VoteOptionRepository voteOptionRepository;
+    private OpenAiChatClient openAiChatClient;
 
     @BeforeEach
     void setUp() {
@@ -75,6 +77,7 @@ class ChatMessageServiceTest {
         questProgressService = mock(QuestProgressService.class);
         voteRepository = mock(VoteRepository.class);
         voteOptionRepository = mock(VoteOptionRepository.class);
+        openAiChatClient = mock(OpenAiChatClient.class);
 
         chatMessageService = new ChatMessageService(
                 chatMessageRepository,
@@ -85,6 +88,7 @@ class ChatMessageServiceTest {
                 questProgressService,
                 voteRepository,
                 voteOptionRepository,
+                openAiChatClient,
                 newsClusterRepository,
                 chatMessageNewsShareService
         );
@@ -161,6 +165,71 @@ class ChatMessageServiceTest {
         assertEquals(ErrorCode.CHAT_MESSAGE_EMPTY, exception.getErrorCode());
         verify(chatMessageRepository, never()).save(any());
         verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("sendMessage handles /영 command as user message and system message")
+    void sendMessage_youngCommand_success() {
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("groupUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        Group group = Group.builder().name("group-1").build();
+        ReflectionTestUtils.setField(group, "id", 1L);
+
+        GroupMember groupMember = GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMember.GroupMemberRole.MEMBER)
+                .status(GroupMember.GroupMemberStatus.ACTIVE)
+                .build();
+
+        ChatMessage savedUserMessage = ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.CHAT)
+                .content("영")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(savedUserMessage, "id", 22L);
+
+        ChatMessage savedSystemMessage = ChatMessage.builder()
+                .group(group)
+                .messageType(MessageType.SYSTEM)
+                .content("차")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(savedSystemMessage, "id", 23L);
+
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(chatMessageRepository.countByGroup_IdAndUser_UserIdAndCreatedAtAfter(
+                eq(1L), eq(userId), any(OffsetDateTime.class))
+        ).thenReturn(0L);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(chatMessageRepository.save(any(ChatMessage.class)))
+                .thenReturn(savedUserMessage, savedSystemMessage);
+
+        ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
+
+        chatMessageService.sendMessage("/영", userId, null);
+
+        verify(openAiChatClient, never()).ask(any(), any(), any());
+        verify(chatMessageRepository, times(2)).save(captor.capture());
+        verify(eventPublisher, times(2)).publishEvent(any(ChatMessageCreatedEvent.class));
+        verify(questProgressService).handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
+
+        List<ChatMessage> capturedMessages = captor.getAllValues();
+        assertEquals(MessageType.CHAT, capturedMessages.get(0).getMessageType());
+        assertEquals("영", capturedMessages.get(0).getContent());
+        assertEquals(MessageType.SYSTEM, capturedMessages.get(1).getMessageType());
+        assertEquals("차", capturedMessages.get(1).getContent());
+        assertNull(capturedMessages.get(1).getUser());
     }
 
     @Test
@@ -303,3 +372,4 @@ class ChatMessageServiceTest {
         assertEquals("https://image.test/thumb.png", result.newsShare().thumbnailUrl());
     }
 }
+

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -95,8 +95,9 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("sendMessage publishes event and quest progress")
+    @DisplayName("메시지 전송 시 이벤트 발행과 퀘스트 진행도가 반영된다")
     void sendMessage_success() {
+        // given
         UUID userId = UUID.randomUUID();
         String content = "hello";
 
@@ -136,8 +137,10 @@ class ChatMessageServiceTest {
 
         ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
 
+        // when
         chatMessageService.sendMessage(content, userId, null);
 
+        // then
         verify(chatMessageRepository, times(1))
                 .countByGroup_IdAndUser_UserIdAndCreatedAtAfter(eq(1L), eq(userId), any(OffsetDateTime.class));
         verify(chatSpamGuard, times(1))
@@ -155,21 +158,25 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("sendMessage rejects blank content")
+    @DisplayName("빈 메시지를 전송하면 예외가 발생한다")
     void sendMessage_fail_blank() {
+        // given
         UUID userId = UUID.randomUUID();
 
+        // when
         BusinessException exception = assertThrows(BusinessException.class,
                 () -> chatMessageService.sendMessage(" ", userId, null));
 
+        // then
         assertEquals(ErrorCode.CHAT_MESSAGE_EMPTY, exception.getErrorCode());
         verify(chatMessageRepository, never()).save(any());
         verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
-    @DisplayName("sendMessage handles /영 command as user message and system message")
+    @DisplayName("/영 명령어를 전송하면 사용자 메시지와 시스템 메시지가 함께 저장된다")
     void sendMessage_youngCommand_success() {
+        // given
         UUID userId = UUID.randomUUID();
 
         User user = User.builder()
@@ -217,8 +224,10 @@ class ChatMessageServiceTest {
 
         ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
 
+        // when
         chatMessageService.sendMessage("/영", userId, null);
 
+        // then
         verify(openAiChatClient, never()).ask(any(), any(), any());
         verify(chatMessageRepository, times(2)).save(captor.capture());
         verify(eventPublisher, times(2)).publishEvent(any(ChatMessageCreatedEvent.class));
@@ -233,8 +242,79 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("getMessages computes hasNext and nextCursor")
+    @DisplayName("/wefini AI 호출이 실패해도 질문 메시지는 남고 안내 시스템 메시지가 발행된다")
+    void sendMessage_wefiniCommand_aiFailure_keepsQuestionAndPublishesFallback() {
+        // given
+        UUID userId = UUID.randomUUID();
+
+        User user = User.builder()
+                .email("test@test.com")
+                .nickname("groupUser")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        Group group = Group.builder().name("group-1").build();
+        ReflectionTestUtils.setField(group, "id", 1L);
+
+        GroupMember groupMember = GroupMember.builder()
+                .user(user)
+                .group(group)
+                .role(GroupMember.GroupMemberRole.MEMBER)
+                .status(GroupMember.GroupMemberStatus.ACTIVE)
+                .build();
+
+        ChatMessage savedUserMessage = ChatMessage.builder()
+                .user(user)
+                .group(group)
+                .messageType(MessageType.CHAT)
+                .content("/wefini 질문")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(savedUserMessage, "id", 30L);
+
+        ChatMessage savedSystemMessage = ChatMessage.builder()
+                .group(group)
+                .messageType(MessageType.SYSTEM)
+                .content("AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        ReflectionTestUtils.setField(savedSystemMessage, "id", 31L);
+
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(chatMessageRepository.countByGroup_IdAndUser_UserIdAndCreatedAtAfter(
+                eq(1L), eq(userId), any(OffsetDateTime.class))
+        ).thenReturn(0L);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(openAiChatClient.ask(any(), eq("질문"), any()))
+                .thenThrow(new BusinessException(ErrorCode.AI_CHAT_REQUEST_FAILED));
+        when(chatMessageRepository.save(any(ChatMessage.class)))
+                .thenReturn(savedUserMessage, savedSystemMessage);
+
+        ArgumentCaptor<ChatMessage> captor = ArgumentCaptor.forClass(ChatMessage.class);
+
+        // when
+        chatMessageService.sendMessage("  /wefini 질문  ", userId, null);
+
+        // then
+        verify(chatMessageRepository, times(2)).save(captor.capture());
+        verify(eventPublisher, times(2)).publishEvent(any(ChatMessageCreatedEvent.class));
+        verify(questProgressService, never()).handleEvent(userId, QuestEventType.USE_AI_CHAT);
+        verify(questProgressService, never()).handleEvent(userId, QuestEventType.SEND_GROUP_CHAT);
+
+        List<ChatMessage> capturedMessages = captor.getAllValues();
+        assertEquals(MessageType.CHAT, capturedMessages.get(0).getMessageType());
+        assertEquals("/wefini 질문", capturedMessages.get(0).getContent());
+        assertEquals(MessageType.SYSTEM, capturedMessages.get(1).getMessageType());
+        assertEquals("AI 응답을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.", capturedMessages.get(1).getContent());
+        assertNull(capturedMessages.get(1).getUser());
+    }
+
+    @Test
+    @DisplayName("메시지 조회 시 hasNext와 nextCursor를 올바르게 계산한다")
     void getMessages_success_with_hasNext_and_nextCursor() {
+        // given
         UUID userId = UUID.randomUUID();
 
         User user = User.builder()
@@ -286,8 +366,10 @@ class ChatMessageServiceTest {
         when(chatMessageRepository.findMessagesByGroupId(eq(3L), any(Pageable.class)))
                 .thenReturn(List.of(latestMessage, middleMessage, oldestMessage));
 
+        // when
         ChatMessagesInfo result = chatMessageService.getMessages(userId, null, 2);
 
+        // then
         assertEquals(2, result.messages().size());
         assertTrue(result.hasNext());
         assertEquals(2L, result.nextCursor());
@@ -298,8 +380,9 @@ class ChatMessageServiceTest {
     }
 
     @Test
-    @DisplayName("shareNews returns response with news share payload")
+    @DisplayName("뉴스 공유 시 뉴스 공유 정보가 포함된 응답을 반환한다")
     void shareNews_success() {
+        // given
         UUID userId = UUID.randomUUID();
 
         User user = User.builder()
@@ -351,8 +434,10 @@ class ChatMessageServiceTest {
                     return newsShare;
                 });
 
+        // when
         var result = chatMessageService.shareNews(userId, new ShareNewsCommand(55L));
 
+        // then
         verify(chatMessageRepository).save(argThat(message ->
                 message.getMessageType() == MessageType.NEWS
                         && "cluster title".equals(message.getContent())
@@ -372,4 +457,3 @@ class ChatMessageServiceTest {
         assertEquals("https://image.test/thumb.png", result.newsShare().thumbnailUrl());
     }
 }
-

--- a/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
@@ -74,8 +74,9 @@ class VoteServiceTest {
     }
 
     @Test
-    @DisplayName("createVote saves vote options and shares chat message")
+    @DisplayName("투표 생성 시 선택지를 저장하고 채팅 공유를 수행한다")
     void createVote_success() {
+        // given
         UUID userId = UUID.randomUUID();
         User user = createUser(userId);
         Group group = createGroup(1L);
@@ -100,8 +101,10 @@ class VoteServiceTest {
             return vote;
         });
 
+        // when
         VoteInfo result = voteService.createVote(userId, command);
 
+        // then
         assertThat(result.voteId()).isEqualTo(10L);
         assertThat(result.title()).isEqualTo("Lunch menu vote");
         assertThat(result.maxSelectCount()).isEqualTo(1);
@@ -112,8 +115,9 @@ class VoteServiceTest {
     }
 
     @Test
-    @DisplayName("createVote fails when user is not an active group member")
+    @DisplayName("활성 그룹 멤버가 아니면 투표 생성에 실패한다")
     void createVote_fail_when_user_is_not_active_member() {
+        // given
         UUID userId = UUID.randomUUID();
         User user = createUser(userId);
         Group group = createGroup(1L);
@@ -133,18 +137,21 @@ class VoteServiceTest {
                 GroupMember.GroupMemberStatus.ACTIVE
         )).willReturn(false);
 
+        // when
         assertThatThrownBy(() -> voteService.createVote(userId, command))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.GROUP_MEMBER_FORBIDDEN);
 
+        // then
         verify(voteRepository, never()).save(any(Vote.class));
         verify(voteOptionRepository, never()).saveAll(any());
         verify(chatMessageService, never()).shareVote(any(), any());
     }
 
     @Test
-    @DisplayName("createVote fails when options contain duplicates after trimming")
+    @DisplayName("선택지를 trim한 뒤 중복이 있으면 투표 생성에 실패한다")
     void createVote_fail_when_options_are_duplicated() {
+        // given
         UUID userId = UUID.randomUUID();
         CreateVoteCommand command = new CreateVoteCommand(
                 1L,
@@ -154,17 +161,20 @@ class VoteServiceTest {
                 1L
         );
 
+        // when
         assertThatThrownBy(() -> voteService.createVote(userId, command))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT);
 
+        // then
         verify(userRepository, never()).findById(any());
         verify(voteRepository, never()).save(any(Vote.class));
     }
 
     @Test
-    @DisplayName("submitVote replaces existing selections when user changes vote")
+    @DisplayName("투표를 다시 제출하면 기존 선택을 대체한다")
     void submitVote_success_when_replacing_existing_selection() {
+        // given
         UUID userId = UUID.randomUUID();
         User user = createUser(userId);
         Vote vote = createVoteEntity(5L, 2);
@@ -188,8 +198,10 @@ class VoteServiceTest {
         given(voteAnswerRepository.countByVoteIdGroupByOptionId(5L))
                 .willReturn(List.<Object[]>of(new Object[]{102L, 1L}));
 
+        // when
         VoteResultInfo result = voteService.submitVote(userId, 5L, new SubmitVoteCommand(List.of(102L)));
 
+        // then
         assertThat(result.voteId()).isEqualTo(5L);
         assertThat(result.options()).hasSize(2);
         assertThat(result.options().stream().filter(option -> option.selectedByMe())).hasSize(1);
@@ -206,8 +218,9 @@ class VoteServiceTest {
     }
 
     @Test
-    @DisplayName("submitVote returns result for valid option")
+    @DisplayName("유효한 선택지로 투표하면 결과를 반환한다")
     void submitVote_success() {
+        // given
         UUID userId = UUID.randomUUID();
         User user = createUser(userId);
         Vote vote = createVoteEntity(7L, 2);
@@ -230,8 +243,10 @@ class VoteServiceTest {
         given(voteAnswerRepository.countByVoteIdGroupByOptionId(7L))
                 .willReturn(List.<Object[]>of(new Object[]{201L, 1L}));
 
+        // when
         VoteResultInfo result = voteService.submitVote(userId, 7L, new SubmitVoteCommand(List.of(201L)));
 
+        // then
         assertThat(result.voteId()).isEqualTo(7L);
         assertThat(result.participantCount()).isEqualTo(1L);
         assertThat(result.options()).hasSize(1);


### PR DESCRIPTION
## 📌 PR 설명

그룹 채팅에서 슬래시 커맨드를 입력하면 정해진 기능이 실행되도록 커맨드 기능을 백엔드에 추가했습니다.  
우선 `/wefini 질문` 명령을 지원하도록 구현했고, 입력된 질문은 그룹 채팅에 저장된 뒤 AI 응답이 그룹 채팅 SYSTEM 메시지로 이어서 노출되도록 연결했습니다.  
또한 테스트용 커맨드 `/영`도 함께 추가해 커맨드 분기와 시스템 응답 흐름을 확인할 수 있도록 했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 제목: **[WEF-82] 그룹 채팅 커맨드 기능 백엔드 구현**

- [x] 그룹 채팅 메시지 전송 시 슬래시 커맨드 여부를 먼저 분기하도록 처리
- [x] `/wefini 질문` 형식의 커맨드 파싱 및 실행 로직 추가
- [x] `/wefini` 질문 본문이 비어 있을 경우 안내용 SYSTEM 메시지 반환
- [x] `/wefini 질문` 입력 시 사용자 질문 메시지를 그룹 채팅에 먼저 저장하도록 처리
- [x] AI 응답을 그룹 채팅 SYSTEM 메시지로 저장 및 브로드캐스트하도록 구현
- [x] 기존 AI 호출 로직에서 OpenAI 클라이언트를 재사용해 그룹 채팅 커맨드 응답에 연결
- [x] `/영` 입력 시 사용자 입력 메시지와 시스템 응답 메시지를 함께 생성하는 테스트용 커맨드 추가
- [x] 그룹 채팅 커맨드 실행 흐름에 대한 서비스 테스트 추가 및 수정

<br>

## 💭 고민과 해결과정

- `/vote`처럼 단순 UI 액션 성격의 명령과 달리 `/wefini 질문`은 실제 서버 자원을 사용하고 그룹 채팅 메시지를 생성해야 해서, 프론트 처리보다 백엔드에서 커맨드를 해석하고 실행하는 구조가 더 적절하다고 판단했습니다.
- 커맨드 실행 결과를 별도 테이블로 분리하기보다 기존 그룹 채팅 메시지 흐름 안에서 처리하는 편이 자연스러워 보여, AI 응답은 SYSTEM 메시지로 저장하고 기존 브로드캐스트 이벤트를 그대로 활용했습니다.
- `/wefini 질문`의 경우 응답만 보이는 것보다 사용자가 입력한 질문도 대화 흐름 안에 함께 남아야 맥락이 자연스러워서, 질문 메시지 저장 후 SYSTEM 응답이 이어지도록 구성했습니다.
- 개인 AI 채팅 서비스 전체를 재사용하기보다는, 실제 OpenAI 호출에 사용하는 클라이언트만 재사용하고 그룹 채팅 저장/브로드캐스트는 그룹 채팅 서비스 책임으로 분리해 역할을 나눴습니다.
- 커맨드 기능은 이후 `/help`, `/vote`, 추가 명령어 등으로 확장될 수 있어, 일반 메시지 저장 전에 명령어를 먼저 분기하는 방식으로 두어 확장 가능성을 열어두었습니다.

<br>

### 🔗 관련 이슈
Closes #82

[WEF-82]: https://sol-v.atlassian.net/browse/WEF-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 채팅에서 특정 명령어 인식 및 처리 기능 추가
  * AI 기반 질문 응답 기능(명령어 연동) 도입
  * 시스템 메시지 생성·발행 기능 추가로 메시지 흐름 개선
  * 명령어 실행 시 관련 퀘스트 진행도 자동 업데이트

* **테스트**
  * 명령어·AI 실패 시 동작 검증 등 관련 단위 테스트 추가 및 보완
<!-- end of auto-generated comment: release notes by coderabbit.ai -->