### PR TITLE
[WEF-680] 재사용 코드 조회

### DIFF
--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -136,8 +136,12 @@ public class GroupService {
     }
 
     public GroupInviteInfo getLatestInviteCode(Long groupId, UUID userId) {
-        Group group = groupRepository.findByIdForUpdate(groupId)
+        Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        if (group.isHomeGroup()) {
+            throw new BusinessException(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
+        }
 
         boolean isMember = groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                 userId,

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -135,6 +135,33 @@ public class GroupService {
         return GroupInviteInfo.from(invite);
     }
 
+    public GroupInviteInfo getLatestInviteCode(Long groupId, UUID userId) {
+        Group group = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        boolean isMember = groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                userId,
+                group,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        if (!isMember) {
+            throw new BusinessException(ErrorCode.GROUP_INVITE_FORBIDDEN);
+        }
+
+        OffsetDateTime now = OffsetDateTime.now();
+
+        GroupInvite invite = groupInviteRepository
+                .findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                        group,
+                        GroupInvite.InviteStatus.PENDING,
+                        now
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_INVITE_NOT_FOUND));
+
+        return GroupInviteInfo.from(invite);
+    }
+
     @Transactional
     public GroupMemberInfo joinGroup(UUID userId, UUID inviteCode) {
         GroupInvite invite = groupInviteRepository.findByInviteCode(inviteCode)

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -135,6 +135,7 @@ public class GroupService {
         return GroupInviteInfo.from(invite);
     }
 
+    @Transactional(readOnly = true)
     public GroupInviteInfo getLatestInviteCode(Long groupId, UUID userId) {
         Group group = groupRepository.findById(groupId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -15,7 +15,7 @@ public enum ErrorCode {
     GROUP_MEMBER_FORBIDDEN(403, "해당 그룹의 멤버만 조회할 수 있습니다."),
     GROUP_MEMBER_NOT_FOUND(404, "그룹 멤버를 찾을 수 없습니다."),
     GROUP_MEMBER_ALREADY_INACTIVE(400, "이미 비활성화된 그룹 멤버입니다."),
-    GROUP_INVITE_FORBIDDEN(403, "해당 그룹의 초대 코드를 생성할 권한이 없습니다."),
+    GROUP_INVITE_FORBIDDEN(403, "해당 그룹의 초대 코드를 조회하거나 생성할 권한이 없습니다."),
     GROUP_INVITE_NOT_FOUND(404, "초대 코드를 찾을 수 없습니다."),
     GROUP_INVITE_EXPIRED(400, "만료된 초대 코드입니다."),
     GROUP_FULL(400, "그룹 인원이 가득 찼습니다."),

--- a/src/main/java/com/solv/wefin/web/group/GroupController.java
+++ b/src/main/java/com/solv/wefin/web/group/GroupController.java
@@ -50,6 +50,15 @@ public class GroupController {
         return ApiResponse.success(CreateGroupInviteResponse.from(inviteInfo));
     }
 
+    @GetMapping("/{groupId}/invite-codes/latest")
+    public ApiResponse<CreateGroupInviteResponse> getLatestInviteCode(
+            @PathVariable Long groupId,
+            @AuthenticationPrincipal UUID userId
+    ) {
+        GroupInviteInfo info = groupService.getLatestInviteCode(groupId, userId);
+        return ApiResponse.success(CreateGroupInviteResponse.from(info));
+    }
+
     @PostMapping("/join")
     public ApiResponse<JoinGroupResponse> joinGroup(
             @RequestBody @Valid JoinGroupRequest request,

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
@@ -252,7 +252,7 @@ class GroupInviteServiceTest {
                     GroupInvite.InviteStatus.PENDING
             );
 
-            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
+            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
             when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -275,7 +275,7 @@ class GroupInviteServiceTest {
                     () -> assertThat(result.expiredAt()).isNotNull()
             );
 
-            verify(groupRepository).findByIdForUpdate(1L);
+            verify(groupRepository).findById(1L);
             verify(groupMemberRepository).existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -295,7 +295,7 @@ class GroupInviteServiceTest {
 
             Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
 
-            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
+            when(groupRepository.findById(1L)).thenReturn(Optional.of(group));
             when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
                     userId,
                     group,
@@ -313,6 +313,26 @@ class GroupInviteServiceTest {
             );
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("홈 그룹이면 최신 초대 코드 조회가 불가하다")
+        void getLatestInviteCode_fail_when_home_group() throws Exception {
+            UUID userId = UUID.randomUUID();
+            Group homeGroup = createGroup(1L, "리더의 그룹", GroupType.HOME);
+
+            when(groupRepository.findById(1L)).thenReturn(Optional.of(homeGroup));
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.getLatestInviteCode(1L, userId)
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED);
+            verify(groupMemberRepository, never()).existsByUser_UserIdAndGroupAndStatus(any(), any(), any());
+            verify(groupInviteRepository, never()).findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    any(), any(), any()
+            );
         }
     }
 }

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupInviteServiceTest.java
@@ -226,4 +226,93 @@ class GroupInviteServiceTest {
             verify(groupInviteRepository, never()).save(any());
         }
     }
+
+    @Nested
+    @DisplayName("getLatestInviteCode")
+    class GetLatestInviteCodeTest {
+
+        @Test
+        @DisplayName("유효한 초대 코드가 있으면 반환한다")
+        void success() throws Exception {
+            UUID userId = UUID.randomUUID();
+
+            Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
+            var user = createUser(
+                    userId,
+                    "leader@test.com",
+                    "리더",
+                    "encoded-password"
+            );
+
+            GroupInvite existingInvite = createGroupInvite(
+                    10L,
+                    group,
+                    user,
+                    UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                    GroupInvite.InviteStatus.PENDING
+            );
+
+            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
+            when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                    userId,
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(true);
+            when(groupInviteRepository.findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            )).thenReturn(Optional.of(existingInvite));
+
+            GroupInviteInfo result = groupService.getLatestInviteCode(1L, userId);
+
+            assertAll(
+                    () -> assertThat(result.codeId()).isEqualTo(10L),
+                    () -> assertThat(result.groupId()).isEqualTo(1L),
+                    () -> assertThat(result.inviteCode())
+                            .isEqualTo(UUID.fromString("550e8400-e29b-41d4-a716-446655440000")),
+                    () -> assertThat(result.status()).isEqualTo(GroupInvite.InviteStatus.PENDING),
+                    () -> assertThat(result.expiredAt()).isNotNull()
+            );
+
+            verify(groupRepository).findByIdForUpdate(1L);
+            verify(groupMemberRepository).existsByUser_UserIdAndGroupAndStatus(
+                    userId,
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+            verify(groupInviteRepository).findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            );
+        }
+
+        @Test
+        @DisplayName("초대 코드가 없으면 예외가 발생한다")
+        void fail_not_found() throws Exception {
+            UUID userId = UUID.randomUUID();
+
+            Group group = createGroup(1L, "테스트 그룹", GroupType.SHARED);
+
+            when(groupRepository.findByIdForUpdate(1L)).thenReturn(Optional.of(group));
+            when(groupMemberRepository.existsByUser_UserIdAndGroupAndStatus(
+                    userId,
+                    group,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(true);
+            when(groupInviteRepository.findFirstByGroupAndStatusAndExpiredAtAfterOrderByCreatedAtDesc(
+                    eq(group),
+                    eq(GroupInvite.InviteStatus.PENDING),
+                    any(OffsetDateTime.class)
+            )).thenReturn(Optional.empty());
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.getLatestInviteCode(1L, userId)
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_INVITE_NOT_FOUND);
+        }
+    }
 }

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -6,6 +6,8 @@ import com.solv.wefin.domain.group.dto.LeaveGroupInfo;
 import com.solv.wefin.domain.group.entity.GroupInvite;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -137,6 +139,23 @@ class GroupControllerTest {
                 .andExpect(jsonPath("$.data.inviteCode").value("550e8400-e29b-41d4-a716-446655440000"))
                 .andExpect(jsonPath("$.data.status").value("PENDING"))
                 .andExpect(jsonPath("$.data.expiredAt").exists());
+    }
+
+    @Test
+    @DisplayName("홈 그룹이면 최신 초대 코드 조회에 실패한다")
+    void getLatestInviteCode_fail_when_home_group() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        given(groupService.getLatestInviteCode(1L, userId))
+                .willThrow(new BusinessException(ErrorCode.GROUP_HOME_INVITE_NOT_ALLOWED));
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userId, null, List.of());
+
+        mockMvc.perform(get("/api/groups/{groupId}/invite-codes/latest", 1L)
+                        .with(authentication(authentication)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("GROUP_HOME_INVITE_NOT_ALLOWED"));
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/group/GroupControllerTest.java
@@ -111,6 +111,35 @@ class GroupControllerTest {
     }
 
     @Test
+    @DisplayName("최신 그룹 초대 코드 조회에 성공한다")
+    void getLatestInviteCode_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime expiredAt = OffsetDateTime.now().plusHours(24);
+
+        given(groupService.getLatestInviteCode(1L, userId))
+                .willReturn(new GroupInviteInfo(
+                        10L,
+                        1L,
+                        UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+                        GroupInvite.InviteStatus.PENDING,
+                        expiredAt
+                ));
+
+        UsernamePasswordAuthenticationToken authentication =
+                new UsernamePasswordAuthenticationToken(userId, null, List.of());
+
+        mockMvc.perform(get("/api/groups/{groupId}/invite-codes/latest", 1L)
+                        .with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.codeId").value(10))
+                .andExpect(jsonPath("$.data.groupId").value(1))
+                .andExpect(jsonPath("$.data.inviteCode").value("550e8400-e29b-41d4-a716-446655440000"))
+                .andExpect(jsonPath("$.data.status").value("PENDING"))
+                .andExpect(jsonPath("$.data.expiredAt").exists());
+    }
+
+    @Test
     @DisplayName("그룹 탈퇴에 성공한다")
     void leaveGroup_success() throws Exception {
         // given


### PR DESCRIPTION
## 📌 PR 설명
정 화면 진입 시 기존 초대 코드를 조회할 수 있도록 최신 초대 코드 조회 API를 추가.

## ✅ 완료한 기능 명세

- [x]  최신 초대 코드 조회 API 추가 (GET /api/groups/{groupId}/invite-codes/latest)
- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 동일 그룹 내에서 유효한 코드가 존재하면 재사용 없을 경우에만 신규 생성하도록 설계
- 프론트에서 기존 코드를 표시하기 위해 조회 API 필요성 확인 후 추가
- 초대 코드 조회 시 유효한 코드만 반환하도록 expiredAt 기준 필터링 적용
- 프론트에서는 404 응답을 null로 처리하여 자연스럽게 코드 없음 UI 구성
<br>

### 🔗 관련 이슈
Closes #309 

<br>
