### PR TITLE
[FIX] 게임 브리핑 2주치 조회

### DIFF
--- a/src/main/java/com/solv/wefin/domain/game/news/repository/BriefingCacheRepository.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/repository/BriefingCacheRepository.java
@@ -18,6 +18,8 @@ public interface BriefingCacheRepository extends JpaRepository<BriefingCache, UU
 
     List<BriefingCache> findByTargetDateIn(Collection<LocalDate> targetDates);
 
+    List<BriefingCache> findTop14ByTargetDateBeforeOrderByTargetDateDesc(LocalDate date);
+
     @Query("SELECT bc.targetDate " +
             "FROM BriefingCache bc " +
             "WHERE bc.targetDate IN :dates")

--- a/src/main/java/com/solv/wefin/domain/game/news/service/GameBriefingService.java
+++ b/src/main/java/com/solv/wefin/domain/game/news/service/GameBriefingService.java
@@ -1,6 +1,8 @@
 package com.solv.wefin.domain.game.news.service;
 
 import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import com.solv.wefin.domain.game.news.entity.BriefingCache;
+import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
 import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import com.solv.wefin.domain.game.participant.entity.ParticipantStatus;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
@@ -14,6 +16,8 @@ import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -32,6 +36,7 @@ public class GameBriefingService {
     private final GameParticipantRepository gameParticipantRepository;
     private final GameTurnRepository gameTurnRepository;
     private final BriefingService briefingService;
+    private final BriefingCacheRepository briefingCacheRepository;
 
     public BriefingInfo getBriefingForRoom(UUID roomId, UUID userId) {
         // 1. 게임방 확인
@@ -56,5 +61,32 @@ public class GameBriefingService {
                 parts.keyIssues(),
                 parts.investmentHint()
         );
+    }
+
+    /**
+     * 당일 브리핑 + 과거 최대 14개 브리핑을 함께 반환한다.
+     * 당일: 캐시 미스 시 크롤링+AI 생성 (기존 로직).
+     * 과거: DB에 있는 것만 최신순 14개 조회. 크롤링하지 않는다.
+     */
+    public List<BriefingInfo> getBriefingsForRoom(UUID roomId, UUID userId) {
+        // 당일 브리핑 (검증 + 크롤링 포함)
+        BriefingInfo today = getBriefingForRoom(roomId, userId);
+
+        // 과거 14개 — DB에 존재하는 것만
+        List<BriefingCache> pastCaches =
+                briefingCacheRepository.findTop14ByTargetDateBeforeOrderByTargetDateDesc(today.targetDate());
+
+        List<BriefingInfo> result = new ArrayList<>(1 + pastCaches.size());
+        result.add(today);
+        for (BriefingCache cache : pastCaches) {
+            result.add(new BriefingInfo(
+                    cache.getTargetDate(),
+                    cache.getMarketOverview(),
+                    cache.getKeyIssues(),
+                    cache.getInvestmentHint()
+            ));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/solv/wefin/web/game/briefing/BriefingController.java
+++ b/src/main/java/com/solv/wefin/web/game/briefing/BriefingController.java
@@ -12,16 +12,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/rooms/{roomId}/briefing")
+@RequestMapping("/api/rooms/{roomId}")
 public class BriefingController {
 
     private final GameBriefingService gameBriefingService;
 
-    @GetMapping
+    @GetMapping("/briefing")
     public ResponseEntity<ApiResponse<BriefingResponse>> getBriefing(
             @AuthenticationPrincipal UUID userId,
             @PathVariable UUID roomId) {
@@ -30,5 +31,18 @@ public class BriefingController {
         BriefingResponse response = BriefingResponse.from(info);
 
         return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/briefings")
+    public ResponseEntity<ApiResponse<List<BriefingResponse>>> getBriefings(
+            @AuthenticationPrincipal UUID userId,
+            @PathVariable UUID roomId) {
+
+        List<BriefingInfo> infos = gameBriefingService.getBriefingsForRoom(roomId, userId);
+        List<BriefingResponse> responses = infos.stream()
+                .map(BriefingResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.success(responses));
     }
 }

--- a/src/test/java/com/solv/wefin/domain/game/news/service/GameBriefingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/news/service/GameBriefingServiceTest.java
@@ -1,6 +1,8 @@
 package com.solv.wefin.domain.game.news.service;
 
 import com.solv.wefin.domain.game.news.dto.BriefingInfo;
+import com.solv.wefin.domain.game.news.entity.BriefingCache;
+import com.solv.wefin.domain.game.news.repository.BriefingCacheRepository;
 import com.solv.wefin.domain.game.openai.OpenAiBriefingClient.BriefingParts;
 import com.solv.wefin.domain.game.participant.entity.GameParticipant;
 import com.solv.wefin.domain.game.participant.repository.GameParticipantRepository;
@@ -20,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -47,6 +50,9 @@ class GameBriefingServiceTest {
 
     @Mock
     private BriefingService briefingService;
+
+    @Mock
+    private BriefingCacheRepository briefingCacheRepository;
 
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
@@ -190,6 +196,73 @@ class GameBriefingServiceTest {
 
         // ACTIVE 턴이 없으면 하위 BriefingService는 호출되지 않아야 한다
         verify(briefingService, never()).getBriefingForDate(any());
+    }
+
+    // === getBriefingsForRoom 테스트 ===
+
+    @Test
+    @DisplayName("브리핑 목록 조회 성공 — 당일 + 과거 캐시 합산 반환")
+    void getBriefingsForRoom_withPastData() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        LocalDate turnDate = activeTurn.getTurnDate();
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(briefingService.getBriefingForDate(turnDate))
+                .willReturn(TEST_PARTS);
+
+        // 과거 캐시 2건
+        BriefingCache past1 = BriefingCache.create(turnDate.minusDays(1), "어제 개요", "어제 이슈", "어제 힌트");
+        BriefingCache past2 = BriefingCache.create(turnDate.minusDays(2), "그저께 개요", "그저께 이슈", "그저께 힌트");
+        given(briefingCacheRepository.findTop14ByTargetDateBeforeOrderByTargetDateDesc(turnDate))
+                .willReturn(List.of(past1, past2));
+
+        // When
+        List<BriefingInfo> result = gameBriefingService.getBriefingsForRoom(roomId, TEST_USER_ID);
+
+        // Then — 당일 1건 + 과거 2건 = 총 3건, 당일이 첫 번째
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).targetDate()).isEqualTo(turnDate);
+        assertThat(result.get(1).targetDate()).isEqualTo(turnDate.minusDays(1));
+        assertThat(result.get(2).targetDate()).isEqualTo(turnDate.minusDays(2));
+    }
+
+    @Test
+    @DisplayName("브리핑 목록 조회 성공 — 과거 캐시가 없으면 당일만 반환")
+    void getBriefingsForRoom_noPastData() {
+        // Given
+        GameRoom gameRoom = createGameRoom();
+        UUID roomId = gameRoom.getRoomId();
+        GameParticipant participant = GameParticipant.createLeader(gameRoom, TEST_USER_ID);
+        GameTurn activeTurn = GameTurn.createFirst(gameRoom);
+        LocalDate turnDate = activeTurn.getTurnDate();
+
+        given(gameRoomRepository.findById(roomId))
+                .willReturn(Optional.of(gameRoom));
+        given(gameParticipantRepository.findByGameRoomAndUserId(gameRoom, TEST_USER_ID))
+                .willReturn(Optional.of(participant));
+        given(gameTurnRepository.findByGameRoomAndStatus(gameRoom, TurnStatus.ACTIVE))
+                .willReturn(Optional.of(activeTurn));
+        given(briefingService.getBriefingForDate(turnDate))
+                .willReturn(TEST_PARTS);
+        given(briefingCacheRepository.findTop14ByTargetDateBeforeOrderByTargetDateDesc(turnDate))
+                .willReturn(List.of());
+
+        // When
+        List<BriefingInfo> result = gameBriefingService.getBriefingsForRoom(roomId, TEST_USER_ID);
+
+        // Then — 당일 1건만
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).targetDate()).isEqualTo(turnDate);
+        assertThat(result.get(0).marketOverview()).isEqualTo(TEST_PARTS.marketOverview());
     }
 
     // === 헬퍼 메서드 ===


### PR DESCRIPTION
## 📌 PR 설명
<br>
게임 브리핑 2주치 조회

## ✅ 완료한 기능 명세

- [x] 게임 브리핑 2주치 조회

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #이슈번호

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 게임 브리핑의 다중 조회 기능 추가 - 현재 날짜의 브리핑과 함께 최근 이전 브리핑들을 목록으로 조회 가능

## 테스트
* 다중 브리핑 조회 기능에 대한 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->