### PR TITLE
ai 채팅 응답 파싱 및 채팅 알림 로직 수정

### DIFF
--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatInfo.java
@@ -1,6 +1,7 @@
 package com.solv.wefin.domain.chat.aiChat.dto.info;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record AiChatInfo(
@@ -8,6 +9,16 @@ public record AiChatInfo(
         UUID userId,
         String role,
         String content,
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+        List<AiChatParsedSectionInfo> parsedSections
 ) {
+    public AiChatInfo(
+            Long messageId,
+            UUID userId,
+            String role,
+            String content,
+            OffsetDateTime createdAt
+    ) {
+        this(messageId, userId, role, content, createdAt, List.of());
+    }
 }

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatParsedSectionInfo.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/dto/info/AiChatParsedSectionInfo.java
@@ -1,0 +1,9 @@
+package com.solv.wefin.domain.chat.aiChat.dto.info;
+
+import java.util.List;
+
+public record AiChatParsedSectionInfo(
+        String title,
+        List<String> items
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatAnswerParser.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatAnswerParser.java
@@ -1,0 +1,107 @@
+package com.solv.wefin.domain.chat.aiChat.service;
+
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatParsedSectionInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public final class AiChatAnswerParser {
+
+    private static final Pattern NUMBERED_HEADING = Pattern.compile("^\\d+[.)]\\s+(.+)$");
+    private static final Pattern BULLET = Pattern.compile("^[-*\\u2022]\\s+(.+)$");
+
+    private AiChatAnswerParser() {
+    }
+
+    public static List<AiChatParsedSectionInfo> parse(String role, String content) {
+        if (!"AI".equals(role) || content == null || content.isBlank()) {
+            return List.of();
+        }
+
+        List<AiChatParsedSectionInfo> sections = new ArrayList<>();
+        String currentTitle = null;
+        List<String> currentItems = new ArrayList<>();
+
+        for (String rawLine : content.replace("\r\n", "\n").split("\n")) {
+            String line = rawLine.trim();
+            if (line.isBlank()) {
+                continue;
+            }
+
+            String heading = toHeading(line);
+            if (heading != null) {
+                addSection(sections, currentTitle, currentItems);
+                currentTitle = heading;
+                currentItems = new ArrayList<>();
+                continue;
+            }
+
+            String item = toItem(line);
+            if (currentTitle == null) {
+                currentTitle = "답변";
+            }
+            currentItems.add(item);
+        }
+
+        addSection(sections, currentTitle, currentItems);
+        return List.copyOf(sections);
+    }
+
+    private static String toHeading(String line) {
+        String normalized = stripMarkdown(line);
+
+        if (line.startsWith("#")) {
+            return stripMarkdown(line.replaceFirst("^#+\\s*", ""));
+        }
+
+        var numberedMatcher = NUMBERED_HEADING.matcher(normalized);
+        if (numberedMatcher.matches()) {
+            String value = stripMarkdown(numberedMatcher.group(1));
+            return isHeadingLike(value) ? value : null;
+        }
+
+        return isHeadingLike(normalized) ? normalized : null;
+    }
+
+    private static String toItem(String line) {
+        var bulletMatcher = BULLET.matcher(line);
+        if (bulletMatcher.matches()) {
+            return stripMarkdown(bulletMatcher.group(1));
+        }
+
+        return stripMarkdown(line);
+    }
+
+    private static boolean isHeadingLike(String line) {
+        if (line.length() > 32) {
+            return false;
+        }
+
+        if (line.endsWith(".") || line.endsWith("?") || line.endsWith("!")) {
+            return false;
+        }
+
+        return !BULLET.matcher(line).matches();
+    }
+
+    private static String stripMarkdown(String value) {
+        return value
+                .replaceAll("\\*\\*(.*?)\\*\\*", "$1")
+                .replaceAll("__(.*?)__", "$1")
+                .replaceAll("`", "")
+                .trim();
+    }
+
+    private static void addSection(
+            List<AiChatParsedSectionInfo> sections,
+            String title,
+            List<String> items
+    ) {
+        if (title == null || items.isEmpty()) {
+            return;
+        }
+
+        sections.add(new AiChatParsedSectionInfo(title, List.copyOf(items)));
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
+++ b/src/main/java/com/solv/wefin/domain/chat/aiChat/service/AiChatService.java
@@ -168,7 +168,8 @@ public class AiChatService {
                 message.getUser().getUserId(),
                 message.getRole().name(),
                 message.getContent(),
-                message.getCreatedAt()
+                message.getCreatedAt(),
+                AiChatAnswerParser.parse(message.getRole().name(), message.getContent())
         );
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
+++ b/src/main/java/com/solv/wefin/domain/game/participant/service/GamePortfolioService.java
@@ -16,9 +16,11 @@ import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -32,6 +34,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GamePortfolioService {
@@ -41,6 +44,7 @@ public class GamePortfolioService {
     private final GameTurnRepository gameTurnRepository;
     private final GameHoldingRepository gameHoldingRepository;
     private final StockDailyRepository stockDailyRepository;
+    private final QuestProgressService questProgressService;
 
     public PortfolioInfo getPortfolio(UUID roomId, UUID userId) {
 
@@ -77,6 +81,8 @@ public class GamePortfolioService {
                 : totalAsset.subtract(seedMoney)
                         .multiply(new BigDecimal("100"))
                         .divide(seedMoney, 2, RoundingMode.HALF_UP);
+
+        handleProfitRateSafely(userId, profitRate);
 
         return new PortfolioInfo(seedMoney, cash, stockValue, totalAsset, profitRate);
     }
@@ -182,5 +188,13 @@ public class GamePortfolioService {
                         sd -> sd.getStockInfo().getSymbol(),
                         Function.identity()
                 ));
+    }
+
+    private void handleProfitRateSafely(UUID userId, BigDecimal profitRate) {
+        try {
+            questProgressService.handleProfitRate(userId, profitRate);
+        } catch (RuntimeException e) {
+            log.warn("수익률 퀘스트 반영 실패 userId={}, profitRate={}", userId, profitRate, e);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
+++ b/src/main/java/com/solv/wefin/domain/game/result/service/GameResultService.java
@@ -15,9 +15,11 @@ import com.solv.wefin.domain.game.room.entity.RoomStatus;
 import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.snapshot.dto.SnapshotInfo;
 import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -31,6 +33,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class GameResultService {
 
@@ -40,6 +43,7 @@ public class GameResultService {
     private final GamePortfolioSnapshotRepository snapshotRepository;
     private final GameOrderRepository gameOrderRepository;
     private final UserRepository userRepository;
+    private final QuestProgressService questProgressService;
 
     /**
      * 게임 결과 조회.
@@ -101,6 +105,9 @@ public class GameResultService {
                             : i + 1;
 
             boolean isMine = r.getParticipant().getUserId().equals(userId);
+            if (isMine) {
+                handleGameRankSafely(userId, rank);
+            }
 
             rankings.add(new GameResultInfo.RankingEntry(
                     rank,
@@ -241,5 +248,13 @@ public class GameResultService {
                 .collect(Collectors.toMap(
                         user -> user.getUserId(),
                         user -> user.getNickname()));
+    }
+
+    private void handleGameRankSafely(UUID userId, int rank) {
+        try {
+            questProgressService.handleGameRank(userId, rank);
+        } catch (RuntimeException e) {
+            log.warn("寃뚯엫 寃곌낵 ?쒖쐞 ?섏뒪??諛섏쁺 ?ㅽ뙣 userId={}, rank={}", userId, rank, e);
+        }
     }
 }

--- a/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
+++ b/src/main/java/com/solv/wefin/domain/game/room/service/GameRoomService.java
@@ -15,8 +15,11 @@ import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -33,6 +36,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class GameRoomService {
@@ -42,6 +46,7 @@ public class GameRoomService {
     private final GameTurnRepository gameTurnRepository;
     private final StockDailyRepository stockDailyRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final QuestProgressService questProgressService;
 
 
     //게임방 생성
@@ -87,6 +92,7 @@ public class GameRoomService {
         GameParticipant host = GameParticipant.createLeader(gameRoom, userId);
 
         gameParticipantRepository.save(host);
+        handleQuestEventSafely(userId, QuestEventType.CREATE_GAME_ROOM);
 
         return gameRoom;
     }
@@ -151,6 +157,7 @@ public class GameRoomService {
             }
             participant.rejoin();
             eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
+            handleQuestEventSafely(userId, QuestEventType.JOIN_GAME_ROOM);
             return participant;
         }
 
@@ -171,6 +178,7 @@ public class GameRoomService {
         }
 
         eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
+        handleQuestEventSafely(userId, QuestEventType.JOIN_GAME_ROOM);
         return member;
     }
 
@@ -266,6 +274,14 @@ public class GameRoomService {
 
         eventPublisher.publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.GAME_STARTED));
         return new StartRoomInfo(gameRoom, firstTurn);
+    }
+
+    private void handleQuestEventSafely(UUID userId, QuestEventType eventType) {
+        try {
+            questProgressService.handleEvent(userId, eventType);
+        } catch (RuntimeException e) {
+            log.warn("퀘스트 진행도 반영 실패 userId={}, eventType={}", userId, eventType, e);
+        }
     }
 }
 

--- a/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatResponse.java
+++ b/src/main/java/com/solv/wefin/web/chat/aiChat/dto/response/AiChatResponse.java
@@ -1,8 +1,10 @@
 package com.solv.wefin.web.chat.aiChat.dto.response;
 
 import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatInfo;
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatParsedSectionInfo;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record AiChatResponse(
@@ -10,7 +12,8 @@ public record AiChatResponse(
         UUID userId,
         String role,
         String content,
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+        List<AiChatParsedSectionInfo> parsedSections
 ) {
     public static AiChatResponse from(AiChatInfo info) {
         return new AiChatResponse(
@@ -18,7 +21,8 @@ public record AiChatResponse(
                 info.userId(),
                 info.role(),
                 info.content(),
-                info.createdAt()
+                info.createdAt(),
+                info.parsedSections()
         );
     }
 }

--- a/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
+++ b/src/main/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListener.java
@@ -1,9 +1,7 @@
 package com.solv.wefin.web.chat.common.listener;
 
-import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
 import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
-import com.solv.wefin.domain.chat.globalChat.event.GlobalChatMessageCreatedEvent;
 import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
@@ -28,35 +26,7 @@ public class ChatUnreadNotificationEventListener {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatReadStateService chatReadStateService;
-    private final UserRepository userRepository;
     private final GroupMemberRepository groupMemberRepository;
-
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleGlobalChatCreated(GlobalChatMessageCreatedEvent event) {
-        List<UUID> recipientIds = userRepository.findAllActiveUserIds().stream()
-                .filter(userId -> !userId.equals(event.getUserId()))
-                .toList();
-
-        for (UUID recipientId : recipientIds) {
-            try {
-                ChatUnreadInfo info = chatReadStateService.getUnreadInfoSnapshot(recipientId);
-                sendUnreadNotification(
-                        recipientId,
-                        ChatUnreadNotificationResponse.of(
-                                "GLOBAL",
-                                event.getMessageId(),
-                                null,
-                                event.getSender(),
-                                event.getContent(),
-                                info
-                        )
-                );
-            } catch (RuntimeException e) {
-                log.warn("chat unread snapshot failed userId={}", recipientId, e);
-            }
-        }
-    }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatAnswerParserTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatAnswerParserTest.java
@@ -1,0 +1,71 @@
+package com.solv.wefin.domain.chat.aiChat.service;
+
+import com.solv.wefin.domain.chat.aiChat.dto.info.AiChatParsedSectionInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AiChatAnswerParserTest {
+
+    @Test
+    @DisplayName("AI 답변을 제목과 목록 단위로 파싱한다")
+    void parse_aiAnswer() {
+        // given
+        String answer = """
+                요약
+                - 반도체 업황 회복 기대가 있습니다.
+                - 단기 변동성은 주의해야 합니다.
+                
+                주의사항
+                무리한 단기 매수는 피하는 편이 좋습니다.
+                """;
+
+        // when
+        List<AiChatParsedSectionInfo> result = AiChatAnswerParser.parse("AI", answer);
+
+        // then
+        assertEquals(2, result.size());
+        assertEquals("요약", result.get(0).title());
+        assertEquals(List.of(
+                "반도체 업황 회복 기대가 있습니다.",
+                "단기 변동성은 주의해야 합니다."
+        ), result.get(0).items());
+        assertEquals("주의사항", result.get(1).title());
+        assertEquals(List.of("무리한 단기 매수는 피하는 편이 좋습니다."), result.get(1).items());
+    }
+
+    @Test
+    @DisplayName("사용자 메시지는 파싱하지 않는다")
+    void parse_userMessage() {
+        // given
+        String answer = """
+                요약
+                - 사용자 입력입니다.
+                """;
+
+        // when
+        List<AiChatParsedSectionInfo> result = AiChatAnswerParser.parse("USER", answer);
+
+        // then
+        assertEquals(List.of(), result);
+    }
+
+    @Test
+    @DisplayName("문장 안의 굵게 마크다운을 제거한다")
+    void parse_inlineBoldMarkdown() {
+        // given
+        String answer = """
+                요약
+                - **정치요인과 규제**: 글로벌 시장의 정치적 불확실성이 있습니다.
+                """;
+
+        // when
+        List<AiChatParsedSectionInfo> result = AiChatAnswerParser.parse("AI", answer);
+
+        // then
+        assertEquals("정치요인과 규제: 글로벌 시장의 정치적 불확실성이 있습니다.", result.get(0).items().get(0));
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/participant/service/GamePortfolioServiceTest.java
@@ -16,6 +16,7 @@ import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.entity.TurnStatus;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +37,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class GamePortfolioServiceTest {
@@ -53,6 +55,8 @@ class GamePortfolioServiceTest {
     private GameHoldingRepository gameHoldingRepository;
     @Mock
     private StockDailyRepository stockDailyRepository;
+    @Mock
+    private QuestProgressService questProgressService;
 
     private static final UUID TEST_ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000002");
@@ -86,6 +90,7 @@ class GamePortfolioServiceTest {
             assertThat(result.stockValue()).isEqualByComparingTo(BigDecimal.ZERO);
             assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("10000000"));
             assertThat(result.profitRate()).isEqualByComparingTo(new BigDecimal("0.00"));
+            verify(questProgressService).handleProfitRate(TEST_USER_ID, new BigDecimal("0.00"));
         }
 
         @Test
@@ -118,6 +123,7 @@ class GamePortfolioServiceTest {
                     .multiply(new BigDecimal("100"))
                     .divide(new BigDecimal("10000000"), 2, RoundingMode.HALF_UP);
             assertThat(result.profitRate()).isEqualByComparingTo(expectedRate);
+            verify(questProgressService).handleProfitRate(TEST_USER_ID, expectedRate);
         }
 
         @Test
@@ -152,6 +158,7 @@ class GamePortfolioServiceTest {
             assertThat(result.totalAsset()).isEqualByComparingTo(new BigDecimal("4250000"));
             // profitRate = (4250000 - 10000000) / 10000000 × 100 = -57.50
             assertThat(result.profitRate()).isEqualByComparingTo(new BigDecimal("-57.50"));
+            verify(questProgressService).handleProfitRate(TEST_USER_ID, new BigDecimal("-57.50"));
         }
     }
 

--- a/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/result/service/GameResultServiceTest.java
@@ -21,6 +21,7 @@ import com.solv.wefin.domain.game.snapshot.entity.GamePortfolioSnapshot;
 import com.solv.wefin.domain.game.snapshot.repository.GamePortfolioSnapshotRepository;
 import com.solv.wefin.domain.game.stock.entity.StockInfo;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -46,9 +47,12 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
 @ExtendWith(MockitoExtension.class)
@@ -69,6 +73,8 @@ class GameResultServiceTest {
     private GameOrderRepository gameOrderRepository;
     @Mock
     private UserRepository userRepository;
+    @Mock
+    private QuestProgressService questProgressService;
 
     private static final UUID ROOM_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final UUID USER_A = UUID.fromString("00000000-0000-4000-a000-000000000002");
@@ -141,6 +147,7 @@ class GameResultServiceTest {
             assertThat(info.rankings().get(2).rank()).isEqualTo(3);
             assertThat(info.rankings().get(2).userName()).isEqualTo("재훈");
             assertThat(info.rankings().get(2).isMine()).isTrue();
+            verify(questProgressService).handleGameRank(USER_A, 3);
         }
 
         @Test
@@ -210,6 +217,7 @@ class GameResultServiceTest {
             assertThat(info.rankings()).isEmpty();
             assertThat(info.startDate()).isEqualTo(START_DATE);
             assertThat(info.endDate()).isEqualTo(END_DATE);
+            verify(questProgressService, never()).handleGameRank(any(), anyInt());
         }
 
         @Test

--- a/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/game/room/service/GameRoomServiceTest.java
@@ -13,6 +13,8 @@ import com.solv.wefin.domain.game.room.repository.GameRoomRepository;
 import com.solv.wefin.domain.game.stock.repository.StockDailyRepository;
 import com.solv.wefin.domain.game.turn.entity.GameTurn;
 import com.solv.wefin.domain.game.turn.repository.GameTurnRepository;
+import com.solv.wefin.domain.quest.entity.QuestEventType;
+import com.solv.wefin.domain.quest.service.QuestProgressService;
 import com.solv.wefin.global.error.BusinessException;
 import com.solv.wefin.global.error.ErrorCode;
 import com.solv.wefin.domain.game.room.dto.CreateRoomCommand;
@@ -62,6 +64,9 @@ class GameRoomServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private QuestProgressService questProgressService;
+
     private static final UUID TEST_USER_ID = UUID.fromString("00000000-0000-4000-a000-000000000001");
     private static final Long TEST_GROUP_ID = 1L;
 
@@ -98,6 +103,7 @@ class GameRoomServiceTest {
 
         // GameParticipant(방장)가 저장됐는지 확인
         verify(gameParticipantRepository).save(any());
+        verify(questProgressService).handleEvent(TEST_USER_ID, QuestEventType.CREATE_GAME_ROOM);
     }
 
     @Test
@@ -269,6 +275,7 @@ class GameRoomServiceTest {
         assertThat(result.getGameRoom().getRoomId()).isEqualTo(roomId);
         assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.WAITING);
         verify(gameParticipantRepository).save(any(GameParticipant.class));
+        verify(questProgressService).handleEvent(OTHER_USER_ID, QuestEventType.JOIN_GAME_ROOM);
     }
 
     @Test
@@ -293,6 +300,7 @@ class GameRoomServiceTest {
         assertThat(result.getGameRoom().getStatus()).isEqualTo(RoomStatus.IN_PROGRESS);
         verify(gameParticipantRepository).save(any(GameParticipant.class));
         verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
+        verify(questProgressService).handleEvent(OTHER_USER_ID, QuestEventType.JOIN_GAME_ROOM);
     }
 
     @Test
@@ -319,6 +327,7 @@ class GameRoomServiceTest {
         assertThat(result.getStatus()).isEqualTo(ParticipantStatus.ACTIVE); // LEFT → ACTIVE
         verify(gameParticipantRepository, never()).save(any()); // 더티 체킹이니까 save 안 부름
         verify(eventPublisher).publishEvent(new GameRoomEvent(roomId, GameRoomEvent.EventType.PARTICIPANT_JOINED));
+        verify(questProgressService).handleEvent(OTHER_USER_ID, QuestEventType.JOIN_GAME_ROOM);
     }
 
     @Test

--- a/src/test/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListenerTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/common/listener/ChatUnreadNotificationEventListenerTest.java
@@ -1,11 +1,9 @@
 package com.solv.wefin.web.chat.common.listener;
 
-import com.solv.wefin.domain.auth.repository.UserRepository;
 import com.solv.wefin.domain.chat.common.dto.info.ChatUnreadInfo;
 import com.solv.wefin.domain.chat.common.service.ChatReadStateService;
 import com.solv.wefin.domain.chat.groupChat.dto.info.ChatMessageInfo;
 import com.solv.wefin.domain.chat.groupChat.event.ChatMessageCreatedEvent;
-import com.solv.wefin.domain.chat.globalChat.event.GlobalChatMessageCreatedEvent;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
 import com.solv.wefin.web.chat.common.dto.response.ChatUnreadNotificationResponse;
@@ -20,14 +18,12 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.*;
 
 class ChatUnreadNotificationEventListenerTest {
 
     private SimpMessagingTemplate messagingTemplate;
     private ChatReadStateService chatReadStateService;
-    private UserRepository userRepository;
     private GroupMemberRepository groupMemberRepository;
     private ChatUnreadNotificationEventListener listener;
 
@@ -35,62 +31,13 @@ class ChatUnreadNotificationEventListenerTest {
     void setUp() {
         messagingTemplate = mock(SimpMessagingTemplate.class);
         chatReadStateService = mock(ChatReadStateService.class);
-        userRepository = mock(UserRepository.class);
         groupMemberRepository = mock(GroupMemberRepository.class);
 
         listener = new ChatUnreadNotificationEventListener(
                 messagingTemplate,
                 chatReadStateService,
-                userRepository,
                 groupMemberRepository
         );
-    }
-
-    @Test
-    @DisplayName("전체 채팅 이벤트가 오면 발신자를 제외한 사용자에게 unread 알림을 보낸다")
-    void handleGlobalChatCreated_success() {
-        UUID senderId = UUID.randomUUID();
-        UUID receiverId = UUID.randomUUID();
-
-        when(userRepository.findAllActiveUserIds()).thenReturn(List.of(senderId, receiverId));
-        when(chatReadStateService.getUnreadInfoSnapshot(receiverId))
-                .thenReturn(new ChatUnreadInfo(3L, 1L, 44L, 55L));
-
-        GlobalChatMessageCreatedEvent event = new GlobalChatMessageCreatedEvent(
-                11L,
-                senderId,
-                "USER",
-                "보낸사람",
-                "전체 채팅 메시지",
-                OffsetDateTime.now()
-        );
-
-        ArgumentCaptor<ChatUnreadNotificationResponse> payloadCaptor =
-                ArgumentCaptor.forClass(ChatUnreadNotificationResponse.class);
-
-        listener.handleGlobalChatCreated(event);
-
-        verify(messagingTemplate).convertAndSendToUser(
-                eq(receiverId.toString()),
-                eq("/queue/chat-unread"),
-                payloadCaptor.capture()
-        );
-        verify(messagingTemplate, never()).convertAndSendToUser(
-                eq(senderId.toString()),
-                eq("/queue/chat-unread"),
-                any()
-        );
-        verify(chatReadStateService, never()).getUnreadInfoSnapshot(senderId);
-
-        ChatUnreadNotificationResponse payload = payloadCaptor.getValue();
-        assertEquals("GLOBAL", payload.chatType());
-        assertEquals(11L, payload.messageId());
-        assertNull(payload.groupId());
-        assertEquals("보낸사람", payload.sender());
-        assertEquals("전체 채팅 메시지", payload.content());
-        assertEquals(4L, payload.totalUnreadCount());
-        assertEquals(44L, payload.lastReadGlobalMessageId());
-        assertEquals(55L, payload.lastReadGroupMessageId());
     }
 
     @Test


### PR DESCRIPTION
## 📌 PR 설명
<br>

퀘스트 템플릿으로 등록되어 있던 게임/수익률/랭킹 관련 퀘스트를 실제 서비스 흐름에 연결했습니다.  
또한 AI 채팅 응답 파싱 안정성을 보강하고, 전체채팅 unread 알림이 유저 수만큼 DB 조회를 발생시키던 구조를 개선했습니다.

<br>

## ✅ 완료한 기능 명세

- [x] 게임방 생성 시 `CREATE_GAME_ROOM` 퀘스트 진행 처리 연결
- [x] 게임방 참가/재참가 시 `JOIN_GAME_ROOM` 퀘스트 진행 처리 연결
- [x] 게임 포트폴리오 조회 시 수익률 기반 퀘스트 진행 처리 연결
- [x] 게임 랭킹 조회 시 현재 유저 순위 기반 퀘스트 진행 처리 연결
- [x] 퀘스트 처리 실패가 게임/포트폴리오/랭킹 주요 흐름을 막지 않도록 예외 격리
- [x] AI 채팅 응답 파싱 로직 안정화
- [x] 전체채팅 unread 알림의 유저별 DB snapshot 조회 제거
- [x] 전체채팅은 기존 글로벌 채팅 topic 수신을 활용하도록 알림 구조 개선
- [x] 그룹채팅 unread 알림은 기존 개인 큐 기반으로 유지
<br>


## 💭 고민과 해결과정

퀘스트 템플릿 데이터는 존재했지만 실제 서비스 호출 지점과 연결되지 않아, 유저가 게임방을 만들거나 참여해도 퀘스트 진행 상태가 갱신되지 않는 문제가 있었습니다. 이를 해결하기 위해 게임방 생성/참가, 포트폴리오 조회, 랭킹 조회 시점에 `QuestProgressService`를 호출하도록 연결했습니다. 다만 퀘스트 처리는 부가 기능이므로, 퀘스트 처리 중 예외가 발생해도 핵심 서비스 흐름이 실패하지 않도록 예외를 로깅하고 격리했습니다.

AI 채팅 응답은 외부 응답이나 백엔드 처리 결과가 예상 구조와 다를 경우 런타임 오류로 이어질 수 있어, 응답 파싱 단계에서 구조를 명확히 검증하도록 개선했습니다. 이를 통해 잘못된 응답이 내려왔을 때 문제를 더 빠르게 감지하고 안정적으로 예외 처리할 수 있도록 했습니다.

채팅 unread 알림은 전체채팅 메시지 1건마다 활성 유저를 순회하며 각 유저의 unread snapshot을 DB에서 계산하는 구조였습니다. 전체채팅은 모든 유저가 참여하는 특성상 유저 수가 증가하면 메시지 1건당 DB 조회가 급격히 늘어날 수 있어, 전체채팅 unread 개인 알림 루프를 제거했습니다. 대신 전체채팅은 이미 브로드캐스트되는 글로벌 채팅 topic을 프론트에서 알림 트리거로 활용하고, 서버는 그룹채팅처럼 대상이 제한적인 알림만 개인 큐로 유지하도록 역할을 분리했습니다.

<br>