### PR TITLE
[CHORE] 관리자 계정 기능 추가 및 대회용 계정 발급 기능 추가

### DIFF
--- a/src/main/java/com/solv/wefin/domain/admin/service/AdminAuthorizationService.java
+++ b/src/main/java/com/solv/wefin/domain/admin/service/AdminAuthorizationService.java
@@ -1,0 +1,37 @@
+package com.solv.wefin.domain.admin.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.entity.UserStatus;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAuthorizationService {
+
+    private final UserRepository userRepository;
+
+    public void requireAdmin(UUID userId) {
+        if (userId == null) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.AUTH_UNAUTHORIZED));
+
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new BusinessException(ErrorCode.AUTH_UNAUTHORIZED);
+        }
+
+        if (!user.isAdmin()) {
+            throw new BusinessException(ErrorCode.ADMIN_FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/solv/wefin/domain/auth/dto/IssueAccountCommand.java
+++ b/src/main/java/com/solv/wefin/domain/auth/dto/IssueAccountCommand.java
@@ -1,0 +1,12 @@
+package com.solv.wefin.domain.auth.dto;
+
+import com.solv.wefin.domain.auth.entity.UserAccountType;
+
+public record IssueAccountCommand(
+        String email,
+        String nickname,
+        String password,
+        UserAccountType accountType,
+        Long targetGroupId
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/auth/dto/IssuedAccountInfo.java
+++ b/src/main/java/com/solv/wefin/domain/auth/dto/IssuedAccountInfo.java
@@ -1,0 +1,15 @@
+package com.solv.wefin.domain.auth.dto;
+
+import com.solv.wefin.domain.auth.entity.UserAccountType;
+
+import java.util.UUID;
+
+public record IssuedAccountInfo(
+        UUID userId,
+        String email,
+        String nickname,
+        UserAccountType accountType,
+        Long activeGroupId,
+        String activeGroupName
+) {
+}

--- a/src/main/java/com/solv/wefin/domain/auth/entity/User.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/User.java
@@ -2,9 +2,10 @@ package com.solv.wefin.domain.auth.entity;
 
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.global.common.BaseEntity;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
@@ -36,6 +37,14 @@ public class User extends BaseEntity {
     @Column(name = "status", nullable = false, length = 20)
     private UserStatus status;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "account_type", nullable = false, length = 20)
+    private UserAccountType accountType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false, length = 20)
+    private UserRole role;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "home_group_id")
     private Group homeGroup;
@@ -46,12 +55,30 @@ public class User extends BaseEntity {
     @Column(name = "last_read_global_at")
     private OffsetDateTime lastReadGlobalAt;
 
-    @Builder
-    public User(String email, String nickname, String password) {
+    private User(String email, String nickname, String password, UserAccountType accountType, UserRole role) {
         this.email = email;
         this.nickname = nickname;
         this.password = password;
         this.status = UserStatus.ACTIVE;
+        this.accountType = accountType;
+        this.role = role;
+    }
+
+    public static User createNormalAccount(String email, String nickname, String password) {
+        return new User(email, nickname, password, UserAccountType.NORMAL, UserRole.USER);
+    }
+
+    public static User createIssuedAccount(
+            String email,
+            String nickname,
+            String password,
+            UserAccountType accountType
+    ) {
+        if (accountType == UserAccountType.NORMAL) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        return new User(email, nickname, password, accountType, UserRole.USER);
     }
 
     public void setHomeGroup(Group homeGroup) {
@@ -79,5 +106,9 @@ public class User extends BaseEntity {
         this.homeGroup = null;
         this.email = "withdrawn_" + this.userId + "@deleted.local";
         this.nickname = "wd_" + this.userId.toString().substring(0, 8);
+    }
+
+    public boolean isAdmin() {
+        return this.role == UserRole.ADMIN;
     }
 }

--- a/src/main/java/com/solv/wefin/domain/auth/entity/UserAccountType.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/UserAccountType.java
@@ -1,0 +1,7 @@
+package com.solv.wefin.domain.auth.entity;
+
+public enum UserAccountType {
+    NORMAL,
+    CONTEST,
+    BUSINESS
+}

--- a/src/main/java/com/solv/wefin/domain/auth/entity/UserRole.java
+++ b/src/main/java/com/solv/wefin/domain/auth/entity/UserRole.java
@@ -1,0 +1,6 @@
+package com.solv.wefin.domain.auth.entity;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
+++ b/src/main/java/com/solv/wefin/domain/auth/service/AuthService.java
@@ -1,14 +1,18 @@
 package com.solv.wefin.domain.auth.service;
 
+import com.solv.wefin.domain.auth.dto.IssueAccountCommand;
+import com.solv.wefin.domain.auth.dto.IssuedAccountInfo;
 import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.entity.RefreshToken;
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.entity.UserAccountType;
 import com.solv.wefin.domain.auth.entity.UserStatus;
 import com.solv.wefin.domain.auth.entity.VerificationPurpose;
 import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
@@ -55,10 +59,112 @@ public class AuthService {
 
     @Transactional
     public SignupInfo signup(SignupCommand command) {
-        String email = command.email();
-        String nickname = command.nickname();
-        String password = command.password();
+        NormalizedAccountInput input = normalizeAccountInput(
+                command.email(),
+                command.nickname(),
+                command.password()
+        );
 
+        emailVerificationService.validateVerifiedEmail(input.email(), VerificationPurpose.SIGNUP);
+
+        CreatedAccount createdAccount = createUserWithDefaults(
+                input,
+                UserAccountType.NORMAL
+        );
+        User savedUser = createdAccount.user();
+
+        emailVerificationService.consumeVerifiedEmail(savedUser.getEmail(), VerificationPurpose.SIGNUP);
+
+        return new SignupInfo(
+                savedUser.getUserId(),
+                savedUser.getEmail(),
+                savedUser.getNickname()
+        );
+    }
+
+    @Transactional
+    public IssuedAccountInfo issueAccount(IssueAccountCommand command) {
+        if (command.accountType() == null || command.accountType() == UserAccountType.NORMAL) {
+            throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
+        }
+
+        NormalizedAccountInput input = normalizeAccountInput(
+                command.email(),
+                command.nickname(),
+                command.password()
+        );
+
+        CreatedAccount createdAccount = createUserWithDefaults(
+                input,
+                command.accountType()
+        );
+        Group activeGroup = createdAccount.activeGroup();
+
+        if (command.targetGroupId() != null) {
+            GroupMemberInfo activeGroupInfo = groupService.assignUserToSharedGroup(
+                    createdAccount.user().getUserId(),
+                    command.targetGroupId()
+            );
+
+            return new IssuedAccountInfo(
+                    createdAccount.user().getUserId(),
+                    createdAccount.user().getEmail(),
+                    createdAccount.user().getNickname(),
+                    createdAccount.user().getAccountType(),
+                    activeGroupInfo.groupId(),
+                    activeGroupInfo.groupName()
+            );
+        }
+
+        return new IssuedAccountInfo(
+                createdAccount.user().getUserId(),
+                createdAccount.user().getEmail(),
+                createdAccount.user().getNickname(),
+                createdAccount.user().getAccountType(),
+                activeGroup.getId(),
+                activeGroup.getName()
+        );
+    }
+
+    private CreatedAccount createUserWithDefaults(
+            NormalizedAccountInput input,
+            UserAccountType accountType
+    ) {
+        if (userRepository.existsByEmail(input.email())) {
+            throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
+        }
+        if (userRepository.existsByNickname(input.nickname())) {
+            throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
+        }
+
+        try {
+            String encodedPassword = passwordEncoder.encode(input.password());
+            User user = accountType == UserAccountType.NORMAL
+                    ? User.createNormalAccount(
+                            input.email(),
+                            input.nickname(),
+                            encodedPassword
+                    )
+                    : User.createIssuedAccount(
+                            input.email(),
+                            input.nickname(),
+                            encodedPassword,
+                            accountType
+                    );
+
+            User savedUser = userRepository.saveAndFlush(user);
+            Group homeGroup = groupService.createDefaultGroup(savedUser);
+            savedUser.setHomeGroup(homeGroup);
+            virtualAccountService.createAccount(savedUser.getUserId());
+
+            return new CreatedAccount(savedUser, homeGroup);
+
+        } catch (DataIntegrityViolationException e) {
+            throw mapConstraintViolation(e);
+        }
+    }
+
+    private NormalizedAccountInput normalizeAccountInput(String email, String nickname, String password) {
         if (email == null || nickname == null || password == null) {
             throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
         }
@@ -74,40 +180,7 @@ public class AuthService {
             throw new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED);
         }
 
-        emailVerificationService.validateVerifiedEmail(email, VerificationPurpose.SIGNUP);
-
-
-        if (userRepository.existsByEmail(email)) {
-            throw new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED);
-        }
-        if (userRepository.existsByNickname(nickname)) {
-            throw new BusinessException(ErrorCode.AUTH_NICKNAME_DUPLICATED);
-        }
-
-        try {
-            User user = User.builder()
-                    .email(email)
-                    .nickname(nickname)
-                    .password(passwordEncoder.encode(password))
-                    .build();
-
-            User savedUser = userRepository.saveAndFlush(user);
-
-            Group homeGroup = groupService.createDefaultGroup(savedUser);
-            savedUser.setHomeGroup(homeGroup);
-
-            virtualAccountService.createAccount(savedUser.getUserId());
-            emailVerificationService.consumeVerifiedEmail(savedUser.getEmail(), VerificationPurpose.SIGNUP);
-
-            return new SignupInfo(
-                    savedUser.getUserId(),
-                    savedUser.getEmail(),
-                    savedUser.getNickname()
-            );
-
-        } catch (DataIntegrityViolationException e) {
-            throw mapConstraintViolation(e);
-        }
+        return new NormalizedAccountInput(email, nickname, password);
     }
 
     @Transactional
@@ -338,5 +411,18 @@ public class AuthService {
         }
 
         return new BusinessException(ErrorCode.DUPLICATE_RESOURCE);
+    }
+
+    private record NormalizedAccountInput(
+            String email,
+            String nickname,
+            String password
+    ) {
+    }
+
+    private record CreatedAccount(
+            User user,
+            Group activeGroup
+    ) {
     }
 }

--- a/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
+++ b/src/main/java/com/solv/wefin/domain/group/service/GroupService.java
@@ -226,6 +226,55 @@ public class GroupService {
     }
 
     @Transactional
+    public GroupMemberInfo assignUserToSharedGroup(UUID userId, Long groupId) {
+        User user = getUserForMembershipTransition(userId);
+
+        Group targetGroup = groupRepository.findByIdForUpdate(groupId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.GROUP_NOT_FOUND));
+
+        if (targetGroup.isHomeGroup()) {
+            throw new BusinessException(ErrorCode.GROUP_HOME_JOIN_NOT_ALLOWED);
+        }
+
+        GroupMember currentActiveMember = groupMemberRepository
+                .findByUser_UserIdAndStatus(userId, GroupMember.GroupMemberStatus.ACTIVE)
+                .orElse(null);
+
+        if (currentActiveMember != null
+                && currentActiveMember.getGroup().getId().equals(targetGroup.getId())) {
+            throw new BusinessException(ErrorCode.GROUP_ALREADY_JOINED);
+        }
+
+        long activeMemberCount = groupMemberRepository.countByGroupAndStatus(
+                targetGroup,
+                GroupMember.GroupMemberStatus.ACTIVE
+        );
+
+        if (activeMemberCount >= MAX_GROUP_MEMBER_COUNT) {
+            throw new BusinessException(ErrorCode.GROUP_FULL);
+        }
+
+        if (currentActiveMember != null) {
+            currentActiveMember.deactivate();
+            groupMemberRepository.flush();
+        }
+
+        GroupMember targetMembership = groupMemberRepository
+                .findByUser_UserIdAndGroup_Id(userId, targetGroup.getId())
+                .orElse(null);
+
+        if (targetMembership != null) {
+            targetMembership.activate();
+            return GroupMemberInfo.from(targetMembership);
+        }
+
+        GroupMember newMember = GroupMember.createMember(user, targetGroup);
+        groupMemberRepository.save(newMember);
+
+        return GroupMemberInfo.from(newMember);
+    }
+
+    @Transactional
     public LeaveGroupInfo leaveGroup(Long groupId, UUID userId) {
         User user = getUserForMembershipTransition(userId);
 

--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.solv.wefin.global.config;
 
+import com.solv.wefin.global.config.security.AdminAuthorizationFilter;
 import com.solv.wefin.global.config.security.JwtAuthenticationEntryPoint;
 import com.solv.wefin.global.config.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final AdminAuthorizationFilter adminAuthorizationFilter;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
@@ -36,13 +38,14 @@ public class SecurityConfig {
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/chat/global/messages").permitAll()
                         .requestMatchers("/api/news/recommended/**").authenticated()
+                        .requestMatchers("/api/admin", "/api/admin/**").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**",
                             "/api/market-trends/overview",
                             "/api/stocks/**", "/api/ranking/**").permitAll()
-                        .requestMatchers("/api/admin/**").permitAll() // 임시
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterAfter(adminAuthorizationFilter, JwtAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/solv/wefin/global/config/security/AdminAuthorizationFilter.java
+++ b/src/main/java/com/solv/wefin/global/config/security/AdminAuthorizationFilter.java
@@ -1,0 +1,77 @@
+package com.solv.wefin.global.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.admin.service.AdminAuthorizationService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class AdminAuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String ADMIN_PATH_PREFIX = "/api/admin";
+
+    private final ObjectProvider<AdminAuthorizationService> adminAuthorizationServiceProvider;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (!isAdminPath(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof UUID userId)) {
+            writeError(response, ErrorCode.AUTH_UNAUTHORIZED);
+            return;
+        }
+
+        AdminAuthorizationService adminAuthorizationService = adminAuthorizationServiceProvider.getIfAvailable();
+        if (adminAuthorizationService == null) {
+            writeError(response, ErrorCode.AUTH_UNAUTHORIZED);
+            return;
+        }
+
+        try {
+            adminAuthorizationService.requireAdmin(userId);
+
+        } catch (BusinessException e) {
+            writeError(response, e.getErrorCode());
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isAdminPath(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.equals(ADMIN_PATH_PREFIX) || path.startsWith(ADMIN_PATH_PREFIX + "/");
+    }
+
+    private void writeError(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        response.setStatus(errorCode.getStatus());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(ApiResponse.error(errorCode)));
+    }
+}

--- a/src/main/java/com/solv/wefin/global/error/ErrorCode.java
+++ b/src/main/java/com/solv/wefin/global/error/ErrorCode.java
@@ -51,6 +51,9 @@ public enum ErrorCode {
     DUPLICATE_RESOURCE(409, "중복된 리소스입니다."),
     INTERNAL_SERVER_ERROR(500, "서버 내부 오류가 발생했습니다."),
 
+    // Admin
+    ADMIN_FORBIDDEN(403, "관리자 권한이 필요합니다."),
+
     // Auth - SIGNUP
     AUTH_EMAIL_DUPLICATED(409, "이미 사용 중인 이메일입니다."),
     AUTH_NICKNAME_DUPLICATED(409, "이미 사용 중인 닉네임입니다."),

--- a/src/main/java/com/solv/wefin/web/admin/AccountAdminController.java
+++ b/src/main/java/com/solv/wefin/web/admin/AccountAdminController.java
@@ -1,0 +1,39 @@
+package com.solv.wefin.web.admin;
+
+import com.solv.wefin.domain.auth.dto.IssueAccountCommand;
+import com.solv.wefin.domain.auth.dto.IssuedAccountInfo;
+import com.solv.wefin.domain.auth.service.AuthService;
+import com.solv.wefin.global.common.ApiResponse;
+import com.solv.wefin.web.admin.dto.IssueAccountRequest;
+import com.solv.wefin.web.admin.dto.IssueAccountResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/accounts")
+@RequiredArgsConstructor
+public class AccountAdminController {
+
+    private final AuthService authService;
+
+    @PostMapping
+    public ApiResponse<IssueAccountResponse> issueAccount(
+            @RequestBody @Valid IssueAccountRequest request
+    ) {
+        IssuedAccountInfo result = authService.issueAccount(
+                new IssueAccountCommand(
+                        request.email(),
+                        request.nickname(),
+                        request.password(),
+                        request.accountType(),
+                        request.targetGroupId()
+                )
+        );
+
+        return ApiResponse.success(201, IssueAccountResponse.from(result));
+    }
+}

--- a/src/main/java/com/solv/wefin/web/admin/dto/IssueAccountRequest.java
+++ b/src/main/java/com/solv/wefin/web/admin/dto/IssueAccountRequest.java
@@ -1,0 +1,34 @@
+package com.solv.wefin.web.admin.dto;
+
+import com.solv.wefin.domain.auth.entity.UserAccountType;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record IssueAccountRequest(
+        @NotNull(message = "계정 유형은 필수입니다.")
+        UserAccountType accountType,
+
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하이어야 합니다.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d).+$",
+                message = "비밀번호는 영문과 숫자를 포함해야 합니다."
+        )
+        String password,
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 20자 이하이어야 합니다.")
+        String nickname,
+
+        @Positive(message = "그룹 ID는 1 이상이어야 합니다.")
+        Long targetGroupId
+) {
+}

--- a/src/main/java/com/solv/wefin/web/admin/dto/IssueAccountResponse.java
+++ b/src/main/java/com/solv/wefin/web/admin/dto/IssueAccountResponse.java
@@ -1,0 +1,26 @@
+package com.solv.wefin.web.admin.dto;
+
+import com.solv.wefin.domain.auth.dto.IssuedAccountInfo;
+import com.solv.wefin.domain.auth.entity.UserAccountType;
+
+import java.util.UUID;
+
+public record IssueAccountResponse(
+        UUID userId,
+        String email,
+        String nickname,
+        UserAccountType accountType,
+        Long activeGroupId,
+        String activeGroupName
+) {
+    public static IssueAccountResponse from(IssuedAccountInfo info) {
+        return new IssueAccountResponse(
+                info.userId(),
+                info.email(),
+                info.nickname(),
+                info.accountType(),
+                info.activeGroupId(),
+                info.activeGroupName()
+        );
+    }
+}

--- a/src/main/resources/db/migration/V53__add_user_account_type_and_role.sql
+++ b/src/main/resources/db/migration/V53__add_user_account_type_and_role.sql
@@ -1,0 +1,33 @@
+ALTER TABLE users
+    ADD COLUMN account_type VARCHAR(20);
+
+UPDATE users
+SET account_type = 'NORMAL'
+WHERE account_type IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN account_type SET DEFAULT 'NORMAL';
+
+ALTER TABLE users
+    ALTER COLUMN account_type SET NOT NULL;
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_account_type
+        CHECK (account_type IN ('NORMAL', 'CONTEST', 'BUSINESS'));
+
+ALTER TABLE users
+    ADD COLUMN role VARCHAR(20);
+
+UPDATE users
+SET role = 'USER'
+WHERE role IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN role SET DEFAULT 'USER';
+
+ALTER TABLE users
+    ALTER COLUMN role SET NOT NULL;
+
+ALTER TABLE users
+    ADD CONSTRAINT chk_users_role
+        CHECK (role IN ('USER', 'ADMIN'));

--- a/src/test/java/com/solv/wefin/domain/admin/service/AdminAuthorizationServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/admin/service/AdminAuthorizationServiceTest.java
@@ -1,0 +1,107 @@
+package com.solv.wefin.domain.admin.service;
+
+import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.entity.UserRole;
+import com.solv.wefin.domain.auth.entity.UserStatus;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAuthorizationServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private AdminAuthorizationService adminAuthorizationService;
+
+    @Test
+    @DisplayName("ACTIVE ADMIN 유저는 관리자 권한 검증을 통과한다")
+    void requireAdmin_success() {
+        UUID userId = UUID.randomUUID();
+        User admin = User.createNormalAccount("admin@example.com", "admin", "password");
+        ReflectionTestUtils.setField(admin, "userId", userId);
+        ReflectionTestUtils.setField(admin, "role", UserRole.ADMIN);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(admin));
+
+        assertDoesNotThrow(() -> adminAuthorizationService.requireAdmin(userId));
+    }
+
+    @Test
+    @DisplayName("userId가 null이면 AUTH_UNAUTHORIZED 예외가 발생한다")
+    void requireAdmin_fail_when_user_id_null() {
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> adminAuthorizationService.requireAdmin(null)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 AUTH_UNAUTHORIZED 예외가 발생한다")
+    void requireAdmin_fail_when_user_not_found() {
+        UUID userId = UUID.randomUUID();
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> adminAuthorizationService.requireAdmin(userId)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태가 아니면 AUTH_UNAUTHORIZED 예외가 발생한다")
+    void requireAdmin_fail_when_user_not_active() {
+        UUID userId = UUID.randomUUID();
+        User admin = User.createNormalAccount("admin@example.com", "admin", "password");
+        ReflectionTestUtils.setField(admin, "userId", userId);
+        ReflectionTestUtils.setField(admin, "role", UserRole.ADMIN);
+        ReflectionTestUtils.setField(admin, "status", UserStatus.LOCKED);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(admin));
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> adminAuthorizationService.requireAdmin(userId)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("ADMIN 권한이 없으면 ADMIN_FORBIDDEN 예외가 발생한다")
+    void requireAdmin_fail_when_user_not_admin() {
+        UUID userId = UUID.randomUUID();
+        User user = User.createNormalAccount("user@example.com", "user", "password");
+        ReflectionTestUtils.setField(user, "userId", userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        BusinessException exception = assertThrows(
+                BusinessException.class,
+                () -> adminAuthorizationService.requireAdmin(userId)
+        );
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ADMIN_FORBIDDEN);
+    }
+}

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthServiceTest.java
@@ -1,14 +1,18 @@
 package com.solv.wefin.domain.auth.service;
 
+import com.solv.wefin.domain.auth.dto.IssueAccountCommand;
+import com.solv.wefin.domain.auth.dto.IssuedAccountInfo;
 import com.solv.wefin.domain.auth.dto.LoginInfo;
 import com.solv.wefin.domain.auth.dto.SignupCommand;
 import com.solv.wefin.domain.auth.dto.SignupInfo;
 import com.solv.wefin.domain.auth.entity.RefreshToken;
 import com.solv.wefin.domain.auth.entity.User;
+import com.solv.wefin.domain.auth.entity.UserAccountType;
 import com.solv.wefin.domain.auth.entity.UserStatus;
 import com.solv.wefin.domain.auth.entity.VerificationPurpose;
 import com.solv.wefin.domain.auth.repository.RefreshTokenRepository;
 import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.group.dto.GroupMemberInfo;
 import com.solv.wefin.domain.group.entity.Group;
 import com.solv.wefin.domain.group.entity.GroupMember;
 import com.solv.wefin.domain.group.repository.GroupMemberRepository;
@@ -100,11 +104,11 @@ class AuthServiceTest {
             when(userRepository.existsByNickname("testuser")).thenReturn(false);
             when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
 
-            User savedUser = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User savedUser = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(savedUser, "userId", userId);
 
@@ -299,11 +303,11 @@ class AuthServiceTest {
 
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email(email)
-                    .nickname("testuser")
-                    .password("old-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    email,
+                    "testuser",
+                    "old-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
@@ -363,6 +367,220 @@ class AuthServiceTest {
     }
 
     @Nested
+    @DisplayName("issueAccount")
+    class IssueAccountTest {
+
+        @Test
+        @DisplayName("대회 계정 발급에 성공하면 홈 그룹과 가상계좌를 함께 생성한다")
+        void issueAccount_success_contest() {
+            UUID userId = UUID.randomUUID();
+
+            when(userRepository.existsByEmail("contest@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("contest-user")).thenReturn(false);
+            when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
+
+            User savedUser = User.createIssuedAccount(
+                    "contest@example.com",
+                    "contest-user",
+                    "encoded-password",
+                    UserAccountType.CONTEST
+            );
+            ReflectionTestUtils.setField(savedUser, "userId", userId);
+
+            Group homeGroup = Group.createHomeGroup("contest-user의 그룹");
+            ReflectionTestUtils.setField(homeGroup, "id", 100L);
+
+            when(userRepository.saveAndFlush(any(User.class))).thenReturn(savedUser);
+            when(groupService.createDefaultGroup(savedUser)).thenReturn(homeGroup);
+
+            IssuedAccountInfo result = authService.issueAccount(
+                    new IssueAccountCommand(
+                            "  CONTEST@Example.com  ",
+                            "  contest-user  ",
+                            "pass1234",
+                            UserAccountType.CONTEST,
+                            null
+                    )
+            );
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).saveAndFlush(captor.capture());
+            verify(groupService).createDefaultGroup(savedUser);
+            verify(virtualAccountService).createAccount(userId);
+            verify(emailVerificationService, never()).validateVerifiedEmail(anyString(), any());
+            verify(emailVerificationService, never()).consumeVerifiedEmail(anyString(), any());
+
+            User capturedUser = captor.getValue();
+            assertAll(
+                    () -> assertThat(capturedUser.getEmail()).isEqualTo("contest@example.com"),
+                    () -> assertThat(capturedUser.getNickname()).isEqualTo("contest-user"),
+                    () -> assertThat(capturedUser.getPassword()).isEqualTo("encoded-password"),
+                    () -> assertThat(capturedUser.getAccountType()).isEqualTo(UserAccountType.CONTEST),
+                    () -> assertThat(result.userId()).isEqualTo(userId),
+                    () -> assertThat(result.email()).isEqualTo("contest@example.com"),
+                    () -> assertThat(result.nickname()).isEqualTo("contest-user"),
+                    () -> assertThat(result.accountType()).isEqualTo(UserAccountType.CONTEST),
+                    () -> assertThat(result.activeGroupId()).isEqualTo(100L),
+                    () -> assertThat(result.activeGroupName()).isEqualTo("contest-user의 그룹")
+            );
+        }
+
+        @Test
+        @DisplayName("비즈니스 계정 발급에 성공한다")
+        void issueAccount_success_business() {
+            UUID userId = UUID.randomUUID();
+
+            when(userRepository.existsByEmail("business@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("business-user")).thenReturn(false);
+            when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
+
+            User savedUser = User.createIssuedAccount(
+                    "business@example.com",
+                    "business-user",
+                    "encoded-password",
+                    UserAccountType.BUSINESS
+            );
+            ReflectionTestUtils.setField(savedUser, "userId", userId);
+            Group homeGroup = Group.createHomeGroup("business-user의 그룹");
+            ReflectionTestUtils.setField(homeGroup, "id", 100L);
+
+            when(userRepository.saveAndFlush(any(User.class))).thenReturn(savedUser);
+            when(groupService.createDefaultGroup(savedUser)).thenReturn(homeGroup);
+
+            IssuedAccountInfo result = authService.issueAccount(
+                    new IssueAccountCommand(
+                            "business@example.com",
+                            "business-user",
+                            "pass1234",
+                            UserAccountType.BUSINESS,
+                            null
+                    )
+            );
+
+            assertThat(result.accountType()).isEqualTo(UserAccountType.BUSINESS);
+            verify(virtualAccountService).createAccount(userId);
+        }
+
+        @Test
+        @DisplayName("대상 그룹이 있으면 홈 그룹 생성 후 지정 공유 그룹에 배정한다")
+        void issueAccount_success_with_target_group() {
+            UUID userId = UUID.randomUUID();
+            Long targetGroupId = 10L;
+
+            when(userRepository.existsByEmail("contest@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("contest-user")).thenReturn(false);
+            when(passwordEncoder.encode("pass1234")).thenReturn("encoded-password");
+
+            User savedUser = User.createIssuedAccount(
+                    "contest@example.com",
+                    "contest-user",
+                    "encoded-password",
+                    UserAccountType.CONTEST
+            );
+            ReflectionTestUtils.setField(savedUser, "userId", userId);
+
+            Group homeGroup = Group.createHomeGroup("contest-user의 그룹");
+            ReflectionTestUtils.setField(homeGroup, "id", 100L);
+
+            when(userRepository.saveAndFlush(any(User.class))).thenReturn(savedUser);
+            when(groupService.createDefaultGroup(savedUser)).thenReturn(homeGroup);
+            when(groupService.assignUserToSharedGroup(userId, targetGroupId))
+                    .thenReturn(new GroupMemberInfo(
+                            userId,
+                            targetGroupId,
+                            "대회 A반",
+                            "contest-user",
+                            "MEMBER"
+                    ));
+
+            IssuedAccountInfo result = authService.issueAccount(
+                    new IssueAccountCommand(
+                            "contest@example.com",
+                            "contest-user",
+                            "pass1234",
+                            UserAccountType.CONTEST,
+                            targetGroupId
+                    )
+            );
+
+            InOrder inOrder = inOrder(groupService, virtualAccountService);
+            inOrder.verify(groupService).createDefaultGroup(savedUser);
+            inOrder.verify(virtualAccountService).createAccount(userId);
+            inOrder.verify(groupService).assignUserToSharedGroup(userId, targetGroupId);
+
+            assertAll(
+                    () -> assertThat(result.activeGroupId()).isEqualTo(targetGroupId),
+                    () -> assertThat(result.activeGroupName()).isEqualTo("대회 A반")
+            );
+        }
+
+        @Test
+        @DisplayName("NORMAL 계정은 관리자 발급 API로 생성할 수 없다")
+        void issueAccount_fail_when_account_type_normal() {
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.issueAccount(
+                            new IssueAccountCommand(
+                                    "normal@example.com",
+                                    "normal-user",
+                                    "pass1234",
+                                    UserAccountType.NORMAL,
+                                    null
+                            )
+                    )
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_VALIDATION_FAILED);
+            verify(userRepository, never()).saveAndFlush(any(User.class));
+        }
+
+        @Test
+        @DisplayName("이메일이 중복되면 예외가 발생한다")
+        void issueAccount_fail_when_email_duplicated() {
+            when(userRepository.existsByEmail("contest@example.com")).thenReturn(true);
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.issueAccount(
+                            new IssueAccountCommand(
+                                    "contest@example.com",
+                                    "contest-user",
+                                    "pass1234",
+                                    UserAccountType.CONTEST,
+                                    null
+                            )
+                    )
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_EMAIL_DUPLICATED);
+            verify(userRepository, never()).saveAndFlush(any(User.class));
+        }
+
+        @Test
+        @DisplayName("닉네임이 중복되면 예외가 발생한다")
+        void issueAccount_fail_when_nickname_duplicated() {
+            when(userRepository.existsByEmail("contest@example.com")).thenReturn(false);
+            when(userRepository.existsByNickname("contest-user")).thenReturn(true);
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> authService.issueAccount(
+                            new IssueAccountCommand(
+                                    "contest@example.com",
+                                    "contest-user",
+                                    "pass1234",
+                                    UserAccountType.CONTEST,
+                                    null
+                            )
+                    )
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.AUTH_NICKNAME_DUPLICATED);
+            verify(userRepository, never()).saveAndFlush(any(User.class));
+        }
+    }
+
+    @Nested
     @DisplayName("login")
     class LoginTest {
 
@@ -372,11 +590,11 @@ class AuthServiceTest {
             UUID userId = UUID.randomUUID();
             OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
             ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
@@ -415,11 +633,11 @@ class AuthServiceTest {
             UUID userId = UUID.randomUUID();
             OffsetDateTime expiresAt = OffsetDateTime.now().plusDays(14);
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
             ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
@@ -466,11 +684,11 @@ class AuthServiceTest {
         void login_fail_when_password_not_matched() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
             ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
@@ -492,11 +710,11 @@ class AuthServiceTest {
         void login_fail_when_account_locked() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
             ReflectionTestUtils.setField(user, "status", UserStatus.LOCKED);
@@ -544,11 +762,11 @@ class AuthServiceTest {
         void changePassword_success() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-old-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-old-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
@@ -568,11 +786,11 @@ class AuthServiceTest {
         void changePassword_fail_when_password_mismatch() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-old-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-old-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
@@ -592,11 +810,11 @@ class AuthServiceTest {
         void changePassword_fail_when_same_password() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-old-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-old-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
@@ -636,11 +854,11 @@ class AuthServiceTest {
         void withdraw_success() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
@@ -673,11 +891,11 @@ class AuthServiceTest {
         void withdraw_transfers_leadership_when_leader_leaves_shared_group() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 
@@ -730,11 +948,11 @@ class AuthServiceTest {
         void withdraw_fail_when_password_mismatch() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder()
-                    .email("test@example.com")
-                    .nickname("testuser")
-                    .password("encoded-password")
-                    .build();
+            User user = User.createNormalAccount(
+                    "test@example.com",
+                    "testuser",
+                    "encoded-password"
+            );
 
             ReflectionTestUtils.setField(user, "userId", userId);
 

--- a/src/test/java/com/solv/wefin/domain/auth/service/AuthTokenServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/auth/service/AuthTokenServiceTest.java
@@ -56,7 +56,7 @@ class AuthTokenServiceTest {
     private AuthService authService;
 
     private User activeUser(UUID userId) {
-        User user = User.builder().build();
+        User user = User.createNormalAccount("test@example.com", "testuser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
         ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
         return user;
@@ -313,7 +313,7 @@ class AuthTokenServiceTest {
         void logout_fail_when_user_not_active() {
             UUID userId = UUID.randomUUID();
 
-            User user = User.builder().build();
+            User user = User.createNormalAccount("test@example.com", "testuser", "password");
             ReflectionTestUtils.setField(user, "userId", userId);
             ReflectionTestUtils.setField(user, "status", UserStatus.LOCKED);
 

--- a/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/aiChat/service/AiChatServiceTest.java
@@ -399,11 +399,7 @@ class AiChatServiceTest {
     }
 
     private User createUser(UUID userId) {
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("ai-user")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "ai-user", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
         return user;
     }

--- a/src/test/java/com/solv/wefin/domain/chat/common/service/ChatReadStateServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/common/service/ChatReadStateServiceTest.java
@@ -209,11 +209,7 @@ class ChatReadStateServiceTest {
     }
 
     private User createUser(UUID userId) {
-        User user = User.builder()
-                .email("read@test.com")
-                .nickname("reader")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("read@test.com", "reader", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
         return user;
     }

--- a/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/globalChat/service/GlobalChatServiceTest.java
@@ -58,11 +58,7 @@ public class GlobalChatServiceTest {
         UUID userId = UUID.randomUUID();
         String content = "hello";
 
-        User user = User.builder()
-                .email("test1@test.com")
-                .nickname("testUser")
-                .password("password1")
-                .build();
+        User user = User.createNormalAccount("test1@test.com", "testUser", "password1");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         GlobalChatMessage savedMessage = GlobalChatMessage.builder()
@@ -139,11 +135,7 @@ public class GlobalChatServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test1@test.com")
-                .nickname("testUser1")
-                .password("password1")
-                .build();
+        User user = User.createNormalAccount("test1@test.com", "testUser1", "password1");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         GlobalChatMessage message = GlobalChatMessage.builder()
@@ -233,11 +225,7 @@ public class GlobalChatServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test1@test.com")
-                .nickname("testUser1")
-                .password("password1")
-                .build();
+        User user = User.createNormalAccount("test1@test.com", "testUser1", "password1");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         GlobalChatMessage latestMessage = GlobalChatMessage.builder()

--- a/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/chat/groupChat/service/ChatMessageServiceTest.java
@@ -107,11 +107,7 @@ class ChatMessageServiceTest {
         UUID userId = UUID.randomUUID();
         String content = "hello";
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "groupUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         Group group = Group.builder().name("group-1").build();
@@ -187,11 +183,7 @@ class ChatMessageServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "groupUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         Group group = Group.builder().name("group-1").build();
@@ -255,11 +247,7 @@ class ChatMessageServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "groupUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         Group group = Group.builder().name("group-1").build();
@@ -328,11 +316,7 @@ class ChatMessageServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "groupUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         Group group = Group.builder().name("group-1").build();
@@ -396,11 +380,7 @@ class ChatMessageServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("groupUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "groupUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         Group group = Group.builder().name("group").build();

--- a/src/test/java/com/solv/wefin/domain/group/service/GroupJoinServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/GroupJoinServiceTest.java
@@ -382,4 +382,118 @@ class GroupJoinServiceTest {
             verify(groupMemberRepository, never()).flush();
         }
     }
+
+    @Nested
+    @DisplayName("assignUserToSharedGroup")
+    class AssignUserToSharedGroupTest {
+
+        @Test
+        @DisplayName("사용자를 지정 SHARED 그룹에 배정한다")
+        void assignUserToSharedGroup_success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            Group targetGroup = createGroup(1L, "대회 A반", GroupType.SHARED);
+            Group homeGroup = createGroup(100L, "홈 그룹", GroupType.HOME);
+            var user = createUser(userId, "contest@test.com", "대회유저", "pw");
+            GroupMember currentActiveHomeMember = createGroupMember(
+                    20L,
+                    user,
+                    homeGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+            GroupMember newMember = createGroupMember(
+                    21L,
+                    user,
+                    targetGroup,
+                    GroupMember.GroupMemberRole.MEMBER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+            when(groupRepository.findByIdForUpdate(targetGroup.getId())).thenReturn(Optional.of(targetGroup));
+            when(groupMemberRepository.findByUser_UserIdAndStatus(
+                    userId,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(Optional.of(currentActiveHomeMember));
+            when(groupMemberRepository.countByGroupAndStatus(
+                    targetGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(1L);
+            when(groupMemberRepository.findByUser_UserIdAndGroup_Id(userId, targetGroup.getId()))
+                    .thenReturn(Optional.empty());
+            when(groupMemberRepository.save(any(GroupMember.class))).thenReturn(newMember);
+
+            GroupMemberInfo result = groupService.assignUserToSharedGroup(userId, targetGroup.getId());
+
+            assertAll(
+                    () -> assertThat(result.groupId()).isEqualTo(targetGroup.getId()),
+                    () -> assertThat(result.groupName()).isEqualTo("대회 A반"),
+                    () -> assertThat(result.role()).isEqualTo("MEMBER"),
+                    () -> assertThat(currentActiveHomeMember.isActive()).isFalse()
+            );
+
+            verify(groupMemberRepository).flush();
+            verify(groupMemberRepository).save(any(GroupMember.class));
+        }
+
+        @Test
+        @DisplayName("HOME 그룹에는 관리자 배정을 할 수 없다")
+        void assignUserToSharedGroup_fail_when_home_group() throws Exception {
+            UUID userId = UUID.randomUUID();
+            Group homeGroup = createGroup(100L, "홈 그룹", GroupType.HOME);
+            var user = createUser(userId, "contest@test.com", "대회유저", "pw");
+
+            when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+            when(groupRepository.findByIdForUpdate(homeGroup.getId())).thenReturn(Optional.of(homeGroup));
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.assignUserToSharedGroup(userId, homeGroup.getId())
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_HOME_JOIN_NOT_ALLOWED);
+
+            verify(groupMemberRepository, never()).findByUser_UserIdAndStatus(any(), any());
+            verify(groupMemberRepository, never()).countByGroupAndStatus(any(), any());
+            verify(groupMemberRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("정원이 찬 그룹에는 관리자 배정을 할 수 없다")
+        void assignUserToSharedGroup_fail_when_group_full() throws Exception {
+            UUID userId = UUID.randomUUID();
+            Group targetGroup = createGroup(1L, "대회 A반", GroupType.SHARED);
+            Group homeGroup = createGroup(100L, "홈 그룹", GroupType.HOME);
+            var user = createUser(userId, "contest@test.com", "대회유저", "pw");
+            GroupMember currentActiveHomeMember = createGroupMember(
+                    20L,
+                    user,
+                    homeGroup,
+                    GroupMember.GroupMemberRole.LEADER,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            );
+
+            when(userRepository.findByIdForUpdate(userId)).thenReturn(Optional.of(user));
+            when(groupRepository.findByIdForUpdate(targetGroup.getId())).thenReturn(Optional.of(targetGroup));
+            when(groupMemberRepository.findByUser_UserIdAndStatus(
+                    userId,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(Optional.of(currentActiveHomeMember));
+            when(groupMemberRepository.countByGroupAndStatus(
+                    targetGroup,
+                    GroupMember.GroupMemberStatus.ACTIVE
+            )).thenReturn(6L);
+
+            BusinessException exception = assertThrows(
+                    BusinessException.class,
+                    () -> groupService.assignUserToSharedGroup(userId, targetGroup.getId())
+            );
+
+            assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.GROUP_FULL);
+            assertThat(currentActiveHomeMember.isActive()).isTrue();
+
+            verify(groupMemberRepository, never()).flush();
+            verify(groupMemberRepository, never()).save(any());
+        }
+    }
 }

--- a/src/test/java/com/solv/wefin/domain/group/service/support/GroupTestFixtures.java
+++ b/src/test/java/com/solv/wefin/domain/group/service/support/GroupTestFixtures.java
@@ -29,9 +29,7 @@ public final class GroupTestFixtures {
     }
 
     public static User createUser(UUID userId, String email, String nickname, String password) throws Exception {
-        Constructor<User> constructor = User.class.getDeclaredConstructor(String.class, String.class, String.class);
-        constructor.setAccessible(true);
-        User user = constructor.newInstance(email, nickname, password);
+        User user = User.createNormalAccount(email, nickname, password);
 
         Field userIdField = User.class.getDeclaredField("userId");
         userIdField.setAccessible(true);

--- a/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/QuestProgressServiceTest.java
@@ -128,11 +128,7 @@ class QuestProgressServiceTest {
             int targetValue,
             int progress
     ) {
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("quest-user")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "quest-user", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         QuestTemplate template = mock(QuestTemplate.class);

--- a/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/quest/service/UserQuestServiceTest.java
@@ -75,11 +75,7 @@ class UserQuestServiceTest {
         UUID userId = UUID.randomUUID();
         LocalDate today = LocalDate.now(KST);
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("questUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "questUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         DailyQuest dailyQuest1 = DailyQuest.create(mock(QuestTemplate.class), today, 3, 100);
@@ -147,11 +143,7 @@ class UserQuestServiceTest {
         // given
         UUID userId = UUID.randomUUID();
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("questUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "questUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         QuestTemplate template = mock(QuestTemplate.class);

--- a/src/test/java/com/solv/wefin/domain/user/UserServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/user/UserServiceTest.java
@@ -40,11 +40,7 @@ class UserServiceTest {
         UUID userId = UUID.randomUUID();
         OffsetDateTime createdAt = OffsetDateTime.parse("2026-04-01T09:00:00+09:00");
 
-        User user = User.builder()
-                .email("user@example.com")
-                .nickname("희민")
-                .password("encodedPassword")
-                .build();
+        User user = User.createNormalAccount("user@example.com", "희민", "encodedPassword");
 
         ReflectionTestUtils.setField(user, "userId", userId);
         ReflectionTestUtils.setField(user, "createdAt", createdAt);
@@ -82,17 +78,9 @@ class UserServiceTest {
         UUID userId1 = UUID.randomUUID();
         UUID userId2 = UUID.randomUUID();
 
-        User user1 = User.builder()
-                .email("user1@example.com")
-                .nickname("유저1")
-                .password("pw1")
-                .build();
+        User user1 = User.createNormalAccount("user1@example.com", "유저1", "pw1");
 
-        User user2 = User.builder()
-                .email("user2@example.com")
-                .nickname("유저2")
-                .password("pw2")
-                .build();
+        User user2 = User.createNormalAccount("user2@example.com", "유저2", "pw2");
 
         ReflectionTestUtils.setField(user1, "userId", userId1);
         ReflectionTestUtils.setField(user2, "userId", userId2);

--- a/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
+++ b/src/test/java/com/solv/wefin/domain/vote/service/VoteServiceTest.java
@@ -257,11 +257,7 @@ class VoteServiceTest {
     }
 
     private User createUser(UUID userId) {
-        User user = User.builder()
-                .email("vote@test.com")
-                .nickname("vote-user")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("vote@test.com", "vote-user", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
         return user;
     }

--- a/src/test/java/com/solv/wefin/global/config/security/AdminAuthorizationFilterTest.java
+++ b/src/test/java/com/solv/wefin/global/config/security/AdminAuthorizationFilterTest.java
@@ -1,0 +1,140 @@
+package com.solv.wefin.global.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.solv.wefin.domain.admin.service.AdminAuthorizationService;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AdminAuthorizationFilterTest {
+
+    @Mock
+    private AdminAuthorizationService adminAuthorizationService;
+
+    private AdminAuthorizationFilter filter;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        ObjectProvider<AdminAuthorizationService> adminAuthorizationServiceProvider = mock(ObjectProvider.class);
+        lenient().when(adminAuthorizationServiceProvider.getIfAvailable()).thenReturn(adminAuthorizationService);
+        filter = new AdminAuthorizationFilter(adminAuthorizationServiceProvider, new ObjectMapper());
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("admin 경로가 아니면 권한 검사를 건너뛴다")
+    void doFilterInternal_skips_non_admin_path() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/news");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(adminAuthorizationService, never()).requireAdmin(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("admin 경로에서 인증 정보가 없으면 401을 반환한다")
+    void doFilterInternal_returns_unauthorized_when_anonymous() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/accounts");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH_UNAUTHORIZED");
+    }
+
+    @Test
+    @DisplayName("admin 경로에서 일반 유저면 403을 반환한다")
+    void doFilterInternal_returns_forbidden_when_not_admin() throws Exception {
+        UUID userId = UUID.randomUUID();
+        setAuthentication(userId);
+
+        doThrow(new BusinessException(ErrorCode.ADMIN_FORBIDDEN))
+                .when(adminAuthorizationService)
+                .requireAdmin(userId);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/accounts");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThat(response.getContentAsString()).contains("ADMIN_FORBIDDEN");
+    }
+
+    @Test
+    @DisplayName("admin 경로에서 비활성 유저면 401을 반환한다")
+    void doFilterInternal_returns_unauthorized_when_user_not_active() throws Exception {
+        UUID userId = UUID.randomUUID();
+        setAuthentication(userId);
+
+        doThrow(new BusinessException(ErrorCode.AUTH_UNAUTHORIZED))
+                .when(adminAuthorizationService)
+                .requireAdmin(userId);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/accounts");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        filter.doFilter(request, response, new MockFilterChain());
+
+        assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getContentAsString()).contains("AUTH_UNAUTHORIZED");
+    }
+
+    @Test
+    @DisplayName("admin 경로에서 ADMIN 유저면 요청을 통과시킨다")
+    void doFilterInternal_allows_admin() throws Exception {
+        UUID userId = UUID.randomUUID();
+        setAuthentication(userId);
+
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/accounts");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(adminAuthorizationService).requireAdmin(userId);
+    }
+
+    private void setAuthentication(UUID userId) {
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(
+                        userId,
+                        null,
+                        AuthorityUtils.NO_AUTHORITIES
+                )
+        );
+    }
+}

--- a/src/test/java/com/solv/wefin/web/admin/AccountAdminControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/admin/AccountAdminControllerTest.java
@@ -1,0 +1,146 @@
+package com.solv.wefin.web.admin;
+
+import com.solv.wefin.domain.auth.dto.IssueAccountCommand;
+import com.solv.wefin.domain.auth.dto.IssuedAccountInfo;
+import com.solv.wefin.domain.auth.entity.UserAccountType;
+import com.solv.wefin.domain.auth.repository.UserRepository;
+import com.solv.wefin.domain.auth.service.AuthService;
+import com.solv.wefin.domain.admin.service.AdminAuthorizationService;
+import com.solv.wefin.global.config.security.JwtProvider;
+import com.solv.wefin.global.error.BusinessException;
+import com.solv.wefin.global.error.ErrorCode;
+import com.solv.wefin.global.error.GlobalExceptionHandler;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AccountAdminController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(GlobalExceptionHandler.class)
+class AccountAdminControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AdminAuthorizationService adminAuthorizationService;
+
+    @MockitoBean
+    private AuthService authService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JwtProvider jwtProvider;
+
+    @Nested
+    @DisplayName("POST /api/admin/accounts")
+    class IssueAccountTest {
+
+        @Test
+        @DisplayName("관리자가 대회 계정을 발급하면 201과 생성 계정 정보를 반환한다")
+        void issueAccount_success() throws Exception {
+            UUID adminUserId = UUID.randomUUID();
+            UUID issuedUserId = UUID.randomUUID();
+
+            when(authService.issueAccount(any(IssueAccountCommand.class)))
+                    .thenReturn(new IssuedAccountInfo(
+                            issuedUserId,
+                            "contest@example.com",
+                            "contest-user",
+                            UserAccountType.CONTEST,
+                            10L,
+                            "대회 A반"
+                    ));
+
+            mockMvc.perform(post("/api/admin/accounts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "accountType": "CONTEST",
+                                      "email": "contest@example.com",
+                                      "password": "pass1234",
+                                      "nickname": "contest-user",
+                                      "targetGroupId": 10
+                                    }
+                                    """))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.userId").value(issuedUserId.toString()))
+                    .andExpect(jsonPath("$.data.email").value("contest@example.com"))
+                    .andExpect(jsonPath("$.data.nickname").value("contest-user"))
+                    .andExpect(jsonPath("$.data.accountType").value("CONTEST"))
+                    .andExpect(jsonPath("$.data.activeGroupId").value(10))
+                    .andExpect(jsonPath("$.data.activeGroupName").value("대회 A반"));
+
+            ArgumentCaptor<IssueAccountCommand> captor = ArgumentCaptor.forClass(IssueAccountCommand.class);
+            verify(authService).issueAccount(captor.capture());
+
+            IssueAccountCommand command = captor.getValue();
+            assertThat(command.accountType()).isEqualTo(UserAccountType.CONTEST);
+            assertThat(command.email()).isEqualTo("contest@example.com");
+            assertThat(command.nickname()).isEqualTo("contest-user");
+            assertThat(command.password()).isEqualTo("pass1234");
+            assertThat(command.targetGroupId()).isEqualTo(10L);
+        }
+
+        @Test
+        @DisplayName("NORMAL 계정 발급 요청은 400을 반환한다")
+        void issueAccount_fail_when_account_type_normal() throws Exception {
+            when(authService.issueAccount(any(IssueAccountCommand.class)))
+                    .thenThrow(new BusinessException(ErrorCode.AUTH_VALIDATION_FAILED));
+
+            mockMvc.perform(post("/api/admin/accounts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "accountType": "NORMAL",
+                                      "email": "normal@example.com",
+                                      "password": "pass1234",
+                                      "nickname": "normal-user"
+                                    }
+                                    """))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("AUTH_VALIDATION_FAILED"));
+        }
+
+        @Test
+        @DisplayName("중복 이메일이면 409를 반환한다")
+        void issueAccount_fail_when_email_duplicated() throws Exception {
+            when(authService.issueAccount(any(IssueAccountCommand.class)))
+                    .thenThrow(new BusinessException(ErrorCode.AUTH_EMAIL_DUPLICATED));
+
+            mockMvc.perform(post("/api/admin/accounts")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content("""
+                                    {
+                                      "accountType": "BUSINESS",
+                                      "email": "business@example.com",
+                                      "password": "pass1234",
+                                      "nickname": "business-user"
+                                    }
+                                    """))
+                    .andExpect(status().isConflict())
+                    .andExpect(jsonPath("$.code").value("AUTH_EMAIL_DUPLICATED"));
+        }
+    }
+}

--- a/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
+++ b/src/test/java/com/solv/wefin/web/chat/globalChat/GlobalChatWebSocketTest.java
@@ -60,11 +60,7 @@ class GlobalChatWebSocketTest extends WebSocketIntegrationTestBase {
         AtomicReference<UUID> savedUserIdRef = new AtomicReference<>();
 
         requiresNewTx.executeWithoutResult(status -> {
-            User user = User.builder()
-                    .email("test1@test.com")
-                    .nickname("testUser")
-                    .password("password1")
-                    .build();
+            User user = User.createNormalAccount("test1@test.com", "testUser", "password1");
             userRepository.saveAndFlush(user);
 
             savedUserIdRef.set(user.getUserId());

--- a/src/test/java/com/solv/wefin/web/quest/QuestControllerTest.java
+++ b/src/test/java/com/solv/wefin/web/quest/QuestControllerTest.java
@@ -60,11 +60,7 @@ class QuestControllerTest {
         DailyQuest dailyQuest = DailyQuest.create(template, today, 3, 100);
         ReflectionTestUtils.setField(dailyQuest, "id", 11L);
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("questUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "questUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         UserQuest userQuest = UserQuest.assign(user, dailyQuest);
@@ -127,11 +123,7 @@ class QuestControllerTest {
         DailyQuest dailyQuest = DailyQuest.create(template, today, 3, 100);
         ReflectionTestUtils.setField(dailyQuest, "id", 11L);
 
-        User user = User.builder()
-                .email("test@test.com")
-                .nickname("questUser")
-                .password("password")
-                .build();
+        User user = User.createNormalAccount("test@test.com", "questUser", "password");
         ReflectionTestUtils.setField(user, "userId", userId);
 
         UserQuest userQuest = UserQuest.assign(user, dailyQuest);


### PR DESCRIPTION
## 📌 PR 설명

기존 페이지에 계정 발급 기능 추가했습니다. 이메일 인증 없이도 관리자가 계정을  생성할 수 있고 대회계정과 비즈니스 계정을 발급할 수 있습니다.
계정은 노말 / contest(대회용) / business (비즈니스) 3가지 타입으로 나뉘고
관리자 계정은 role에서 구분 됩니다
<br>
## ✅ 완료한 기능 명세

- [x] admin페이지에 계정 발급 기능 추가
- [x] 계정타입 칼럼 추가 (일반계정, 대회용계정, 비즈니스계정)
- [x] 관리자 계정 기능 추가 (관리자는 회원가입 페이지가 아닌 db에서 Role을 admin으로 변경 시 관리자 계정으로 사용 가능하고 변경되면 해당 아이디는 관리자 페이지만 접근 가능하게 됨)

<br>

## 📸 스크린샷
<img width="2942" height="1760" alt="image" src="https://github.com/user-attachments/assets/91899f31-d93b-4629-a71e-8f0719e4fa73" />
<img width="1320" height="196" alt="image" src="https://github.com/user-attachments/assets/ffc72b9d-9991-4285-9968-78629771fca2" />
<img width="586" height="496" alt="image" src="https://github.com/user-attachments/assets/e7274cab-7752-426a-97a8-ab4d87c1d47b" />

<br>

## 💭 고민과 해결과정

<br>

<br>
