### PR TITLE
[WEF-DEP] Admin 컨트롤러 desktop 프로필 추가

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/batch/BatchAdminController.java
+++ b/src/main/java/com/solv/wefin/domain/game/batch/BatchAdminController.java
@@ -23,7 +23,7 @@ import java.util.Map;
 @RestController
 @RequestMapping("/api/admin/batch")
 @RequiredArgsConstructor
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 public class BatchAdminController {
 
     private final StockInitService stockInitService;

--- a/src/main/java/com/solv/wefin/web/market/MarketAdminController.java
+++ b/src/main/java/com/solv/wefin/web/market/MarketAdminController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/market")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/market/trend/MarketTrendAdminController.java
+++ b/src/main/java/com/solv/wefin/web/market/trend/MarketTrendAdminController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 금융 동향 수동 트리거 (로컬/개발 전용)
  */
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/market-trends")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/ClusterMergeAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/ClusterMergeAdminController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news/clustering")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/ClusteringAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/ClusteringAdminController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news/clustering")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/EmbeddingAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/EmbeddingAdminController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news/embeddings")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/RelevanceAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/RelevanceAdminController.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * 금융 관련성 재판정 관리자 엔드포인트 (local/dev only).
  */
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news/relevance")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/SummaryAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/SummaryAdminController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news/summary")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/TaggingAdminController.java
+++ b/src/main/java/com/solv/wefin/web/news/TaggingAdminController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news/tagging")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
+++ b/src/main/java/com/solv/wefin/web/news/controller/NewsCollectController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/news")
 @RequiredArgsConstructor

--- a/src/main/java/com/solv/wefin/web/trading/dart/DartAdminController.java
+++ b/src/main/java/com/solv/wefin/web/trading/dart/DartAdminController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile({"local", "dev", "desktop"})
 @RestController
 @RequestMapping("/api/admin/dart")
 @RequiredArgsConstructor


### PR DESCRIPTION
 ## 📌 PR 설명
  Admin 컨트롤러에 `desktop` 프로필을 추가하여 신한 서버에서 수동 배치 API를 사용할 수 있도록 합니다.

  ## 왜 필요한가
  - 신한 서버 프로필이 `desktop`인데, Admin 컨트롤러가 `@Profile({"local", "dev"})`로만 설정되어 있어 빈 등록이 안 됨
  - `/api/admin/news/collect` 등 배치 수동 트리거 API가 `No static resource` 404 발생
  - #329 에서 `application-desktop.yml`은 추가했지만 컨트롤러 프로필은 누락된 상태

  ## 작업 내용
  - Admin 컨트롤러 11개에 `"desktop"` 프로필 추가
    - `NewsCollectController`, `EmbeddingAdminController`, `TaggingAdminController`
    - `ClusteringAdminController`, `SummaryAdminController`, `ClusterMergeAdminController`
    - `RelevanceAdminController`, `MarketAdminController`, `MarketTrendAdminController`
    - `BatchAdminController`, `DartAdminController`

  ## 테스트
  - [ ] 신한 서버 배포 후 `curl -s -X POST http://localhost/api/admin/news/collect` 정상 응답 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 데스크탑 환경에서 배치, 시장, 뉴스, 거래 관련 관리 기능이 활성화되도록 설정 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->