### PR TITLE
[WEF-682] 회원 탈퇴

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/entity/User.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/User.java
@@ -54,4 +54,9 @@ public class User extends BaseEntity {
     public void changePassword(String password) {
         this.password = password;
     }
+
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAWN;
+        this.homeGroup = null;
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/entity/User.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/User.java
@@ -58,5 +58,7 @@ public class User extends BaseEntity {
     public void withdraw() {
         this.status = UserStatus.WITHDRAWN;
         this.homeGroup = null;
+        this.email = "withdrawn_" + this.userId + "@deleted.local";
+        this.nickname = "wd_" + this.userId.toString().substring(0, 8);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -10,9 +10,10 @@ import com.solv.wefin.domain.auth.entity.VerificationPurpose;
 import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.domain.quest.entity.QuestEventType;
-import com.solv.wefin.domain.quest.entity.UserQuest;
 import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.domain.quest.service.UserQuestService;
 import com.solv.wefin.domain.trading.account.service.VirtualAccountService;
@@ -28,6 +29,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
@@ -49,6 +51,7 @@ public class AuthService {
     private final QuestProgressService questProgressService;
     private final VirtualAccountService virtualAccountService;
     private final UserQuestService userQuestService;
+    private final GroupMemberRepository groupMemberRepository;
 
     @Transactional
     public SignupInfo signup(SignupCommand command) {
@@ -232,6 +235,34 @@ public class AuthService {
             throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
         }
         savedToken.revoke();
+    }
+
+    @Transactional
+    public void withdraw(UUID userId, String password) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessException(ErrorCode.AUTH_PASSWORD_MISMATCH);
+        }
+
+        List<GroupMember> activeMembers = groupMemberRepository.findAllByUser_UserIdAndStatus(
+                userId,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        for (GroupMember activeMember : activeMembers) {
+            activeMember.deactivate();
+        }
+
+        refreshTokenRepository.findById(userId)
+                .ifPresent(RefreshToken::revoke);
+
+        user.withdraw();
     }
 
     private RefreshToken getValidRefreshTokenForUpdate(String refreshToken) {

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -256,7 +256,34 @@ public class AuthService {
         );
 
         for (GroupMember activeMember : activeMembers) {
+            boolean wasLeader = activeMember.isLeader();
+            Group group = activeMember.getGroup();
+
+            if (wasLeader) {
+                activeMember.changeRoleToMember();
+            }
+
             activeMember.deactivate();
+            groupMemberRepository.flush();
+
+            if (wasLeader && group.isSharedGroup()) {
+                long remainingActiveMemberCount = groupMemberRepository.countByGroupAndStatus(
+                        group,
+                        GroupMember.GroupMemberStatus.ACTIVE
+                );
+
+                if (remainingActiveMemberCount > 0) {
+                    GroupMember nextLeader = groupMemberRepository
+                            .findFirstByGroupAndStatusAndUser_UserIdNotOrderByIdAsc(
+                                    group,
+                                    GroupMember.GroupMemberStatus.ACTIVE,
+                                    userId
+                            )
+                            .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_LEADER_TRANSFER_FAILED));
+
+                    nextLeader.changeRoleToLeader();
+                }
+            }
         }
 
         refreshTokenRepository.findById(userId)

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
@@ -21,6 +21,11 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             GroupMember.GroupMemberStatus status
     );
 
+    List<GroupMember> findAllByUser_UserIdAndStatus(
+            UUID userId,
+            GroupMember.GroupMemberStatus status
+    );
+
     Optional<GroupMember> findByUser_UserIdAndGroup_Id(UUID userId, Long groupId);
 
     Optional<GroupMember> findByUser_UserIdAndGroup_GroupType(

--- a/src/main/java/com/solv/wefin/web/auth/AuthController.java
+++ b/src/main/java/com/solv/wefin/web/auth/AuthController.java
@@ -126,4 +126,13 @@ public class AuthController {
 
         return ApiResponse.success(null);
     }
+
+    @DeleteMapping("/me")
+    public ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal UUID userId,
+            @RequestBody @Valid WithdrawRequest request
+    ) {
+        authService.withdraw(userId, request.getPassword());
+        return ApiResponse.success(null);
+    }
 }

--- a/src/main/java/com/solv/wefin/web/auth/dto/WithdrawRequest.java
+++ b/src/main/java/com/solv/wefin/web/auth/dto/WithdrawRequest.java
@@ -1,0 +1,11 @@
+package com.solv.wefin.web.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class WithdrawRequest {
+
+    @NotBlank
+    private String password;
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -631,7 +632,7 @@ class AuthServiceTest {
     class WithdrawTest {
 
         @Test
-        @DisplayName("회원 탈퇴에 성공한다")
+        @DisplayName("회원 탈퇴 시 ACTIVE 그룹 멤버가 모두 비활성화되고 refresh token이 revoke된다")
         void withdraw_success() {
             UUID userId = UUID.randomUUID();
 
@@ -643,6 +644,10 @@ class AuthServiceTest {
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
+            GroupMember member1 = mock(GroupMember.class);
+            GroupMember member2 = mock(GroupMember.class);
+            RefreshToken refreshToken = mock(RefreshToken.class);
+
             when(userRepository.findByIdForUpdate(userId))
                     .thenReturn(Optional.of(user));
             when(passwordEncoder.matches("pass1234", "encoded-password"))
@@ -650,15 +655,74 @@ class AuthServiceTest {
             when(groupMemberRepository.findAllByUser_UserIdAndStatus(
                     userId,
                     GroupMember.GroupMemberStatus.ACTIVE
-            )).thenReturn(List.of());
+            )).thenReturn(List.of(member1, member2));
+            when(refreshTokenRepository.findById(userId))
+                    .thenReturn(Optional.of(refreshToken));
+
+            authService.withdraw(userId, "pass1234");
+
+            verify(member1).deactivate();
+            verify(member2).deactivate();
+            verify(refreshToken).revoke();
+            assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
+            assertThat(user.getHomeGroup()).isNull();
+        }
+
+        @Test
+        @DisplayName("shared group 리더가 탈퇴하면 다음 ACTIVE 멤버에게 리더가 승계된다")
+        void withdraw_transfers_leadership_when_leader_leaves_shared_group() {
+            UUID userId = UUID.randomUUID();
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+
+            Group sharedGroup = Group.createSharedGroup("공유 그룹");
+
+            GroupMember leaderMember = mock(GroupMember.class);
+            GroupMember nextLeader = mock(GroupMember.class);
+
+            when(userRepository.findByIdForUpdate(userId))
+                    .thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pass1234", "encoded-password"))
+                    .thenReturn(true);
+
+            when(groupMemberRepository.findAllByUser_UserIdAndStatus(
+                    userId,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(List.of(leaderMember));
+
+            when(leaderMember.isLeader()).thenReturn(true);
+            when(leaderMember.getGroup()).thenReturn(sharedGroup);
+
+            when(groupMemberRepository.countByGroupAndStatus(
+                    sharedGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(1L);
+
+            when(groupMemberRepository.findFirstByGroupAndStatusAndUser_UserIdNotOrderByIdAsc(
+                    sharedGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE,
+                    userId
+            )).thenReturn(Optional.of(nextLeader));
+
             when(refreshTokenRepository.findById(userId))
                     .thenReturn(Optional.empty());
 
             authService.withdraw(userId, "pass1234");
 
+            InOrder inOrder = inOrder(leaderMember, groupMemberRepository, nextLeader);
+
+            inOrder.verify(leaderMember).changeRoleToMember();
+            inOrder.verify(leaderMember).deactivate();
+            inOrder.verify(groupMemberRepository).flush();
+            inOrder.verify(nextLeader).changeRoleToLeader();
+
             assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
-            assertThat(user.getHomeGroup()).isNull();
-            verify(refreshTokenRepository).findById(userId);
         }
 
         @Test

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -10,6 +10,8 @@ import com.solv.wefin.domain.auth.entity.VerificationPurpose;
 import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.domain.group.service.GroupService;
 import com.solv.wefin.domain.quest.entity.QuestEventType;
 import com.solv.wefin.domain.quest.service.QuestProgressService;
@@ -33,6 +35,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.sql.SQLException;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -72,6 +75,9 @@ class AuthServiceTest {
 
     @Mock
     private UserQuestService userQuestService;
+
+    @Mock
+    private GroupMemberRepository groupMemberRepository;
 
     @InjectMocks
     private AuthService authService;
@@ -617,6 +623,70 @@ class AuthServiceTest {
             );
 
             assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw")
+    class WithdrawTest {
+
+        @Test
+        @DisplayName("회원 탈퇴에 성공한다")
+        void withdraw_success() {
+            UUID userId = UUID.randomUUID();
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+
+            when(userRepository.findByIdForUpdate(userId))
+                    .thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("pass1234", "encoded-password"))
+                    .thenReturn(true);
+            when(groupMemberRepository.findAllByUser_UserIdAndStatus(
+                    userId,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(List.of());
+            when(refreshTokenRepository.findById(userId))
+                    .thenReturn(Optional.empty());
+
+            authService.withdraw(userId, "pass1234");
+
+            assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
+            assertThat(user.getHomeGroup()).isNull();
+            verify(refreshTokenRepository).findById(userId);
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 탈퇴에 실패한다")
+        void withdraw_fail_when_password_mismatch() {
+            UUID userId = UUID.randomUUID();
+
+            User user = User.builder()
+                    .email("test@example.com")
+                    .nickname("testuser")
+                    .password("encoded-password")
+                    .build();
+
+            ReflectionTestUtils.setField(user, "userId", userId);
+
+            when(userRepository.findByIdForUpdate(userId))
+                    .thenReturn(Optional.of(user));
+            when(passwordEncoder.matches("wrong-password", "encoded-password"))
+                    .thenReturn(false);
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.withdraw(userId, "wrong-password")
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_PASSWORD_MISMATCH);
+            verify(groupMemberRepository, never()).findAllByUser_UserIdAndStatus(any(), any());
+            verify(refreshTokenRepository, never()).findById(any());
         }
     }
 }

--- a/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/auth/AuthControllerTest.java
@@ -33,6 +33,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 
 @WebMvcTest(AuthController.class)
 @Import(AuthExceptionHandler.class)
@@ -565,6 +566,97 @@ class AuthControllerTest {
                     .andExpect(jsonPath("$.status").value(400))
                     .andExpect(jsonPath("$.code").value("AUTH_PASSWORD_SAME_AS_OLD"))
                     .andExpect(jsonPath("$.message").value("새 비밀번호는 기존 비밀번호와 달라야 합니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/auth/me")
+    class WithdrawTest {
+
+        private String withdrawRequest(String password) {
+            return """
+        {
+          "password": "%s"
+        }
+        """.formatted(password);
+        }
+
+        @Test
+        @DisplayName("회원 탈퇴 성공 시 200을 반환한다")
+        void withdraw_success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            String requestBody = withdrawRequest("pass1234");
+
+            mockMvc.perform(delete("/api/auth/me")
+                            .with(csrf())
+                            .with(authentication(
+                                    new UsernamePasswordAuthenticationToken(
+                                            userId,
+                                            null,
+                                            AuthorityUtils.NO_AUTHORITIES
+                                    )
+                            ))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data").value(org.hamcrest.Matchers.nullValue()));
+
+            verify(authService).withdraw(userId, "pass1234");
+        }
+
+        @Test
+        @DisplayName("비밀번호가 비어 있으면 validation 에러를 반환한다")
+        void withdraw_fail_when_password_blank() throws Exception {
+            UUID userId = UUID.randomUUID();
+
+            String requestBody = """
+        {
+          "password": ""
+        }
+        """;
+
+            mockMvc.perform(delete("/api/auth/me")
+                            .with(csrf())
+                            .with(authentication(
+                                    new UsernamePasswordAuthenticationToken(
+                                            userId,
+                                            null,
+                                            AuthorityUtils.NO_AUTHORITIES
+                                    )
+                            ))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.code").value("AUTH_VALIDATION_FAILED"))
+                    .andExpect(jsonPath("$.data.password").exists());
+        }
+
+        @Test
+        @DisplayName("비밀번호가 일치하지 않으면 400 에러를 반환한다")
+        void withdraw_fail_when_password_mismatch() throws Exception {
+            UUID userId = UUID.randomUUID();
+            String requestBody = withdrawRequest("wrong-password");
+
+            doThrow(new BusinessException(ErrorCode.AUTH_PASSWORD_MISMATCH))
+                    .when(authService).withdraw(userId, "wrong-password");
+
+            mockMvc.perform(delete("/api/auth/me")
+                            .with(csrf())
+                            .with(authentication(
+                                    new UsernamePasswordAuthenticationToken(
+                                            userId,
+                                            null,
+                                            AuthorityUtils.NO_AUTHORITIES
+                                    )
+                            ))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status").value(400))
+                    .andExpect(jsonPath("$.code").value("AUTH_PASSWORD_MISMATCH"))
+                    .andExpect(jsonPath("$.message").value("현재 비밀번호가 일치하지 않습니다."));
         }
     }
 }


### PR DESCRIPTION
## 📌 PR 설명
회원 탈퇴 기능을 구현.
사용자는 비밀번호 검증 후 탈퇴할 수 있으며, 탈퇴 시 관련 데이터는 soft delete 방식으로 처리.
<br>

## ✅ 완료한 기능 명세

- [x] 회원 탈퇴 API 추가 (DELETE /api/auth/me)
- [x] 비밀번호 검증 로직 적용
- [x] User 상태를 WITHDRAWN으로 변경 (soft delete)
- [x] homeGroup null 처리
- [x] 모든 그룹 멤버십 비활성화 (GroupMember → INACTIVE)
- [x] refresh token revoke 처리
- [x] AuthService 단위 테스트 추가
- [x] AuthController 테스트 추가
- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
- 기존 GroupService.leaveGroup()을 재사용하지 않고 회원 탈퇴 시에는 직접 그룹 멤버십을 정리하도록 구현
→ 해당 메서드는 home group으로 복귀시키는 로직이 있어 탈퇴와 충돌

- soft delete 구조를 유지하기 위해 UserStatus.WITHDRAWN 상태를 활용
→ 기존 로그인/토큰 로직에서 ACTIVE만 허용하고 있어 별도 인증 차단 로직 추가 없이 처리 가능

- 탈퇴 시 homeGroup FK가 남는 문제를 방지하기 위해 null 처리

- refresh token은 삭제가 아닌 revoke 방식으로 일관성 유지
<br>

### 🔗 관련 이슈
Closes #312 

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 계정 탈퇴 기능이 추가되었습니다. 사용자는 비밀번호 검증을 통해 계정을 탈퇴할 수 있으며, 탈퇴 시 활성 그룹 멤버십이 비활성화되고 갱신 토큰이 취소됩니다.

* **테스트**
  * 계정 탈퇴 기능의 성공 및 실패 시나리오에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->