### PR TITLE
[FIX] admin 필터 범위 변경

### DIFF
--- a/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
+++ b/src/main/java/com/solv/wefin/global/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                         .requestMatchers("/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/chat/global/messages").permitAll()
                         .requestMatchers("/api/news/recommended/**").authenticated()
-                        .requestMatchers("/api/admin", "/api/admin/**").authenticated()
+                        .requestMatchers("/api/admin/accounts", "/api/admin/accounts/**").authenticated()
+                        .requestMatchers("/api/admin", "/api/admin/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/news/**", "/api/market/**",
                             "/api/market-trends/overview",
                             "/api/stocks/**", "/api/ranking/**").permitAll()

--- a/src/main/java/com/solv/wefin/global/config/security/AdminAuthorizationFilter.java
+++ b/src/main/java/com/solv/wefin/global/config/security/AdminAuthorizationFilter.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AdminAuthorizationFilter extends OncePerRequestFilter {
 
-    private static final String ADMIN_PATH_PREFIX = "/api/admin";
+    private static final String ADMIN_ACCOUNTS_PATH_PREFIX = "/api/admin/accounts";
 
     private final ObjectProvider<AdminAuthorizationService> adminAuthorizationServiceProvider;
     private final ObjectMapper objectMapper;
@@ -65,7 +65,8 @@ public class AdminAuthorizationFilter extends OncePerRequestFilter {
 
     private boolean isAdminPath(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return path.equals(ADMIN_PATH_PREFIX) || path.startsWith(ADMIN_PATH_PREFIX + "/");
+        return path.equals(ADMIN_ACCOUNTS_PATH_PREFIX)
+                || path.startsWith(ADMIN_ACCOUNTS_PATH_PREFIX + "/");
     }
 
     private void writeError(HttpServletResponse response, ErrorCode errorCode) throws IOException {

--- a/src/test/java/com/solv/wefin/global/config/security/AdminAuthorizationFilterTest.java
+++ b/src/test/java/com/solv/wefin/global/config/security/AdminAuthorizationFilterTest.java
@@ -50,7 +50,7 @@ class AdminAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("admin 경로가 아니면 권한 검사를 건너뛴다")
+    @DisplayName("admin accounts 경로가 아니면 권한 검사를 건너뛴다")
     void doFilterInternal_skips_non_admin_path() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/news");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -63,7 +63,20 @@ class AdminAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("admin 경로에서 인증 정보가 없으면 401을 반환한다")
+    @DisplayName("admin batch 경로는 권한 검사를 건너뛴다")
+    void doFilterInternal_skips_admin_batch_path() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/batch/news");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain filterChain = new MockFilterChain();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        verify(adminAuthorizationService, never()).requireAdmin(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("admin accounts 경로에서 인증 정보가 없으면 401을 반환한다")
     void doFilterInternal_returns_unauthorized_when_anonymous() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/admin/accounts");
         MockHttpServletResponse response = new MockHttpServletResponse();
@@ -75,7 +88,7 @@ class AdminAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("admin 경로에서 일반 유저면 403을 반환한다")
+    @DisplayName("admin accounts 경로에서 일반 유저면 403을 반환한다")
     void doFilterInternal_returns_forbidden_when_not_admin() throws Exception {
         UUID userId = UUID.randomUUID();
         setAuthentication(userId);
@@ -94,7 +107,7 @@ class AdminAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("admin 경로에서 비활성 유저면 401을 반환한다")
+    @DisplayName("admin accounts 경로에서 비활성 유저면 401을 반환한다")
     void doFilterInternal_returns_unauthorized_when_user_not_active() throws Exception {
         UUID userId = UUID.randomUUID();
         setAuthentication(userId);
@@ -113,7 +126,7 @@ class AdminAuthorizationFilterTest {
     }
 
     @Test
-    @DisplayName("admin 경로에서 ADMIN 유저면 요청을 통과시킨다")
+    @DisplayName("admin accounts 경로에서 ADMIN 유저면 요청을 통과시킨다")
     void doFilterInternal_allows_admin() throws Exception {
         UUID userId = UUID.randomUUID();
         setAuthentication(userId);


### PR DESCRIPTION
## 📌 PR 설명
<br>  관리자 권한 필터 적용 범위 수정

## ✅ 완료한 기능 명세

- [x] 관리자 권한 필터 적용 범위를 /api/admin 전체에서 /api/admin/accounts로 변경
- [x] 수동 admin batch 경로가 관리자 권한 검사를 건너뛰는 테스트 추가

<br>

## 📸 스크린샷

<br>

## 💭 고민과 해결과정

<br>

### 🔗 관련 이슈
Closes #이슈번호

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **Bug Fixes**
  * 관리자 계정 관련 엔드포인트에 인증이 필수로 설정되었습니다. 기타 관리자 API 엔드포인트의 접근 제어 규칙이 재정의되어 세밀한 권한 관리가 가능해졌습니다.

* **Tests**
  * 경로별 접근 제어 동작을 검증하는 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->