### PR TITLE
[FIX] 운영 기본값 수정 (wefin-news의 base-url)

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -81,7 +81,7 @@ batch:
     rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
 wefin-news:
   api:
-    base-url: ${WEFIN_NEWS_BASE_URL:https://wefin.ai.kr}
+    base-url: ${WEFIN_NEWS_BASE_URL:https://api.wefin.ai.kr}
 
 websocket:
   allowed-origins:


### PR DESCRIPTION
## 📌 PR 설명
WEFIN_NEWS_BASE_URL 기본값을 https://wefin.ai.kr → https://api.wefin.ai.kr로 수정했습니다.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 프로덕션 환경의 API 기본 엔드포인트가 업데이트되어 서비스의 안정적인 연결을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->