### PR TITLE
[FIX] 게임 시작 일 보정 기능 수정

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -66,8 +66,8 @@ public class GameRoomService {
         }
 
         // start_date 랜덤 추출 + 거래일 보정
-        LocalDate rangeStart = stockDailyRepository.findEarliestTradeDate()
-                .orElseThrow(() -> new IllegalStateException("주가 데이터가 없습니다. 데이터 수집이 필요합니다."));
+        LocalDate rangeStart = stockDailyRepository.findEarliestTradeDateAfter(LocalDate.of(2020, 12, 31))
+                .orElseThrow(() -> new IllegalStateException("2021년 이후 주가 데이터가 없습니다. 데이터 수집이 필요합니다."));
         LocalDate rangeEnd = LocalDate.of(2024, 12, 31).minusMonths(command.periodMonths());
         long daysBetween = ChronoUnit.DAYS.between(rangeStart, rangeEnd);
         long randomDays = ThreadLocalRandom.current().nextLong(daysBetween + 1);

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -78,8 +78,8 @@ class GameRoomServiceTest {
         given(gameRoomRepository.countByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(0L);
-        // DB 최초 거래일 — 방 생성 시 시작일 범위 하한
-        given(stockDailyRepository.findEarliestTradeDate())
+        // 2021년 이후 최초 거래일 — 방 생성 시 시작일 범위 하한
+        given(stockDailyRepository.findEarliestTradeDateAfter(LocalDate.of(2020, 12, 31)))
                 .willReturn(Optional.of(LocalDate.of(2021, 1, 4)));
         // 랜덤으로 뽑힌 날짜는 이하에서 가장 가까운 거래일로 보정
         given(stockDailyRepository.findLatestTradeDateOnOrBefore(any(LocalDate.class)))
@@ -111,7 +111,7 @@ class GameRoomServiceTest {
         given(gameRoomRepository.countByUserIdAndStartedAtBetween(
                 any(UUID.class), any(OffsetDateTime.class), any(OffsetDateTime.class)))
                 .willReturn(0L);
-        given(stockDailyRepository.findEarliestTradeDate())
+        given(stockDailyRepository.findEarliestTradeDateAfter(LocalDate.of(2020, 12, 31)))
                 .willReturn(Optional.of(LocalDate.of(2021, 1, 4)));
         LocalDate adjustedTradeDate = LocalDate.of(2022, 1, 3);
         given(stockDailyRepository.findLatestTradeDateOnOrBefore(any(LocalDate.class)))


### PR DESCRIPTION
## 📌 PR 설명
<br>게임 시작 일 보정 기능을 수정 했습니다.

## ✅ 완료한 기능 명세

- [x] 게임 시작 일 보정 기능 수정
<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
 2021년 1월 1일 에 걸릴 경우 휴장일이라 이전 일로 보정이 되게 하려는 목적으로 설계했으나 2020년의 날짜로 갈 수 있는 현상이 있어 2021년 1월 이후의 날짜로 보정되게 수정했습니다.
<br>

### 🔗 관련 이슈
Closes #이슈번호

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 게임룸 생성 시 거래 데이터 조회 로직을 개선했습니다.
  * 2021년 이후의 데이터만 사용하도록 조정했습니다.
  * 데이터 부족 시 표시되는 오류 메시지를 명확하게 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->