### PR TITLE
[WEF-683] 뉴스 클러스터 조회 순위 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/HotAggregationRunner.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/HotAggregationRunner.java
@@ -1,0 +1,67 @@
+package com.solv.wefin.domain.news.cluster.batch;
+
+import com.solv.wefin.domain.news.cluster.repository.HotAggregationMetaRepository;
+import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.config.NewsHotProperties;
+import com.solv.wefin.global.config.AdvisoryLockKeys;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 뉴스 클러스터 조회수 랭킹({@code sort=view}) 집계 배치 실행부
+ *
+ * {@link NewsClusterRepository#refreshRecentViewCounts} 로 ACTIVE 클러스터들의 최근 N시간 고유 뷰어 수를
+ * 갱신하고, {@link HotAggregationMetaRepository#upsertLatest} 로 헬스체크 메타를 UPSERT 한다.
+ *
+ * advisory lock 획득과 DB 쓰기를 같은 트랜잭션에서 처리해 커넥션 경계로 인한 lock leak 을 원천 차단한다.
+ * {@code pg_try_advisory_xact_lock} 은 트랜잭션 commit/rollback 시 자동 해제되므로 명시적 unlock 이 필요 없다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotAggregationRunner {
+
+    private final NewsClusterRepository newsClusterRepository;
+    private final HotAggregationMetaRepository metaRepository;
+    private final NewsHotProperties newsHotProperties;
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * 최근 N시간 윈도우 조회수를 ACTIVE 클러스터에 대해 재계산하고 메타 row 를 갱신한다.
+     */
+    @Transactional
+    public void doRefresh() {
+        // advisory lock 시도 (트랜잭션 단위). 이미 다른 실행이 있으면 false 반환 (대기하지 않음)
+        Boolean acquired = jdbcTemplate.queryForObject(
+                "SELECT pg_try_advisory_xact_lock(?)", Boolean.class, AdvisoryLockKeys.HOT_NEWS_AGG);
+
+        if (!Boolean.TRUE.equals(acquired)) {
+            log.info("[hot-news-agg] result=skipped reason=lock_held_by_other_instance");
+            return; // 다른 인스턴스/스레드가 수행 중 → 중복 실행 방지
+        }
+
+        long start = System.currentTimeMillis(); // 수행 시간 측정 시작
+        OffsetDateTime now = OffsetDateTime.now();
+        // 최근 N시간 윈도우 시작 시각 계산
+        OffsetDateTime windowStart = now.minusHours(newsHotProperties.windowHours());
+
+        // ACTIVE 클러스터 대상 최근 조회수 재집계
+        // 내부적으로 "변경된 row만 UPDATE" (IS DISTINCT FROM)로 write 최소화
+        int updated = newsClusterRepository.refreshRecentViewCounts(windowStart);
+
+        int tookMs = (int) (System.currentTimeMillis() - start); // 수행 시간 계산
+
+        // 배치 메타 정보 UPSERT (id=1 고정)
+        // → FE에서 last_success_at 기반 fallback 판단에 사용
+        metaRepository.upsertLatest(now, windowStart, updated, tookMs);
+
+        // 구조화 로그: 결과/윈도우/갱신건수/소요시간 → metric-like 집계 가능
+        log.info("[hot-news-agg] result=success windowStart={} updated={} tookMs={}",
+                windowStart, updated, tookMs);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/HotAggregationRunner.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/HotAggregationRunner.java
@@ -10,6 +10,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 
 /**
@@ -30,6 +31,11 @@ public class HotAggregationRunner {
     private final HotAggregationMetaRepository metaRepository;
     private final NewsHotProperties newsHotProperties;
     private final JdbcTemplate jdbcTemplate;
+    /**
+     * 윈도우 시작 시각을 산출할 때 사용하는 시계.
+     * 테스트에서 {@code Clock.fixed(...)} 를 주입하면 배치 집계 로직을 시간 의존 없이 검증할 수 있다.
+     */
+    private final Clock clock;
 
     /**
      * 최근 N시간 윈도우 조회수를 ACTIVE 클러스터에 대해 재계산하고 메타 row 를 갱신한다.
@@ -46,7 +52,7 @@ public class HotAggregationRunner {
         }
 
         long start = System.currentTimeMillis(); // 수행 시간 측정 시작
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = OffsetDateTime.now(clock);
         // 최근 N시간 윈도우 시작 시각 계산
         OffsetDateTime windowStart = now.minusHours(newsHotProperties.windowHours());
 

--- a/src/main/java/com/solv/wefin/domain/news/cluster/batch/HotClusterAggregationScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/batch/HotClusterAggregationScheduler.java
@@ -1,0 +1,36 @@
+package com.solv.wefin.domain.news.cluster.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 뉴스 클러스터 조회수 랭킹({@code sort=view}) 집계 배치 스케줄러
+ *
+ * 호출 트리거와 스케줄 정책(주기, initialDelay)만 담당.
+ * 실제 집계와 advisory lock 은 {@link HotAggregationRunner} 가 같은 트랜잭션에서 처리한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HotClusterAggregationScheduler {
+
+    private final HotAggregationRunner runner;
+
+    @Scheduled(
+            fixedDelayString = "${news.hot.aggregation-interval-seconds:300}",
+            initialDelayString = "${news.hot.initial-delay-seconds:30}",
+            timeUnit = TimeUnit.SECONDS
+    )
+    public void refresh() {
+        try {
+            runner.doRefresh();
+        } catch (Exception e) {
+            // 예외 swallow: 다음 주기에 자연 재시도. 로그 수집기에서 result=error 로 집계 가능.
+            log.error("[hot-news-agg] result=error message={}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/HotAggregationMeta.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/HotAggregationMeta.java
@@ -1,0 +1,67 @@
+package com.solv.wefin.domain.news.cluster.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 뉴스 클러스터 조회수 랭킹({@code sort=view}) 집계 배치의 마지막 성공 상태 메타
+ *
+ * 랭킹: 조회수 기준 뉴스 클러스터 순위 피처 ({@code GET /api/news/clusters?sort=view})
+ * 테이블 추적 대상: 랭킹 피처를 뒷받침하는
+ *                {@link com.solv.wefin.domain.news.cluster.batch.HotClusterAggregationScheduler}
+ *                배치의 마지막 성공 실행 스냅샷
+ * 단일 row (id=1) 고정 — 배치 성공마다 UPSERT 로 덮어씀. 이력은 Micrometer 메트릭 담당
+ * {@code sort=view} 응답에 {@code lastSuccessAt} 노출
+ *          → FE 가 랭킹 데이터 지연을 감지하면
+ *            "집계 준비 중" 안내 또는 {@code sort=publishedAt} 폴백을 판단할 수 있음
+ */
+@Entity
+@Table(name = "hot_aggregation_meta")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class HotAggregationMeta {
+
+    public static final short SINGLETON_ID = 1;
+
+    @Id
+    @Column(name = "id")
+    private Short id;
+
+    @Column(name = "last_success_at", nullable = false)
+    private OffsetDateTime lastSuccessAt;
+
+    @Column(name = "last_window_start", nullable = false)
+    private OffsetDateTime lastWindowStart;
+
+    @Column(name = "last_updated_count", nullable = false)
+    private int lastUpdatedCount;
+
+    @Column(name = "last_took_ms", nullable = false)
+    private int lastTookMs;
+
+    /**
+     * 테스트/디버깅 목적의 객체 생성 팩토리
+     *
+     * 프로덕션 경로에서는 {@code HotAggregationMetaRepository.upsertLatest} 네이티브 쿼리로만 저장되므로
+     * 이 메서드는 테스트 fixture 생성과 같은 용도로만 사용한다.
+     */
+    public static HotAggregationMeta forTest(OffsetDateTime lastSuccessAt,
+                                             OffsetDateTime lastWindowStart,
+                                             int lastUpdatedCount,
+                                             int lastTookMs) {
+        HotAggregationMeta meta = new HotAggregationMeta();
+        meta.id = SINGLETON_ID;
+        meta.lastSuccessAt = lastSuccessAt;
+        meta.lastWindowStart = lastWindowStart;
+        meta.lastUpdatedCount = lastUpdatedCount;
+        meta.lastTookMs = lastTookMs;
+        return meta;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/entity/NewsCluster.java
@@ -66,6 +66,12 @@ public class NewsCluster extends BaseEntity {
     @Column(name = "article_count", nullable = false)
     private int articleCount = 0;
 
+    @Column(name = "unique_viewer_count", nullable = false)
+    private long uniqueViewerCount = 0L;
+
+    @Column(name = "recent_view_count", nullable = false)
+    private long recentViewCount = 0L;
+
     public enum ClusterStatus {
         ACTIVE, INACTIVE
     }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/HotAggregationMetaRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/HotAggregationMetaRepository.java
@@ -1,0 +1,48 @@
+package com.solv.wefin.domain.news.cluster.repository;
+
+import com.solv.wefin.domain.news.cluster.entity.HotAggregationMeta;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+
+public interface HotAggregationMetaRepository extends JpaRepository<HotAggregationMeta, Short> {
+
+    /**
+     * 뉴스 클러스터 조회수 랭킹 배치의 성공 이력을 단일 row(id=1) 에 UPSERT 한다.
+     *
+     * 이력 보관은 이 테이블의 책임이 아니며(tookMs 추이는 Micrometer 메트릭 담당),
+     * FE 폴백 판단에 필요한 "마지막 성공 시각"만 항상 최신 값으로 유지한다.
+     *
+     * @param lastSuccessAt   이번 배치가 성공한 시각
+     * @param lastWindowStart 이번 집계에 사용한 윈도우 시작 시각
+     * @param lastUpdatedCount 이번 배치가 실제로 UPDATE한 클러스터 수
+     * @param lastTookMs      이번 배치 수행 시간(ms)
+     * @return UPSERT된 row 수 (항상 1)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO hot_aggregation_meta
+                (id, last_success_at, last_window_start, last_updated_count, last_took_ms)
+            VALUES (1, :lastSuccessAt, :lastWindowStart, :lastUpdatedCount, :lastTookMs)
+            ON CONFLICT (id) DO UPDATE SET
+                last_success_at    = EXCLUDED.last_success_at,
+                last_window_start  = EXCLUDED.last_window_start,
+                last_updated_count = EXCLUDED.last_updated_count,
+                last_took_ms       = EXCLUDED.last_took_ms
+            """, nativeQuery = true)
+    int upsertLatest(@Param("lastSuccessAt") OffsetDateTime lastSuccessAt,
+                     @Param("lastWindowStart") OffsetDateTime lastWindowStart,
+                     @Param("lastUpdatedCount") int lastUpdatedCount,
+                     @Param("lastTookMs") int lastTookMs);
+
+    /**
+     * 단일 row(id=1) 를 조회한다. 최초 배포 후 첫 배치 이전에는 {@code Optional.empty()}.
+     */
+    default Optional<HotAggregationMeta> findSingleton() {
+        return findById(HotAggregationMeta.SINGLETON_ID);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -285,23 +285,28 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
     // --- 조회수 카운트 업데이트 (JPQL 원자 UPDATE로 Lost Update 방지) ---
 
     /**
-     * ACTIVE 클러스터의 고유 뷰어 누적 카운트를 1 증가시킨다.
+     * 지정한 상태의 클러스터에 한해 고유 뷰어 누적 카운트를 1 증가시킨다.
      *
      * {@code markRead} 에서 신규 INSERT가 성공한 경우에만 호출한다.
      *
-     * {@code status = 'ACTIVE'} 가드는 {@code validateActiveCluster} 와 insert 사이 TOCTOU race 에서
+     * status 가드는 {@code validateActiveCluster} 와 insert 사이 TOCTOU race 에서
      * 방금 INACTIVE 로 전환된 클러스터의 count 가 누적되지 않도록 방어한다. affected=0 이면 race 신호로 경고 로그.
+     * 호출부는 보통 {@link ClusterStatus#ACTIVE} 를 전달한다.
+     *
+     * JPQL 에서 enum 리터럴을 인라인으로 쓰면 Hibernate 6 파서가 엔티티 이름과 혼동해
+     * SemanticException 을 던지므로 파라미터 바인딩으로 전달한다.
      *
      * {@code clearAutomatically=true} 는 같은 트랜잭션에서 이후 JPA 로 NewsCluster 를 읽을 때
-     * 네이티브/JPQL UPDATE 로 인한 L1 캐시 stale entity 를 피하기 위한 선방어.
+     * JPQL UPDATE 로 인한 L1 캐시 stale entity 를 피하기 위한 선방어.
      *
      * @param id 대상 클러스터 ID
+     * @param status 가드에 걸릴 상태 값 (보통 ACTIVE)
      * @return 영향받은 row 수 — 정상이면 1, 0 이면 INACTIVE 전환 race 가능성으로 경고 로그 남겨야 함
      */
     @Modifying(clearAutomatically = true)
     @Query("UPDATE NewsCluster c SET c.uniqueViewerCount = c.uniqueViewerCount + 1 " +
-            "WHERE c.id = :id AND c.status = NewsCluster.ClusterStatus.ACTIVE")
-    int incrementUniqueViewerCount(@Param("id") Long id);
+            "WHERE c.id = :id AND c.status = :status")
+    int incrementUniqueViewerCount(@Param("id") Long id, @Param("status") ClusterStatus status);
 
     /**
      * 최근 N시간 윈도우 내 고유 뷰어 수를 ACTIVE 클러스터 전체에 대해 일괄 갱신한다.

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/NewsClusterRepository.java
@@ -7,6 +7,7 @@ import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -249,4 +250,83 @@ public interface NewsClusterRepository extends JpaRepository<NewsCluster, Long> 
             @Param("tagType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType tagType,
             @Param("tagCodes") List<String> tagCodes,
             Pageable pageable);
+
+    // --- 피드 목록: 조회수 정렬 (sort=view, Top N 고정, cursor 미지원) ---
+    // publishedAt NULLS LAST: publishedAt == null 이면 정렬 상단에 끼지 않도록 명시.
+    // cold start 시 동점(recent_view_count = 0) 에서 최신 우선 배치 의도 유지.
+
+    @Query("SELECT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "ORDER BY c.recentViewCount DESC, c.publishedAt DESC NULLS LAST, c.id DESC")
+    List<NewsCluster> findHotClusters(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            Pageable pageable);
+
+    @Query("SELECT DISTINCT c FROM NewsCluster c " +
+            "WHERE c.status = :status " +
+            "AND c.summaryStatus IN :summaryStatuses " +
+            "AND c.title IS NOT NULL " +
+            "AND EXISTS (SELECT 1 FROM NewsClusterArticle nca " +
+            "            JOIN NewsArticleTag t ON t.newsArticleId = nca.newsArticleId " +
+            "            WHERE nca.newsClusterId = c.id " +
+            "            AND t.tagType = :tagType " +
+            "            AND t.tagCode IN :tagCodes) " +
+            "ORDER BY c.recentViewCount DESC, c.publishedAt DESC NULLS LAST, c.id DESC")
+    List<NewsCluster> findHotClustersByTags(
+            @Param("status") ClusterStatus status,
+            @Param("summaryStatuses") List<SummaryStatus> summaryStatuses,
+            @Param("tagType") com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType tagType,
+            @Param("tagCodes") List<String> tagCodes,
+            Pageable pageable);
+
+    // --- 조회수 카운트 업데이트 (JPQL 원자 UPDATE로 Lost Update 방지) ---
+
+    /**
+     * ACTIVE 클러스터의 고유 뷰어 누적 카운트를 1 증가시킨다.
+     *
+     * {@code markRead} 에서 신규 INSERT가 성공한 경우에만 호출한다.
+     *
+     * {@code status = 'ACTIVE'} 가드는 {@code validateActiveCluster} 와 insert 사이 TOCTOU race 에서
+     * 방금 INACTIVE 로 전환된 클러스터의 count 가 누적되지 않도록 방어한다. affected=0 이면 race 신호로 경고 로그.
+     *
+     * {@code clearAutomatically=true} 는 같은 트랜잭션에서 이후 JPA 로 NewsCluster 를 읽을 때
+     * 네이티브/JPQL UPDATE 로 인한 L1 캐시 stale entity 를 피하기 위한 선방어.
+     *
+     * @param id 대상 클러스터 ID
+     * @return 영향받은 row 수 — 정상이면 1, 0 이면 INACTIVE 전환 race 가능성으로 경고 로그 남겨야 함
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NewsCluster c SET c.uniqueViewerCount = c.uniqueViewerCount + 1 " +
+            "WHERE c.id = :id AND c.status = NewsCluster.ClusterStatus.ACTIVE")
+    int incrementUniqueViewerCount(@Param("id") Long id);
+
+    /**
+     * 최근 N시간 윈도우 내 고유 뷰어 수를 ACTIVE 클러스터 전체에 대해 일괄 갱신한다.
+     *
+     * - 단일 UPDATE로 윈도우 스캔 1회만 수행 (2-step 분리보다 효율적)
+     * - {@code IS DISTINCT FROM COALESCE(agg.cnt, 0)} 가드로 실제 값이 변한 row만 write — vacuum 부담 최소화
+     * - 윈도우 밖으로 빠진 클러스터는 {@code agg.cnt IS NULL} → {@code COALESCE(0)} 로 자동 0 리셋
+     *
+     * @param windowStart 집계 대상 시각 하한(exclusive). 이 시각 이후의 read만 카운트됨
+     * @return 실제로 값이 바뀌어 UPDATE된 row 수
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            UPDATE news_cluster c
+            SET recent_view_count = COALESCE(agg.cnt, 0)
+            FROM news_cluster active
+            LEFT JOIN (
+                SELECT news_cluster_id AS id, COUNT(*) AS cnt
+                FROM user_news_cluster_read
+                WHERE read_at > :windowStart
+                GROUP BY news_cluster_id
+            ) agg ON agg.id = active.news_cluster_id
+            WHERE c.news_cluster_id = active.news_cluster_id
+              AND active.status = 'ACTIVE'
+              AND c.recent_view_count IS DISTINCT FROM COALESCE(agg.cnt, 0)
+            """, nativeQuery = true)
+    int refreshRecentViewCounts(@Param("windowStart") OffsetDateTime windowStart);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/repository/UserNewsClusterReadRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/repository/UserNewsClusterReadRepository.java
@@ -2,7 +2,11 @@ package com.solv.wefin.domain.news.cluster.repository;
 
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -11,4 +15,43 @@ public interface UserNewsClusterReadRepository extends JpaRepository<UserNewsClu
     boolean existsByUserIdAndNewsClusterId(UUID userId, Long newsClusterId);
 
     List<UserNewsClusterRead> findByUserIdAndNewsClusterIdIn(UUID userId, List<Long> newsClusterIds);
+
+    /**
+     * 사용자-클러스터 조회 이력을 중복 없이 원자적으로 기록한다.
+     *
+     * @return 1: 신규 INSERT (최초 조회)
+     *         0: 이미 존재하여 INSERT 생략 (중복 조회)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO user_news_cluster_read (user_id, news_cluster_id, read_at)
+            VALUES (:userId, :clusterId, :readAt)
+            ON CONFLICT (user_id, news_cluster_id) DO NOTHING
+            """, nativeQuery = true)
+    int insertIfAbsent(@Param("userId") UUID userId,
+                       @Param("clusterId") Long clusterId,
+                       @Param("readAt") OffsetDateTime readAt);
+
+    /**
+     * 재방문 시 {@code read_at} 을 최신 시각으로 갱신하되, 이미 최근에 갱신된 경우(stale 기준 미만) skip 한다.
+     *
+     * UPSERT 기반 "최근 N시간 내 본 고유 유저 수" 지표를 유지하려면 재방문에도 {@code read_at} 이 갱신돼야 한다.
+     * 다만 동일 유저의 짧은 간격 재호출(FE 버그/더블클릭)까지 매번 UPDATE 하면 read_at 인덱스 때문에
+     * HOT update 가 깨져 bloat 이 커지므로, 마지막 갱신이 {@code staleThreshold} 보다 이전일 때만 UPDATE 한다.
+     *
+     * @param staleThreshold 이 시각보다 read_at 이 이전이면 UPDATE 대상 (보통 {@code readAt - throttle})
+     * @return 갱신되었으면 1, 스로틀로 인해 skip 되었으면 0 (정상 동작)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            UPDATE user_news_cluster_read
+            SET read_at = :readAt
+            WHERE user_id = :userId
+              AND news_cluster_id = :clusterId
+              AND read_at < :staleThreshold
+            """, nativeQuery = true)
+    int touchReadAtIfStale(@Param("userId") UUID userId,
+                           @Param("clusterId") Long clusterId,
+                           @Param("readAt") OffsetDateTime readAt,
+                           @Param("staleThreshold") OffsetDateTime staleThreshold);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -16,6 +16,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
@@ -36,6 +37,7 @@ public class ClusterInteractionService {
     private final UserNewsClusterFeedbackRepository feedbackRepository;
     private final ClusterInterestWeightService interestWeightService;
     private final NewsHotProperties newsHotProperties;
+    private final Clock clock;
 
     /**
      * 클러스터 읽음을 기록한다.
@@ -56,7 +58,7 @@ public class ClusterInteractionService {
     public void markRead(UUID userId, Long clusterId) {
         validateActiveCluster(clusterId);
 
-        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime now = OffsetDateTime.now(clock);
         OffsetDateTime staleThreshold = now.minusSeconds(newsHotProperties.markReadThrottleSeconds());
 
         int inserted = readRepository.insertIfAbsent(userId, clusterId, now);

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -4,10 +4,10 @@ import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.FeedbackType;
-import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.domain.news.config.NewsHotProperties;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +16,13 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 /**
  * 클러스터 읽음 처리 및 피드백 서비스
  *
- * 읽음: 중복 시 무시 (idempotent)
+ * 읽음: UPSERT 기반 — 첫 방문 시 insert 후 uniqueViewerCount 증가, 재방문 시 read_at 갱신(짧은 간격은 throttle)
  * 피드백: 1회만 가능, 중복 시 409
  * 가중치 업데이트는 ClusterInterestWeightService에서 별도 트랜잭션으로 처리
  */
@@ -34,23 +35,47 @@ public class ClusterInteractionService {
     private final UserNewsClusterReadRepository readRepository;
     private final UserNewsClusterFeedbackRepository feedbackRepository;
     private final ClusterInterestWeightService interestWeightService;
+    private final NewsHotProperties newsHotProperties;
 
     /**
      * 클러스터 읽음을 기록한다.
-     * 이미 읽은 경우 무시한다 (idempotent).
-     * 동시 요청 시 unique violation을 잡아 무시한다
+     *
+     * 동작:
+     * - 해당 유저가 처음 보는 클러스터면 INSERT 하고 {@code unique_viewer_count} 를 원자적으로 +1
+     * - 이미 본 클러스터면 read_at 을 현재 시각으로 갱신 (단, 최근 throttle 윈도우 내 재호출이면 skip)
+     *
+     * {@code recent_view_count} 는 배치가 집계하므로 여기서 건드리지 않는다.
+     * 동시 INSERT 는 unique 제약 + {@code ON CONFLICT DO NOTHING} 으로 한쪽만 성공하도록 보장.
+     *
+     * 관측:
+     * - result=throttled: 같은 userId+clusterId 가 throttle 윈도우(기본 60s) 내 반복 호출 →
+     *   FE 가 세션 debounce 계약을 지키지 않거나 어뷰저 가능성. debug 로그로 집계하여 이상치 탐지.
+     * - increment_missed: insertIfAbsent 는 성공했으나 status 가드에 걸려 count 증가 실패 → INACTIVE race
      */
     @Transactional
     public void markRead(UUID userId, Long clusterId) {
         validateActiveCluster(clusterId);
 
-        if (readRepository.existsByUserIdAndNewsClusterId(userId, clusterId)) {
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime staleThreshold = now.minusSeconds(newsHotProperties.markReadThrottleSeconds());
+
+        int inserted = readRepository.insertIfAbsent(userId, clusterId, now);
+
+        if (inserted == 1) {
+            int affected = newsClusterRepository.incrementUniqueViewerCount(clusterId);
+            if (affected == 0) {
+                log.warn("[markRead] result=increment_missed reason=inactive_race_or_deleted clusterId={}",
+                        clusterId);
+            }
             return;
         }
-        try {
-            readRepository.save(UserNewsClusterRead.create(userId, clusterId));
-        } catch (DataIntegrityViolationException e) {
-            log.debug("읽음 중복 저장 무시 — userId: {}, clusterId: {}", userId, clusterId);
+
+        // 재방문 — 최근 throttle 윈도우 내라면 자연스럽게 touchAffected=0 이 되어 write 없이 종료.
+        // 양쪽 모두 0이면 throttle 내 반복 호출이라는 의미 → FE 계약 위반 / 어뷰징 신호.
+        int touchAffected = readRepository.touchReadAtIfStale(userId, clusterId, now, staleThreshold);
+        if (touchAffected == 0) {
+            log.debug("[markRead] result=throttled userId={} clusterId={} thresholdSeconds={}",
+                    userId, clusterId, newsHotProperties.markReadThrottleSeconds());
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -72,10 +72,12 @@ public class ClusterInteractionService {
 
         // 재방문 — 최근 throttle 윈도우 내라면 자연스럽게 touchAffected=0 이 되어 write 없이 종료.
         // 양쪽 모두 0이면 throttle 내 반복 호출이라는 의미 → FE 계약 위반 / 어뷰징 신호.
+        // 로그에는 userId 를 남기지 않는다(PII). 어뷰저 단위 집계는 추후 Micrometer 도입 시
+        // IP/Account-hash 기반 태그로 재구성.
         int touchAffected = readRepository.touchReadAtIfStale(userId, clusterId, now, staleThreshold);
         if (touchAffected == 0) {
-            log.debug("[markRead] result=throttled userId={} clusterId={} thresholdSeconds={}",
-                    userId, clusterId, newsHotProperties.markReadThrottleSeconds());
+            log.debug("[markRead] result=throttled clusterId={} thresholdSeconds={}",
+                    clusterId, newsHotProperties.markReadThrottleSeconds());
         }
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionService.java
@@ -62,7 +62,7 @@ public class ClusterInteractionService {
         int inserted = readRepository.insertIfAbsent(userId, clusterId, now);
 
         if (inserted == 1) {
-            int affected = newsClusterRepository.incrementUniqueViewerCount(clusterId);
+            int affected = newsClusterRepository.incrementUniqueViewerCount(clusterId, ClusterStatus.ACTIVE);
             if (affected == 0) {
                 log.warn("[markRead] result=increment_missed reason=inactive_race_or_deleted clusterId={}",
                         clusterId);

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryService.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.news.article.repository.NewsArticleRepository;
 import com.solv.wefin.domain.news.cluster.entity.ClusterSuggestedQuestion;
 import com.solv.wefin.domain.news.cluster.entity.ClusterSummarySection;
 import com.solv.wefin.domain.news.cluster.entity.ClusterSummarySectionSource;
+import com.solv.wefin.domain.news.cluster.entity.HotAggregationMeta;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
@@ -13,6 +14,7 @@ import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
 import com.solv.wefin.domain.news.cluster.repository.ClusterSuggestedQuestionRepository;
 import com.solv.wefin.domain.news.cluster.repository.ClusterSummarySectionRepository;
 import com.solv.wefin.domain.news.cluster.repository.ClusterSummarySectionSourceRepository;
+import com.solv.wefin.domain.news.cluster.repository.HotAggregationMetaRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
@@ -58,6 +60,7 @@ public class NewsClusterQueryService {
     private final ClusterSuggestedQuestionRepository questionRepository;
     private final ClusterSummarySectionRepository sectionRepository;
     private final ClusterSummarySectionSourceRepository sectionSourceRepository;
+    private final HotAggregationMetaRepository hotAggregationMetaRepository;
     private final ClusterTagAggregator tagAggregator;
 
     /**
@@ -87,8 +90,7 @@ public class NewsClusterQueryService {
     public ClusterFeedResult getFeed(OffsetDateTime cursorTime, Long cursorId,
                                      int pageSize, UUID userId, String tab, String sortBy,
                                      TagType tagType, List<String> tagCodes) {
-        int fetchSize = pageSize + 1;
-        boolean sortByUpdatedAt = "updatedAt".equalsIgnoreCase(sortBy);
+        SortMode sortMode = SortMode.from(sortBy);
 
         List<String> filterTagCodes;
         TagType filterTagType;
@@ -101,20 +103,24 @@ public class NewsClusterQueryService {
             filterTagCodes = categoryCode != null ? List.of(categoryCode) : null;
         }
 
+        // sort=view: 페이지네이션 미지원 — Top N 고정, cursor 무시, hasNext=false
+        // 커서 갱신으로 인한 정렬 키 흔들림(페이지 중복/누락)을 원천 차단
+        int fetchSize = sortMode == SortMode.VIEW ? pageSize : pageSize + 1;
         List<NewsCluster> clusters = fetchClusters(cursorTime, cursorId, fetchSize,
-                filterTagType, filterTagCodes, sortByUpdatedAt);
+                filterTagType, filterTagCodes, sortMode);
 
-        // 다음 페이지 존재 여부
-        boolean hasNext = clusters.size() > pageSize;
-
-        // pageSize만큼 실제 반환
+        boolean hasNext = sortMode != SortMode.VIEW && clusters.size() > pageSize;
         if (hasNext) {
             clusters = clusters.subList(0, pageSize);
         }
 
-        // 결과 없으면 빈 응답 반환
+        OffsetDateTime lastAggregatedAt = sortMode == SortMode.VIEW
+                ? hotAggregationMetaRepository.findSingleton()
+                        .map(HotAggregationMeta::getLastSuccessAt).orElse(null)
+                : null;
+
         if (clusters.isEmpty()) {
-            return ClusterFeedResult.empty();
+            return ClusterFeedResult.empty(lastAggregatedAt);
         }
 
         /* 부가 정보 일괄 조회 */
@@ -149,15 +155,32 @@ public class NewsClusterQueryService {
                         sourcesMap.getOrDefault(c.getId(), List.of()),
                         stocksMap.getOrDefault(c.getId(), List.of()),
                         topicsMap.getOrDefault(c.getId(), List.of()),
-                        readClusterIds.contains(c.getId())
+                        readClusterIds.contains(c.getId()),
+                        c.getRecentViewCount()
                 ))
                 .toList();
 
-        // 다음 커서 생성 (마지막 데이터 기준, 정렬 필드에 맞춰 커서 시각 결정)
-        NewsCluster last = clusters.get(clusters.size() - 1);
-        OffsetDateTime nextCursorTime = sortByUpdatedAt ? last.getUpdatedAt() : last.getPublishedAt();
+        // 다음 커서 생성 (sort=view 는 커서 없음)
+        if (!hasNext) {
+            return new ClusterFeedResult(items, false, null, null, lastAggregatedAt);
+        }
 
-        return new ClusterFeedResult(items, hasNext, nextCursorTime, last.getId());
+        NewsCluster last = clusters.get(clusters.size() - 1);
+        OffsetDateTime nextCursorTime = sortMode == SortMode.UPDATED_AT
+                ? last.getUpdatedAt() : last.getPublishedAt();
+
+        return new ClusterFeedResult(items, true, nextCursorTime, last.getId(), lastAggregatedAt);
+    }
+
+    /** 내부 정렬 모드 표현 — 컨트롤러 sort 문자열을 한 번만 해석한다 */
+    private enum SortMode {
+        PUBLISHED_AT, UPDATED_AT, VIEW;
+
+        static SortMode from(String sortBy) {
+            if ("updatedAt".equalsIgnoreCase(sortBy)) return UPDATED_AT;
+            if ("view".equalsIgnoreCase(sortBy)) return VIEW;
+            return PUBLISHED_AT;
+        }
     }
 
     /**
@@ -189,44 +212,56 @@ public class NewsClusterQueryService {
     /**
      * 태그 필터 + 커서 조건 + 정렬 기준에 따라 클러스터를 조회한다.
      *
+     * sort=view 는 cursor 를 무시하고 Top N 을 반환한다 (페이지네이션 미지원).
+     *
      * @param filterTagType 태그 유형 (null이면 필터 없음)
      * @param filterTagCodes 태그 코드 목록 (null 또는 빈 리스트면 필터 없음)
      */
     private List<NewsCluster> fetchClusters(OffsetDateTime cursorTime, Long cursorId,
                                              int fetchSize, TagType filterTagType,
-                                             List<String> filterTagCodes, boolean sortByUpdatedAt) {
-        boolean hasCursor = cursorTime != null && cursorId != null;
+                                             List<String> filterTagCodes, SortMode sortMode) {
         Pageable pageable = PageRequest.of(0, fetchSize);
+        boolean hasTagFilter = filterTagType != null
+                && filterTagCodes != null && !filterTagCodes.isEmpty();
 
-        if (filterTagCodes == null || filterTagCodes.isEmpty() || filterTagType == null) {
+        if (sortMode == SortMode.VIEW) {
+            return hasTagFilter
+                    ? newsClusterRepository.findHotClustersByTags(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, pageable)
+                    : newsClusterRepository.findHotClusters(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, pageable);
+        }
+
+        boolean hasCursor = cursorTime != null && cursorId != null;
+        boolean sortByUpdatedAt = sortMode == SortMode.UPDATED_AT;
+
+        if (!hasTagFilter) {
             if (sortByUpdatedAt) {
                 return hasCursor
                         ? newsClusterRepository.findForFeedAfterCursorByUpdatedAt(
                                 ClusterStatus.ACTIVE, VISIBLE_STATUSES, cursorTime, cursorId, pageable)
                         : newsClusterRepository.findForFeedFirstPageByUpdatedAt(
                                 ClusterStatus.ACTIVE, VISIBLE_STATUSES, pageable);
-            } else {
-                return hasCursor
-                        ? newsClusterRepository.findForFeedAfterCursorByPublishedAt(
-                                ClusterStatus.ACTIVE, VISIBLE_STATUSES, cursorTime, cursorId, pageable)
-                        : newsClusterRepository.findForFeedFirstPageByPublishedAt(
-                                ClusterStatus.ACTIVE, VISIBLE_STATUSES, pageable);
             }
-        } else {
-            if (sortByUpdatedAt) {
-                return hasCursor
-                        ? newsClusterRepository.findForFeedByTagsAfterCursorByUpdatedAt(
-                                ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, cursorTime, cursorId, pageable)
-                        : newsClusterRepository.findForFeedByTagsFirstPageByUpdatedAt(
-                                ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, pageable);
-            } else {
-                return hasCursor
-                        ? newsClusterRepository.findForFeedByTagsAfterCursorByPublishedAt(
-                                ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, cursorTime, cursorId, pageable)
-                        : newsClusterRepository.findForFeedByTagsFirstPageByPublishedAt(
-                                ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, pageable);
-            }
+            return hasCursor
+                    ? newsClusterRepository.findForFeedAfterCursorByPublishedAt(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, cursorTime, cursorId, pageable)
+                    : newsClusterRepository.findForFeedFirstPageByPublishedAt(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, pageable);
         }
+
+        if (sortByUpdatedAt) {
+            return hasCursor
+                    ? newsClusterRepository.findForFeedByTagsAfterCursorByUpdatedAt(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, cursorTime, cursorId, pageable)
+                    : newsClusterRepository.findForFeedByTagsFirstPageByUpdatedAt(
+                            ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, pageable);
+        }
+        return hasCursor
+                ? newsClusterRepository.findForFeedByTagsAfterCursorByPublishedAt(
+                        ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, cursorTime, cursorId, pageable)
+                : newsClusterRepository.findForFeedByTagsFirstPageByPublishedAt(
+                        ClusterStatus.ACTIVE, VISIBLE_STATUSES, filterTagType, filterTagCodes, pageable);
     }
 
     /**
@@ -372,16 +407,21 @@ public class NewsClusterQueryService {
     // --- Result Records ---
 
     /**
-     * 커서 기반 페이징 결과
+     * 커서 기반 페이징 결과.
+     *
+     * sort=view 응답은 {@code hasNext=false}, cursor 필드는 null 이며
+     * {@code lastAggregatedAt} 에 배치 마지막 성공 시각이 들어간다
+     * (첫 배포 전이면 null — FE가 "준비 중" UX 또는 폴백 처리).
      */
     public record ClusterFeedResult(
             List<ClusterFeedItem> items,
             boolean hasNext,
             OffsetDateTime nextCursorPublishedAt,
-            Long nextCursorId
+            Long nextCursorId,
+            OffsetDateTime lastAggregatedAt
     ) {
-        public static ClusterFeedResult empty() {
-            return new ClusterFeedResult(List.of(), false, null, null);
+        public static ClusterFeedResult empty(OffsetDateTime lastAggregatedAt) {
+            return new ClusterFeedResult(List.of(), false, null, null, lastAggregatedAt);
         }
     }
 
@@ -398,7 +438,8 @@ public class NewsClusterQueryService {
             List<SourceInfo> sources,
             List<StockInfo> relatedStocks,
             List<String> marketTags,
-            boolean isRead
+            boolean isRead,
+            long recentViewCount
     ) {
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsConfig.java
@@ -7,7 +7,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
-@EnableConfigurationProperties(NewsBatchProperties.class)
+@EnableConfigurationProperties({NewsBatchProperties.class, NewsHotProperties.class})
 public class NewsConfig {
 
     @Bean

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsHotProperties.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsHotProperties.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.domain.news.config;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * 뉴스 클러스터 조회수 랭킹({@code sort=view}) 운영 설정
+ *
+ * 윈도우 길이, 배치 주기, 페이지 상한, markRead throttle 관리
+ * 운영 중 트래픽과 데이터 분포에 따라 환경변수로 튜닝
+ *
+ * @param windowHours               recent_view_count 집계 윈도우 (시간). 3h는 휘발성↔관성 균형의 가설값
+ * @param aggregationIntervalSeconds HotClusterAggregationScheduler 실행 주기 (초)
+ * @param initialDelaySeconds       앱 기동 후 첫 집계 실행까지 대기 시간 (초). warmup/rolling 배포 시 부하 분산용
+ * @param maxSize                   sort=view 요청의 응답 항목 상한. hot feed UX 특성상 Top N 고정
+ * @param markReadThrottleSeconds   touchReadAtIfStale 의 throttle 기준. 이 시간 내 재호출은 write skip
+ */
+@Validated
+@ConfigurationProperties(prefix = "news.hot")
+public record NewsHotProperties(
+        @Min(1) @Max(24) int windowHours,
+        @Min(60) @Max(3600) int aggregationIntervalSeconds,
+        @Min(0) @Max(600) int initialDelaySeconds,
+        @Min(1) @Max(50) int maxSize,
+        @Min(1) @Max(3600) int markReadThrottleSeconds
+) {
+}

--- a/src/main/java/com/solv/wefin/global/config/AdvisoryLockKeys.java
+++ b/src/main/java/com/solv/wefin/global/config/AdvisoryLockKeys.java
@@ -1,0 +1,26 @@
+package com.solv.wefin.global.config;
+
+/**
+ * PostgreSQL advisory lock 키 중앙 레지스트리
+ *
+ * PostgreSQL advisory lock
+ *   - DB 가 제공하는 애플리케이션 정의 lock
+ *   - 같은 PostgreSQL 인스턴스에 붙어있는 모든 커넥션/프로세스가 공유하는 전역 락이라,
+ *   - 다중 인스턴스 환경에서도 한 번에 하나만 실행 보장 가능
+ *
+ * 트랜잭션 단위 사용 패턴
+ *   1) 락 획득 시도. 이미 다른 세션이 잡고 있으면 false 반환 (대기 X)
+ *   2) 실제 배치 작업 수행
+ *   3) 트랜잭션 commit/rollback 시 락 자동 해제. 명시적 unlock 불필요
+ *
+ * 가독성을 위해 6자리 숫자 범위에서 기능별 접두어를 둔다:
+ *  - 100_xxx — 뉴스/클러스터 도메인
+ */
+public final class AdvisoryLockKeys {
+
+    /** 뉴스 클러스터 조회수 랭킹(sort=view) 집계 배치 — 2026-04-20 도입 */
+    public static final long HOT_NEWS_AGG = 100_001L;
+
+    private AdvisoryLockKeys() {
+    }
+}

--- a/src/main/java/com/solv/wefin/global/config/JpaConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/JpaConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+import java.time.Clock;
 import java.time.OffsetDateTime;
 import java.util.Optional;
 
@@ -12,8 +13,16 @@ import java.util.Optional;
 @EnableJpaAuditing(dateTimeProviderRef = "offsetDateTimeProvider")
 public class JpaConfig {
 
+    /**
+     * 애플리케이션 공용 시계 빈
+     */
     @Bean
-    public DateTimeProvider offsetDateTimeProvider() {
-        return () -> Optional.of(OffsetDateTime.now());
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+
+    @Bean
+    public DateTimeProvider offsetDateTimeProvider(Clock clock) {
+        return () -> Optional.of(OffsetDateTime.now(clock));
     }
 }

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsClusterController.java
@@ -5,6 +5,7 @@ import com.solv.wefin.domain.news.article.entity.NewsArticleTag.TagType;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterDetailResult;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
+import com.solv.wefin.domain.news.config.NewsHotProperties;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -34,10 +35,12 @@ public class NewsClusterController {
     private static final int DEFAULT_PAGE_SIZE = 10;
     private static final int MAX_PAGE_SIZE = 50;
     private static final int MAX_TAG_CODES = 20;
-    private static final Set<String> VALID_SORT_VALUES = Set.of("publishedAt", "updatedAt");
+    private static final String SORT_VIEW = "view";
+    private static final Set<String> VALID_SORT_VALUES = Set.of("publishedAt", "updatedAt", SORT_VIEW);
 
     private final NewsClusterQueryService newsClusterQueryService;
     private final ClusterInteractionService clusterInteractionService;
+    private final NewsHotProperties newsHotProperties;
 
     /**
      * 뉴스 클러스터 피드 목록을 조회한다.
@@ -46,18 +49,26 @@ public class NewsClusterController {
      * - tab: 홈 카테고리 탭 (ALL/FINANCE/TECH/INDUSTRY/ENERGY/BIO/CRYPTO)
      * - tagType + tagCodes: 특정 태그들로 필터 (SECTOR/STOCK + 태그코드 목록)
      *
-     * @param cursor "timestamp_id" 형식의 커서 (첫 페이지면 null)
-     * @param pageSize 페이지 크기 (기본 10, 최대 50)
+     * 정렬 옵션:
+     * - publishedAt / updatedAt: 시간 기준 커서 페이지네이션 지원 (size 최대 50)
+     * - view: 최근 N시간(기본 3h) 윈도우 내 고유 뷰어 수 기준 Top N. 페이지네이션 미지원,
+     *   size 는 {@code news.hot.max-size} 상한 (초과 시 400 INVALID_INPUT).
+     *   cursor 를 보내도 무시되며 {@code hasNext=false}, {@code nextCursor=null}.
+     *   응답의 {@code lastAggregatedAt} 은 배치 마지막 성공 시각이며, 첫 배치 전이면 null.
+     *   FE 는 임계(예: 15분) 초과 시 {@code sort=publishedAt} 으로 자동 폴백 권장.
+     *
+     * @param cursor "timestamp_id" 형식의 커서 (첫 페이지면 null, sort=view 면 무시)
+     * @param pageSize 페이지 크기 (기본 10, 최대 50 / sort=view 는 news.hot.max-size)
      * @param tab 카테고리 탭 (기본 ALL)
      * @param tagType 태그 유형 (SECTOR 또는 STOCK)
      * @param tagCodes 태그 코드 목록 (tagType과 함께 사용)
-     * @param sort 정렬 기준 (publishedAt 또는 updatedAt, 기본 publishedAt)
+     * @param sort 정렬 기준 (publishedAt / updatedAt / view, 기본 publishedAt)
      * @param userId 사용자 ID (비인증 시 null)
      */
     @GetMapping
     public ApiResponse<ClusterFeedResponse> getFeed(
             @RequestParam(name = "cursor", required = false) String cursor,
-            @RequestParam(name = "size", defaultValue = "" + DEFAULT_PAGE_SIZE) int pageSize,
+            @RequestParam(name = "size", required = false) Integer pageSizeParam,
             @RequestParam(name = "tab", defaultValue = "ALL") String tab,
             @RequestParam(name = "tagType", required = false) String tagType,
             @RequestParam(name = "tagCodes", required = false) List<String> tagCodes,
@@ -68,6 +79,7 @@ public class NewsClusterController {
         if (!VALID_SORT_VALUES.contains(normalizedSort)) {
             throw new BusinessException(ErrorCode.FEED_SORT_UNSUPPORTED);
         }
+        boolean isHotSort = SORT_VIEW.equals(normalizedSort);
 
         String normalizedTagType = tagType == null ? null : tagType.trim();
         boolean hasTagType = normalizedTagType != null && !normalizedTagType.isEmpty();
@@ -99,12 +111,29 @@ public class NewsClusterController {
             }
         }
 
-        pageSize = Math.min(Math.max(pageSize, 1), MAX_PAGE_SIZE);
+        int pageSize;
+        if (isHotSort) {
+            int hotMaxSize = newsHotProperties.maxSize();
+            if (pageSizeParam == null) {
+                // size 미지정 — DEFAULT_PAGE_SIZE 와 hotMaxSize 중 작은 쪽 사용.
+                // 운영자가 max-size 를 작게 튜닝했을 때 "size 안 보냈는데 거절당함" UX 방지.
+                pageSize = Math.min(DEFAULT_PAGE_SIZE, hotMaxSize);
+            } else if (pageSizeParam < 1 || pageSizeParam > hotMaxSize) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT,
+                        "sort=view 의 size 는 1 ~ " + hotMaxSize + " 사이여야 합니다: " + pageSizeParam);
+            } else {
+                pageSize = pageSizeParam;
+            }
+        } else {
+            int raw = pageSizeParam == null ? DEFAULT_PAGE_SIZE : pageSizeParam;
+            pageSize = Math.min(Math.max(raw, 1), MAX_PAGE_SIZE);
+        }
 
         OffsetDateTime cursorTime = null;
         Long cursorId = null;
 
-        if (cursor != null) {
+        // sort=view 는 cursor 파라미터를 무시한다 (forward compat: 구 클라이언트가 붙여 보내도 에러 없이 Top N 반환)
+        if (!isHotSort && cursor != null) {
             try {
                 String[] parts = cursor.split("_", 2);
                 if (parts.length != 2) {
@@ -143,7 +172,14 @@ public class NewsClusterController {
 
     /**
      * 클러스터 읽음을 기록한다.
-     * 비회원(userId=null)은 무시한다
+     *
+     * 비회원(userId=null)은 무시한다.
+     *
+     * 호출 계약(FE 권장):
+     * - 상세 진입 세션 당 1회
+     * - 같은 세션 내 재진입은 FE 에서 30초 쿨다운 debounce
+     * 서버는 {@code news.hot.mark-read-throttle-seconds} 내 반복 호출에 대해
+     * read_at UPDATE 를 skip 하여 방어 계층을 이중으로 둔다.
      *
      * @param clusterId 클러스터 ID
      * @param userId 사용자 ID (비인증 시 null)

--- a/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
+++ b/src/main/java/com/solv/wefin/web/news/dto/response/ClusterFeedResponse.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.web.news.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedItem;
 import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
 import com.solv.wefin.domain.news.cluster.dto.SourceInfo;
@@ -13,11 +14,15 @@ import java.util.List;
  *
  * - Service 레이어의 ClusterFeedResult를 API 응답 형태로 변환
  * - 커서 기반 페이지네이션 정보를 문자열 형태로 가공하여 전달
+ * - sort=view 응답에서는 {@code lastAggregatedAt} 으로 배치 마지막 성공 시각을 노출해
+ *   FE 가 집계 지연 시 폴백(sort=publishedAt)을 판단할 수 있게 한다.
+ *   sort 가 publishedAt/updatedAt 인 응답에서는 null 이며 {@code @JsonInclude(NON_NULL)} 로 응답에서 생략됨.
  */
 public record ClusterFeedResponse(
         List<ClusterItemResponse> items,
         boolean hasNext,
-        String nextCursor
+        String nextCursor,
+        @JsonInclude(JsonInclude.Include.NON_NULL) OffsetDateTime lastAggregatedAt
 ) {
 
     /**
@@ -25,6 +30,7 @@ public record ClusterFeedResponse(
      *
      * 1) 내부 ClusterFeedItem → ClusterItemResponse로 변환
      * 2) nextCursor를 문자열로 인코딩
+     * 3) lastAggregatedAt 은 sort=view 응답에서만 값이 들어오고 그 외에는 null
      */
     public static ClusterFeedResponse from(ClusterFeedResult result) {
 
@@ -39,11 +45,13 @@ public record ClusterFeedResponse(
                 + "_" + result.nextCursorId()
                 : null;
 
-        return new ClusterFeedResponse(items, result.hasNext(), nextCursor);
+        return new ClusterFeedResponse(items, result.hasNext(), nextCursor, result.lastAggregatedAt());
     }
 
     /**
      * 클러스터 단일 아이템 응답 DTO
+     *
+     * @param recentViewCount 최근 N시간(기본 3h) 내 이 클러스터를 본 고유 유저 수
      */
     public record ClusterItemResponse(
             Long clusterId,
@@ -55,7 +63,8 @@ public record ClusterFeedResponse(
             List<SourceResponse> sources,
             List<StockResponse> relatedStocks,
             List<String> marketTags,
-            boolean isRead
+            boolean isRead,
+            long recentViewCount
     ) {
         public static ClusterItemResponse from(ClusterFeedItem item) {
             return new ClusterItemResponse(
@@ -70,7 +79,8 @@ public record ClusterFeedResponse(
                             .toList(),
                     item.relatedStocks().stream().map(StockResponse::from).toList(),
                     item.marketTags(),
-                    item.isRead()
+                    item.isRead(),
+                    item.recentViewCount()
             );
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,14 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+news:
+  hot:
+    window-hours: ${NEWS_HOT_WINDOW_HOURS:3}
+    aggregation-interval-seconds: ${NEWS_HOT_AGG_INTERVAL_SECONDS:300}
+    initial-delay-seconds: ${NEWS_HOT_INITIAL_DELAY_SECONDS:30}
+    max-size: ${NEWS_HOT_MAX_SIZE:20}
+    mark-read-throttle-seconds: ${NEWS_HOT_MARK_READ_THROTTLE_SECONDS:60}
+
 market:
   trend:
     cron: ${MARKET_TREND_CRON:${MARKET_BATCH_CRON:0 */30 * * * *}}

--- a/src/main/resources/db/migration/V50__add_cluster_view_metrics.sql
+++ b/src/main/resources/db/migration/V50__add_cluster_view_metrics.sql
@@ -1,0 +1,29 @@
+-- news_cluster: 고유 사용자 기준 누적 조회 수 + 최근 시간 윈도우 조회 수
+-- unique_viewer_count는 전체 기간 동안의 distinct user 수를 의미하며,
+-- recent_view_count는 최근 N시간(기본 3h) 내 distinct user 수로 Hot 정렬에 사용
+ALTER TABLE news_cluster
+    ADD COLUMN unique_viewer_count BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN recent_view_count   BIGINT NOT NULL DEFAULT 0;
+
+-- sort=view 피드 조회 성능을 위한 partial index
+-- ACTIVE 상태의 클러스터만 대상으로 recent_view_count 기반 정렬을 최적화
+-- (recent_view_count → published_at → news_cluster_id) 순으로 타이브레이커까지 포함한 안정 정렬
+CREATE INDEX idx_news_cluster_hot
+    ON news_cluster (recent_view_count DESC, published_at DESC, news_cluster_id DESC)
+    WHERE status = 'ACTIVE';
+
+-- 최근 시간 윈도우 집계(batch aggregation) 최적화를 위한 인덱스
+-- read_at 기준 범위 스캔 후 news_cluster_id 단위 그룹 집계 성능 개선 목적
+CREATE INDEX idx_user_news_cluster_read_at
+    ON user_news_cluster_read (read_at, news_cluster_id);
+
+-- Hot 집계 배치 실행 메타 정보 (singleton row, id=1 고정 UPSERT)
+-- Micrometer가 상세 메트릭을 담당하며,
+-- 본 테이블은 FE fallback 판단을 위한 최소 상태(last_success_at 등)만 유지
+CREATE TABLE hot_aggregation_meta (
+                                      id                 SMALLINT PRIMARY KEY CHECK (id = 1),
+                                      last_success_at    TIMESTAMPTZ NOT NULL,
+                                      last_window_start  TIMESTAMPTZ NOT NULL,
+                                      last_updated_count INTEGER     NOT NULL,
+                                      last_took_ms       INTEGER     NOT NULL
+);

--- a/src/main/resources/db/migration/V50__add_cluster_view_metrics.sql
+++ b/src/main/resources/db/migration/V50__add_cluster_view_metrics.sql
@@ -5,11 +5,27 @@ ALTER TABLE news_cluster
     ADD COLUMN unique_viewer_count BIGINT NOT NULL DEFAULT 0,
     ADD COLUMN recent_view_count   BIGINT NOT NULL DEFAULT 0;
 
+-- 기존 user_news_cluster_read 데이터 기반으로 unique_viewer_count 백필
+-- (user_id, news_cluster_id) UNIQUE 제약(uk_user_news_cluster_read_user_cluster)이 있어
+-- COUNT(*) = COUNT(DISTINCT user_id) 이므로 COUNT(*) 사용
+-- 단일 UPDATE 로 수행. user_news_cluster_read 규모가 큰 환경에선 별도 데이터 마이그레이션 도구로 분리 고려
+-- recent_view_count 는 배포 후 첫 집계 배치가 채우므로 백필 불필요
+UPDATE news_cluster c
+SET unique_viewer_count = agg.cnt
+FROM (
+    SELECT news_cluster_id, COUNT(*) AS cnt
+    FROM user_news_cluster_read
+    GROUP BY news_cluster_id
+) agg
+WHERE c.news_cluster_id = agg.news_cluster_id;
+
 -- sort=view 피드 조회 성능을 위한 partial index
 -- ACTIVE 상태의 클러스터만 대상으로 recent_view_count 기반 정렬을 최적화
 -- (recent_view_count → published_at → news_cluster_id) 순으로 타이브레이커까지 포함한 안정 정렬
+-- NULLS LAST 명시: findHotClusters 의 ORDER BY "published_at DESC NULLS LAST" 와 B-tree 정렬을 일치시켜
+--                  index-only ORDER BY 활용 가능 (Postgres 는 DESC 시 기본 NULLS FIRST)
 CREATE INDEX idx_news_cluster_hot
-    ON news_cluster (recent_view_count DESC, published_at DESC, news_cluster_id DESC)
+    ON news_cluster (recent_view_count DESC, published_at DESC NULLS LAST, news_cluster_id DESC)
     WHERE status = 'ACTIVE';
 
 -- 최근 시간 윈도우 집계(batch aggregation) 최적화를 위한 인덱스

--- a/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
@@ -1,0 +1,284 @@
+package com.solv.wefin.domain.news.cluster.repository;
+
+import com.solv.wefin.domain.news.cluster.entity.HotAggregationMeta;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
+import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 주요뉴스 관련 네이티브 SQL 통합 테스트
+ *
+ * 검증 대상:
+ *  {@code UserNewsClusterReadRepository.insertIfAbsent} — UPSERT DO NOTHING 시맨틱 (affected rows)
+ *  {@code UserNewsClusterReadRepository.touchReadAtIfStale} — throttle 경계 동작
+ *  {@code NewsClusterRepository.refreshRecentViewCounts} — IS DISTINCT FROM 가드 + 윈도우 밖 0 리셋
+ *  {@code NewsClusterRepository.incrementUniqueViewerCount} — ACTIVE 가드
+ *  {@code HotAggregationMetaRepository.upsertLatest} — id=1 단일 row UPSERT
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class HotNewsAggregationIntegrationTest {
+
+    @ServiceConnection
+    static final PostgreSQLContainer<?> postgres =
+            new PostgreSQLContainer<>(
+                    DockerImageName.parse("pgvector/pgvector:pg16")
+                            .asCompatibleSubstituteFor("postgres"))
+                    .withDatabaseName("wefin_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    static {
+        postgres.start();
+    }
+
+    @Autowired private NewsClusterRepository newsClusterRepository;
+    @Autowired private UserNewsClusterReadRepository userReadRepository;
+    @Autowired private HotAggregationMetaRepository metaRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        transactionTemplate.executeWithoutResult(tx -> {
+            entityManager.createNativeQuery("DELETE FROM user_news_cluster_read").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM news_cluster").executeUpdate();
+            entityManager.createNativeQuery("DELETE FROM hot_aggregation_meta").executeUpdate();
+        });
+    }
+
+    // --- insertIfAbsent ---
+
+    @Test
+    @DisplayName("insertIfAbsent — 첫 호출은 1 반환, 동일 (user,cluster) 재호출은 0")
+    void insertIfAbsent_upsertSemantics() {
+        Long clusterId = seedActiveCluster();
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime now = OffsetDateTime.now();
+
+        int first = transactionTemplate.execute(tx ->
+                userReadRepository.insertIfAbsent(userId, clusterId, now));
+        int second = transactionTemplate.execute(tx ->
+                userReadRepository.insertIfAbsent(userId, clusterId, now.plusSeconds(10)));
+
+        assertThat(first).isEqualTo(1);
+        assertThat(second).isEqualTo(0);
+
+        // 실제 row 는 하나만 존재하며 read_at 은 첫 insert 시각 유지 (DO NOTHING 동작)
+        Number total = (Number) entityManager.createNativeQuery(
+                        "SELECT COUNT(*) FROM user_news_cluster_read WHERE user_id = ? AND news_cluster_id = ?")
+                .setParameter(1, userId).setParameter(2, clusterId).getSingleResult();
+        assertThat(total.intValue()).isEqualTo(1);
+    }
+
+    // --- touchReadAtIfStale ---
+
+    @Test
+    @DisplayName("touchReadAtIfStale — threshold 이내 호출은 0 반환 (skip), 이전 값은 유지")
+    void touchReadAtIfStale_withinThreshold_skips() {
+        Long clusterId = seedActiveCluster();
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime initial = OffsetDateTime.now().minusSeconds(10);
+
+        transactionTemplate.executeWithoutResult(tx ->
+                userReadRepository.insertIfAbsent(userId, clusterId, initial));
+
+        // threshold = now - 60s, initial 이 10s 전이므로 stale 아님
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime threshold = now.minusSeconds(60);
+
+        int affected = transactionTemplate.execute(tx ->
+                userReadRepository.touchReadAtIfStale(userId, clusterId, now, threshold));
+
+        assertThat(affected).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("touchReadAtIfStale — threshold 초과하면 1 반환하고 read_at 갱신")
+    void touchReadAtIfStale_beyondThreshold_updates() {
+        Long clusterId = seedActiveCluster();
+        UUID userId = UUID.randomUUID();
+        OffsetDateTime oldTime = OffsetDateTime.now().minusMinutes(10);
+
+        transactionTemplate.executeWithoutResult(tx ->
+                userReadRepository.insertIfAbsent(userId, clusterId, oldTime));
+
+        OffsetDateTime now = OffsetDateTime.now();
+        OffsetDateTime threshold = now.minusSeconds(60);
+
+        int affected = transactionTemplate.execute(tx ->
+                userReadRepository.touchReadAtIfStale(userId, clusterId, now, threshold));
+
+        assertThat(affected).isEqualTo(1);
+    }
+
+    // --- incrementUniqueViewerCount ---
+
+    @Test
+    @DisplayName("incrementUniqueViewerCount — ACTIVE 클러스터는 1 반환, INACTIVE 는 0 반환하며 값 변경 없음")
+    void incrementUniqueViewerCount_activeGuard() {
+        Long activeId = seedActiveCluster();
+        Long inactiveId = seedInactiveCluster();
+
+        int affectedActive = transactionTemplate.execute(tx ->
+                newsClusterRepository.incrementUniqueViewerCount(activeId));
+        int affectedInactive = transactionTemplate.execute(tx ->
+                newsClusterRepository.incrementUniqueViewerCount(inactiveId));
+
+        assertThat(affectedActive).isEqualTo(1);
+        assertThat(affectedInactive).isEqualTo(0);
+
+        Number activeCount = (Number) entityManager.createNativeQuery(
+                "SELECT unique_viewer_count FROM news_cluster WHERE news_cluster_id = ?")
+                .setParameter(1, activeId).getSingleResult();
+        Number inactiveCount = (Number) entityManager.createNativeQuery(
+                "SELECT unique_viewer_count FROM news_cluster WHERE news_cluster_id = ?")
+                .setParameter(1, inactiveId).getSingleResult();
+
+        assertThat(activeCount.longValue()).isEqualTo(1L);
+        assertThat(inactiveCount.longValue()).isEqualTo(0L);
+    }
+
+    // --- refreshRecentViewCounts ---
+
+    @Test
+    @DisplayName("refreshRecentViewCounts — 변경분만 UPDATE (IS DISTINCT FROM 가드)")
+    void refreshRecentViewCounts_updatesOnlyChangedRows() {
+        Long c1 = seedActiveCluster();
+        Long c2 = seedActiveCluster();
+
+        // c1 에 2건 read, c2 에 0건
+        seedReadAt(c1, OffsetDateTime.now().minusMinutes(5));
+        seedReadAt(c1, OffsetDateTime.now().minusMinutes(10));
+
+        OffsetDateTime windowStart = OffsetDateTime.now().minusHours(3);
+
+        int updated = transactionTemplate.execute(tx ->
+                newsClusterRepository.refreshRecentViewCounts(windowStart));
+        // c1 (0→2), c2 (0→0 이지만 IS DISTINCT FROM 가드로 skip) → 1 row 만 UPDATE
+        assertThat(updated).isEqualTo(1);
+
+        assertThat(readRecentView(c1)).isEqualTo(2L);
+        assertThat(readRecentView(c2)).isEqualTo(0L);
+
+        // 두 번째 호출 — 값 변동 없으면 0 row UPDATE (IS DISTINCT FROM 가드 검증)
+        int secondUpdated = transactionTemplate.execute(tx ->
+                newsClusterRepository.refreshRecentViewCounts(windowStart));
+        assertThat(secondUpdated).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("refreshRecentViewCounts — 윈도우 밖으로 빠진 클러스터는 0으로 리셋")
+    void refreshRecentViewCounts_resetsOutOfWindow() {
+        Long c = seedActiveCluster();
+
+        // 초기: 윈도우 안에 read 1건 → recent_view_count = 1
+        seedReadAt(c, OffsetDateTime.now().minusMinutes(30));
+        OffsetDateTime tightWindow = OffsetDateTime.now().minusHours(1);
+        transactionTemplate.executeWithoutResult(tx ->
+                newsClusterRepository.refreshRecentViewCounts(tightWindow));
+        assertThat(readRecentView(c)).isEqualTo(1L);
+
+        // 윈도우를 좁혀서 read 를 경계 밖으로 밀어냄 (윈도우 = 최근 10분)
+        OffsetDateTime narrowerWindow = OffsetDateTime.now().minusMinutes(10);
+        int updated = transactionTemplate.execute(tx ->
+                newsClusterRepository.refreshRecentViewCounts(narrowerWindow));
+
+        assertThat(updated).isEqualTo(1);            // 1→0 으로 변경됐으므로
+        assertThat(readRecentView(c)).isEqualTo(0L); // 경계 밖 리셋 검증
+    }
+
+    // --- hot_aggregation_meta UPSERT ---
+
+    @Test
+    @DisplayName("upsertLatest — 여러 번 호출해도 row 는 id=1 하나만 유지되며 최신 값 반영")
+    void upsertLatest_singleRow() {
+        OffsetDateTime t1 = OffsetDateTime.now().minusMinutes(10);
+        OffsetDateTime t2 = OffsetDateTime.now();
+
+        transactionTemplate.executeWithoutResult(tx ->
+                metaRepository.upsertLatest(t1, t1.minusHours(3), 5, 100));
+        transactionTemplate.executeWithoutResult(tx ->
+                metaRepository.upsertLatest(t2, t2.minusHours(3), 42, 200));
+
+        // row 수 = 1
+        Number total = (Number) entityManager.createNativeQuery(
+                "SELECT COUNT(*) FROM hot_aggregation_meta").getSingleResult();
+        assertThat(total.intValue()).isEqualTo(1);
+
+        // 최신 값 반영
+        Optional<HotAggregationMeta> latest = metaRepository.findSingleton();
+        assertThat(latest).isPresent();
+        assertThat(latest.get().getLastUpdatedCount()).isEqualTo(42);
+        assertThat(latest.get().getLastTookMs()).isEqualTo(200);
+        // 시각 비교는 초 단위 오차 허용 (DB round-trip / 정밀도 차이)
+        assertThat(
+                java.time.Duration.between(latest.get().getLastSuccessAt(), t2).abs().getSeconds())
+                .isLessThanOrEqualTo(10);
+    }
+
+    // --- helpers ---
+
+    private Long seedActiveCluster() {
+        return seedCluster(ClusterStatus.ACTIVE);
+    }
+
+    private Long seedInactiveCluster() {
+        return seedCluster(ClusterStatus.INACTIVE);
+    }
+
+    private Long seedCluster(ClusterStatus status) {
+        return transactionTemplate.execute(tx -> {
+            NewsCluster cluster = NewsCluster.builder()
+                    .clusterType(NewsCluster.ClusterType.GENERAL)
+                    .centroidVector(new float[]{0.1f})
+                    .representativeArticleId(1L)
+                    .publishedAt(OffsetDateTime.now())
+                    .build();
+            ReflectionTestUtils.setField(cluster, "title", "테스트 클러스터");
+            ReflectionTestUtils.setField(cluster, "summary", "테스트 요약");
+            ReflectionTestUtils.setField(cluster, "status", status);
+            ReflectionTestUtils.setField(cluster, "summaryStatus", SummaryStatus.GENERATED);
+            newsClusterRepository.save(cluster);
+            return cluster.getId();
+        });
+    }
+
+    private void seedReadAt(Long clusterId, OffsetDateTime readAt) {
+        transactionTemplate.executeWithoutResult(tx ->
+                userReadRepository.insertIfAbsent(UUID.randomUUID(), clusterId, readAt));
+    }
+
+    private long readRecentView(Long clusterId) {
+        entityManager.flush();
+        entityManager.clear();
+        Number n = (Number) entityManager.createNativeQuery(
+                "SELECT recent_view_count FROM news_cluster WHERE news_cluster_id = ?")
+                .setParameter(1, clusterId).getSingleResult();
+        return n.longValue();
+    }
+
+}

--- a/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
@@ -297,8 +297,10 @@ class HotNewsAggregationIntegrationTest {
     }
 
     private long readRecentView(Long clusterId) {
-        entityManager.flush();
-        entityManager.clear();
+        // refreshRecentViewCounts 는 바로 앞의 transactionTemplate 에서 이미 commit 되었으므로
+        // 네이티브 SELECT 만으로 최신 DB 상태를 읽을 수 있다.
+        // flush/clear 를 직접 호출하면 이 메서드가 트랜잭션 밖에서 동작하기 때문에
+        // TransactionRequiredException 이 발생한다 → 호출 불필요.
         Number n = (Number) entityManager.createNativeQuery(
                 "SELECT recent_view_count FROM news_cluster WHERE news_cluster_id = ?")
                 .setParameter(1, clusterId).getSingleResult();

--- a/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
@@ -67,6 +67,9 @@ class HotNewsAggregationIntegrationTest {
             entityManager.createNativeQuery("DELETE FROM user_news_cluster_read").executeUpdate();
             entityManager.createNativeQuery("DELETE FROM news_cluster").executeUpdate();
             entityManager.createNativeQuery("DELETE FROM hot_aggregation_meta").executeUpdate();
+            entityManager.createNativeQuery(
+                            "DELETE FROM users WHERE email LIKE 'hot-news-agg-%@test'")
+                    .executeUpdate();
         });
     }
 
@@ -76,7 +79,7 @@ class HotNewsAggregationIntegrationTest {
     @DisplayName("insertIfAbsent — 첫 호출은 1 반환, 동일 (user,cluster) 재호출은 0")
     void insertIfAbsent_upsertSemantics() {
         Long clusterId = seedActiveCluster();
-        UUID userId = UUID.randomUUID();
+        UUID userId = seedUser();
         OffsetDateTime now = OffsetDateTime.now();
 
         int first = transactionTemplate.execute(tx ->
@@ -100,7 +103,7 @@ class HotNewsAggregationIntegrationTest {
     @DisplayName("touchReadAtIfStale — threshold 이내 호출은 0 반환 (skip), 이전 값은 유지")
     void touchReadAtIfStale_withinThreshold_skips() {
         Long clusterId = seedActiveCluster();
-        UUID userId = UUID.randomUUID();
+        UUID userId = seedUser();
         OffsetDateTime initial = OffsetDateTime.now().minusSeconds(10);
 
         transactionTemplate.executeWithoutResult(tx ->
@@ -120,7 +123,7 @@ class HotNewsAggregationIntegrationTest {
     @DisplayName("touchReadAtIfStale — threshold 초과하면 1 반환하고 read_at 갱신")
     void touchReadAtIfStale_beyondThreshold_updates() {
         Long clusterId = seedActiveCluster();
-        UUID userId = UUID.randomUUID();
+        UUID userId = seedUser();
         OffsetDateTime oldTime = OffsetDateTime.now().minusMinutes(10);
 
         transactionTemplate.executeWithoutResult(tx ->
@@ -252,10 +255,11 @@ class HotNewsAggregationIntegrationTest {
 
     private Long seedCluster(ClusterStatus status) {
         return transactionTemplate.execute(tx -> {
+            // representativeArticleId 는 news_cluster → news_article FK 가 있어 실 기사 seed 없이는 세팅 불가.
+            // 이 테스트는 기사 참조가 필요 없으므로 null 로 둔다 (컬럼은 NULL 허용).
             NewsCluster cluster = NewsCluster.builder()
                     .clusterType(NewsCluster.ClusterType.GENERAL)
                     .centroidVector(new float[]{0.1f})
-                    .representativeArticleId(1L)
                     .publishedAt(OffsetDateTime.now())
                     .build();
             ReflectionTestUtils.setField(cluster, "title", "테스트 클러스터");
@@ -267,9 +271,29 @@ class HotNewsAggregationIntegrationTest {
         });
     }
 
-    private void seedReadAt(Long clusterId, OffsetDateTime readAt) {
+    /**
+     * user_news_cluster_read.user_id 는 users 테이블 FK 가 있어 임의 UUID 로는 insert 불가.
+     * 유효 UUID 를 만들기 위해 users row 를 한 건 삽입하고 그 UUID 를 반환한다.
+     */
+    private UUID seedUser() {
+        UUID userId = UUID.randomUUID();
+        String nickname = userId.toString().substring(0, 8);
         transactionTemplate.executeWithoutResult(tx ->
-                userReadRepository.insertIfAbsent(UUID.randomUUID(), clusterId, readAt));
+                entityManager.createNativeQuery(
+                                "INSERT INTO users(user_id, email, nickname, password) " +
+                                "VALUES (?, ?, ?, ?) ON CONFLICT (user_id) DO NOTHING")
+                        .setParameter(1, userId)
+                        .setParameter(2, "hot-news-agg-" + userId + "@test")
+                        .setParameter(3, "han-" + nickname)
+                        .setParameter(4, "x")
+                        .executeUpdate());
+        return userId;
+    }
+
+    private void seedReadAt(Long clusterId, OffsetDateTime readAt) {
+        UUID userId = seedUser();
+        transactionTemplate.executeWithoutResult(tx ->
+                userReadRepository.insertIfAbsent(userId, clusterId, readAt));
     }
 
     private long readRecentView(Long clusterId) {

--- a/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/repository/HotNewsAggregationIntegrationTest.java
@@ -144,9 +144,9 @@ class HotNewsAggregationIntegrationTest {
         Long inactiveId = seedInactiveCluster();
 
         int affectedActive = transactionTemplate.execute(tx ->
-                newsClusterRepository.incrementUniqueViewerCount(activeId));
+                newsClusterRepository.incrementUniqueViewerCount(activeId, ClusterStatus.ACTIVE));
         int affectedInactive = transactionTemplate.execute(tx ->
-                newsClusterRepository.incrementUniqueViewerCount(inactiveId));
+                newsClusterRepository.incrementUniqueViewerCount(inactiveId, ClusterStatus.ACTIVE));
 
         assertThat(affectedActive).isEqualTo(1);
         assertThat(affectedInactive).isEqualTo(0);

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
@@ -54,11 +54,11 @@ class ClusterInteractionServiceTest {
     void markRead_firstVisit_incrementsUniqueViewer() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
         given(readRepository.insertIfAbsent(eq(USER_ID), eq(CLUSTER_ID), any())).willReturn(1);
-        given(newsClusterRepository.incrementUniqueViewerCount(CLUSTER_ID)).willReturn(1);
+        given(newsClusterRepository.incrementUniqueViewerCount(CLUSTER_ID, ClusterStatus.ACTIVE)).willReturn(1);
 
         service.markRead(USER_ID, CLUSTER_ID);
 
-        verify(newsClusterRepository).incrementUniqueViewerCount(CLUSTER_ID);
+        verify(newsClusterRepository).incrementUniqueViewerCount(CLUSTER_ID, ClusterStatus.ACTIVE);
         verify(readRepository, never()).touchReadAtIfStale(any(), any(), any(), any());
     }
 
@@ -72,7 +72,7 @@ class ClusterInteractionServiceTest {
 
         service.markRead(USER_ID, CLUSTER_ID);
 
-        verify(newsClusterRepository, never()).incrementUniqueViewerCount(anyLong());
+        verify(newsClusterRepository, never()).incrementUniqueViewerCount(anyLong(), any());
         verify(readRepository).touchReadAtIfStale(eq(USER_ID), eq(CLUSTER_ID), any(), any());
     }
 
@@ -81,11 +81,11 @@ class ClusterInteractionServiceTest {
     void markRead_firstVisit_incrementMiss_logsWarn() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
         given(readRepository.insertIfAbsent(eq(USER_ID), eq(CLUSTER_ID), any())).willReturn(1);
-        given(newsClusterRepository.incrementUniqueViewerCount(CLUSTER_ID)).willReturn(0);
+        given(newsClusterRepository.incrementUniqueViewerCount(CLUSTER_ID, ClusterStatus.ACTIVE)).willReturn(0);
 
         service.markRead(USER_ID, CLUSTER_ID);
 
-        verify(newsClusterRepository).incrementUniqueViewerCount(CLUSTER_ID);
+        verify(newsClusterRepository).incrementUniqueViewerCount(CLUSTER_ID, ClusterStatus.ACTIVE);
         verify(readRepository, never()).touchReadAtIfStale(any(), any(), any(), any());
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
@@ -6,12 +6,12 @@ import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterFeedback.Feedbac
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterFeedbackRepository;
 import com.solv.wefin.domain.news.cluster.repository.UserNewsClusterReadRepository;
+import com.solv.wefin.domain.news.config.NewsHotProperties;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -34,32 +34,59 @@ class ClusterInteractionServiceTest {
     @Mock private UserNewsClusterFeedbackRepository feedbackRepository;
     @Mock private ClusterInterestWeightService interestWeightService;
 
-    @InjectMocks
     private ClusterInteractionService service;
 
     private static final UUID USER_ID = UUID.randomUUID();
     private static final Long CLUSTER_ID = 1L;
+    // windowHours=3, aggIntervalSeconds=300, initialDelaySeconds=30, maxSize=20, throttleSeconds=60
+    private static final NewsHotProperties HOT_PROPS =
+            new NewsHotProperties(3, 300, 30, 20, 60);
 
-    @Test
-    @DisplayName("markRead — 정상 저장")
-    void markRead_success() {
-        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
-        given(readRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(false);
-
-        service.markRead(USER_ID, CLUSTER_ID);
-
-        verify(readRepository).save(any());
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        service = new ClusterInteractionService(
+                newsClusterRepository, readRepository, feedbackRepository,
+                interestWeightService, HOT_PROPS);
     }
 
     @Test
-    @DisplayName("markRead — 중복 호출 시 idempotent")
-    void markRead_duplicate_ignored() {
+    @DisplayName("markRead — 첫 방문: UPSERT INSERT 성공 시 unique_viewer_count +1 호출")
+    void markRead_firstVisit_incrementsUniqueViewer() {
         given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
-        given(readRepository.existsByUserIdAndNewsClusterId(USER_ID, CLUSTER_ID)).willReturn(true);
+        given(readRepository.insertIfAbsent(eq(USER_ID), eq(CLUSTER_ID), any())).willReturn(1);
+        given(newsClusterRepository.incrementUniqueViewerCount(CLUSTER_ID)).willReturn(1);
 
         service.markRead(USER_ID, CLUSTER_ID);
 
-        verify(readRepository, never()).save(any());
+        verify(newsClusterRepository).incrementUniqueViewerCount(CLUSTER_ID);
+        verify(readRepository, never()).touchReadAtIfStale(any(), any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("markRead — 재방문: INSERT skip → touchReadAtIfStale 호출 (throttle 조건으로 DB가 판단)")
+    void markRead_revisit_callsTouch() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(readRepository.insertIfAbsent(eq(USER_ID), eq(CLUSTER_ID), any())).willReturn(0);
+        given(readRepository.touchReadAtIfStale(eq(USER_ID), eq(CLUSTER_ID), any(), any()))
+                .willReturn(1);
+
+        service.markRead(USER_ID, CLUSTER_ID);
+
+        verify(newsClusterRepository, never()).incrementUniqueViewerCount(anyLong());
+        verify(readRepository).touchReadAtIfStale(eq(USER_ID), eq(CLUSTER_ID), any(), any());
+    }
+
+    @Test
+    @DisplayName("markRead — INSERT 성공했지만 increment 결과 0이면 경고 로그 후 정상 반환")
+    void markRead_firstVisit_incrementMiss_logsWarn() {
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(readRepository.insertIfAbsent(eq(USER_ID), eq(CLUSTER_ID), any())).willReturn(1);
+        given(newsClusterRepository.incrementUniqueViewerCount(CLUSTER_ID)).willReturn(0);
+
+        service.markRead(USER_ID, CLUSTER_ID);
+
+        verify(newsClusterRepository).incrementUniqueViewerCount(CLUSTER_ID);
+        verify(readRepository, never()).touchReadAtIfStale(any(), any(), any(), any());
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusterInteractionServiceTest.java
@@ -41,12 +41,15 @@ class ClusterInteractionServiceTest {
     // windowHours=3, aggIntervalSeconds=300, initialDelaySeconds=30, maxSize=20, throttleSeconds=60
     private static final NewsHotProperties HOT_PROPS =
             new NewsHotProperties(3, 300, 30, 20, 60);
+    // 결정론적 검증을 위해 고정 시각을 주입 (2026-04-20T12:00:00Z)
+    private static final java.time.Clock FIXED_CLOCK = java.time.Clock.fixed(
+            java.time.Instant.parse("2026-04-20T12:00:00Z"), java.time.ZoneOffset.UTC);
 
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
         service = new ClusterInteractionService(
                 newsClusterRepository, readRepository, feedbackRepository,
-                interestWeightService, HOT_PROPS);
+                interestWeightService, HOT_PROPS, FIXED_CLOCK);
     }
 
     @Test
@@ -74,6 +77,26 @@ class ClusterInteractionServiceTest {
 
         verify(newsClusterRepository, never()).incrementUniqueViewerCount(anyLong(), any());
         verify(readRepository).touchReadAtIfStale(eq(USER_ID), eq(CLUSTER_ID), any(), any());
+    }
+
+    @Test
+    @DisplayName("markRead — 고정 Clock 으로 now / staleThreshold 계산이 결정론적임을 검증")
+    void markRead_revisit_passesDeterministicTimestamps() {
+        OffsetDateTime expectedNow = OffsetDateTime.ofInstant(
+                java.time.Instant.parse("2026-04-20T12:00:00Z"), java.time.ZoneOffset.UTC);
+        // throttleSeconds=60 → staleThreshold = now - 60s
+        OffsetDateTime expectedThreshold = expectedNow.minusSeconds(60);
+
+        given(newsClusterRepository.findById(CLUSTER_ID)).willReturn(Optional.of(activeCluster()));
+        given(readRepository.insertIfAbsent(eq(USER_ID), eq(CLUSTER_ID), eq(expectedNow))).willReturn(0);
+        given(readRepository.touchReadAtIfStale(
+                eq(USER_ID), eq(CLUSTER_ID), eq(expectedNow), eq(expectedThreshold))).willReturn(1);
+
+        service.markRead(USER_ID, CLUSTER_ID);
+
+        // Clock.fixed 로 주입된 시각이 그대로 쿼리 파라미터에 전달되는지 확인
+        verify(readRepository).touchReadAtIfStale(
+                eq(USER_ID), eq(CLUSTER_ID), eq(expectedNow), eq(expectedThreshold));
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/NewsClusterQueryServiceTest.java
@@ -12,6 +12,7 @@ import com.solv.wefin.domain.news.article.repository.NewsArticleTagRepository;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.ClusterStatus;
 import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
+import com.solv.wefin.domain.news.cluster.entity.HotAggregationMeta;
 import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.entity.UserNewsClusterRead;
 import com.solv.wefin.domain.news.cluster.repository.ClusterSuggestedQuestionRepository;
@@ -58,6 +59,7 @@ class NewsClusterQueryServiceTest {
     @Mock private ClusterSummarySectionRepository sectionRepository;
     @Mock private ClusterSuggestedQuestionRepository questionRepository;
     @Mock private ClusterSummarySectionSourceRepository sectionSourceRepository;
+    @Mock private com.solv.wefin.domain.news.cluster.repository.HotAggregationMetaRepository hotAggregationMetaRepository;
 
     private NewsClusterQueryService queryService;
 
@@ -69,7 +71,7 @@ class NewsClusterQueryServiceTest {
                 newsClusterRepository, clusterArticleRepository,
                 newsArticleRepository, readRepository, feedbackRepository,
                 questionRepository, sectionRepository, sectionSourceRepository,
-                tagAggregator);
+                hotAggregationMetaRepository, tagAggregator);
     }
 
     @Test
@@ -420,6 +422,83 @@ class NewsClusterQueryServiceTest {
         assertThat(result.relatedSectors().get(0).code()).isEqualTo("BIO");
         assertThat(result.relatedSectors().get(0).name()).isEqualTo("바이오");
     }
+
+    // --- sort=view 분기 ---
+
+    @Test
+    @DisplayName("sort=view — findHotClusters 호출 + 페이지네이션 미지원 + lastAggregatedAt 포함")
+    void getFeed_sortView_callsHotClusterQuery() {
+        OffsetDateTime publishedAt = OffsetDateTime.now();
+        NewsCluster hot = createCluster(7L, "핫뉴스", "요약", publishedAt, 5);
+        ReflectionTestUtils.setField(hot, "recentViewCount", 999L);
+
+        given(newsClusterRepository.findHotClusters(any(), any(), any())).willReturn(List.of(hot));
+        given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
+
+        OffsetDateTime aggTime = OffsetDateTime.now().minusMinutes(2);
+        HotAggregationMeta meta = HotAggregationMeta.forTest(
+                aggTime, aggTime.minusHours(3), 42, 120);
+        given(hotAggregationMetaRepository.findSingleton()).willReturn(Optional.of(meta));
+
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, null, null, "view");
+
+        assertThat(result.items()).hasSize(1);
+        assertThat(result.items().get(0).recentViewCount()).isEqualTo(999L);
+        assertThat(result.hasNext()).isFalse();
+        assertThat(result.nextCursorPublishedAt()).isNull();
+        assertThat(result.nextCursorId()).isNull();
+        assertThat(result.lastAggregatedAt()).isEqualTo(aggTime);
+
+        // 일반 피드 쿼리는 호출되지 않음
+        verify(newsClusterRepository).findHotClusters(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("sort=view — 메타 비어있으면 lastAggregatedAt=null (첫 배포 케이스)")
+    void getFeed_sortView_metaEmpty_lastAggregatedAtNull() {
+        given(newsClusterRepository.findHotClusters(any(), any(), any())).willReturn(List.of());
+        given(hotAggregationMetaRepository.findSingleton()).willReturn(Optional.empty());
+
+        ClusterFeedResult result = queryService.getFeed(null, null, 10, null, null, "view");
+
+        assertThat(result.items()).isEmpty();
+        assertThat(result.lastAggregatedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("sort=view — cursor 파라미터 수신해도 무시하고 Top N 반환")
+    void getFeed_sortView_ignoresCursor() {
+        NewsCluster hot = createCluster(1L, "핫", "요약", OffsetDateTime.now(), 1);
+        given(newsClusterRepository.findHotClusters(any(), any(), any())).willReturn(List.of(hot));
+        given(hotAggregationMetaRepository.findSingleton()).willReturn(Optional.empty());
+        given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
+
+        OffsetDateTime bogusCursor = OffsetDateTime.now();
+        ClusterFeedResult result = queryService.getFeed(bogusCursor, 999L, 10, null, null, "view");
+
+        assertThat(result.items()).hasSize(1);
+        // cursor 가 findHot 쿼리에 전달되지 않았음을 간접 검증 — cursor 기반 find 메서드 미호출
+        verify(newsClusterRepository).findHotClusters(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("sort=view + tagType/tagCodes — findHotClustersByTags 호출")
+    void getFeed_sortView_withTagFilter() {
+        NewsCluster hot = createCluster(1L, "핫", "요약", OffsetDateTime.now(), 1);
+        given(newsClusterRepository.findHotClustersByTags(any(), any(), eq(TagType.SECTOR), any(), any()))
+                .willReturn(List.of(hot));
+        given(hotAggregationMetaRepository.findSingleton()).willReturn(Optional.empty());
+        given(clusterArticleRepository.findByNewsClusterIdIn(any())).willReturn(List.of());
+
+        ClusterFeedResult result = queryService.getFeed(
+                null, null, 10, null, "ALL", "view",
+                TagType.SECTOR, List.of("FINANCE"));
+
+        assertThat(result.items()).hasSize(1);
+        verify(newsClusterRepository).findHotClustersByTags(any(), any(), eq(TagType.SECTOR), any(), any());
+    }
+
+    // --- getDetail 테스트 계속 ---
 
     @Test
     @DisplayName("상세 조회 — 존재하지 않는 clusterId는 예외")

--- a/src/test/java/com/solv/wefin/web/news/controller/NewsClusterControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/news/controller/NewsClusterControllerTest.java
@@ -1,0 +1,123 @@
+package com.solv.wefin.web.news.controller;
+
+import com.solv.wefin.domain.news.cluster.service.ClusterInteractionService;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService;
+import com.solv.wefin.domain.news.cluster.service.NewsClusterQueryService.ClusterFeedResult;
+import com.solv.wefin.domain.news.config.NewsHotProperties;
+import com.solv.wefin.global.config.security.JwtProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(NewsClusterController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(NewsClusterControllerTest.TestConfig.class)
+@TestPropertySource(properties = {
+        "news.hot.window-hours=3",
+        "news.hot.aggregation-interval-seconds=300",
+        "news.hot.initial-delay-seconds=30",
+        "news.hot.max-size=20",
+        "news.hot.mark-read-throttle-seconds=60"
+})
+class NewsClusterControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NewsClusterQueryService newsClusterQueryService;
+
+    @MockitoBean
+    private ClusterInteractionService clusterInteractionService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @org.springframework.boot.context.properties.EnableConfigurationProperties(NewsHotProperties.class)
+    static class TestConfig {
+    }
+
+    @Test
+    @DisplayName("sort=view — size 가 max-size 초과면 INVALID_INPUT")
+    void sortView_sizeExceedsMax_returns400() throws Exception {
+        mockMvc.perform(get("/api/news/clusters").param("sort", "view").param("size", "21"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("sort=view — size 미지정 시 maxSize 이하 기본값으로 조회")
+    void sortView_noSize_usesDefaultClamped() throws Exception {
+        given(newsClusterQueryService.getFeed(any(), any(), anyInt(), any(), any(), eq("view"), any(), any()))
+                .willReturn(new ClusterFeedResult(List.of(), false, null, null, OffsetDateTime.now()));
+
+        mockMvc.perform(get("/api/news/clusters").param("sort", "view"))
+                .andExpect(status().isOk());
+
+        // DEFAULT_PAGE_SIZE=10, maxSize=20 → 10이 전달되어야 함
+        verify(newsClusterQueryService).getFeed(any(), any(), eq(10), any(), any(), eq("view"), any(), any());
+    }
+
+    @Test
+    @DisplayName("sort=view — cursor 파라미터 수신해도 서비스엔 null 전달 (cursor 무시)")
+    void sortView_ignoresCursorParam() throws Exception {
+        given(newsClusterQueryService.getFeed(any(), any(), anyInt(), any(), any(), eq("view"), any(), any()))
+                .willReturn(new ClusterFeedResult(List.of(), false, null, null, null));
+
+        mockMvc.perform(get("/api/news/clusters")
+                        .param("sort", "view")
+                        .param("cursor", "1700000000000_123")
+                        .param("size", "5"))
+                .andExpect(status().isOk());
+
+        verify(newsClusterQueryService).getFeed(eq(null), eq(null), eq(5), any(), any(), eq("view"), any(), any());
+    }
+
+    @Test
+    @DisplayName("sort 파라미터가 허용값 아니면 에러")
+    void sort_unsupported_returns400() throws Exception {
+        mockMvc.perform(get("/api/news/clusters").param("sort", "unknown"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("sort=view 응답 — lastAggregatedAt 포함 (null 아닐 때)")
+    void sortView_responseIncludesLastAggregatedAt() throws Exception {
+        OffsetDateTime aggTime = OffsetDateTime.parse("2026-04-20T10:00:00Z");
+        given(newsClusterQueryService.getFeed(any(), any(), anyInt(), any(), any(), eq("view"), any(), any()))
+                .willReturn(new ClusterFeedResult(List.of(), false, null, null, aggTime));
+
+        mockMvc.perform(get("/api/news/clusters").param("sort", "view"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.lastAggregatedAt").exists())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("sort=publishedAt 응답 — lastAggregatedAt 은 null 이므로 응답에서 생략")
+    void sortPublished_omitsLastAggregatedAt() throws Exception {
+        given(newsClusterQueryService.getFeed(any(), any(), anyInt(), any(), any(), eq("publishedAt"), any(), any()))
+                .willReturn(new ClusterFeedResult(List.of(), false, null, null, null));
+
+        mockMvc.perform(get("/api/news/clusters"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.lastAggregatedAt").doesNotExist());
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,6 +25,12 @@ news:
     display: 10
   collect:
     cron: "-"
+  hot:
+    window-hours: 3
+    aggregation-interval-seconds: 300
+    initial-delay-seconds: 99999
+    max-size: 20
+    mark-read-throttle-seconds: 60
 
 market:
   bok:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -28,7 +28,9 @@ news:
   hot:
     window-hours: 3
     aggregation-interval-seconds: 300
-    initial-delay-seconds: 99999
+    # NewsHotProperties.@Max(600) 상한 내에서 최대치. 단위 테스트는 수초 내 종료되므로
+    # 600초 초기 지연이면 테스트 중 배치가 실행되지 않음
+    initial-delay-seconds: 600
     max-size: 20
     mark-read-throttle-seconds: 60
 


### PR DESCRIPTION
## 📌 PR 설명
뉴스 클러스터 조회수 랭킹(`sort=view`) 피처를 추가합니다. 최근 3시간 윈도우의 고유 뷰어 수 기준으로 정렬된 Top N 을 별도 랭킹 페이지에 노출합니다.
기존 `GET /api/news/clusters` 엔드포인트에 `sort=view` 파라미터를 확장하는 방식으로 구현해, 탭/태그 필터와 자연스럽게 조합됩니다.

**왜 필요한가**
- 기존 피드는 `publishedAt`/`updatedAt` 정렬만 지원 → 사용자가 "지금 사람들이 많이 보는 뉴스"를 빠르게 소비할 방법이 없었음
- 금융 뉴스 서비스 특성상 "지금 뜨는" 이슈는 타임라인 정렬로는 위로 안 올라오는 경우가 많음

**핵심 설계 결정**
- **누적 조회수가 아닌 "최근 N시간 윈도우 내 고유 뷰어 수"로 정렬** — 먼저 올라온 뉴스일수록 유리한 bias 제거
- **배치 기반 집계** — Hacker News 스타일 실시간 감쇠 점수는 매 요청마다 재계산 필요 + 커서 페이지네이션 불안정. 대신 5분마다 `recent_view_count` 컬럼을 갱신
- **sort=view 는 페이지네이션 미지원, Top N 고정** — 정렬 키가 배치로 바뀌어 cursor 기반 페이지네이션에서 중복/누락 발생. 랭킹 페이지는 Top 20 소비가 전부이므로 원천 차단
- **Advisory xact lock 기반 배치 중복 실행 차단** — ShedLock 신규 의존성 도입 회피 (PostgreSQL 중심 원칙)
- **FE 폴백 장치 내장** — 배치 실패 시 응답의 `lastAggregatedAt` 으로 FE가 자동으로 `sort=publishedAt` 폴백 판단 가능
<br>

## ✅ 완료한 기능 명세
1. `V50__add_cluster_view_metrics.sql` — `news_cluster` 에 `unique_viewer_count` / `recent_view_count` 컬럼, `hot_aggregation_meta` 단일 row 테이블, 부분 인덱스 3개
2. `HotAggregationMeta.java` — 배치 실행 메타 엔티티 (id=1 singleton, `forTest` 팩토리)
3. `HotAggregationMetaRepository.java` — `upsertLatest` 네이티브 UPSERT + `findSingleton`
4. `NewsHotProperties.java` — ConfigurationProperties (윈도우/주기/throttle/maxSize)
5. `AdvisoryLockKeys.java` — 프로젝트 advisory lock 키 중앙 레지스트리
6. `HotAggregationRunner.java` — `@Transactional doRefresh` — advisory_xact_lock + 집계 UPDATE + 메타 UPSERT
7. `HotClusterAggregationScheduler.java` — `@Scheduled` 트리거 (fixedDelay + initialDelay)
8. `NewsCluster.java` — `uniqueViewerCount`, `recentViewCount` 필드 추가
9. `NewsClusterRepository.java` — `findHotClusters`, `findHotClustersByTags`, `incrementUniqueViewerCount`, `refreshRecentViewCounts`
10. `UserNewsClusterReadRepository.java` — `insertIfAbsent` (UPSERT), `touchReadAtIfStale` (throttle)
11. `ClusterInteractionService.markRead` — UPSERT 기반 재작성 (신규 유입만 unique_viewer_count +1, 재방문은 read_at throttle 갱신)
12. `NewsClusterQueryService.java` — `sort=view` 분기 (Top N 쿼리, cursor 무시, `lastAggregatedAt` 포함), 내부 `SortMode` enum
13. `NewsClusterController.java` — sort 값 검증에 `view` 추가, size 상한 검증, Swagger 설명 보강
14. `ClusterFeedResponse.java` — `recentViewCount`, `lastAggregatedAt` 필드 추가 (후자는 `@JsonInclude(NON_NULL)`)
15. `NewsConfig.java` — `NewsHotProperties` 등록
16. `application.yml` / `application-test.yml` — `news.hot.*` 설정값 추가
17. `HotNewsAggregationIntegrationTest.java` (신규, 7 tests) — Testcontainers + pgvector
18. `NewsClusterControllerTest.java` (신규, 6 tests) — `@WebMvcTest`
19. `NewsClusterQueryServiceTest.java` — `sort=view` 분기 4 tests 추가
20. `ClusterInteractionServiceTest.java` — UPSERT 패턴 기반으로 재작성

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정
### PostgreSQL advisory xact lock
**advisory lock 이란**
- DB 가 제공하는 애플리케이션 정의 lock. 테이블/row 락과 달리 의미는 애플리케이션이 부여
- 같은 PostgreSQL 인스턴스에 연결된 모든 커넥션/프로세스가 공유하는 전역 락 → 다중 인스턴스 환경에서도 "한 번에 하나만 실행" 보장 가능 (ShedLock/Redis/Zookeeper 불필요)

<br>

### 🔗 관련 이슈
Closes #314

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 뉴스 피드에 sort=view 추가 — 최근 조회수 기반 정렬, 항목별 recentViewCount 및 lastAggregatedAt 제공.
  * 정기적 배치로 조회수 집계 자동 실행 및 집계 시각 표시.
  * 읽기 표시(throttle)로 빈번한 읽기 업데이트 제한.

* **Behavior / Validation**
  * view 정렬에서 페이지네이션 무시(커서 사용 안 함), size 제한 및 초과 시 400 응답 처리.

* **Tests**
  * 관련 통합·단위 테스트 추가 및 보강.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->