### PR TITLE
[WEF-688] 뉴스 파이프라인 PENDING 기사 노출 방지 및 relevance strict 필터 적용

### DIFF
--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -43,13 +43,20 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
 
     /**
      * 재판정 가능한 PENDING 기사를 id 오름차순으로 조회한다.
+     *
+     * 클러스터링 단계가 24시간 윈도우(`ClusteringService.HOURS_RANGE`) 안의 기사만 받기 때문에,
+     * 그 윈도우를 벗어난 PENDING은 재판정해 FINANCIAL로 바뀌어도 노출되지 않는다.
+     * 따라서 cron 호출은 노출 가능한 시간 범위 안의 기사로 한정해 LLM 비용 누수를 막는다.
+     * (admin 직접 호출 path인 {@code rejudgeByIds}는 이 제한을 받지 않는다)
      */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.relevance = :relevance " +
             "AND a.content IS NOT NULL AND TRIM(a.content) <> '' " +
+            "AND a.createdAt > :since " +
             "ORDER BY a.id ASC")
     List<NewsArticle> findRejudgeTargets(
             @Param("relevance") NewsArticle.RelevanceStatus relevance,
+            @Param("since") OffsetDateTime since,
             Pageable pageable);
 
     List<NewsArticle> findByCrawlStatusInAndCrawlRetryCountLessThanOrderByCollectedAtDesc(

--- a/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
+++ b/src/main/java/com/solv/wefin/domain/news/article/repository/NewsArticleRepository.java
@@ -57,10 +57,13 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
 
     /**
      * 임베딩 대상 기사를 조회한다.
+     *
+     * 태깅이 완료되어 금융 관련성이 확정(FINANCIAL)된 기사만 후속 파이프라인에 진입시킨다.
+     * PENDING(미판정) 기사를 임베딩하면 클러스터에 무관 기사가 섞일 수 있으므로 제외한다.
      */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.crawlStatus = :crawlStatus " +
-            "AND a.relevance <> :excludedRelevance " +
+            "AND a.relevance = :requiredRelevance " +
             "AND a.embeddingRetryCount < :maxRetryCount " +
             "AND (a.embeddingStatus IN :embeddingStatuses " +
             "     OR (a.embeddingStatus = :processingStatus AND a.embeddingAttemptedAt < :staleBefore)) " +
@@ -71,7 +74,7 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
             @Param("processingStatus") NewsArticle.EmbeddingStatus processingStatus,
             @Param("maxRetryCount") int maxRetryCount,
             @Param("staleBefore") OffsetDateTime staleBefore,
-            @Param("excludedRelevance") NewsArticle.RelevanceStatus excludedRelevance,
+            @Param("requiredRelevance") NewsArticle.RelevanceStatus requiredRelevance,
             Pageable pageable);
 
     /**
@@ -94,16 +97,19 @@ public interface NewsArticleRepository extends JpaRepository<NewsArticle, Long> 
 
     /**
      * 클러스터링 대상 기사를 조회한다.
+     *
+     * 금융 관련성이 확정(FINANCIAL)된 기사만 클러스터링한다.
+     * PENDING(미판정) 기사가 섞이면 노출 시점에 무관 기사가 클러스터에 포함될 수 있으므로 제외한다.
      */
     @Query("SELECT a FROM NewsArticle a " +
             "WHERE a.embeddingStatus = :embeddingStatus " +
-            "AND a.relevance <> :excludedRelevance " +
+            "AND a.relevance = :requiredRelevance " +
             "AND NOT EXISTS (SELECT 1 FROM NewsClusterArticle nca WHERE nca.newsArticleId = a.id) " +
             "AND a.createdAt > :since " +
             "ORDER BY a.collectedAt DESC")
     List<NewsArticle> findClusteringTargets(
             @Param("embeddingStatus") NewsArticle.EmbeddingStatus embeddingStatus,
             @Param("since") OffsetDateTime since,
-            @Param("excludedRelevance") NewsArticle.RelevanceStatus excludedRelevance,
+            @Param("requiredRelevance") NewsArticle.RelevanceStatus requiredRelevance,
             Pageable pageable);
 }

--- a/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusteringService.java
+++ b/src/main/java/com/solv/wefin/domain/news/cluster/service/ClusteringService.java
@@ -127,7 +127,7 @@ public class ClusteringService {
         return newsArticleRepository.findClusteringTargets(
                 NewsArticle.EmbeddingStatus.SUCCESS,
                 since,
-                NewsArticle.RelevanceStatus.IRRELEVANT,
+                NewsArticle.RelevanceStatus.FINANCIAL,
                 PageRequest.of(0, batchProperties.clusteringSize()));
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/config/NewsBatchProperties.java
+++ b/src/main/java/com/solv/wefin/domain/news/config/NewsBatchProperties.java
@@ -20,9 +20,11 @@ import org.springframework.validation.annotation.Validated;
  * @param taggingSize     태깅 배치 1회당 처리 기사 수.
  *                        OpenAI chat API TPM(600K) 대비 1000건 × 평균 300토큰 ≈ 300K 기준 상한
  * @param clusteringSize  클러스터링 배치 1회당 처리 기사 수
- * @param summarySize     요약 배치 1회당 처리 클러스터 수.
- *                        OpenAI chat API 호출 비용 방어 (클러스터당 기사 N건 합산)
- * @param rejudgeMaxLimit 관련성 재판단 수동 실행 시 허용 상한
+ * @param summarySize       요약 배치 1회당 처리 클러스터 수.
+ *                          OpenAI chat API 호출 비용 방어 (클러스터당 기사 N건 합산)
+ * @param rejudgeMaxLimit   관련성 재판단 수동 실행 시 허용 상한 (admin endpoint 보호용)
+ * @param rejudgeBatchSize  관련성 재판단 cron 1회당 처리 기사 수.
+ *                          태깅 retry 한도 초과 등으로 PENDING으로 남은 기사를 정기 구제하는 용도
  */
 @Validated
 @ConfigurationProperties(prefix = "batch.news")
@@ -32,6 +34,7 @@ public record NewsBatchProperties(
         @Min(1) @Max(1000) int taggingSize,
         @Min(1) @Max(5000) int clusteringSize,
         @Min(1) @Max(200) int summarySize,
-        @Min(1) @Max(2000) int rejudgeMaxLimit
+        @Min(1) @Max(2000) int rejudgeMaxLimit,
+        @Min(1) @Max(2000) int rejudgeBatchSize
 ) {
 }

--- a/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/solv/wefin/domain/news/embedding/service/EmbeddingService.java
@@ -85,7 +85,7 @@ public class EmbeddingService {
                 EmbeddingStatus.PROCESSING,
                 MAX_RETRY,
                 staleBefore,
-                RelevanceStatus.IRRELEVANT,
+                RelevanceStatus.FINANCIAL,
                 PageRequest.of(0, batchProperties.embeddingSize()));
     }
 

--- a/src/main/java/com/solv/wefin/domain/news/tagging/batch/RelevanceRejudgeScheduler.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/batch/RelevanceRejudgeScheduler.java
@@ -1,0 +1,46 @@
+package com.solv.wefin.domain.news.tagging.batch;
+
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
+import com.solv.wefin.domain.news.tagging.service.RelevanceRejudgeService;
+import com.solv.wefin.domain.news.tagging.service.RelevanceRejudgeService.RejudgeSummary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * PENDING 상태로 남은 기사의 금융 관련성을 정기적으로 재판정한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RelevanceRejudgeScheduler {
+
+    private final RelevanceRejudgeService relevanceRejudgeService;
+    private final NewsBatchProperties batchProperties;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    @Scheduled(cron = "${rejudge.collect.cron:-}")
+    public void rejudgePending() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("관련성 재판정이 이미 실행 중입니다. 스킵합니다.");
+            return;
+        }
+
+        log.info("=== 관련성 재판정 배치 시작 ===");
+        long start = System.currentTimeMillis();
+
+        try {
+            RejudgeSummary summary = relevanceRejudgeService.rejudgePending(batchProperties.rejudgeBatchSize());
+            log.info("관련성 재판정 배치 결과 — {}", summary);
+        } catch (Exception e) {
+            log.error("관련성 재판정 배치 실패: {}", e.getMessage(), e);
+        } finally {
+            running.set(false);
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("=== 관련성 재판정 배치 종료 ({}ms) ===", elapsed);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/client/OpenAiTaggingClient.java
@@ -24,7 +24,7 @@ import java.util.Map;
 public class OpenAiTaggingClient {
 
     private static final String OPENAI_CHAT_URL = "https://api.openai.com/v1/chat/completions";
-    private static final int MAX_CONTENT_LENGTH = 3000;
+    private static final int MAX_CONTENT_LENGTH = 3000; //  태깅 본문용 최대 길이
 
     private static final String SYSTEM_PROMPT = """
             당신은 금융 뉴스 기사를 분석하여 태그를 추출하고 한 줄 요약을 작성하는 전문가입니다.

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -22,6 +23,8 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class RelevanceRejudgeService {
+
+    private static final int REJUDGE_WINDOW_HOURS = 24; // cron 기반 PENDING 재판정 윈도우
 
     private final NewsArticleRepository newsArticleRepository;
     private final OpenAiTaggingClient openAiTaggingClient;
@@ -55,6 +58,10 @@ public class RelevanceRejudgeService {
     /**
      * PENDING 상태의 기사를 배치 크기만큼 재판정한다.
      *
+     * 노출 가능한 시간 윈도우({@link #REJUDGE_WINDOW_HOURS}시간) 안의 기사로 한정한다.
+     * 클러스터링이 24시간 안의 기사만 받기 때문에, 윈도우를 벗어난 PENDING은
+     * 재판정해도 클러스터에 진입할 수 없어 LLM 비용만 발생한다.
+     *
      * @param limit 한 번에 처리할 최대 기사 수
      *              (허용 범위: 1 ~ {@code batch.news.rejudge-max-limit})
      * @return 재판정 처리 결과 요약
@@ -62,9 +69,11 @@ public class RelevanceRejudgeService {
     public RejudgeSummary rejudgePending(int limit) {
         validateLimit(limit);
 
+        OffsetDateTime since = OffsetDateTime.now().minusHours(REJUDGE_WINDOW_HOURS);
         List<NewsArticle> articles = newsArticleRepository.findRejudgeTargets(
-                RelevanceStatus.PENDING, PageRequest.of(0, limit));
-        log.info("관련성 재판정 시작(PENDING) — 대상: {}건 (limit: {})", articles.size(), limit);
+                RelevanceStatus.PENDING, since, PageRequest.of(0, limit));
+        log.info("관련성 재판정 시작(PENDING) — 대상: {}건 (limit: {}, since: {})",
+                articles.size(), limit, since);
 
         RejudgeResult result = rejudgeArticles(articles);
         RejudgeSummary summary = new RejudgeSummary(

--- a/src/main/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeService.java
+++ b/src/main/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeService.java
@@ -59,8 +59,6 @@ public class RelevanceRejudgeService {
      * PENDING 상태의 기사를 배치 크기만큼 재판정한다.
      *
      * 노출 가능한 시간 윈도우({@link #REJUDGE_WINDOW_HOURS}시간) 안의 기사로 한정한다.
-     * 클러스터링이 24시간 안의 기사만 받기 때문에, 윈도우를 벗어난 PENDING은
-     * 재판정해도 클러스터에 진입할 수 없어 LLM 비용만 발생한다.
      *
      * @param limit 한 번에 처리할 최대 기사 수
      *              (허용 범위: 1 ~ {@code batch.news.rejudge-max-limit})

--- a/src/main/resources/application-desktop.yml
+++ b/src/main/resources/application-desktop.yml
@@ -71,6 +71,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+rejudge:
+  collect:
+    cron: ${REJUDGE_COLLECT_CRON:-}
+
 batch:
   news:
     crawl-size: ${NEWS_CRAWL_BATCH_SIZE:500}
@@ -79,6 +83,7 @@ batch:
     clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
     summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
     rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
+    rejudge-batch-size: ${NEWS_REJUDGE_BATCH_SIZE:50}
 wefin-news:
   api:
     base-url: ${WEFIN_NEWS_BASE_URL:https://wefin.shinhanacademy.co.kr/}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -74,6 +74,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+rejudge:
+  collect:
+    cron: ${REJUDGE_COLLECT_CRON:-}
+
 batch:
   news:
     crawl-size: ${NEWS_CRAWL_BATCH_SIZE:500}
@@ -82,6 +86,7 @@ batch:
     clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
     summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
     rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
+    rejudge-batch-size: ${NEWS_REJUDGE_BATCH_SIZE:50}
 wefin-news:
   api:
     base-url: ${WEFIN_NEWS_BASE_URL:https://dev-api.wefin.ai.kr}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -86,6 +86,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:-}
 
+rejudge:
+  collect:
+    cron: ${REJUDGE_COLLECT_CRON:-}
+
 batch:
   news:
     crawl-size: ${NEWS_CRAWL_BATCH_SIZE:100}
@@ -94,6 +98,7 @@ batch:
     clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:100}
     summary-size: ${NEWS_SUMMARY_BATCH_SIZE:20}
     rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:100}
+    rejudge-batch-size: ${NEWS_REJUDGE_BATCH_SIZE:30}
 wefin-news:
   api:
     base-url: https://dev-api.wefin.ai.kr

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -71,6 +71,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+rejudge:
+  collect:
+    cron: ${REJUDGE_COLLECT_CRON:-}
+
 batch:
   news:
     crawl-size: ${NEWS_CRAWL_BATCH_SIZE:500}
@@ -79,6 +83,7 @@ batch:
     clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
     summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
     rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
+    rejudge-batch-size: ${NEWS_REJUDGE_BATCH_SIZE:50}
 wefin-news:
   api:
     base-url: ${WEFIN_NEWS_BASE_URL:https://api.wefin.ai.kr}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,10 @@ summary:
   collect:
     cron: ${SUMMARY_COLLECT_CRON:${NEWS_BATCH_CRON:0 */30 * * * *}}
 
+rejudge:
+  collect:
+    cron: ${REJUDGE_COLLECT_CRON:-}
+
 news:
   hot:
     window-hours: ${NEWS_HOT_WINDOW_HOURS:3}
@@ -88,6 +92,7 @@ batch:
     clustering-size: ${NEWS_CLUSTERING_BATCH_SIZE:500}
     summary-size: ${NEWS_SUMMARY_BATCH_SIZE:50}
     rejudge-max-limit: ${NEWS_REJUDGE_MAX_LIMIT:500}
+    rejudge-batch-size: ${NEWS_REJUDGE_BATCH_SIZE:50}
 
 websocket:
   allowed-origins:

--- a/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusteringServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/cluster/service/ClusteringServiceTest.java
@@ -8,6 +8,7 @@ import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
 import com.solv.wefin.domain.news.cluster.service.ClusterMatchingService.MatchResult;
 import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.ScoreResult;
 import com.solv.wefin.domain.news.cluster.service.SuspiciousScoringService.Verdict;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,7 +55,7 @@ class ClusteringServiceTest {
         clusteringService = new ClusteringService(
                 newsArticleRepository, newsClusterRepository, articleVectorService,
                 clusterMatchingService, suspiciousScoringService, persistenceService,
-                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500));
+                new NewsBatchProperties(500, 500, 500, 500, 50, 500, 50));
     }
 
     private NewsArticle createArticle(Long id) {

--- a/src/test/java/com/solv/wefin/domain/news/config/NewsBatchPropertiesBindingTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/config/NewsBatchPropertiesBindingTest.java
@@ -27,7 +27,8 @@ class NewsBatchPropertiesBindingTest {
                         "batch.news.tagging-size=100",
                         "batch.news.clustering-size=100",
                         "batch.news.summary-size=20",
-                        "batch.news.rejudge-max-limit=100")
+                        "batch.news.rejudge-max-limit=100",
+                        "batch.news.rejudge-batch-size=50")
                 .run(ctx -> {
                     assertThat(ctx).hasNotFailed();
                     NewsBatchProperties props = ctx.getBean(NewsBatchProperties.class);

--- a/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/crawl/ArticleCrawlServiceTest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.news.crawl;
 
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.ingestion.service.ArticleCrawlPersistenceService;
 import com.solv.wefin.domain.news.ingestion.service.ArticleCrawlService;
 import com.solv.wefin.domain.news.ingestion.crawler.ArticleContentExtractor;
@@ -74,7 +75,7 @@ class ArticleCrawlServiceTest {
                 persistenceService,
                 List.of(extractor),
                 newsRestTemplate,
-                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500)
+                new NewsBatchProperties(500, 500, 500, 500, 50, 500, 50)
         );
     }
 

--- a/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/embedding/service/EmbeddingServiceTest.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.domain.news.embedding.service;
 
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.embedding.chunk.ArticleChunker;
 import com.solv.wefin.domain.news.embedding.client.OpenAiEmbeddingClient;
 import com.solv.wefin.domain.news.embedding.entity.ArticleEmbedding;
@@ -47,7 +48,7 @@ class EmbeddingServiceTest {
     void setUp() {
         embeddingService = new EmbeddingService(
                 newsArticleRepository, openAiEmbeddingClient, articleChunker, persistenceService,
-                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500));
+                new NewsBatchProperties(500, 500, 500, 500, 50, 500, 50));
         ReflectionTestUtils.setField(embeddingService, "embeddingModel", "text-embedding-3-small");
         ReflectionTestUtils.setField(embeddingService, "embeddingVersion", "v1");
     }

--- a/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/summary/service/SummaryServiceTest.java
@@ -7,6 +7,7 @@ import com.solv.wefin.domain.news.cluster.entity.NewsCluster.SummaryStatus;
 import com.solv.wefin.domain.news.cluster.entity.NewsClusterArticle;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterArticleRepository;
 import com.solv.wefin.domain.news.cluster.repository.NewsClusterRepository;
+import com.solv.wefin.domain.news.config.NewsBatchProperties;
 import com.solv.wefin.domain.news.summary.client.OpenAiClientException;
 import com.solv.wefin.domain.news.summary.client.OpenAiSummaryClient;
 import com.solv.wefin.domain.news.summary.dto.SummaryResult;
@@ -55,7 +56,7 @@ class SummaryServiceTest {
         summaryService = new SummaryService(
                 newsClusterRepository, clusterArticleRepository, newsArticleRepository,
                 openAiSummaryClient, outlierDetectionService, persistenceService,
-                new com.solv.wefin.domain.news.config.NewsBatchProperties(500, 500, 500, 500, 50, 500));
+                new NewsBatchProperties(500, 500, 500, 500, 50, 500, 50));
     }
 
     private NewsCluster createCluster(Long id, int articleCount, SummaryStatus status) {

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeServiceTest.java
@@ -47,7 +47,7 @@ class RelevanceRejudgeServiceTest {
 
     @BeforeEach
     void setUp() {
-        batchProperties = new NewsBatchProperties(500, 500, 500, 500, 50, TEST_REJUDGE_MAX_LIMIT);
+        batchProperties = new NewsBatchProperties(500, 500, 500, 500, 50, TEST_REJUDGE_MAX_LIMIT, 50);
         rejudgeService = new RelevanceRejudgeService(newsArticleRepository, openAiTaggingClient, persistenceService,
                 batchProperties);
     }

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/RelevanceRejudgeServiceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import com.solv.wefin.global.error.BusinessException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -173,7 +174,7 @@ class RelevanceRejudgeServiceTest {
         List<NewsArticle> pending = List.of(
                 createArticle(1L, "t1", "c1"),
                 createArticle(2L, "t2", "c2"));
-        given(newsArticleRepository.findRejudgeTargets(RelevanceStatus.PENDING, PageRequest.of(0, 50)))
+        given(newsArticleRepository.findRejudgeTargets(eq(RelevanceStatus.PENDING), any(), eq(PageRequest.of(0, 50))))
                 .willReturn(pending);
         given(openAiTaggingClient.analyzeTags(anyString(), anyString()))
                 .willReturn(parseResult("FINANCIAL"));

--- a/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/news/tagging/service/TaggingServiceTest.java
@@ -53,7 +53,7 @@ class TaggingServiceTest {
     void setUp() {
         taggingService = new TaggingService(newsArticleRepository, openAiTaggingClient,
                 persistenceService, stockCodeValidator,
-                new NewsBatchProperties(500, 500, 500, 500, 50, 500));
+                new NewsBatchProperties(500, 500, 500, 500, 50, 500, 50));
         lenient().when(stockCodeValidator.loadStockMap())
                 .thenReturn(java.util.Map.of(
                         "005930", "삼성전자",


### PR DESCRIPTION
## 📌 PR 설명

운영 비용 절감을 위해 `.env.prod`에서 뉴스 배치 cap(건수)을 축소하고 cron 빈도를 일 2회(07:00, 19:00)로 변경한 뒤, 금융과 무관한 기사들이 노출되는 문제가 발생했습니다.

원인은 embedding/clustering 단계의 relevance 필터 조건이 `<> IRRELEVANT` (negative filter) 였다는 것입니다. 이 필터는 `PENDING(미판정) + FINANCIAL` 둘 다 통과시키므로, 태깅이 끝나기 전인 PENDING 기사가 임베딩되고 클러스터에 섞여 그대로 사용자에게 노출됐습니다.

기존 설계는 PENDING은 분 단위의 일시적 상태라는 가정 하에 recall(노출 누락 방지) > precision(무관 기사 제거) 트레이드오프를 의식적으로 선택한 구조입니다. 하지만 비용 절감 변경으로 cap이 줄고 cron 빈도가 떨어지면서 PENDING이 시간~일 단위로 누적되어 가정이 깨졌습니다.

이번 PR은 두 가지를 적용합니다:

1. 필터 strict 전환 — embedding/clustering 쿼리를 `= FINANCIAL`로 변경. 태깅 완료된 금융 기사만 후속 파이프라인에 진입
2. PENDING 사각지대 구제 cron 신설 — strict 전환 부작용으로, tagging retry 한도 초과해 PENDING으로 영원히 남는 기사가 노출되지 않게 됩니다. 이를 정기 재판정하는 안전망 스케줄러 추가
3. cron 시간차 분리 — strict 필터와 짝이 되는 변경. embedding이 tagging과 동시 출발하면 같은 회차에 신규 기사가 임베딩까지 도달 못 함(12시간 지연). 시간차 분리로 약 1시간 내 처리

<br>

## ✅ 변경 파일

1. `NewsArticleRepository.java` — 두 쿼리(`findEmbeddingTargets`, `findClusteringTargets`)의 `<>` → `=` 전환 (modified)
2. `EmbeddingService.java`, `ClusteringService.java` — 호출부 인자 `IRRELEVANT` → `FINANCIAL` (modified)
3. `RelevanceRejudgeScheduler.java` — PENDING 안전망 스케줄러 (new)
4. `NewsBatchProperties.java` — `rejudgeBatchSize` 필드 추가 (수동 max-limit과 분리) (modified)
5. `application*.yml` (5개) — `rejudge.collect.cron`, `batch.news.rejudge-batch-size` 추가
6. `.env.prod` — `REJUDGE_COLLECT_CRON=0 0 3 * * *`, `NEWS_REJUDGE_BATCH_SIZE=50` 추가, cron 시간차 분리

<br>


## 💭 고민과 해결과정
### 1. 원래 코드가 `<> IRRELEVANT`인 이유

- `OpenAiTaggingClient` 프롬프트에 `"판정이 애매하면 'FINANCIAL'로 기울여 선택 (false negative 방지)"` 명시
- `findRejudgeTargets` 어드민 endpoint를 따로 만들어 PENDING 재판정 가능하도록 설계
- embedding과 tagging cron을 같은 시각(`0 */30 * * * *`)에 출발시켜 같은 회차 내 정합 회복 가정

즉 PENDING은 일시적 상태이며, 분 단위에 끝난다는 운영 가정 위에 만든 recall > precision 선택

### 2. 가정이 깨진 메커니즘

`.env.prod` 변경 후:

| 가정                        | 실제                                                           |
| --------------------------- | -------------------------------------------------------------- |
| PENDING 윈도우 = 분 단위    | cron 2회/일 + 태깅 cap 100 ⇒ PENDING이 수시간~수일 단위로 누적 |
| 같은 회차 안에 태깅 완료    | 크롤 200/회 vs 태깅 100/회 ⇒ 회차마다 100건씩 미판정 적체      |
| `<> IRRELEVANT`로 일시 노출 | 일시 노출이 상시 노출로 변환                                   |

### 3. 트레이드오프 재선택

저빈도·저cap 운영 환경에서는 precision 우선이 옳다고 판단했습니다. 사용자 신뢰가 throughput보다 비싸기 때문입니다.

| 항목             | 이전 (`<> IRRELEVANT`)      | 이후 (`= FINANCIAL`)            |
| ---------------- | --------------------------- | ------------------------------- |
| 태깅 지연 시     | 무관 기사 노출 (precision↓) | 노출 누락 (recall↓)             |
| 적합한 운영 환경 | 고빈도·고cap (지연 짧음)    | 저빈도·저cap (지연 길어도 안전) |
| 핵심 보호 대상   | throughput                  | 사용자 신뢰                     |

### 4. PENDING 재판정 cron이 필요한 이유

strict 전환 후 부작용: tagging이 retry 한도 초과해 실패한 기사는 relevance가 PENDING으로 남고, 임베딩/클러스터링에서 영원히 제외되어 노출되지 않는 사각지대가 됩니다.

- 만약 그 기사가 사실 FINANCIAL이었어야 했다면, 영영 노출 안 됨 (recall 저하)
- 정기적으로 PENDING 기사를 LLM을 호출하여 FINANCIAL/IRRELEVANT로 확정시켜야 함

`RelevanceRejudgeService.rejudgePending(int)`는 admin endpoint용으로 이미 구현되어 있어, scheduler wrapper만 추가함

### 5. cron 1회/일 (03:00) 선택

- 3:00 = 다른 cron 일정과 겹치지 않는 새벽 idle 시간
- rejudge cron의 역할은 "tagging이 retry 한도 초과로 PENDING 남긴 기사 구제"로 한정
- tagging cap에 걸려 못 처리된 신규 기사는 다음 회차 tagging이 자동으로 가져가므로 rejudge 불필요
- 따라서 자주 돌릴 이유 없음. idle 시간 1회면 충분
- 비용도 일 50건만 (gpt-4o-mini 단가 기준 ≈ $0.001/일)


<br>

### 🔗 관련 이슈
Closes #335

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 뉴스 관련성 자동 재평가 스케줄러 추가

* **개선 사항**
  * 금융 관련 뉴스 필터링 로직 개선으로 데이터 처리 정확도 향상
  * 배치 처리 설정 확장 및 성능 최적화 옵션 추가

* **Chores**
  * 환경별 배치 처리 구성 및 환경 변수 지원 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->