### PR TITLE
[WeF-681] 채팅방 알람 기능 구현

### DIFF
--- a/src/main/java/com/solv/wefin/domain/auth/entity/User.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/User.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Entity
@@ -39,6 +40,12 @@ public class User extends BaseEntity {
     @JoinColumn(name = "home_group_id")
     private Group homeGroup;
 
+    @Column(name = "last_read_global_message_id")
+    private Long lastReadGlobalMessageId;
+
+    @Column(name = "last_read_global_at")
+    private OffsetDateTime lastReadGlobalAt;
+
     @Builder
     public User(String email, String nickname, String password) {
         this.email = email;
@@ -53,6 +60,18 @@ public class User extends BaseEntity {
 
     public void changePassword(String password) {
         this.password = password;
+    }
+
+    public void markGlobalChatRead(Long messageId) {
+        if (messageId == null) {
+            this.lastReadGlobalAt = OffsetDateTime.now();
+            return;
+        }
+
+        if (this.lastReadGlobalMessageId == null || messageId >= this.lastReadGlobalMessageId) {
+            this.lastReadGlobalMessageId = messageId;
+            this.lastReadGlobalAt = OffsetDateTime.now();
+        }
     }
 
     public void withdraw() {

--- a/src/main/java/com/solv/wefin/domain/auth/repository/UserRepository.java
+++ b/src/main/java/com/solv/wefin/domain/auth/repository/UserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
+import java.util.List;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
@@ -19,4 +20,11 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select u from User u where u.userId = :userId")
     Optional<User> findByIdForUpdate(@Param("userId") UUID userId);
+
+    @Query("""
+            select u.userId
+            from User u
+            where u.status = com.solv.wefin.domain.auth.entity.UserStatus.ACTIVE
+            """)
+    List<UUID> findAllActiveUserIds();
 }

--- a/src/main/java/com/solv/wefin/domain/chat/common/dto/info/ChatUnreadInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/common/dto/info/ChatUnreadInfo.java
@@ -2,7 +2,9 @@ package com.solv.wefin.domain.chat.common.dto.info;
 
 public record ChatUnreadInfo(
         long globalUnreadCount,
-        long groupUnreadCount
+        long groupUnreadCount,
+        Long lastReadGlobalMessageId,
+        Long lastReadGroupMessageId
 ) {
     public boolean hasGlobalUnread() {
         return globalUnreadCount > 0;

--- a/src/main/java/com/solv/wefin/domain/chat/common/dto/info/ChatUnreadInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/common/dto/info/ChatUnreadInfo.java
@@ -1,0 +1,18 @@
+package com.solv.wefin.domain.chat.common.dto.info;
+
+public record ChatUnreadInfo(
+        long globalUnreadCount,
+        long groupUnreadCount
+) {
+    public boolean hasGlobalUnread() {
+        return globalUnreadCount > 0;
+    }
+
+    public boolean hasGroupUnread() {
+        return groupUnreadCount > 0;
+    }
+
+    public long totalUnreadCount() {
+        return globalUnreadCount + groupUnreadCount;
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/common/service/ChatReadStateService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/common/service/ChatReadStateService.java
@@ -39,7 +39,12 @@ public class ChatReadStateService {
         long globalUnreadCount = initializeAndCountGlobalUnread(user);
         long groupUnreadCount = initializeAndCountGroupUnread(groupMember);
 
-        return new ChatUnreadInfo(globalUnreadCount, groupUnreadCount);
+        return new ChatUnreadInfo(
+                globalUnreadCount,
+                groupUnreadCount,
+                user.getLastReadGlobalMessageId(),
+                groupMember.getLastReadChatMessageId()
+        );
     }
 
     @Transactional(readOnly = true)
@@ -53,10 +58,19 @@ public class ChatReadStateService {
                 )
                 .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN));
 
-        long globalUnreadCount = countGlobalUnread(user.getLastReadGlobalMessageId());
-        long groupUnreadCount = countGroupUnread(groupMember.getGroup().getId(), groupMember.getLastReadChatMessageId());
+        long globalUnreadCount = countGlobalUnread(user.getLastReadGlobalMessageId(), userId);
+        long groupUnreadCount = countGroupUnread(
+                groupMember.getGroup().getId(),
+                groupMember.getLastReadChatMessageId(),
+                userId
+        );
 
-        return new ChatUnreadInfo(globalUnreadCount, groupUnreadCount);
+        return new ChatUnreadInfo(
+                globalUnreadCount,
+                groupUnreadCount,
+                user.getLastReadGlobalMessageId(),
+                groupMember.getLastReadChatMessageId()
+        );
     }
 
     @Transactional
@@ -87,7 +101,7 @@ public class ChatReadStateService {
             return 0L;
         }
 
-        return countGlobalUnread(lastReadMessageId);
+        return countGlobalUnread(lastReadMessageId, user.getUserId());
     }
 
     private long initializeAndCountGroupUnread(GroupMember groupMember) {
@@ -99,22 +113,22 @@ public class ChatReadStateService {
             return 0L;
         }
 
-        return countGroupUnread(groupMember.getGroup().getId(), lastReadMessageId);
+        return countGroupUnread(groupMember.getGroup().getId(), lastReadMessageId, groupMember.getUser().getUserId());
     }
 
-    private long countGlobalUnread(Long lastReadMessageId) {
+    private long countGlobalUnread(Long lastReadMessageId, UUID userId) {
         if (lastReadMessageId == null) {
             return 0L;
         }
 
-        return globalChatMessageRepository.countByIdGreaterThan(lastReadMessageId);
+        return globalChatMessageRepository.countUnreadAfterMessageId(lastReadMessageId, userId);
     }
 
-    private long countGroupUnread(Long groupId, Long lastReadMessageId) {
+    private long countGroupUnread(Long groupId, Long lastReadMessageId, UUID userId) {
         if (lastReadMessageId == null) {
             return 0L;
         }
 
-        return chatMessageRepository.countByGroup_IdAndIdGreaterThan(groupId, lastReadMessageId);
+        return chatMessageRepository.countUnreadAfterMessageId(groupId, lastReadMessageId, userId);
     }
 }

--- a/src/main/java/com/solv/wefin/domain/chat/common/service/ChatReadStateService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/common/service/ChatReadStateService.java
@@ -1,0 +1,120 @@
+package com.solv.wefin.domain.chat.common.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import com.solv.wefin.domain.chat.globalChat.repository.GlobalChatMessageRepository;
+import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageRepository;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatReadStateService {
+
+    private final UserRepository userRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final GlobalChatMessageRepository globalChatMessageRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    @Transactional
+    public ChatUnreadInfo getUnreadInfo(UUID userId) {
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findByUser_UserIdAndStatus(
+                        userId,
+                        GroupMember.GroupMemberStatus.ACTIVE
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN));
+
+        long globalUnreadCount = initializeAndCountGlobalUnread(user);
+        long groupUnreadCount = initializeAndCountGroupUnread(groupMember);
+
+        return new ChatUnreadInfo(globalUnreadCount, groupUnreadCount);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatUnreadInfo getUnreadInfoSnapshot(UUID userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        GroupMember groupMember = groupMemberRepository.findByUser_UserIdAndStatus(
+                        userId,
+                        GroupMember.GroupMemberStatus.ACTIVE
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN));
+
+        long globalUnreadCount = countGlobalUnread(user.getLastReadGlobalMessageId());
+        long groupUnreadCount = countGroupUnread(groupMember.getGroup().getId(), groupMember.getLastReadChatMessageId());
+
+        return new ChatUnreadInfo(globalUnreadCount, groupUnreadCount);
+    }
+
+    @Transactional
+    public void markGlobalChatRead(UUID userId) {
+        User user = userRepository.findByIdForUpdate(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Long latestMessageId = globalChatMessageRepository.findLatestMessageId();
+        user.markGlobalChatRead(latestMessageId);
+    }
+
+    @Transactional
+    public void markGroupChatRead(UUID userId) {
+        GroupMember groupMember = groupMemberRepository.findByUser_UserIdAndStatus(
+                        userId,
+                        GroupMember.GroupMemberStatus.ACTIVE
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN));
+
+        Long latestMessageId = chatMessageRepository.findLatestMessageIdByGroupId(groupMember.getGroup().getId());
+        groupMember.markGroupChatRead(latestMessageId);
+    }
+
+    private long initializeAndCountGlobalUnread(User user) {
+        Long lastReadMessageId = user.getLastReadGlobalMessageId();
+        if (lastReadMessageId == null) {
+            user.markGlobalChatRead(globalChatMessageRepository.findLatestMessageId());
+            return 0L;
+        }
+
+        return countGlobalUnread(lastReadMessageId);
+    }
+
+    private long initializeAndCountGroupUnread(GroupMember groupMember) {
+        Long lastReadMessageId = groupMember.getLastReadChatMessageId();
+        if (lastReadMessageId == null) {
+            groupMember.markGroupChatRead(
+                    chatMessageRepository.findLatestMessageIdByGroupId(groupMember.getGroup().getId())
+            );
+            return 0L;
+        }
+
+        return countGroupUnread(groupMember.getGroup().getId(), lastReadMessageId);
+    }
+
+    private long countGlobalUnread(Long lastReadMessageId) {
+        if (lastReadMessageId == null) {
+            return 0L;
+        }
+
+        return globalChatMessageRepository.countByIdGreaterThan(lastReadMessageId);
+    }
+
+    private long countGroupUnread(Long groupId, Long lastReadMessageId) {
+        if (lastReadMessageId == null) {
+            return 0L;
+        }
+
+        return chatMessageRepository.countByGroup_IdAndIdGreaterThan(groupId, lastReadMessageId);
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/common/service/ChatReadStateService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/common/service/ChatReadStateService.java
@@ -13,8 +13,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -52,24 +52,18 @@ public class ChatReadStateService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        GroupMember groupMember = groupMemberRepository.findByUser_UserIdAndStatus(
-                        userId,
-                        GroupMember.GroupMemberStatus.ACTIVE
-                )
-                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_MEMBER_FORBIDDEN));
-
+        Optional<GroupMember> groupMemberOpt = groupMemberRepository
+                .findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE);
         long globalUnreadCount = countGlobalUnread(user.getLastReadGlobalMessageId(), userId);
-        long groupUnreadCount = countGroupUnread(
-                groupMember.getGroup().getId(),
-                groupMember.getLastReadChatMessageId(),
-                userId
-        );
+        long groupUnreadCount = groupMemberOpt
+                .map(gm -> countGroupUnread(gm.getGroup().getId(), gm.getLastReadChatMessageId(), userId))
+                .orElse(0L);
 
         return new ChatUnreadInfo(
                 globalUnreadCount,
                 groupUnreadCount,
                 user.getLastReadGlobalMessageId(),
-                groupMember.getLastReadChatMessageId()
+                groupMemberOpt.map(GroupMember::getLastReadChatMessageId).orElse(null)
         );
     }
 

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/repository/GlobalChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/repository/GlobalChatMessageRepository.java
@@ -29,4 +29,12 @@ public interface GlobalChatMessageRepository extends JpaRepository<GlobalChatMes
     List<GlobalChatMessage> findMessagesBefore(Long beforeMessageId, Pageable pageable);
 
     long countByUser_UserIdAndCreatedAtAfter(UUID userId, OffsetDateTime time);
+
+    long countByIdGreaterThan(Long messageId);
+
+    @Query("""
+        select max(m.id)
+        from GlobalChatMessage m
+    """)
+    Long findLatestMessageId();
 }

--- a/src/main/java/com/solv/wefin/domain/chat/globalChat/repository/GlobalChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/globalChat/repository/GlobalChatMessageRepository.java
@@ -30,7 +30,14 @@ public interface GlobalChatMessageRepository extends JpaRepository<GlobalChatMes
 
     long countByUser_UserIdAndCreatedAtAfter(UUID userId, OffsetDateTime time);
 
-    long countByIdGreaterThan(Long messageId);
+    @Query("""
+        select count(m)
+        from GlobalChatMessage m
+        where m.id > :messageId
+          and (m.user is null or m.user.userId <> :userId)
+    """)
+    long countUnreadAfterMessageId(@org.springframework.data.repository.query.Param("messageId") Long messageId,
+                                   @org.springframework.data.repository.query.Param("userId") UUID userId);
 
     @Query("""
         select max(m.id)

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
@@ -50,7 +50,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
     Optional<ChatMessage> findByIdAndGroup_Id(Long messageId, Long groupId);
 
-    long countByGroup_IdAndIdGreaterThan(Long groupId, Long messageId);
+    @Query("""
+        select count(m)
+        from ChatMessage m
+        where m.group.id = :groupId
+          and m.id > :messageId
+          and (m.user is null or m.user.userId <> :userId)
+    """)
+    long countUnreadAfterMessageId(@Param("groupId") Long groupId,
+                                   @Param("messageId") Long messageId,
+                                   @Param("userId") UUID userId);
 
     @Query("""
         select max(m.id)

--- a/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/solv/wefin/domain/chat/groupChat/repository/ChatMessageRepository.java
@@ -49,4 +49,13 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
     long countByGroup_IdAndUser_UserIdAndCreatedAtAfter(Long groupId, UUID userId, OffsetDateTime time);
 
     Optional<ChatMessage> findByIdAndGroup_Id(Long messageId, Long groupId);
+
+    long countByGroup_IdAndIdGreaterThan(Long groupId, Long messageId);
+
+    @Query("""
+        select max(m.id)
+        from ChatMessage m
+        where m.group.id = :groupId
+    """)
+    Long findLatestMessageIdByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
+++ b/src/main/java/com/solv/wefin/domain/group/entity/GroupMember.java
@@ -42,6 +42,12 @@ public class GroupMember {
     @Column(name = "left_at")
     private OffsetDateTime leftAt;
 
+    @Column(name = "last_read_chat_message_id")
+    private Long lastReadChatMessageId;
+
+    @Column(name = "last_read_chat_at")
+    private OffsetDateTime lastReadChatAt;
+
     @Builder
     private GroupMember(User user, Group group, GroupMemberRole role, GroupMemberStatus status) {
         this.user = user;
@@ -91,6 +97,18 @@ public class GroupMember {
 
     public void changeRoleToMember() {
         this.role = GroupMemberRole.MEMBER;
+    }
+
+    public void markGroupChatRead(Long messageId) {
+        if (messageId == null) {
+            this.lastReadChatAt = OffsetDateTime.now();
+            return;
+        }
+
+        if (this.lastReadChatMessageId == null || messageId >= this.lastReadChatMessageId) {
+            this.lastReadChatMessageId = messageId;
+            this.lastReadChatAt = OffsetDateTime.now();
+        }
     }
 
     public boolean isActive() {

--- a/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/solv/wefin/domain/group/repository/GroupMemberRepository.java
@@ -57,5 +57,16 @@ public interface GroupMemberRepository extends JpaRepository<GroupMember, Long> 
             @Param("status") GroupMember.GroupMemberStatus status
     );
 
+    @Query("""
+            select gm.user.userId
+            from GroupMember gm
+            where gm.group.id = :groupId
+              and gm.status = :status
+            """)
+    List<UUID> findUserIdsByGroupIdAndStatus(
+            @Param("groupId") Long groupId,
+            @Param("status") GroupMember.GroupMemberStatus status
+    );
+
     long countByGroupAndStatus(Group group, GroupMember.GroupMemberStatus status);
 }

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/ws/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/chat/global/messages").permitAll()
                         .requestMatchers("/api/news/recommended/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**",
                             "/api/market-trends/overview",

--- a/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import java.security.Principal;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -24,83 +25,114 @@ import java.util.UUID;
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     private static final String BEARER_PREFIX = "Bearer ";
+    private static final Set<String> ANONYMOUS_SUBSCRIBE_DESTINATIONS = Set.of(
+            "/topic/chat/global"
+    );
 
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
-    // 메시지가 채널로 보내지기 직전 호출 -> 조건에 안맞으면 차단, 사용자 정보 넣기
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor =
                 MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
 
-        if(accessor == null) {
+        if (accessor == null) {
             return message;
         }
 
         // CONNECT 일때 id를 웹소켓 사용자로 저장
-        if(StompCommand.CONNECT.equals(accessor.getCommand())) {
-            String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
-
-            // jwt 토큰 검증
-            if (authorizationHeader == null || !authorizationHeader.startsWith(BEARER_PREFIX)) {
-                throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
-            }
-
-            String token = authorizationHeader.substring(BEARER_PREFIX.length());
-
-            boolean validAccessToken;
-
-            try {
-                validAccessToken = jwtProvider.isValid(token) && jwtProvider.isAccessToken(token);
-            } catch (RuntimeException e) {
-                validAccessToken = false;
-            }
-
-            if (!validAccessToken) {
-                throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
-            }
-
-            UUID userId;
-            try {
-                userId = jwtProvider.getUserId(token);
-            } catch (RuntimeException e) {
-                throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
-            }
-
-
-            boolean exists = userRepository.existsById(userId);
-
-            if (!exists) {
-                throw new BusinessException(ErrorCode.USER_NOT_FOUND);
-            }
-
-            Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
-            if (sessionAttributes == null) {
-                throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-            }
-
-            accessor.getSessionAttributes().put("userId", userId);
-            accessor.setUser(new StompPrincipal(userId.toString()));
-
-            log.info("CONNECT userIdHeader={}", userId.toString());
-            log.info("existsById={}", exists);
-            log.info("WebSocket CONNECT user={}", userId);
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            handleConnect(accessor);
         }
 
-        // SUBSCRIBE 일때 구독 destination 로그 출력
         if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-            log.info("WebSocket SUBSCRIBE destination={}", accessor.getDestination());
+            handleSubscribe(accessor);
         }
 
-        // SEND 일때 전송 destination 로그 출력
         if (StompCommand.SEND.equals(accessor.getCommand())) {
-            log.info("WebSocket SEND destination={}", accessor.getDestination());
+            handleSend(accessor);
         }
 
         return message;
+    }
 
+    private void handleConnect(StompHeaderAccessor accessor) {
+        String authorizationHeader = accessor.getFirstNativeHeader("Authorization");
 
+        // jwt 토큰 검증
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            log.info("WebSocket CONNECT anonymous");
+            return;
+        }
+
+        if (!authorizationHeader.startsWith(BEARER_PREFIX)) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        String token = authorizationHeader.substring(BEARER_PREFIX.length());
+
+        boolean validAccessToken;
+        try {
+            validAccessToken = jwtProvider.isValid(token) && jwtProvider.isAccessToken(token);
+        } catch (RuntimeException e) {
+            validAccessToken = false;
+        }
+
+        if (!validAccessToken) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        UUID userId;
+        try {
+            userId = jwtProvider.getUserId(token);
+        } catch (RuntimeException e) {
+            throw new BusinessException(ErrorCode.AUTH_INVALID_TOKEN);
+        }
+
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+
+        sessionAttributes.put("userId", userId);
+        accessor.setUser(new StompPrincipal(userId.toString()));
+
+        log.info("WebSocket CONNECT user={}", userId);
+    }
+
+    // SUBSCRIBE 일때 구독 destination 로그 출력
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+
+        if (!isAuthenticated(accessor) && !ANONYMOUS_SUBSCRIBE_DESTINATIONS.contains(destination)) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        log.info("WebSocket SUBSCRIBE destination={}", destination);
+    }
+
+    // SEND 일때 전송 destination 로그 출력
+    private void handleSend(StompHeaderAccessor accessor) {
+        if (!isAuthenticated(accessor)) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        log.info("WebSocket SEND destination={}", accessor.getDestination());
+    }
+
+    private boolean isAuthenticated(StompHeaderAccessor accessor) {
+        Principal user = accessor.getUser();
+        if (user != null && user.getName() != null && !user.getName().isBlank()) {
+            return true;
+        }
+
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        return sessionAttributes != null && sessionAttributes.get("userId") instanceof UUID;
     }
 
     private record StompPrincipal(String value) implements Principal {

--- a/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/solv/wefin/global/config/StompAuthChannelInterceptor.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Component;
 
 import java.security.Principal;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 @Slf4j
@@ -25,10 +24,6 @@ import java.util.UUID;
 public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final Set<String> ANONYMOUS_SUBSCRIBE_DESTINATIONS = Set.of(
-            "/topic/chat/global"
-    );
-
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
 
@@ -109,7 +104,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
     private void handleSubscribe(StompHeaderAccessor accessor) {
         String destination = accessor.getDestination();
 
-        if (!isAuthenticated(accessor) && !ANONYMOUS_SUBSCRIBE_DESTINATIONS.contains(destination)) {
+        if (!isAuthenticated(accessor) && !isAnonymousSubscribeAllowed(destination)) {
             throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
         }
 
@@ -133,6 +128,10 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
         Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
         return sessionAttributes != null && sessionAttributes.get("userId") instanceof UUID;
+    }
+
+    private boolean isAnonymousSubscribeAllowed(String destination) {
+        return "/topic/chat/global".equals(destination);
     }
 
     private record StompPrincipal(String value) implements Principal {

--- a/src/main/java/com/solv/wefin/web/chat/common/ChatReadStateController.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/ChatReadStateController.java
@@ -1,0 +1,29 @@
+package com.solv.wefin.web.chat.common;
+
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.chat.common.dto.response.ChatUnreadResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatReadStateController {
+
+    private final ChatReadStateService chatReadStateService;
+
+    @GetMapping("/unread")
+    public ApiResponse<ChatUnreadResponse> getUnread(
+            @AuthenticationPrincipal UUID userId
+    ) {
+        ChatUnreadInfo info = chatReadStateService.getUnreadInfo(userId);
+        return ApiResponse.success(ChatUnreadResponse.from(info));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/chat/common/dto/response/ChatUnreadNotificationResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/dto/response/ChatUnreadNotificationResponse.java
@@ -1,0 +1,44 @@
+package com.solv.wefin.web.chat.common.dto.response;
+
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import lombok.Builder;
+
+@Builder
+public record ChatUnreadNotificationResponse(
+        String chatType,
+        Long messageId,
+        Long groupId,
+        String sender,
+        String content,
+        long globalUnreadCount,
+        long groupUnreadCount,
+        long totalUnreadCount,
+        boolean hasGlobalUnread,
+        boolean hasGroupUnread,
+        Long lastReadGlobalMessageId,
+        Long lastReadGroupMessageId
+) {
+    public static ChatUnreadNotificationResponse of(
+            String chatType,
+            Long messageId,
+            Long groupId,
+            String sender,
+            String content,
+            ChatUnreadInfo info
+    ) {
+        return ChatUnreadNotificationResponse.builder()
+                .chatType(chatType)
+                .messageId(messageId)
+                .groupId(groupId)
+                .sender(sender)
+                .content(content)
+                .globalUnreadCount(info.globalUnreadCount())
+                .groupUnreadCount(info.groupUnreadCount())
+                .totalUnreadCount(info.totalUnreadCount())
+                .hasGlobalUnread(info.hasGlobalUnread())
+                .hasGroupUnread(info.hasGroupUnread())
+                .lastReadGlobalMessageId(info.lastReadGlobalMessageId())
+                .lastReadGroupMessageId(info.lastReadGroupMessageId())
+                .build();
+    }
+}

--- a/src/main/java/com/solv/wefin/web/chat/common/dto/response/ChatUnreadResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/dto/response/ChatUnreadResponse.java
@@ -1,0 +1,21 @@
+package com.solv.wefin.web.chat.common.dto.response;
+
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+
+public record ChatUnreadResponse(
+        long globalUnreadCount,
+        long groupUnreadCount,
+        long totalUnreadCount,
+        boolean hasGlobalUnread,
+        boolean hasGroupUnread
+) {
+    public static ChatUnreadResponse from(ChatUnreadInfo info) {
+        return new ChatUnreadResponse(
+                info.globalUnreadCount(),
+                info.groupUnreadCount(),
+                info.totalUnreadCount(),
+                info.hasGlobalUnread(),
+                info.hasGroupUnread()
+        );
+    }
+}

--- a/src/main/java/com/solv/wefin/web/chat/common/dto/response/ChatUnreadResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/dto/response/ChatUnreadResponse.java
@@ -7,7 +7,9 @@ public record ChatUnreadResponse(
         long groupUnreadCount,
         long totalUnreadCount,
         boolean hasGlobalUnread,
-        boolean hasGroupUnread
+        boolean hasGroupUnread,
+        Long lastReadGlobalMessageId,
+        Long lastReadGroupMessageId
 ) {
     public static ChatUnreadResponse from(ChatUnreadInfo info) {
         return new ChatUnreadResponse(
@@ -15,7 +17,9 @@ public record ChatUnreadResponse(
                 info.groupUnreadCount(),
                 info.totalUnreadCount(),
                 info.hasGlobalUnread(),
-                info.hasGroupUnread()
+                info.hasGroupUnread(),
+                info.lastReadGlobalMessageId(),
+                info.lastReadGroupMessageId()
         );
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
@@ -10,6 +10,7 @@ import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.web.chat.common.dto.response.ChatUnreadNotificationResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -30,6 +31,7 @@ public class ChatUnreadNotificationEventListener {
     private final UserRepository userRepository;
     private final GroupMemberRepository groupMemberRepository;
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGlobalChatCreated(GlobalChatMessageCreatedEvent event) {
         List<UUID> recipientIds = userRepository.findAllActiveUserIds().stream()
@@ -56,6 +58,7 @@ public class ChatUnreadNotificationEventListener {
         }
     }
 
+    @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleGroupChatCreated(ChatMessageCreatedEvent event) {
         List<UUID> recipientIds = groupMemberRepository.findUserIdsByGroupIdAndStatus(

--- a/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
@@ -37,17 +37,22 @@ public class ChatUnreadNotificationEventListener {
                 .toList();
 
         for (UUID recipientId : recipientIds) {
-            sendUnreadNotification(
-                    recipientId,
-                    ChatUnreadNotificationResponse.of(
-                            "GLOBAL",
-                            event.getMessageId(),
-                            null,
-                            event.getSender(),
-                            event.getContent(),
-                            chatReadStateService.getUnreadInfoSnapshot(recipientId)
-                    )
-            );
+            try {
+                ChatUnreadInfo info = chatReadStateService.getUnreadInfoSnapshot(recipientId);
+                sendUnreadNotification(
+                        recipientId,
+                        ChatUnreadNotificationResponse.of(
+                                "GLOBAL",
+                                event.getMessageId(),
+                                null,
+                                event.getSender(),
+                                event.getContent(),
+                                info
+                        )
+                );
+            } catch (RuntimeException e) {
+                log.warn("chat unread snapshot failed userId={}", recipientId, e);
+            }
         }
     }
 

--- a/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
@@ -66,17 +66,22 @@ public class ChatUnreadNotificationEventListener {
                 .toList();
 
         for (UUID recipientId : recipientIds) {
-            sendUnreadNotification(
-                    recipientId,
-                    ChatUnreadNotificationResponse.of(
-                            "GROUP",
-                            event.getMessage().messageId(),
-                            event.getGroupId(),
-                            event.getMessage().sender(),
-                            event.getMessage().content(),
-                            chatReadStateService.getUnreadInfoSnapshot(recipientId)
-                    )
-            );
+            try {
+                ChatUnreadInfo info = chatReadStateService.getUnreadInfoSnapshot(recipientId);
+                sendUnreadNotification(
+                        recipientId,
+                        ChatUnreadNotificationResponse.of(
+                                "GROUP",
+                                event.getMessage().messageId(),
+                                event.getGroupId(),
+                                event.getMessage().sender(),
+                                event.getMessage().content(),
+                                info
+                        )
+                );
+            } catch (RuntimeException e) {
+                log.warn("chat unread snapshot failed userId={}", recipientId, e);
+            }
         }
     }
 

--- a/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
@@ -1,0 +1,89 @@
+package com.solv.wefin.web.chat.common.listener;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
+import com.solv.wefin.domain.chat.globalChat.event.GlobalChatMessageCreatedEvent;
+import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.web.chat.common.dto.response.ChatUnreadNotificationResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatUnreadNotificationEventListener {
+
+    private static final String USER_QUEUE_DESTINATION = "/queue/chat-unread";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatReadStateService chatReadStateService;
+    private final UserRepository userRepository;
+    private final GroupMemberRepository groupMemberRepository;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleGlobalChatCreated(GlobalChatMessageCreatedEvent event) {
+        List<UUID> recipientIds = userRepository.findAllActiveUserIds().stream()
+                .filter(userId -> !userId.equals(event.getUserId()))
+                .toList();
+
+        for (UUID recipientId : recipientIds) {
+            sendUnreadNotification(
+                    recipientId,
+                    ChatUnreadNotificationResponse.of(
+                            "GLOBAL",
+                            event.getMessageId(),
+                            null,
+                            event.getSender(),
+                            event.getContent(),
+                            chatReadStateService.getUnreadInfoSnapshot(recipientId)
+                    )
+            );
+        }
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleGroupChatCreated(ChatMessageCreatedEvent event) {
+        List<UUID> recipientIds = groupMemberRepository.findUserIdsByGroupIdAndStatus(
+                event.getGroupId(),
+                GroupMember.GroupMemberStatus.ACTIVE
+        ).stream()
+                .filter(userId -> !userId.equals(event.getMessage().userId()))
+                .toList();
+
+        for (UUID recipientId : recipientIds) {
+            sendUnreadNotification(
+                    recipientId,
+                    ChatUnreadNotificationResponse.of(
+                            "GROUP",
+                            event.getMessage().messageId(),
+                            event.getGroupId(),
+                            event.getMessage().sender(),
+                            event.getMessage().content(),
+                            chatReadStateService.getUnreadInfoSnapshot(recipientId)
+                    )
+            );
+        }
+    }
+
+    private void sendUnreadNotification(UUID recipientId, ChatUnreadNotificationResponse payload) {
+        try {
+            messagingTemplate.convertAndSendToUser(
+                    recipientId.toString(),
+                    USER_QUEUE_DESTINATION,
+                    payload
+            );
+        } catch (RuntimeException e) {
+            log.warn("chat unread notification send failed userId={}", recipientId, e);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/globalChat/GlobalChatController.java
@@ -2,6 +2,7 @@ package com.solv.wefin.web.chat.globalChat;
 
 import com.solv.wefin.domain.chat.globalChat.dto.command.GlobalProfitShareCommand;
 import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
 import com.solv.wefin.domain.chat.globalChat.service.GlobalChatService;
 import com.solv.wefin.global.common.ApiResponse;
 import com.solv.wefin.web.chat.globalChat.dto.request.GlobalProfitShareRequest;
@@ -10,9 +11,11 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
 
 @Validated
 @RestController
@@ -21,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 public class GlobalChatController {
 
     private final GlobalChatService globalChatService;
+    private final ChatReadStateService chatReadStateService;
 
     @GetMapping("/messages")
     public ApiResponse<GlobalChatMessagesResponse> getRecentMessage(
@@ -43,6 +47,14 @@ public class GlobalChatController {
 
         globalChatService.sendProfitShareMessage(command);
 
+        return ApiResponse.success(null);
+    }
+
+    @PostMapping("/read")
+    public ApiResponse<Void> markRead(
+            @AuthenticationPrincipal UUID userId
+    ) {
+        chatReadStateService.markGlobalChatRead(userId);
         return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
+++ b/src/main/java/com/solv/wefin/web/chat/groupChat/GroupChatController.java
@@ -2,6 +2,7 @@ package com.solv.wefin.web.chat.groupChat;
 
 import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.common.ApiResponse;
@@ -25,6 +26,7 @@ import java.util.UUID;
 public class GroupChatController {
 
     private final ChatMessageService chatMessageService;
+    private final ChatReadStateService chatReadStateService;
 
     @GetMapping("/messages")
     public ApiResponse<GroupChatMessagesResponse> getRecentMessages(
@@ -57,5 +59,13 @@ public class GroupChatController {
         Group group = chatMessageService.getMyGroup(userId);
 
         return ApiResponse.success(GroupChatMetaResponse.from(group));
+    }
+
+    @PostMapping("/read")
+    public ApiResponse<Void> markRead(
+            @AuthenticationPrincipal UUID userId
+    ) {
+        chatReadStateService.markGroupChatRead(userId);
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/resources/db/migration/V49__add_chat_read_state.sql
+++ b/src/main/resources/db/migration/V49__add_chat_read_state.sql
@@ -8,6 +8,3 @@ ALTER TABLE group_member
 
 CREATE INDEX idx_chat_message_group_message_id
     ON chat_message (group_id, message_id);
-
-CREATE INDEX idx_global_chat_message_message_id
-    ON global_chat_message (message_id);

--- a/src/main/resources/db/migration/V49__add_chat_read_state.sql
+++ b/src/main/resources/db/migration/V49__add_chat_read_state.sql
@@ -1,0 +1,13 @@
+ALTER TABLE users
+    ADD COLUMN last_read_global_message_id BIGINT NULL,
+    ADD COLUMN last_read_global_at TIMESTAMPTZ NULL;
+
+ALTER TABLE group_member
+    ADD COLUMN last_read_chat_message_id BIGINT NULL,
+    ADD COLUMN last_read_chat_at TIMESTAMPTZ NULL;
+
+CREATE INDEX idx_chat_message_group_message_id
+    ON chat_message (group_id, message_id);
+
+CREATE INDEX idx_global_chat_message_message_id
+    ON global_chat_message (message_id);

--- a/src/test/java/com/solv/wefin/domain/chat/common/service/ChatReadStateServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/common/service/ChatReadStateServiceTest.java
@@ -1,0 +1,206 @@
+package com.solv.wefin.domain.chat.common.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import com.solv.wefin.domain.chat.globalChat.repository.GlobalChatMessageRepository;
+import com.solv.wefin.domain.chat.groupChat.repository.ChatMessageRepository;
+import com.solv.wefin.domain.group.entity.Group;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+class ChatReadStateServiceTest {
+
+    private UserRepository userRepository;
+    private GroupMemberRepository groupMemberRepository;
+    private GlobalChatMessageRepository globalChatMessageRepository;
+    private ChatMessageRepository chatMessageRepository;
+    private ChatReadStateService chatReadStateService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository = mock(UserRepository.class);
+        groupMemberRepository = mock(GroupMemberRepository.class);
+        globalChatMessageRepository = mock(GlobalChatMessageRepository.class);
+        chatMessageRepository = mock(ChatMessageRepository.class);
+
+        chatReadStateService = new ChatReadStateService(
+                userRepository,
+                groupMemberRepository,
+                globalChatMessageRepository,
+                chatMessageRepository
+        );
+    }
+
+    @Test
+    @DisplayName("첫 unread 조회 시 읽음 기준이 없으면 현재 시점으로 초기화한다")
+    void getUnreadInfo_success_initialize_read_state() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        GroupMember groupMember = createActiveGroupMember(user);
+
+        when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(globalChatMessageRepository.findLatestMessageId()).thenReturn(15L);
+        when(chatMessageRepository.findLatestMessageIdByGroupId(3L)).thenReturn(27L);
+
+        // when
+        ChatUnreadInfo result = chatReadStateService.getUnreadInfo(userId);
+
+        // then
+        assertEquals(0L, result.globalUnreadCount());
+        assertEquals(0L, result.groupUnreadCount());
+        assertEquals(15L, user.getLastReadGlobalMessageId());
+        assertEquals(27L, groupMember.getLastReadChatMessageId());
+        assertEquals(15L, result.lastReadGlobalMessageId());
+        assertEquals(27L, result.lastReadGroupMessageId());
+    }
+
+    @Test
+    @DisplayName("읽음 기준이 있으면 unread 개수를 계산한다")
+    void getUnreadInfo_success_count_unread() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        ReflectionTestUtils.setField(user, "lastReadGlobalMessageId", 10L);
+
+        GroupMember groupMember = createActiveGroupMember(user);
+        ReflectionTestUtils.setField(groupMember, "lastReadChatMessageId", 20L);
+
+        when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(globalChatMessageRepository.countUnreadAfterMessageId(10L, userId)).thenReturn(2L);
+        when(chatMessageRepository.countUnreadAfterMessageId(3L, 20L, userId)).thenReturn(4L);
+
+        // when
+        ChatUnreadInfo result = chatReadStateService.getUnreadInfo(userId);
+
+        // then
+        assertEquals(2L, result.globalUnreadCount());
+        assertEquals(4L, result.groupUnreadCount());
+        assertEquals(6L, result.totalUnreadCount());
+        assertEquals(10L, result.lastReadGlobalMessageId());
+        assertEquals(20L, result.lastReadGroupMessageId());
+    }
+
+    @Test
+    @DisplayName("내가 보낸 메시지는 unread 개수에서 제외한다")
+    void getUnreadInfo_success_excludes_my_messages() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        ReflectionTestUtils.setField(user, "lastReadGlobalMessageId", 40L);
+
+        GroupMember groupMember = createActiveGroupMember(user);
+        ReflectionTestUtils.setField(groupMember, "lastReadChatMessageId", 50L);
+
+        when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(globalChatMessageRepository.countUnreadAfterMessageId(40L, userId)).thenReturn(0L);
+        when(chatMessageRepository.countUnreadAfterMessageId(3L, 50L, userId)).thenReturn(0L);
+
+        // when
+        ChatUnreadInfo result = chatReadStateService.getUnreadInfo(userId);
+
+        // then
+        assertEquals(0L, result.globalUnreadCount());
+        assertEquals(0L, result.groupUnreadCount());
+        assertEquals(40L, result.lastReadGlobalMessageId());
+        assertEquals(50L, result.lastReadGroupMessageId());
+    }
+
+    @Test
+    @DisplayName("전체 채팅 읽음 처리 시 최신 메시지 id로 갱신한다")
+    void markGlobalChatRead_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        ReflectionTestUtils.setField(user, "lastReadGlobalMessageId", 8L);
+
+        when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+        when(globalChatMessageRepository.findLatestMessageId()).thenReturn(12L);
+
+        // when
+        chatReadStateService.markGlobalChatRead(userId);
+
+        // then
+        assertEquals(12L, user.getLastReadGlobalMessageId());
+    }
+
+    @Test
+    @DisplayName("그룹 채팅 읽음 처리 시 최신 메시지 id로 갱신한다")
+    void markGroupChatRead_success() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        GroupMember groupMember = createActiveGroupMember(user);
+        ReflectionTestUtils.setField(groupMember, "lastReadChatMessageId", 19L);
+
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.of(groupMember));
+        when(chatMessageRepository.findLatestMessageIdByGroupId(3L)).thenReturn(30L);
+
+        // when
+        chatReadStateService.markGroupChatRead(userId);
+
+        // then
+        assertEquals(30L, groupMember.getLastReadChatMessageId());
+    }
+
+    @Test
+    @DisplayName("활성 그룹 멤버가 없으면 GROUP_MEMBER_FORBIDDEN 예외를 던진다")
+    void getUnreadInfo_fail_when_group_member_missing() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+
+        when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+
+        // when
+        BusinessException exception = assertThrows(BusinessException.class,
+                () -> chatReadStateService.getUnreadInfo(userId));
+
+        // then
+        assertEquals(ErrorCode.GROUP_MEMBER_FORBIDDEN, exception.getErrorCode());
+    }
+
+    private User createUser(UUID userId) {
+        User user = User.builder()
+                .email("read@test.com")
+                .nickname("reader")
+                .password("password")
+                .build();
+        ReflectionTestUtils.setField(user, "userId", userId);
+        return user;
+    }
+
+    private GroupMember createActiveGroupMember(User user) {
+        Group group = Group.builder()
+                .name("테스트 그룹")
+                .build();
+        ReflectionTestUtils.setField(group, "id", 3L);
+
+        GroupMember groupMember = GroupMember.createMember(user, group);
+        ReflectionTestUtils.setField(groupMember, "id", 1L);
+        return groupMember;
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/chat/common/service/ChatReadStateServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/common/service/ChatReadStateServiceTest.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -181,6 +182,30 @@ class ChatReadStateServiceTest {
 
         // then
         assertEquals(ErrorCode.GROUP_MEMBER_FORBIDDEN, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("snapshot 조회는 그룹 미가입자여도 글로벌 unread 정보는 반환한다")
+    void getUnreadInfoSnapshot_success_without_group_member() {
+        // given
+        UUID userId = UUID.randomUUID();
+        User user = createUser(userId);
+        ReflectionTestUtils.setField(user, "lastReadGlobalMessageId", 12L);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(groupMemberRepository.findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(Optional.empty());
+        when(globalChatMessageRepository.countUnreadAfterMessageId(12L, userId)).thenReturn(3L);
+
+        // when
+        ChatUnreadInfo result = chatReadStateService.getUnreadInfoSnapshot(userId);
+
+        // then
+        assertEquals(3L, result.globalUnreadCount());
+        assertEquals(0L, result.groupUnreadCount());
+        assertEquals(12L, result.lastReadGlobalMessageId());
+        assertNull(result.lastReadGroupMessageId());
+        verify(chatMessageRepository, never()).countUnreadAfterMessageId(anyLong(), anyLong(), any());
     }
 
     private User createUser(UUID userId) {

--- a/src/test/java/com/solv/wefin/global/config/StompAuthChannelInterceptorTest.java
+++ b/src/test/java/com/solv/wefin/global/config/StompAuthChannelInterceptorTest.java
@@ -1,0 +1,71 @@
+package com.solv.wefin.global.config;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+class StompAuthChannelInterceptorTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private StompAuthChannelInterceptor interceptor;
+
+    @Test
+    @DisplayName("익명 사용자는 전체 채팅 토픽 구독을 할 수 있다")
+    void anonymousSubscribe_globalTopic_success() {
+        Message<byte[]> message = createMessage(StompCommand.SUBSCRIBE, "/topic/chat/global");
+
+        assertDoesNotThrow(() -> interceptor.preSend(message, null));
+    }
+
+    @Test
+    @DisplayName("익명 사용자는 그룹 채팅 토픽을 구독할 수 없다")
+    void anonymousSubscribe_groupTopic_fail() {
+        Message<byte[]> message = createMessage(StompCommand.SUBSCRIBE, "/topic/chat/group/1");
+
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> interceptor.preSend(message, null));
+
+        assertEquals(ErrorCode.AUTH_UNAUTHORIZED, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("익명 사용자는 전체 채팅 메시지를 전송할 수 없다")
+    void anonymousSend_globalChat_fail() {
+        Message<byte[]> message = createMessage(StompCommand.SEND, "/app/chat/global/send");
+
+        BusinessException exception =
+                assertThrows(BusinessException.class, () -> interceptor.preSend(message, null));
+
+        assertEquals(ErrorCode.AUTH_UNAUTHORIZED, exception.getErrorCode());
+    }
+
+    private Message<byte[]> createMessage(StompCommand command, String destination) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(command);
+        accessor.setLeaveMutable(true);
+        accessor.setDestination(destination);
+
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+}

--- a/src/test/java/com/solv/wefin/web/chat/common/ChatReadStateControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/common/ChatReadStateControllerTest.java
@@ -1,0 +1,85 @@
+package com.solv.wefin.web.chat.common;
+
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
+import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatReadStateController.class)
+@Import(GlobalExceptionHandler.class)
+class ChatReadStateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ChatReadStateService chatReadStateService;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("unread 조회 시 그룹과 전체 unread 정보를 반환한다")
+    void getUnread_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        when(chatReadStateService.getUnreadInfo(userId))
+                .thenReturn(new ChatUnreadInfo(2L, 5L, 101L, 202L));
+
+        mockMvc.perform(get("/api/chat/unread")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.globalUnreadCount").value(2))
+                .andExpect(jsonPath("$.data.groupUnreadCount").value(5))
+                .andExpect(jsonPath("$.data.totalUnreadCount").value(7))
+                .andExpect(jsonPath("$.data.hasGlobalUnread").value(true))
+                .andExpect(jsonPath("$.data.hasGroupUnread").value(true))
+                .andExpect(jsonPath("$.data.lastReadGlobalMessageId").value(101))
+                .andExpect(jsonPath("$.data.lastReadGroupMessageId").value(202));
+    }
+
+    @Test
+    @DisplayName("unread 조회 시 인증 사용자 id로 서비스를 호출한다")
+    void getUnread_calls_service_with_authenticated_user() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        when(chatReadStateService.getUnreadInfo(userId))
+                .thenReturn(new ChatUnreadInfo(0L, 0L, 11L, 22L));
+
+        mockMvc.perform(get("/api/chat/unread")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isOk());
+
+        verify(chatReadStateService).getUnreadInfo(userId);
+    }
+}

--- a/src/test/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListenerTest.java
@@ -75,6 +75,11 @@ class ChatUnreadNotificationEventListenerTest {
                 eq("/queue/chat-unread"),
                 payloadCaptor.capture()
         );
+        verify(messagingTemplate, never()).convertAndSendToUser(
+                eq(senderId.toString()),
+                eq("/queue/chat-unread"),
+                any()
+        );
         verify(chatReadStateService, never()).getUnreadInfoSnapshot(senderId);
 
         ChatUnreadNotificationResponse payload = payloadCaptor.getValue();
@@ -121,6 +126,11 @@ class ChatUnreadNotificationEventListenerTest {
                 eq(receiverId.toString()),
                 eq("/queue/chat-unread"),
                 payloadCaptor.capture()
+        );
+        verify(messagingTemplate, never()).convertAndSendToUser(
+                eq(senderId.toString()),
+                eq("/queue/chat-unread"),
+                any()
         );
         verify(chatReadStateService, never()).getUnreadInfoSnapshot(senderId);
 

--- a/src/test/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListenerTest.java
@@ -1,0 +1,137 @@
+package com.solv.wefin.web.chat.common.listener;
+
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
+import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
+import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
+import com.solv.wefin.domain.chat.globalChat.event.GlobalChatMessageCreatedEvent;
+import com.solv.wefin.domain.group.entity.GroupMember;
+import com.solv.wefin.domain.group.repository.GroupMemberRepository;
+import com.solv.wefin.web.chat.common.dto.response.ChatUnreadNotificationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.*;
+
+class ChatUnreadNotificationEventListenerTest {
+
+    private SimpMessagingTemplate messagingTemplate;
+    private ChatReadStateService chatReadStateService;
+    private UserRepository userRepository;
+    private GroupMemberRepository groupMemberRepository;
+    private ChatUnreadNotificationEventListener listener;
+
+    @BeforeEach
+    void setUp() {
+        messagingTemplate = mock(SimpMessagingTemplate.class);
+        chatReadStateService = mock(ChatReadStateService.class);
+        userRepository = mock(UserRepository.class);
+        groupMemberRepository = mock(GroupMemberRepository.class);
+
+        listener = new ChatUnreadNotificationEventListener(
+                messagingTemplate,
+                chatReadStateService,
+                userRepository,
+                groupMemberRepository
+        );
+    }
+
+    @Test
+    @DisplayName("전체 채팅 이벤트가 오면 발신자를 제외한 사용자에게 unread 알림을 보낸다")
+    void handleGlobalChatCreated_success() {
+        UUID senderId = UUID.randomUUID();
+        UUID receiverId = UUID.randomUUID();
+
+        when(userRepository.findAllActiveUserIds()).thenReturn(List.of(senderId, receiverId));
+        when(chatReadStateService.getUnreadInfoSnapshot(receiverId))
+                .thenReturn(new ChatUnreadInfo(3L, 1L, 44L, 55L));
+
+        GlobalChatMessageCreatedEvent event = new GlobalChatMessageCreatedEvent(
+                11L,
+                senderId,
+                "USER",
+                "보낸사람",
+                "전체 채팅 메시지",
+                OffsetDateTime.now()
+        );
+
+        ArgumentCaptor<ChatUnreadNotificationResponse> payloadCaptor =
+                ArgumentCaptor.forClass(ChatUnreadNotificationResponse.class);
+
+        listener.handleGlobalChatCreated(event);
+
+        verify(messagingTemplate).convertAndSendToUser(
+                eq(receiverId.toString()),
+                eq("/queue/chat-unread"),
+                payloadCaptor.capture()
+        );
+        verify(chatReadStateService, never()).getUnreadInfoSnapshot(senderId);
+
+        ChatUnreadNotificationResponse payload = payloadCaptor.getValue();
+        assertEquals("GLOBAL", payload.chatType());
+        assertEquals(11L, payload.messageId());
+        assertNull(payload.groupId());
+        assertEquals("보낸사람", payload.sender());
+        assertEquals("전체 채팅 메시지", payload.content());
+        assertEquals(4L, payload.totalUnreadCount());
+        assertEquals(44L, payload.lastReadGlobalMessageId());
+        assertEquals(55L, payload.lastReadGroupMessageId());
+    }
+
+    @Test
+    @DisplayName("그룹 채팅 이벤트가 오면 발신자를 제외한 그룹 멤버에게 unread 알림을 보낸다")
+    void handleGroupChatCreated_success() {
+        UUID senderId = UUID.randomUUID();
+        UUID receiverId = UUID.randomUUID();
+
+        when(groupMemberRepository.findUserIdsByGroupIdAndStatus(5L, GroupMember.GroupMemberStatus.ACTIVE))
+                .thenReturn(List.of(senderId, receiverId));
+        when(chatReadStateService.getUnreadInfoSnapshot(receiverId))
+                .thenReturn(new ChatUnreadInfo(1L, 2L, 66L, 77L));
+
+        ChatMessageInfo message = new ChatMessageInfo(
+                31L,
+                senderId,
+                5L,
+                "CHAT",
+                "그룹유저",
+                "그룹 채팅 메시지",
+                OffsetDateTime.now(),
+                null,
+                null,
+                null
+        );
+
+        ArgumentCaptor<ChatUnreadNotificationResponse> payloadCaptor =
+                ArgumentCaptor.forClass(ChatUnreadNotificationResponse.class);
+
+        listener.handleGroupChatCreated(new ChatMessageCreatedEvent(5L, message));
+
+        verify(messagingTemplate).convertAndSendToUser(
+                eq(receiverId.toString()),
+                eq("/queue/chat-unread"),
+                payloadCaptor.capture()
+        );
+        verify(chatReadStateService, never()).getUnreadInfoSnapshot(senderId);
+
+        ChatUnreadNotificationResponse payload = payloadCaptor.getValue();
+        assertEquals("GROUP", payload.chatType());
+        assertEquals(31L, payload.messageId());
+        assertEquals(5L, payload.groupId());
+        assertEquals("그룹유저", payload.sender());
+        assertEquals("그룹 채팅 메시지", payload.content());
+        assertEquals(2L, payload.groupUnreadCount());
+        assertEquals(66L, payload.lastReadGlobalMessageId());
+        assertEquals(77L, payload.lastReadGroupMessageId());
+    }
+}

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalControllerTest.java
@@ -2,8 +2,12 @@ package com.solv.wefin.web.chat.globalChat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
+import com.solv.wefin.domain.chat.globalChat.dto.info.GlobalChatMessagesInfo;
 import com.solv.wefin.domain.chat.globalChat.dto.command.GlobalProfitShareCommand;
 import com.solv.wefin.domain.chat.globalChat.service.GlobalChatService;
+import com.solv.wefin.global.config.SecurityConfig;
+import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
+import com.solv.wefin.global.config.security.JwtAuthenticationFilter;
 import com.solv.wefin.global.config.security.JwtProvider;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
@@ -29,10 +33,16 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @WebMvcTest(GlobalChatController.class)
-@Import(GlobalExceptionHandler.class)
+@Import({
+        GlobalExceptionHandler.class,
+        SecurityConfig.class,
+        JwtAuthenticationFilter.class,
+        JwtAuthenticationEntryPoint.class
+})
 class GlobalChatControllerTest {
 
     @Autowired
@@ -49,6 +59,25 @@ class GlobalChatControllerTest {
 
     @MockitoBean
     private JwtProvider jwtProvider;
+
+    @Test
+    @DisplayName("비로그인 사용자도 전체 채팅 메시지를 조회할 수 있다")
+    void getRecentMessages_success_withoutAuthentication() throws Exception {
+        GlobalChatMessagesInfo info = new GlobalChatMessagesInfo(
+                java.util.List.of(),
+                null,
+                false
+        );
+
+        org.mockito.BDDMockito.given(globalChatService.getMessages(null, 30))
+                .willReturn(info);
+
+        mockMvc.perform(get("/api/chat/global/messages"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.data.messages").isArray())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
 
     @Test
     @DisplayName("수익 공유 요청이 들어오면 command로 변환해 서비스에 전달한다")

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalControllerTest.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.web.chat.globalChat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
 import com.solv.wefin.domain.chat.globalChat.dto.command.GlobalProfitShareCommand;
 import com.solv.wefin.domain.chat.globalChat.service.GlobalChatService;
 import com.solv.wefin.global.config.security.JwtProvider;
@@ -14,12 +15,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,6 +43,9 @@ class GlobalChatControllerTest {
 
     @MockitoBean
     private GlobalChatService globalChatService;
+
+    @MockitoBean
+    private ChatReadStateService chatReadStateService;
 
     @MockitoBean
     private JwtProvider jwtProvider;
@@ -118,5 +127,23 @@ class GlobalChatControllerTest {
                         .content(requestBody))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    @DisplayName("markRead updates global chat read state")
+    void markRead_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/chat/global/read")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(chatReadStateService).markGlobalChatRead(userId);
     }
 }

--- a/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/groupChat/GroupChatControllerTest.java
@@ -4,6 +4,7 @@ import com.solv.wefin.domain.chat.groupChat.dto.command.ShareNewsCommand;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessagesInfo;
 import com.solv.wefin.domain.chat.groupChat.dto.info.NewsShareInfo;
+import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
 import com.solv.wefin.domain.chat.groupChat.service.ChatMessageService;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.config.security.JwtProvider;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -44,6 +46,9 @@ class GroupChatControllerTest {
 
     @MockitoBean
     private ChatMessageService chatMessageService;
+
+    @MockitoBean
+    private ChatReadStateService chatReadStateService;
 
     @MockitoBean
     private JwtProvider jwtProvider;
@@ -197,5 +202,23 @@ class GroupChatControllerTest {
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404))
                 .andExpect(jsonPath("$.code").value("NEWS_CLUSTER_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("markRead updates current group chat read state")
+    void markRead_success() throws Exception {
+        UUID userId = UUID.randomUUID();
+
+        mockMvc.perform(post("/api/chat/group/read")
+                        .with(csrf())
+                        .with(authentication(new UsernamePasswordAuthenticationToken(
+                                userId,
+                                null,
+                                AuthorityUtils.NO_AUTHORITIES
+                        ))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200));
+
+        verify(chatReadStateService).markGroupChatRead(userId);
     }
 }


### PR DESCRIPTION
## 📌 PR 설명

채팅 알림 기능 전반을 백엔드에 추가하고, 비로그인 사용자는 전체 채팅을 읽기 전용으로 볼 수 있도록 접근 정책을 분리했습니다.  
사용자별 unread 상태 관리, 읽음 처리 API, 실시간 unread 알림 payload, 읽음 기준선용 lastRead 정보 제공까지 포함했고, 익명 사용자는 전체 채팅 조회와 구독만 가능하도록 제한했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 사용자별 전체/그룹 채팅 unread 상태 계산 로직 추가
- [x] 전체 채팅 읽음 처리 API 추가
- [x] 그룹 채팅 읽음 처리 API 추가
- [x] unread 조회 API 추가
- [x] 실시간 unread WebSocket 개인 알림 추가
- [x] unread payload에 전체/그룹 unread count 포함
- [x] unread payload에 `lastReadGlobalMessageId`, `lastReadGroupMessageId` 포함
- [x] 내 메시지는 unread count에서 제외하도록 보정
- [x] 비로그인 사용자의 `GET /api/chat/global/messages` 접근 허용
- [x] 익명 WebSocket `CONNECT` 허용
- [x] 익명 사용자의 `/topic/chat/global` 구독 허용
- [x] 익명 사용자의 그룹 채팅 구독 차단
- [x] 익명 사용자의 채팅 메시지 전송 차단
- [x] 채팅 알림/읽음 처리/익명 접근 정책 관련 테스트 추가 및 수정

<br>

## 💭 고민과 해결과정

이번 작업의 핵심은 채팅 알림 기능을 붙이면서도, 읽음 상태와 실시간 알림이 서로 꼬이지 않도록 백엔드 기준 상태를 명확히 만드는 것이었습니다.  
그래서 단순히 “알림을 보낸다”보다, 사용자별 `lastRead...MessageId`를 기준으로 unread를 계산하고, 읽음 처리 API와 실시간 unread payload가 같은 기준을 공유하도록 설계했습니다.

또 하나의 고민은 내가 보낸 메시지까지 unread로 잡히면 알림 UX가 어색해진다는 점이었습니다.  
이 부분은 unread count 쿼리에서 발신자 본인의 메시지를 제외하도록 보정해서 해결했습니다.

비로그인 전체 채팅 읽기 전용 요구사항도 함께 들어오면서 보안 범위를 넓게 푸는 대신, HTTP는 `GET /api/chat/global/messages`만 공개하고, STOMP는 익명 사용자가 `/topic/chat/global`만 구독할 수 있도록 제한했습니다.  
즉 익명 사용자는 전체 채팅을 읽을 수는 있지만, 그룹 채팅/개인 큐/메시지 전송은 계속 인증이 필요하도록 유지했습니다.

마지막으로 변경 범위가 보안과 실시간 처리에 걸쳐 있는 만큼, 컨트롤러 테스트와 인터셉터 테스트를 함께 보강해 unread 처리와 익명 접근 정책이 의도대로 동작하는지 확인했습니다.

<br>

### 🔗 관련 이슈
Closes #313 
<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 전역/그룹 채팅에 대한 읽음 상태(마지막 읽음 타임스탬프 및 메시지 ID) 저장 및 집계 추가
  * 사용자가 채팅을 읽음으로 표시하는 API 엔드포인트(전역·그룹) 추가
  * 실시간으로 개인별 미확인 메시지 알림 전송 기능 추가
  * 전역 채팅 토픽에 대한 익명(인증 없이) 구독 허용 및 관련 보안 조정
  * DB 마이그레이션으로 읽음 상태 컬럼 및 인덱스 추가

* **Tests**
  * 읽음 상태 서비스, 컨트롤러, WebSocket 인증/허용 동작 등 포괄적 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->