### PR TITLE
구독 플랜 데이터 추가

### DIFF
--- a/src/main/resources/db/migration/V51__insert_subscription_plans.sql
+++ b/src/main/resources/db/migration/V51__insert_subscription_plans.sql
@@ -1,14 +1,13 @@
-INSERT INTO public.subscription_plan (
-    plan_name,
-    price,
-    billing_cycle,
-    description,
-    is_active
-)
-SELECT 'Monthly Plan', 9900, 'MONTHLY', '월간 구독 플랜', true
-    WHERE NOT EXISTS (
-    SELECT 1 FROM public.subscription_plan WHERE billing_cycle = 'MONTHLY'
-);
+-- 기존 플랜이 비활성 상태로 존재하면 활성화
+UPDATE public.subscription_plan
+SET
+    is_active = true,
+    plan_name = 'Monthly Plan',
+    price = 9900,
+    description = '월간 구독 플랜',
+    updated_at = CURRENT_TIMESTAMP
+WHERE billing_cycle = 'MONTHLY'
+  AND is_active = false;
 
 INSERT INTO public.subscription_plan (
     plan_name,
@@ -17,7 +16,43 @@ INSERT INTO public.subscription_plan (
     description,
     is_active
 )
-SELECT 'Yearly Plan', 99000, 'YEARLY', '연간 구독 플랜 (약 17% 할인)', true
+SELECT
+    'Monthly Plan',
+    9900,
+    'MONTHLY',
+    '월간 구독 플랜',
+    true
     WHERE NOT EXISTS (
-    SELECT 1 FROM public.subscription_plan WHERE billing_cycle = 'YEARLY'
+    SELECT 1
+    FROM public.subscription_plan
+    WHERE billing_cycle = 'MONTHLY'
+);
+
+UPDATE public.subscription_plan
+SET
+    is_active = true,
+    plan_name = 'Yearly Plan',
+    price = 99000,
+    description = '연간 구독 플랜 (약 17% 할인)',
+    updated_at = CURRENT_TIMESTAMP
+WHERE billing_cycle = 'YEARLY'
+  AND is_active = false;
+
+INSERT INTO public.subscription_plan (
+    plan_name,
+    price,
+    billing_cycle,
+    description,
+    is_active
+)
+SELECT
+    'Yearly Plan',
+    99000,
+    'YEARLY',
+    '연간 구독 플랜 (약 17% 할인)',
+    true
+    WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.subscription_plan
+    WHERE billing_cycle = 'YEARLY'
 );

--- a/src/main/resources/db/migration/V51__insert_subscription_plans.sql
+++ b/src/main/resources/db/migration/V51__insert_subscription_plans.sql
@@ -1,0 +1,23 @@
+INSERT INTO public.subscription_plan (
+    plan_name,
+    price,
+    billing_cycle,
+    description,
+    is_active
+)
+SELECT 'Monthly Plan', 9900, 'MONTHLY', '월간 구독 플랜', true
+    WHERE NOT EXISTS (
+    SELECT 1 FROM public.subscription_plan WHERE billing_cycle = 'MONTHLY'
+);
+
+INSERT INTO public.subscription_plan (
+    plan_name,
+    price,
+    billing_cycle,
+    description,
+    is_active
+)
+SELECT 'Yearly Plan', 99000, 'YEARLY', '연간 구독 플랜 (약 17% 할인)', true
+    WHERE NOT EXISTS (
+    SELECT 1 FROM public.subscription_plan WHERE billing_cycle = 'YEARLY'
+);


### PR DESCRIPTION
## 📌 PR 설명
dev 환경에서 구독 결제 시 `구독 상품을 찾을 수 없습니다` 에러가 발생하던 문제를 해결했습니다. 원인은 `subscription_plan` 테이블에 월간/연간 구독 상품 데이터가 존재하지 않아 `planId` 조회가 실패하면서 404가 발생한 것이었습니다.

이를 해결하기 위해 Flyway 마이그레이션을 추가하여 구독 플랜 초기 데이터를 삽입했습니다.
<br>

## ✅ 완료한 기능 명세

- [x] subscription_plan 테이블에 월간/연간 구독 상품 데이터 삽입
- [x] Flyway 마이그레이션 파일 추가
- [x] **Label**을 붙여주세요. ⏰

<br>

## 💭 고민과 해결과정
네트워크 및 로그를 확인한 결과, 백엔드에서 planId로 구독 상품을 조회하는 과정에서 데이터가 존재하지 않아 예외가 발생한 것을 확인했습니다.
<br>

### 🔗 관련 이슈
Closes #323 

<br>
